### PR TITLE
feat(resolver): resolve resolver paths relative to the solution file by default

### DIFF
--- a/docs/design/resolvers.md
+++ b/docs/design/resolvers.md
@@ -2251,6 +2251,58 @@ spec:
 - Avoid using transform for validation (e.g., don't throw errors in CEL expressions)
 - Avoid using validate for data transformation
 
+### Validating a Raw Upstream Response (Split-Resolver Pattern)
+
+The validate phase always runs **after** transform and type coercion, so
+`__self` and the validated value are the resolver's **final output**, never the
+raw provider response. This is intentional: validation rules describe the
+resolver's output contract, and validating a pre-transform value is misleading
+because the rules are written against the expected final shape.
+
+When you need to assert against the **raw upstream response** -- for example,
+checking connectivity or that a remote resource exists before reshaping the
+payload -- do not try to inspect a pre-transform value inside a single resolver.
+Instead, split the work across two resolvers:
+
+1. A **raw resolver** that performs the fetch and carries the connectivity or
+   existence `validate` rules against the unshaped response.
+2. A **transform resolver** that `dependsOn` the raw resolver and reshapes its
+   value into the final contract.
+
+~~~yaml
+spec:
+  resolvers:
+    # 1. Raw fetch + connectivity/existence checks on the unshaped response.
+    userRaw:
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://api.example.com/users/me
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              # Assert on the raw response shape.
+              expression: "__self.statusCode == 200"
+            message: "User endpoint unreachable or returned a non-200 status"
+
+    # 2. Downstream reshape into the final output contract.
+    user:
+      dependsOn: [userRaw]
+      type: object
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.userRaw.body
+~~~
+
+This keeps each resolver single-purpose: `userRaw` owns the fetch and its
+liveness checks, while `user` owns the final shape. It avoids introducing
+implicit pre-transform bindings into the validate phase and keeps the
+output-contract semantics of `validate` intact.
+
 ### Conditional Resolvers
 
 **Use `when:` for feature flags and optional configuration:**

--- a/docs/tutorials/functional-testing.md
+++ b/docs/tutorials/functional-testing.md
@@ -506,6 +506,45 @@ files produce a test `error`** to catch typos early.
 
 ---
 
+## Repo-Root-Relative Paths (`baseDir`)
+
+By default scafctl resolves resolver file paths relative to the **solution
+file's own directory**. A solution that references `./output/data.json` finds
+its files no matter which directory it lives in or where you run the command
+from, so most tests need no special handling.
+
+`baseDir` exists for the case where a solution lives in a subdirectory of a
+repository and its resolvers reference paths relative to the **repository root**
+instead (for example `./config/output/data.json`, including the subdirectory
+prefix). Setting `baseDir` on the test case nests the solution and its files
+under that subdirectory inside the sandbox and runs the command from the sandbox
+root, so those repo-root-relative paths resolve correctly.
+
+```yaml
+cases:
+  read-repo-relative-config:
+    description: Solution under ./config uses repo-root-relative paths
+    baseDir: config
+    command: [run, resolver]
+    args: ["-o", "json"]
+    assertions:
+      - expression: __exitCode == 0
+```
+
+With `baseDir: config`, a solution that references `./config/output/data.json`
+is placed at `<sandbox>/config/solution.yaml` and reads/writes
+`<sandbox>/config/output/data.json`, matching the real repository layout.
+
+`baseDir` must be a relative path and may not traverse above the sandbox root
+(`..`). While the `run resolver` command accepts a `--base-dir` flag, prefer
+setting `baseDir` on the test case rather than passing `--base-dir` through
+`args`: the per-test setting nests the solution in the sandbox correctly and
+keeps each test self-contained and reproducible in CI. When a base template sets
+`baseDir`, cases that `extends` it inherit the value, so you can set it once on a
+shared base case.
+
+---
+
 ## Expected Failures
 
 Test that a command fails as expected:

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -1625,6 +1625,44 @@ resolve:
 | `pages` | int | Number of pages fetched (only when paginating) |
 | `totalItems` | int | Total items collected across all pages (only when paginating) |
 
+#### Non-JSON and Empty Response Bodies
+
+`body` is only parsed into a structured value when `autoParseJson` is enabled
+**and** the response `Content-Type` is JSON **and** the body is non-empty.
+Otherwise `body` is the **raw response string**, and an empty response yields an
+empty string (`""`).
+
+Some endpoints return a bare scalar as `text/plain` rather than JSON --- for
+example, a Microsoft Graph `$count` endpoint returns a number like `42`, and may
+return an empty body when there is nothing to count. Coercing such a `body`
+directly to a number fails on the empty string, so guard it in CEL and supply a
+default before converting:
+
+```yaml
+resolvers:
+  user_count_raw:
+    resolve:
+      with:
+        - provider: http
+          inputs:
+            url: https://graph.microsoft.com/v1.0/users/$count
+            headers:
+              ConsistencyLevel: eventual
+
+  user_count:
+    type: int
+    dependsOn: [user_count_raw]
+    resolve:
+      with:
+        - provider: cel
+          inputs:
+            # Treat an empty/whitespace body as 0, then convert to int.
+            expression: int(_.user_count_raw.body.trim() == "" ? "0" : _.user_count_raw.body.trim())
+```
+
+This keeps the generic `http` provider free of endpoint-specific behavior while
+making the numeric coercion explicit and safe at the solution level.
+
 ### Examples
 
 ```yaml

--- a/docs/tutorials/validation-patterns-tutorial.md
+++ b/docs/tutorials/validation-patterns-tutorial.md
@@ -111,48 +111,59 @@ The `validation` provider runs checks during the **validate phase** of a resolve
 Validate string values against regex patterns:
 
 ```yaml
-# examples/providers/validation/regex-patterns.yaml
-apiVersion: scafctl.io/v1alpha1
+apiVersion: scafctl.io/v1
 kind: Solution
 metadata:
   name: regex-validation-demo
   version: 1.0.0
 spec:
   resolvers:
-    - name: email
-      value: "user@example.com"
+    email:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "user@example.com"
       validate:
         with:
           - provider: validation
-            input:
+            inputs:
               match: '^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
-              message: "Must be a valid email address"
+            message: "Must be a valid email address"
 
-    - name: semver
-      value: "v1.2.3"
+    semver:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "v1.2.3"
       validate:
         with:
           - provider: validation
-            input:
+            inputs:
               match: '^v?\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$'
-              message: "Must be a valid semantic version"
+            message: "Must be a valid semantic version"
 
-    - name: k8s_name
-      value: "my-service-01"
+    k8s_name:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "my-service-01"
       validate:
         with:
           - provider: validation
-            input:
+            inputs:
               match: '^[a-z][a-z0-9-]{0,61}[a-z0-9]$'
               notMatch: '--'
-              message: "Must be a valid Kubernetes resource name"
+            message: "Must be a valid Kubernetes resource name"
 ```
 
 {{% details "▶ Try it" %}}
-Run this example
+Save the snippet above as `regex-patterns.yaml`, then run:
 
 ```bash
-scafctl run solution -f regex-patterns.yaml
+scafctl run resolver -f regex-patterns.yaml
 ```
 {{% /details %}}
 
@@ -161,52 +172,64 @@ scafctl run solution -f regex-patterns.yaml
 Use CEL expressions for complex, type-aware validation:
 
 ```yaml
-# examples/providers/validation/cel-validation.yaml
-apiVersion: scafctl.io/v1alpha1
+apiVersion: scafctl.io/v1
 kind: Solution
 metadata:
   name: cel-validation-demo
   version: 1.0.0
 spec:
   resolvers:
-    - name: port
-      value: 8080
+    port:
+      type: int
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 8080
       validate:
         with:
           - provider: validation
-            input:
+            inputs:
               expression: "__self >= 1024 && __self <= 65535"
-              message: "Port must be in the unprivileged range (1024-65535)"
+            message: "Port must be in the unprivileged range (1024-65535)"
 
-    - name: environment
-      value: "staging"
+    environment:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "staging"
       validate:
         with:
           - provider: validation
-            input:
+            inputs:
               expression: "__self in ['development', 'staging', 'production']"
-              message: "Environment must be one of: development, staging, production"
+            message: "Environment must be one of: development, staging, production"
 
-    - name: password
-      value: "SecureP@ss1"
+    password:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "SecureP@ss1"
       validate:
         with:
           - provider: validation
-            input:
+            inputs:
               match: '.{8,}'
-              message: "Password must be at least 8 characters"
+            message: "Password must be at least 8 characters"
           - provider: validation
-            input:
+            inputs:
               match: '[A-Z]'
-              message: "Password must contain an uppercase letter"
+            message: "Password must contain an uppercase letter"
           - provider: validation
-            input:
+            inputs:
               match: '[0-9]'
-              message: "Password must contain a digit"
+            message: "Password must contain a digit"
           - provider: validation
-            input:
+            inputs:
               match: '[!@#$%^&*]'
-              message: "Password must contain a special character"
+            message: "Password must contain a special character"
 ```
 
 > [!NOTE]
@@ -217,40 +240,110 @@ spec:
 Validate relationships between different resolver values:
 
 ```yaml
-apiVersion: scafctl.io/v1alpha1
+apiVersion: scafctl.io/v1
 kind: Solution
 metadata:
   name: cross-field-validation
   version: 1.0.0
 spec:
   resolvers:
-    - name: min_replicas
-      value: 2
+    min_replicas:
+      type: int
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 2
 
-    - name: max_replicas
-      value: 10
+    max_replicas:
+      type: int
+      dependsOn: [min_replicas]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 10
       validate:
         with:
           - provider: validation
-            input:
+            inputs:
               expression: "__self >= _.min_replicas"
-              message: "max_replicas must be >= min_replicas"
+            message: "max_replicas must be >= min_replicas"
 
-    - name: environment
-      value: "production"
+    environment:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "production"
 
-    - name: replicas
-      value: 3
+    replicas:
+      type: int
+      dependsOn: [environment]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: 3
       validate:
         with:
           - provider: validation
-            input:
+            inputs:
               expression: |
                 _.environment == 'production'
                   ? __self >= 3
                   : __self >= 1
-              message: "Production requires at least 3 replicas"
+            message: "Production requires at least 3 replicas"
 ```
+
+---
+
+### Pattern: Validating a Raw Upstream Response (Split-Resolver)
+
+The validate phase runs **after** transform and type coercion, so `__self` is
+always the resolver's final output -- never the raw provider response. To assert
+against a raw upstream response (for example, checking connectivity or that a
+remote resource exists before reshaping it), split the work across two
+resolvers: a raw resolver that fetches and carries the connectivity/existence
+checks, and a downstream resolver that depends on it and reshapes the value.
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: split-resolver-validation
+  version: 1.0.0
+spec:
+  resolvers:
+    # 1. Raw fetch + connectivity/existence checks on the unshaped response.
+    user_raw:
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://api.example.com/users/me
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "__self.statusCode == 200"
+            message: "User endpoint unreachable or returned a non-200 status"
+
+    # 2. Downstream reshape into the final output contract.
+    user:
+      dependsOn: [user_raw]
+      type: object
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.user_raw.body
+```
+
+This keeps each resolver single-purpose: `user_raw` owns the fetch and its
+liveness checks, while `user` owns the final shape. It avoids inspecting a
+pre-transform value inside a single resolver and preserves the output-contract
+semantics of `validate`.
 
 ---
 
@@ -259,52 +352,52 @@ spec:
 Actions can define a `resultSchema` to validate their output structure using JSON Schema:
 
 ```yaml
-apiVersion: scafctl.io/v1alpha1
+apiVersion: scafctl.io/v1
 kind: Solution
 metadata:
   name: result-schema-demo
   version: 1.0.0
 spec:
   resolvers:
-    - name: config
+    config:
       resolve:
         with:
           - provider: http
-            input:
+            inputs:
               method: GET
               url: https://api.example.com/config
 
-  actions:
-    - name: deploy
-      resultSchema:
-        type: object
-        required:
-          - status
-          - deploymentId
-        properties:
-          status:
-            type: string
-            enum: [success, pending, failed]
-          deploymentId:
-            type: string
-            pattern: "^deploy-[a-f0-9]{8}$"
-          instances:
-            type: array
-            minItems: 1
-            items:
-              type: object
-              required: [id, region]
-              properties:
-                id:
-                  type: string
-                region:
-                  type: string
-                  enum: [us-east-1, us-west-2, eu-west-1]
-        additionalProperties: false
-      steps:
-        - provider: exec
-          input:
-            command: "echo '{\"status\":\"success\",\"deploymentId\":\"deploy-a1b2c3d4\",\"instances\":[{\"id\":\"i-1\",\"region\":\"us-east-1\"}]}'"
+  workflow:
+    actions:
+      deploy:
+        resultSchema:
+          type: object
+          required:
+            - status
+            - deploymentId
+          properties:
+            status:
+              type: string
+              enum: [success, pending, failed]
+            deploymentId:
+              type: string
+              pattern: "^deploy-[a-f0-9]{8}$"
+            instances:
+              type: array
+              minItems: 1
+              items:
+                type: object
+                required: [id, region]
+                properties:
+                  id:
+                    type: string
+                  region:
+                    type: string
+                    enum: [us-east-1, us-west-2, eu-west-1]
+          additionalProperties: false
+        provider: exec
+        inputs:
+          command: "echo '{\"status\":\"success\",\"deploymentId\":\"deploy-a1b2c3d4\",\"instances\":[{\"id\":\"i-1\",\"region\":\"us-east-1\"}]}'"
 ```
 
 If the action output doesn't match the schema, execution fails with a clear error:
@@ -448,21 +541,21 @@ Apply multiple validation rules by chaining `validation` provider entries:
 validate:
   with:
     - provider: validation
-      input:
+      inputs:
         match: '.{8,}'
-        message: "Must be at least 8 characters"
+      message: "Must be at least 8 characters"
     - provider: validation
-      input:
+      inputs:
         match: '[A-Z]'
-        message: "Must contain an uppercase letter"
+      message: "Must contain an uppercase letter"
     - provider: validation
-      input:
+      inputs:
         notMatch: '\s'
-        message: "Must not contain whitespace"
+      message: "Must not contain whitespace"
     - provider: validation
-      input:
+      inputs:
         expression: "__self != _.username"
-        message: "Must not match the username"
+      message: "Must not match the username"
 ```
 
 ---
@@ -481,11 +574,11 @@ validate:
     - provider: validation
       inputs:
         match: "^[a-z][a-z0-9-]*$"
-        message: "expr: 'Invalid name \"' + string(__self) + '\": must start with a lowercase letter and contain only [a-z0-9-]'"
+      message: "expr: 'Invalid name \"' + string(__self) + '\": must start with a lowercase letter and contain only [a-z0-9-]'"
     - provider: validation
       inputs:
         expression: "size(__self) <= 63"
-        message: "expr: 'Name \"' + string(__self) + '\" is ' + string(size(__self)) + ' chars (max 63)'"
+      message: "expr: 'Name \"' + string(__self) + '\" is ' + string(size(__self)) + ' chars (max 63)'"
 ```
 
 ### Go Template Messages
@@ -498,11 +591,11 @@ validate:
     - provider: validation
       inputs:
         expression: "__self != _.environment"
-        message: "tmpl: Name '{{.__self}}' must not match the environment name '{{.environment}}'"
+      message: "tmpl: Name '{{.__self}}' must not match the environment name '{{.environment}}'"
     - provider: validation
       inputs:
         match: "^[a-z]"
-        message: "tmpl: Value '{{.__self}}' must start with a lowercase letter"
+      message: "tmpl: Value '{{.__self}}' must start with a lowercase letter"
 ```
 
 ### Fallback Behavior
@@ -519,7 +612,7 @@ validate:
     - provider: validation
       inputs:
         match: "^[a-z]"
-        message: "Must start with a lowercase letter"
+      message: "Must start with a lowercase letter"
 ```
 
 ---

--- a/examples/providers/README.md
+++ b/examples/providers/README.md
@@ -37,6 +37,7 @@ scafctl run resolver -f examples/providers/http-get.yaml
 |------|-------------|
 | [http-get.yaml](http-get.yaml) | Simple HTTP GET request |
 | [http-autoparse.yaml](http-autoparse.yaml) | Auto-parse JSON responses |
+| [http-empty-body.yaml](http-empty-body.yaml) | Non-JSON and empty response bodies |
 | [http-poll.yaml](http-poll.yaml) | Polling until a condition is met |
 | [http-entra.yaml](http-entra.yaml) | Microsoft Graph API with Entra auth |
 | [github-api.yaml](github-api.yaml) | GitHub API with authentication |

--- a/examples/providers/http-empty-body.yaml
+++ b/examples/providers/http-empty-body.yaml
@@ -1,0 +1,54 @@
+# Prerequisites: scafctl auth login entra --scope https://graph.microsoft.com/.default
+#
+# Run: scafctl run resolver -f examples/providers/http-empty-body.yaml
+
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: http-empty-body-example
+  displayName: HTTP Non-JSON and Empty Body Example
+  category: providers
+  tags:
+    - http
+    - provider-example
+  description: |
+    The HTTP provider only parses `body` into a structured value when
+    autoParseJson is enabled AND the Content-Type is JSON AND the body is
+    non-empty. Otherwise `body` is the raw response string, and an empty
+    response yields an empty string ("").
+
+    Some endpoints return a bare scalar as text/plain rather than JSON --- for
+    example, a Microsoft Graph $count endpoint returns a number like 42 and may
+    return an empty body when there is nothing to count. Coercing such a body
+    directly to a number fails on the empty string, so guard it in CEL and
+    supply a default before converting. This keeps the generic http provider
+    free of endpoint-specific behavior while making the numeric coercion
+    explicit and safe at the solution level.
+
+spec:
+  resolvers:
+    # Raw fetch of a text/plain scalar count. body stays a raw string because
+    # the response is not JSON.
+    user_count_raw:
+      description: Raw $count response (text/plain scalar)
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://graph.microsoft.com/v1.0/users/$count
+              method: GET
+              headers:
+                ConsistencyLevel: eventual
+              authProvider: entra
+              scope: "https://graph.microsoft.com/.default"
+
+    # Guarded coercion: treat an empty/whitespace body as 0, then convert to int.
+    user_count:
+      description: Count coerced to an int, defaulting an empty body to 0
+      type: int
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'int(_.user_count_raw.body.trim() == "" ? "0" : _.user_count_raw.body.trim())'

--- a/examples/resolvers/README.md
+++ b/examples/resolvers/README.md
@@ -28,6 +28,7 @@ This directory contains practical examples demonstrating various resolver patter
 | [transform-pipeline.yaml](transform-pipeline.yaml) | Multi-step data transformation |
 | [foreach-filter.yaml](foreach-filter.yaml) | ForEach in resolve phase with filter to strip nil results |
 | [validation.yaml](validation.yaml) | Input validation patterns |
+| [split-resolver-validation.yaml](split-resolver-validation.yaml) | Validate a raw upstream response, then reshape downstream |
 
 ### CEL Expressions
 

--- a/examples/resolvers/split-resolver-validation.yaml
+++ b/examples/resolvers/split-resolver-validation.yaml
@@ -1,0 +1,56 @@
+# Run: scafctl run resolver -f examples/resolvers/split-resolver-validation.yaml
+# Run: scafctl run resolver -f examples/resolvers/split-resolver-validation.yaml user
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: split-resolver-validation-example
+  displayName: Split-Resolver Validation Example
+  category: resolvers
+  tags:
+    - resolver-example
+    - validation
+    - http
+  description: |
+    The validate phase always runs AFTER transform and type coercion, so
+    `__self` is the resolver's final output --- never the raw provider response.
+    To assert against a raw upstream response (for example, checking
+    connectivity or that a remote resource exists before reshaping it), split
+    the work across two resolvers:
+
+      1. A raw resolver that performs the fetch and carries the
+         connectivity/existence checks against the unshaped response.
+      2. A downstream resolver that depends on the raw resolver and reshapes its
+         value into the final output contract.
+
+    This keeps each resolver single-purpose and preserves the output-contract
+    semantics of validate.
+
+spec:
+  resolvers:
+    # 1. Raw fetch + connectivity check on the unshaped response.
+    user_raw:
+      description: Raw upstream fetch with a connectivity check
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://httpbin.org/json
+              method: GET
+              autoParseJson: true
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "__self.statusCode == 200"
+            message: "User endpoint unreachable or returned a non-200 status"
+
+    # 2. Downstream reshape into the final output contract.
+    user:
+      description: Final shape derived from the validated raw response
+      type: object
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.user_raw.body

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -828,7 +828,7 @@ func addSharedResolverFlags(cCmd *cobra.Command, o *sharedResolverOptions) {
 	cCmd.Flags().StringVar(&o.VersionConstraint, "version", "", "Semver version constraint for catalog resolution (e.g., ^1.0.0, ~2.1, >=1.0 <3.0)")
 	cCmd.Flags().StringVar(&o.TestName, "test-name", "", "Test name for -o test output (derived from command and args when not set)")
 	cCmd.Flags().StringVar(&o.OutputDir, "output-dir", "", "Target directory for action file operations (actions resolve relative paths here instead of CWD)")
-	cCmd.Flags().StringVar(&o.BaseDir, "base-dir", "", "Override base directory for resolver path resolution (when unset, paths resolve from CWD)")
+	cCmd.Flags().StringVar(&o.BaseDir, "base-dir", "", "Override base directory for resolver path resolution (when unset, paths resolve from the solution file's directory when known, otherwise the current directory; use '.' for CWD)")
 	cCmd.Flags().BoolVar(&o.PreRelease, "pre-release", false, "Include pre-release versions when resolving latest from catalog")
 	cCmd.Flags().BoolVar(&o.Strict, "strict", false, "Disable auto-resolution of official providers; require explicit bundle.plugins declarations")
 }

--- a/pkg/provider/builtin/httpprovider/http.go
+++ b/pkg/provider/builtin/httpprovider/http.go
@@ -258,14 +258,14 @@ func NewHTTPProvider() *HTTPProvider {
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"statusCode": schemahelper.IntProp("HTTP response status code (last page when paginating)", schemahelper.WithExample(200)),
-					fieldBody:    schemahelper.AnyProp("Response body as string (default) or parsed JSON object when autoParseJson is true. When paginating with collectPath, contains the JSON array of all collected items"),
+					fieldBody:    schemahelper.AnyProp("Response body. By default (or when the response Content-Type is not JSON, or the body is empty) this is the raw response string; an empty response yields an empty string (\"\"). When autoParseJson is true and the Content-Type is JSON and the body is non-empty, it is the parsed JSON object. When paginating with collectPath, contains the JSON array of all collected items"),
 					fieldHeaders: schemahelper.AnyProp("Response headers (last page when paginating)"),
 					"pages":      schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
 					"totalItems": schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),
 				}),
 				provider.CapabilityTransform: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"statusCode": schemahelper.IntProp("HTTP response status code (last page when paginating)", schemahelper.WithExample(200)),
-					fieldBody:    schemahelper.AnyProp("Response body as string (default) or parsed JSON object when autoParseJson is true. When paginating with collectPath, contains the JSON array of all collected items"),
+					fieldBody:    schemahelper.AnyProp("Response body. By default (or when the response Content-Type is not JSON, or the body is empty) this is the raw response string; an empty response yields an empty string (\"\"). When autoParseJson is true and the Content-Type is JSON and the body is non-empty, it is the parsed JSON object. When paginating with collectPath, contains the JSON array of all collected items"),
 					fieldHeaders: schemahelper.AnyProp("Response headers (last page when paginating)"),
 					"pages":      schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
 					"totalItems": schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),
@@ -273,7 +273,7 @@ func NewHTTPProvider() *HTTPProvider {
 				provider.CapabilityAction: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"success":    schemahelper.BoolProp("Whether the HTTP request completed successfully (2xx status)"),
 					"statusCode": schemahelper.IntProp("HTTP response status code (last page when paginating)", schemahelper.WithExample(200)),
-					fieldBody:    schemahelper.AnyProp("Response body as string (default) or parsed JSON object when autoParseJson is true. When paginating with collectPath, contains the JSON array of all collected items"),
+					fieldBody:    schemahelper.AnyProp("Response body. By default (or when the response Content-Type is not JSON, or the body is empty) this is the raw response string; an empty response yields an empty string (\"\"). When autoParseJson is true and the Content-Type is JSON and the body is non-empty, it is the parsed JSON object. When paginating with collectPath, contains the JSON array of all collected items"),
 					fieldHeaders: schemahelper.AnyProp("Response headers (last page when paginating)"),
 					"pages":      schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
 					"totalItems": schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),

--- a/pkg/solution/soltesting/scaffold.go
+++ b/pkg/solution/soltesting/scaffold.go
@@ -36,12 +36,6 @@ type ScaffoldInput struct {
 	// discovered through static analysis of provider inputs.
 	// These are automatically populated onto generated test cases.
 	FileDependencies []string
-
-	// SolutionSubdir is the subdirectory path of the solution file relative to
-	// the project root (e.g., "myapp" when the solution is at myapp/solution.yaml).
-	// When set, generated test cases include BaseDir so the test runner nests
-	// solution files under this subdirectory within the sandbox.
-	SolutionSubdir string
 }
 
 // Scaffold generates a skeleton test suite from the provided solution data.
@@ -82,16 +76,6 @@ func Scaffold(input *ScaffoldInput) *ScaffoldResult {
 		for name, tc := range result.Cases {
 			if name != filesBaseTemplateName {
 				tc.Extends = []string{filesBaseTemplateName}
-			}
-		}
-	}
-
-	// When the solution lives in a subdirectory, set BaseDir on all non-template
-	// test cases so the runner nests solution files under this subdirectory within the sandbox.
-	if input.SolutionSubdir != "" {
-		for name, tc := range result.Cases {
-			if !strings.HasPrefix(name, "_") {
-				tc.BaseDir = input.SolutionSubdir
 			}
 		}
 	}

--- a/pkg/solution/soltesting/scaffold_test.go
+++ b/pkg/solution/soltesting/scaffold_test.go
@@ -4,7 +4,6 @@
 package soltesting
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/action"
@@ -276,47 +275,11 @@ func TestScaffold_EmptyFileDependenciesOmitted(t *testing.T) {
 	}
 }
 
-func TestScaffold_SolutionSubdirSetsBaseDir(t *testing.T) {
-	result := Scaffold(&ScaffoldInput{
-		SolutionSubdir: "myapp",
-	})
-
-	require.NotNil(t, result)
-
-	// Non-template cases should have BaseDir set
-	for name, tc := range result.Cases {
-		if strings.HasPrefix(name, "_") {
-			assert.Empty(t, tc.BaseDir, "template %q should not have BaseDir", name)
-		} else {
-			assert.Equal(t, "myapp", tc.BaseDir, "test case %q should have BaseDir", name)
-		}
-	}
-}
-
 func TestScaffold_NoSubdirNoBaseDir(t *testing.T) {
 	result := Scaffold(&ScaffoldInput{})
 
 	for name, tc := range result.Cases {
 		assert.Empty(t, tc.BaseDir, "test case %q should not have BaseDir when no subdir", name)
-	}
-}
-
-func TestScaffold_SolutionSubdirWithFileDeps(t *testing.T) {
-	result := Scaffold(&ScaffoldInput{
-		SolutionSubdir:   "nested/app",
-		FileDependencies: []string{"templates/main.yaml"},
-	})
-
-	// _files-base template should NOT have BaseDir
-	tmpl := result.Cases[filesBaseTemplateName]
-	require.NotNil(t, tmpl)
-	assert.Empty(t, tmpl.BaseDir)
-
-	// Non-template cases should have BaseDir
-	for name, tc := range result.Cases {
-		if name != filesBaseTemplateName {
-			assert.Equal(t, "nested/app", tc.BaseDir, "test case %q should have BaseDir", name)
-		}
 	}
 }
 

--- a/tests/integration/solutions/providers/http-empty-body/solution.yaml
+++ b/tests/integration/solutions/providers/http-empty-body/solution.yaml
@@ -1,0 +1,132 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-http-empty-body
+  version: 1.0.0
+  description: |
+    Functional tests for the HTTP provider's non-JSON and empty response-body
+    behavior documented in the provider reference. When autoParseJson is off (or
+    the Content-Type is not JSON, or the body is empty), `body` is the raw
+    response string and an empty response yields "". A downstream CEL resolver
+    guards the empty case before coercing the bare scalar to an int. Uses a mock
+    HTTP server started via testConfig.services.
+
+spec:
+  resolvers:
+    mockBaseUrl:
+      description: Base URL of the mock server from env
+      resolve:
+        with:
+          - provider: env
+            inputs:
+              operation: get
+              name: MOCK_BASE_URL
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.value"
+
+    userCountRaw:
+      description: GET a text/plain scalar count (raw string body, not parsed)
+      dependsOn: [mockBaseUrl]
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/count'"
+              method: GET
+
+    userCount:
+      description: Coerce the raw count to an int, defaulting an empty body to 0
+      dependsOn: [userCountRaw]
+      type: int
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'int(_.userCountRaw.body.trim() == "" ? "0" : _.userCountRaw.body.trim())'
+
+    emptyCountRaw:
+      description: GET an endpoint that returns an empty body
+      dependsOn: [mockBaseUrl]
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/count-empty'"
+              method: GET
+
+    emptyCount:
+      description: Empty body coerces to 0 via the guard
+      dependsOn: [emptyCountRaw]
+      type: int
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'int(_.emptyCountRaw.body.trim() == "" ? "0" : _.emptyCountRaw.body.trim())'
+
+  testing:
+    config:
+      # resolve-defaults: resolvers depend on MOCK_BASE_URL env var and mock routes
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
+      services:
+        - name: mock-api
+          type: http
+          portEnv: MOCK_HTTP_PORT
+          baseUrlEnv: MOCK_BASE_URL
+          routes:
+            - path: /count
+              method: GET
+              status: 200
+              body: "42"
+              headers:
+                Content-Type: text/plain
+            - path: /count-empty
+              method: GET
+              status: 200
+              body: ""
+              headers:
+                Content-Type: text/plain
+
+    cases:
+      _base:
+        description: Base template that allows private IPs so the mock server is reachable
+        command: [run, resolver]
+        args: ["-o", "json", "--config", "config.yaml"]
+        tags: [provider, http, empty-body]
+        init:
+          - command: "printf 'httpClient:\\n  allowPrivateIPs: true\\n' > config.yaml"
+
+      raw-body-is-string:
+        description: A text/plain response leaves body as the raw string
+        extends: [_base]
+        args: ["userCountRaw"]
+        tags: [smoke]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: '__output.userCountRaw.body == "42"'
+            message: "Non-JSON body should be the raw response string"
+
+      scalar-coerces-to-int:
+        description: The raw scalar body coerces to an int
+        extends: [_base]
+        args: ["userCount"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output.userCount == 42
+            message: "Guarded coercion should convert the scalar body to an int"
+
+      empty-body-defaults-to-zero:
+        description: An empty response body is guarded and defaults to 0
+        extends: [_base]
+        args: ["emptyCount"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output.emptyCount == 0
+            message: "Empty body should default to 0 instead of failing coercion"

--- a/tests/integration/solutions/resolvers/split-resolver-validation/solution.yaml
+++ b/tests/integration/solutions/resolvers/split-resolver-validation/solution.yaml
@@ -1,0 +1,140 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-split-resolver-validation
+  version: 1.0.0
+  description: |
+    Functional tests for the split-resolver validation pattern documented in
+    the validation-patterns tutorial. A raw resolver fetches an upstream
+    response and validates connectivity (statusCode == 200) against the
+    unshaped payload, while a downstream resolver reshapes the body into the
+    final output contract. Uses a mock HTTP server started via
+    testConfig.services.
+
+spec:
+  resolvers:
+    mockBaseUrl:
+      description: Base URL of the mock server from env
+      resolve:
+        with:
+          - provider: env
+            inputs:
+              operation: get
+              name: MOCK_BASE_URL
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.value"
+
+    userRaw:
+      description: Raw upstream fetch with a connectivity check on the unshaped response
+      dependsOn: [mockBaseUrl]
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/users/me'"
+              method: GET
+              autoParseJson: true
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "__self.statusCode == 200"
+            message: "User endpoint unreachable or returned a non-200 status"
+
+    user:
+      description: Downstream reshape into the final output contract
+      dependsOn: [userRaw]
+      type: object
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.userRaw.body
+
+    userMissingRaw:
+      description: Raw fetch against a missing endpoint to exercise the failure path
+      dependsOn: [mockBaseUrl]
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/users/missing'"
+              method: GET
+              autoParseJson: true
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "__self.statusCode == 200"
+            message: "User endpoint unreachable or returned a non-200 status"
+
+  testing:
+    config:
+      # resolve-defaults: userMissingRaw fails validation by design
+      # render-defaults: solution has no workflow.actions section
+      skipBuiltins: [resolve-defaults, render-defaults]
+      services:
+        - name: mock-api
+          type: http
+          portEnv: MOCK_HTTP_PORT
+          baseUrlEnv: MOCK_BASE_URL
+          routes:
+            - path: /users/me
+              method: GET
+              status: 200
+              body: '{"id":1,"name":"alice"}'
+              headers:
+                Content-Type: application/json
+            - path: /users/missing
+              method: GET
+              status: 404
+              body: '{"error":"not found"}'
+              headers:
+                Content-Type: application/json
+
+    cases:
+      _base:
+        description: Base template that allows private IPs so the mock server is reachable
+        command: [run, resolver]
+        args: ["-o", "json", "--config", "config.yaml"]
+        tags: [resolver, validation, split-resolver]
+        init:
+          - command: "printf 'httpClient:\\n  allowPrivateIPs: true\\n' > config.yaml"
+
+      raw-validation-passes:
+        description: Raw resolver validates statusCode == 200 on the unshaped response
+        extends: [_base]
+        args: ["userRaw"]
+        tags: [smoke]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output.userRaw.statusCode == 200
+            message: "Raw resolver should expose the upstream status code"
+
+      downstream-reshape:
+        description: Downstream resolver reshapes the validated body into the final contract
+        extends: [_base]
+        args: ["user"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: '__output.user.name == "alice"'
+            message: "Downstream resolver should reshape the raw body into an object"
+          - expression: __output.user.id == 1
+
+      non-200-fails-with-message:
+        description: Raw resolver validation fails on a non-200 upstream response
+        extends: [_base]
+        args: ["userMissingRaw"]
+        tags: [negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+            message: "Non-200 upstream should fail the raw resolver validation"
+          - expression: __stderr.contains("non-200 status")
+            message: "Failure should surface the custom validation message"


### PR DESCRIPTION
- cli: when --base-dir is unset, resolver path resolution now defaults to the solution file's directory instead of the current working directory; pass --base-dir '.' to restore CWD-relative resolution, and the help text documents the new default
- testing: drop the ScaffoldInput.SolutionSubdir workaround and its BaseDir injection, now redundant since paths resolve from the solution directory
- provider(http): clarify the body output schema -- an empty response now documents an empty string, and parsed JSON only applies to non-empty JSON bodies when autoParseJson is enabled
- docs/examples: add http-empty-body and split-resolver-validation examples with integration solutions, and expand the validation patterns tutorial