### PR TITLE
feat : Plugin cache hardening: atomic writes, singleflight dedup, concurrent  fetches

### DIFF
--- a/docs/design/api-plugin-cache.md
+++ b/docs/design/api-plugin-cache.md
@@ -1,0 +1,338 @@
+---
+title: "Plugin Caching (API Server Mode)"
+weight: 10
+---
+
+# Plugin Caching in API Server Mode
+
+## Overview
+
+When running as an API server (`scafctl serve`), scafctl uses a bounded,
+LRU-evicting disk cache to store plugin binaries. This avoids re-downloading
+plugins on every request while keeping disk usage under a configurable budget.
+
+The caching system is built from two internal layers:
+
+- **Versioned Cache** (`pkg/cache/versionedcache`) -- maintains an in-memory
+  semver index for O(1) latest-version lookups
+- **Disk Cache** (`pkg/cache/diskcache`) -- provides bounded LRU storage with
+  pinning, atomic writes, and content-hash deduplication
+
+These layers are only instantiated in API server mode. CLI commands use a
+simpler unbounded filesystem cache with no eviction and no LRU tracking.
+
+---
+
+## Configuration
+
+All plugin caching settings live under the `apiServer.plugins` section of the
+scafctl configuration file:
+
+~~~yaml
+apiServer:
+  plugins:
+    diskCacheMaxSize: "1GB"      # LRU byte budget (default: "512MB")
+    disableDiskCache: false       # Set true to skip caching entirely
+    allowExternal: false          # Allow loading non-official plugins via API
+    allowedPlugins: []            # Allowlist of plugin names (empty = all)
+    allowedCatalogs: []           # Restrict which catalogs plugins are fetched from
+~~~
+
+### Settings Reference
+
+| Setting | Config Key | Default | Description |
+|---------|-----------|---------|-------------|
+| Disk cache max size | `apiServer.plugins.diskCacheMaxSize` | `"512MB"` | LRU byte budget. Accepts human-readable strings (`"256MB"`, `"1GB"`, `"2GB"`) |
+| Disable disk cache | `apiServer.plugins.disableDiskCache` | `false` | Bypasses cache reads -- every request re-fetches plugins from catalogs. Binaries are still written to disk (required for execution) but are not read on subsequent requests |
+| Cache directory | -- | `$XDG_CACHE_HOME/scafctl/plugins/` | Root directory for cached binaries. Determined by `settings.PluginCacheDirFor(binaryName)`. Embedders with a custom binary name get their own isolated directory |
+| Fetch concurrency | -- | `4` (`settings.DefaultFetchConcurrency`) | Maximum concurrent plugin fetch operations |
+| Content hash | -- | xxHash64 | Non-cryptographic hash for write deduplication (not configurable) |
+| File mode | -- | `0o755` | Permissions on cached binaries (not configurable) |
+
+### Cache Sizing
+
+The default 512 MB budget comfortably holds ~35 plugin binaries with room for
+version overlap during updates. Adjust based on your workload:
+
+- **Low traffic / few plugins**: `"256MB"` is sufficient
+- **High concurrency / many plugins**: `"1GB"` or more prevents excessive eviction churn
+- **Signature enforce mode**: Size generously -- every execution re-fetches and writes to the cache, though content-hash dedup avoids redundant I/O when binaries are unchanged
+
+---
+
+## How It Works
+
+### Startup
+
+When the API server starts, it initializes the managed cache and warms it:
+
+~~~go
+cacheSize, _ := pluginCacheMaxSize(cfg) // parses "512MB" -> int64
+mc, err := plugin.NewManagedCache("", cacheSize)
+mc.WarmUp() // scans disk, populates LRU + version index
+~~~
+
+`WarmUp()` walks the cache directory, parses each path into
+`name/version/platform` components, and registers entries in both the disk
+cache LRU and the versioned cache's semver index. Files are adopted **without
+triggering eviction** -- the cache may temporarily exceed its budget until the
+next write. This prevents data loss from a cold start where all entries would
+otherwise be immediately evicted.
+
+If the managed cache fails to initialize (e.g., invalid directory permissions),
+the server falls back to unbounded CLI-mode caching with a warning.
+
+### Request Flow
+
+For each incoming API request, the plugin fetcher checks the cache before
+downloading. Plugins are fetched concurrently using `errgroup` with a limit of
+4, and duplicate in-flight requests for the same plugin are coalesced via
+`singleflight`.
+
+1. **Cache probe**: `GetLatestCachedPin()` -- checks for any cached version
+   across all known catalog identities
+2. **Catalog resolve**: On miss, resolves from catalog via `resolvePlugin()`
+   (singleflight-deduplicated)
+3. **Version check**: `GetPin()` -- checks if the resolved version + registry
+   hash is already cached
+4. **Fetch**: On miss, downloads the binary via `fetchPlugin()`
+   (singleflight-deduplicated)
+5. **Cache store**: `SetPin()` -- writes the binary to disk and pins it
+   atomically
+6. **Register**: Starts the plugin client from the pinned path
+
+### Pin Lifecycle
+
+After the request completes, the caller releases the pin via `defer release()`.
+This decrements the entry's reference count and, if pending eviction was
+deferred, allows the LRU to reclaim the entry.
+
+---
+
+## Pinning
+
+Pinning marks a cache entry as **in-use**, preventing the LRU from evicting it
+while a request is being served. The pin returns a `release` function that the
+caller must invoke when the binary is no longer needed.
+
+~~~go
+path, release, ok := cache.GetPin(name, version, platform, digest)
+if !ok {
+    // not cached
+}
+defer release()
+// use binary at path
+~~~
+
+### Atomic Pin Operations
+
+A direct `Get()` followed by `Pin()` has a TOCTOU race -- the entry could be
+evicted between the two calls. The cache provides atomic alternatives:
+
+| Method | Equivalent | Purpose |
+|--------|-----------|---------|
+| `GetPin()` | `Get()` + `Pin()` | Retrieve and pin a specific version |
+| `GetLatestCachedPin()` | `GetLatestCached()` + `Pin()` | Retrieve and pin the newest version |
+| `SetPin()` | `Put()` + `Pin()` | Write and pin a binary in one step |
+
+### Pin Release Semantics
+
+Pin release uses `atomic.Bool` CAS to guarantee idempotency -- calling
+`release()` multiple times is safe. If a panic occurs during request handling,
+the recover middleware catches it and deferred `release()` calls still fire
+during stack unwinding. This ensures pins cannot leak.
+
+---
+
+## Versioned Cache
+
+The versioned cache (`pkg/cache/versionedcache`) wraps the disk cache with a
+semver-aware in-memory index. It tracks all cached versions per
+name+platform combination, sorted in descending order.
+
+### Latest Version Lookup
+
+~~~go
+version, ok := cache.Latest(name, platform) // O(1) - reads head of sorted list
+~~~
+
+This is used by the plugin fetcher as a fallback when catalog resolution fails
+(e.g., running offline). The index enables returning the best available version
+without scanning the filesystem.
+
+### Index Consistency
+
+The index stays consistent through two mechanisms:
+
+1. **On write**: `Set()` / `SetPin()` insert the version via binary search into
+   the sorted list
+2. **On eviction**: The diskcache `OnEviction` callback removes the version
+   from the index automatically
+
+### Cross-Registry Isolation
+
+Plugins from different catalogs are isolated using a composite name:
+`"pluginName/registryHash"`. The 16-character hex registry hash is derived from
+the catalog's registry URL, preventing version collisions when the same plugin
+name exists in multiple registries.
+
+---
+
+## Disk Cache
+
+The disk cache (`pkg/cache/diskcache`) is a bounded LRU with these properties:
+
+- **Size budget**: Entries are evicted in LRU order when total size exceeds
+  `maxSize`. Pinned entries are skipped during eviction (marked `pendingEvict`)
+  and reclaimed when unpinned
+- **Atomic writes**: Data is written to a temp file, fsynced, then renamed.
+  This prevents partial reads from concurrent access
+- **Content-hash dedup**: On `Set()`, the xxHash64 of new data is compared
+  against the stored hash. If they match, the disk write is skipped entirely
+- **Eviction callbacks**: The versioned cache registers an `OnEviction` callback
+  to keep its semver index in sync
+
+### Content-Hash Dedup
+
+Dedup avoids redundant I/O in two key scenarios:
+
+1. **Signature enforce mode**: Every execution re-fetches from the catalog and
+   calls `SetPin()` with identical bytes. Without dedup, this writes a ~15-50 MB
+   temp file and renames it on every run
+2. **Concurrent API requests**: Multiple requests for the same plugin version
+   race to cache it. The first write succeeds; subsequent writes detect the
+   matching hash and return immediately
+
+The hash is non-cryptographic and used solely for write dedup.
+Security-critical integrity checks use SHA-256 digest verification separately.
+
+---
+
+## Cache Layout
+
+~~~
+$XDG_CACHE_HOME/scafctl/plugins/
+└── <name>/                        # Plugin name (or "auth-handler-<name>")
+    └── [<registryHash>/]          # Optional 16-char hex registry hash
+        └── <version>/             # Semantic version
+            └── <os>-<arch>/       # Platform (e.g., darwin-arm64)
+                └── <name>[.exe]   # Binary (with .exe on Windows)
+~~~
+
+The `<registryHash>` directory level is present when a plugin is fetched from a
+catalog and omitted for plugins installed without catalog metadata (legacy path).
+
+Example:
+
+~~~
+~/.cache/scafctl/plugins/
+├── aws-provider/
+│   └── a1b2c3d4e5f67890/         # Registry hash for catalog "prod"
+│       ├── 1.5.0/
+│       │   └── darwin-arm64/
+│       │       └── aws-provider
+│       └── 1.5.3/
+│           ├── darwin-arm64/
+│           │   └── aws-provider
+│           └── windows-amd64/
+│               └── aws-provider.exe
+├── auth-handler-github/
+│   └── a1b2c3d4e5f67890/
+│       └── 0.3.0/
+│           └── darwin-arm64/
+│               └── auth-handler-github
+└── exec/
+    └── 0.6.1/                     # Legacy path (no registry hash)
+        └── linux-amd64/
+            └── exec
+~~~
+
+---
+
+## Digest Verification
+
+The cache supports optional SHA-256 digest verification on reads. When an
+expected digest is provided to `Get()` or `GetPin()`, the binary is read and
+hashed before the path is returned. Digests use the format `sha256:<hex>`.
+
+~~~go
+path, ok := cache.Get(name, version, platform, "sha256:abc123...")
+~~~
+
+If the digest is empty, no verification is performed.
+
+---
+
+## CLI Mode
+
+In CLI mode (`scafctl run`, `scafctl lint`, etc.), the cache performs direct
+filesystem operations without any LRU, pinning, or version indexing. Binaries
+are written atomically and checked via `os.Stat`. There is no eviction --
+binaries persist until manually removed via `scafctl plugins remove` or by
+deleting the cache directory.
+
+All pin operations return a no-op release function since there is no eviction
+risk.
+
+---
+
+## API Reference
+
+### Plugin Cache (`pkg/plugin/cache.go`)
+
+Most methods accept variadic `CacheOption` arguments. The primary option is
+`WithRegistryHash(hash)` which adds the registry hash directory level to cache
+paths. When the hash is empty, the option is a no-op.
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `NewCache` | `NewCache(cacheDir string) *Cache` | Create unbounded CLI cache |
+| `NewManagedCache` | `NewManagedCache(cacheDir string, maxSize int64) (*Cache, error)` | Create bounded API server cache |
+| `Get` | `Get(name, version, platform, expectedDigest string, opts ...CacheOption) (string, bool)` | Retrieve binary path with optional digest check |
+| `GetPin` | `GetPin(name, version, platform, expectedDigest string, opts ...CacheOption) (string, func(), bool)` | Retrieve + pin atomically |
+| `GetLatestCached` | `GetLatestCached(name, platform string, opts ...CacheOption) (string, string, bool)` | Find newest cached version |
+| `GetLatestCachedPin` | `GetLatestCachedPin(name, platform string, opts ...CacheOption) (string, string, func(), bool)` | Find newest + pin atomically |
+| `Put` | `Put(name, version, platform string, data []byte, opts ...CacheOption) (string, error)` | Write binary with atomic rename |
+| `SetPin` | `SetPin(name, version, platform string, data []byte, opts ...CacheOption) (string, func(), error)` | Write + pin atomically |
+| `Pin` | `Pin(name, version, platform string, opts ...CacheOption) (string, func(), bool)` | Pin existing entry |
+| `WarmUp` | `WarmUp() error` | Populate LRU from disk (managed mode only) |
+| `Digest` | `Digest(name, version, platform string, opts ...CacheOption) (string, error)` | Compute `sha256:<hex>` digest |
+| `Remove` | `Remove(name, version, platform string, opts ...CacheOption) error` | Delete a cached binary |
+| `List` | `List() ([]CachedPlugin, error)` | List all cached entries |
+| `ListCurrentPlatform` | `ListCurrentPlatform() ([]CachedPlugin, error)` | List latest version per plugin for current OS/arch |
+
+### Versioned Cache (`pkg/cache/versionedcache/cache.go`)
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `New` | `New(cacheDir string, maxSize int64, opts ...diskcache.CacheOption) (*Cache, error)` | Create bounded cache with semver index |
+| `Set` | `Set(name, version, platform string, data []byte) error` | Write data and index the version |
+| `SetPin` | `SetPin(name, version, platform string, data []byte) (string, func(), error)` | Write + pin + index atomically |
+| `Pin` | `Pin(name, version, platform string) (string, func(), bool)` | Pin entry, prevent eviction |
+| `Latest` | `Latest(name, platform string) (string, bool)` | O(1) highest version lookup |
+| `Delete` | `Delete(name, version, platform string) bool` | Remove entry (index updated via callback) |
+| `Versions` | `Versions(name, platform string) []string` | All indexed versions, descending |
+| `WarmUp` | `WarmUp() error` | Scan disk and populate LRU + index |
+
+### CachedPlugin
+
+~~~go
+type CachedPlugin struct {
+    Name         string // Plugin name
+    Version      string // Plugin version
+    Platform     string // Target platform (os/arch)
+    Path         string // Absolute path to cached binary
+    Size         int64  // Binary size in bytes
+    RegistryHash string // Registry hash directory (empty for local installs)
+}
+~~~
+
+---
+
+## Windows Support
+
+- Cached binaries on Windows platforms receive a `.exe` extension
+- Legacy caches without `.exe` are migrated automatically on first access (rename in place)
+- Executable permission checks (`0o111`) are skipped on Windows where they are not meaningful
+- Atomic rename uses `MoveFileEx` with `MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH` on Windows (with retry for transient `ERROR_SHARING_VIOLATION` / `ERROR_LOCK_VIOLATION` errors from antivirus or indexers)
+- On Unix, atomic rename uses the standard `os.Rename` (POSIX guarantees atomicity)

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/agext/levenshtein v1.2.3
 	github.com/atotto/clipboard v0.1.4
 	github.com/bmatcuk/doublestar/v4 v4.10.0
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/danielgtaylor/huma/v2 v2.38.0
 	github.com/fsnotify/fsnotify v1.10.1
@@ -62,6 +63,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/sync v0.21.0
+	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
 	golang.org/x/text v0.38.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa
@@ -136,7 +138,6 @@ require (
 	github.com/bytedance/sonic v1.15.1 // indirect
 	github.com/bytedance/sonic/loader v0.5.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260525132238-948f4557a654 // indirect
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect
@@ -315,7 +316,6 @@ require (
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect

--- a/pkg/cache/diskcache/cache.go
+++ b/pkg/cache/diskcache/cache.go
@@ -1,0 +1,566 @@
+package diskcache
+
+import (
+	"container/list"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+)
+
+type Cache struct {
+	baseDir      string
+	items        map[Key]*list.Element
+	order        *list.List
+	maxSize      int64
+	currentSize  int64
+	maxEntrySize int64
+	mu           sync.Mutex
+	fileMode     *os.FileMode
+	hashFunc     func([]byte) (uint64, error)
+	onEviction   func(key Key)
+}
+type Key struct {
+	Key  string
+	Path string
+}
+
+type entry struct {
+	key          Key
+	size         int64
+	contentHash  uint64
+	valid        bool
+	refCount     int
+	pendingEvict bool
+}
+
+type WalkFunc func(path string) (key Key, ok bool)
+
+type WarmUpError struct {
+	Errs []error
+}
+
+func (e *WarmUpError) Error() string {
+	errStrs := make([]string, len(e.Errs))
+	for i, err := range e.Errs {
+		errStrs[i] = err.Error()
+	}
+	return fmt.Sprintf("warm up encountered errors: %s", strings.Join(errStrs, "; "))
+}
+
+var (
+	ErrEntryTooLarge = errors.New("entry size exceeds maximum allowed size")
+	ErrCacheFull     = errors.New("cache is full, unable to add new entry")
+)
+
+type CacheOption func(*Cache)
+
+func WithHashFunc(hashFunc func([]byte) (uint64, error)) CacheOption {
+	return func(c *Cache) {
+		c.hashFunc = hashFunc
+	}
+}
+
+func WithMaxEntrySize(maxEntrySize int64) CacheOption {
+	return func(c *Cache) {
+		c.maxEntrySize = maxEntrySize
+	}
+}
+
+func WithFileMode(mode os.FileMode) CacheOption {
+	return func(c *Cache) {
+		c.fileMode = &mode
+	}
+}
+
+func WithOnEviction(callback func(key Key)) CacheOption {
+	return func(c *Cache) {
+		c.onEviction = callback
+	}
+}
+
+func NewCache(baseDir string, maxSize int64, opts ...CacheOption) (*Cache, error) {
+	if maxSize <= 0 {
+		return nil, fmt.Errorf("maxSize must be greater than 0")
+	}
+	info, err := os.Stat(baseDir)
+	switch {
+	case err == nil:
+		if !info.IsDir() {
+			return nil, fmt.Errorf("baseDir %q is a file, not a directory", baseDir)
+		}
+	case errors.Is(err, os.ErrNotExist):
+		if err := os.MkdirAll(baseDir, 0o750); err != nil {
+			return nil, fmt.Errorf("failed to create baseDir: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("failed to stat baseDir: %w", err)
+	}
+	c := &Cache{
+		baseDir: baseDir,
+		items:   make(map[Key]*list.Element),
+		order:   list.New(),
+		maxSize: maxSize,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c, nil
+}
+
+// Set adds a new entry to cache or updates an existing entry size of bytes <= maxEntrySize.
+// if current size > max size before add or updating , it will attempt to reconcile by evicting old entries until the cache is under budget
+// if it cannot be reconciled, the new entry will not be added and an error will be returned.
+func (c *Cache) Set(key Key, bytes []byte) error {
+	c.mu.Lock()
+	var evicted []Key
+	if elem, ok := c.items[key]; ok {
+		err := c.update(elem, key, bytes, key.Path, &evicted)
+		c.mu.Unlock()
+		c.notifyEvicted(evicted)
+		return err
+	}
+	err := c.add(key.Path, key, bytes, &evicted)
+	c.mu.Unlock()
+	c.notifyEvicted(evicted)
+	return err
+}
+
+func (c *Cache) notifyEvicted(evicted []Key) {
+	if c.onEviction != nil {
+		for _, evictedKey := range evicted {
+			c.onEviction(evictedKey)
+		}
+	}
+}
+
+func (c *Cache) overBudget(evicted *[]Key) error {
+	if c.availableSpace() <= 0 {
+		c.evictFromBack(c.maxSize, nil, evicted)
+		if c.availableSpace() <= 0 {
+			return ErrCacheFull
+		}
+	}
+	return nil
+}
+
+// updates an existing entry in the cache with new bytes.
+// if the new bytes size exceeds maxEntrySize, the entry will be removed and an error will be returned.
+// before update if the cache is over budget (current size > max size), it will attempt to evict old entries to make room for the update.
+// if it cannot be reconciled, the entry will be removed and an error will be returned.
+func (c *Cache) update(elem *list.Element, key Key, bytes []byte, path string, evicted *[]Key) error {
+	size := int64(len(bytes))
+	entry, ok := elem.Value.(*entry)
+	if ok {
+		if size > c.maxEntrySizeEffective() {
+			c.removeEntry(entry, evicted)
+			return ErrEntryTooLarge
+		}
+		c.order.MoveToFront(elem)
+		sizeDiff := size - entry.size
+		if skip := c.skipWrite(bytes, entry.contentHash); skip {
+			return nil
+		}
+
+		if c.currentSize+sizeDiff > c.maxSize && sizeDiff > 0 {
+			c.evictFromBack(c.maxSize-sizeDiff, elem, evicted)
+			if c.currentSize+sizeDiff > c.maxSize {
+				c.removeEntry(entry, evicted)
+				return ErrCacheFull
+			}
+		}
+		c.setHash(entry, bytes)
+		if err := c.writeToDisk(path, bytes); err != nil {
+			return err
+		}
+		if _, ok := c.items[key]; !ok {
+			return c.add(path, key, bytes, evicted)
+		}
+
+		entry.valid = true
+		c.currentSize += sizeDiff
+		entry.pendingEvict = false
+		entry.size = size
+		c.evictFromBack(c.maxSize, elem, evicted)
+		return nil
+	}
+	return nil
+}
+
+func (c *Cache) Get(key Key) (found bool, bytes []byte) {
+	var evicted []Key
+	c.mu.Lock()
+	elem, ok := c.items[key]
+	if !ok {
+		c.mu.Unlock()
+		return false, nil
+	}
+
+	e, _ := elem.Value.(*entry)
+	if !e.valid {
+		c.removeEntry(e, &evicted)
+		c.mu.Unlock()
+		c.notifyEvicted(evicted)
+		return false, nil
+	}
+	c.order.MoveToFront(elem)
+	e.refCount++
+	c.mu.Unlock()
+	// lock free read from disk, if the entry is evicted while reading, the pendingEvict flag will ensure it gets cleaned up after the read completes
+	found, bytes = c.readEntry(key.Path)
+	c.mu.Lock()
+	e.refCount--
+	if e.pendingEvict && e.refCount == 0 {
+		c.removeEntry(e, &evicted)
+	}
+	c.mu.Unlock()
+	c.notifyEvicted(evicted)
+	return found, bytes
+}
+
+func (c *Cache) readEntry(filePath string) (bool, []byte) {
+	fullPath := filepath.Join(c.baseDir, filePath)
+	f, err := os.Stat(fullPath)
+	if err != nil {
+		return false, nil
+	}
+	if f.IsDir() {
+		return false, nil
+	}
+	content, err := os.ReadFile(fullPath)
+	if err != nil {
+		return false, nil
+	}
+	return true, content
+}
+
+func (c *Cache) writeToDisk(path string, bytes []byte) error {
+	fullPath := filepath.Join(c.baseDir, path)
+	dir := filepath.Dir(fullPath)
+	err := os.MkdirAll(dir, 0o755)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(tmp.Name()) //nolint:errcheck
+
+	_, err = tmp.Write(bytes)
+	if err != nil {
+		tmp.Close() //nolint:errcheck
+		return err
+	}
+	if c.fileMode != nil {
+		if err := tmp.Chmod(*c.fileMode); err != nil {
+			tmp.Close() //nolint:errcheck
+			return err
+		}
+	}
+
+	if err := tmp.Sync(); err != nil {
+		tmp.Close() //nolint:errcheck
+		return err
+	}
+
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	return atomicRename(tmp.Name(), fullPath)
+}
+
+func (c *Cache) add(path string, key Key, bytes []byte, evicted *[]Key) error {
+	size := int64(len(bytes))
+	if size > c.maxEntrySizeEffective() {
+		return ErrEntryTooLarge
+	}
+	if err := c.overBudget(evicted); err != nil {
+		return err
+	}
+
+	if err := c.writeToDisk(path, bytes); err != nil {
+		return err
+	}
+	entry := &entry{key: key, size: size, valid: true}
+	c.setHash(entry, bytes)
+	elem := c.order.PushFront(entry)
+	c.items[key] = elem
+	c.currentSize += size
+	c.evictFromBack(c.maxSize, elem, evicted)
+	return nil
+}
+
+func (c *Cache) skipWrite(bytes []byte, expectedHash uint64) bool {
+	if c.hashFunc == nil {
+		return false
+	}
+	if expectedHash == 0 {
+		return false
+	}
+	hash, err := c.hashFunc(bytes)
+	if err != nil {
+		return false
+	}
+	return hash == expectedHash
+}
+
+func (c *Cache) setHash(entry *entry, bytes []byte) {
+	if c.hashFunc == nil {
+		return
+	}
+	hash, err := c.hashFunc(bytes)
+	if err != nil {
+		return
+	}
+	entry.contentHash = hash
+}
+
+func (c *Cache) maxEntrySizeEffective() int64 {
+	if c.maxEntrySize > 0 {
+		return c.maxEntrySize
+	}
+	return c.maxSize
+}
+
+// evictFromBack attempts to remove the least recently used items from the cache until the cache is under its max size limit.
+// If the stop element is provided, it will only evict items that are behind the stop element, allowing for eviction of all items up to but not including the stop element
+func (c *Cache) evictFromBack(target int64, stop *list.Element, evicted *[]Key) {
+	back := c.order.Back()
+	var prev *list.Element
+	for back != nil && c.currentSize > target {
+		if back == stop {
+			return
+		}
+		prev = back.Prev()
+		entry, ok := back.Value.(*entry)
+		if !ok {
+			c.order.Remove(back)
+			back = prev
+			continue
+		}
+		if !entry.valid {
+			back = prev
+			continue
+		}
+		c.removeEntry(entry, evicted)
+		back = prev
+	}
+}
+
+// removeEntry removes the given entry from the cache and deletes the corresponding file from disk.
+// if the file cannot be deleted, the entry is marked as invalid and will attempt deletion on the next access. not thread-safe,
+// should be called with the cache's mutex locked.
+func (c *Cache) removeEntry(entry *entry, evicted *[]Key) {
+	if entry == nil {
+		return
+	}
+
+	if entry.refCount > 0 {
+		entry.pendingEvict = true
+		return
+	}
+	fullPath := filepath.Join(c.baseDir, entry.key.Path)
+	err := os.Remove(fullPath)
+	if err != nil && !os.IsNotExist(err) {
+		entry.valid = false
+		return
+	}
+	if evicted != nil {
+		*evicted = append(*evicted, entry.key)
+	}
+
+	if elem, ok := c.items[entry.key]; ok {
+		c.currentSize -= entry.size
+		c.order.Remove(elem)
+		delete(c.items, entry.key)
+	}
+}
+
+func (c *Cache) availableSpace() int64 {
+	return c.maxSize - c.currentSize
+}
+
+// Pin marks a cache entry as in-use and returns its on-disk path.
+// The entry cannot be evicted until Release is called.
+// Caution: the caller must call the release function when it is done with the entry to avoid memory leaks.
+// Caution: the file content may be modified on disk after Pin returns, so the caller should not assume the content is immutable or consistent with the content at the time of the Pin call.
+// Use Get if you need a consistent snapshot of the content. Pin is intended for use cases where the caller needs to access the file on disk and is able to handle potential modifications to the file content, such as by re-reading the file after a modification is detected.
+// Returns ok=false if the key is not in the cache.
+func (c *Cache) Pin(key Key) (path string, release func(), ok bool) {
+	var evicted []Key
+	c.mu.Lock()
+	elem, exists := c.items[key]
+	if !exists {
+		c.mu.Unlock()
+		return "", nil, false
+	}
+
+	e, _ := elem.Value.(*entry)
+	if !e.valid {
+		c.removeEntry(e, &evicted)
+		c.mu.Unlock()
+		c.notifyEvicted(evicted)
+		return "", nil, false
+	}
+
+	c.order.MoveToFront(elem)
+	e.refCount++
+	c.mu.Unlock()
+	c.notifyEvicted(evicted)
+	fullPath := filepath.Join(c.baseDir, key.Path)
+	var released atomic.Bool
+	release = func() {
+		if !released.CompareAndSwap(false, true) {
+			return
+		}
+		var releaseEvicted []Key
+		c.mu.Lock()
+		e.refCount--
+		if e.pendingEvict && e.refCount == 0 {
+			c.removeEntry(e, &releaseEvicted)
+		}
+		c.mu.Unlock()
+		c.notifyEvicted(releaseEvicted)
+	}
+
+	return fullPath, release, true
+}
+
+// Delete removes the entry associated with the given key from the cache and deletes the corresponding file from disk.
+// Returns true if the entry was found and deleted, false if the key was not found in the cache.
+// If the file cannot be deleted, the entry will be marked as invalid and will attempt deletion on the next access.
+func (c *Cache) Delete(key Key) bool {
+	c.mu.Lock()
+	elem, ok := c.items[key]
+	if !ok {
+		c.mu.Unlock()
+		return false
+	}
+	var evicted []Key
+	e, _ := elem.Value.(*entry)
+	c.removeEntry(e, &evicted)
+	c.mu.Unlock()
+	c.notifyEvicted(evicted)
+	return true
+}
+
+// Adopt attempts to take ownership of an existing file on disk and add it to the cache under the given key, without copying the file content.
+// This is useful for cases where the file content is already on disk and can be added to the cache without needing to be written again,
+// such as when the file is generated by an external process or when migrating existing files into the cache.
+// note: sizing rules on entry's and cache do not apply with this function. so no eviction will occur and the entry will be added even if it exceeds maxEntrySize or maxSize.
+func (c *Cache) Adopt(key Key) {
+	fullPath := filepath.Join(c.baseDir, key.Path)
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		return
+	}
+	size := info.Size()
+	c.mu.Lock()
+	c.adopt(key, size)
+	c.mu.Unlock()
+}
+
+func (c *Cache) adopt(key Key, size int64) {
+	if elem, ok := c.items[key]; ok {
+		e, ok := elem.Value.(*entry)
+		if ok && !e.valid {
+			c.order.MoveToFront(elem)
+			e.valid = true
+			c.currentSize -= e.size
+			c.currentSize += size
+		}
+		return
+	}
+
+	entry := &entry{key: key, size: size, valid: true}
+	elem := c.order.PushFront(entry)
+	c.items[key] = elem
+	c.currentSize += size
+}
+
+// WarmUp walks the cache's base directory and attempts to adopt files into the cache using the provided walkFunc to determine the corresponding cache key for each file.
+// This is useful for pre-populating the cache with existing files on disk, such as after a restart or when initializing the cache with pre-generated content.
+// The walkFunc should return the cache key corresponding to the given file path, and a boolean indicating whether the file should be adopted into the cache (true) or skipped (false).
+func (c *Cache) WarmUp(walkFunc WalkFunc) error {
+	var warmUpErrs []error
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	err := filepath.WalkDir(c.baseDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil //nolint:nilerr // skip inaccessible entries without aborting the walk
+		}
+		relativePath, err := filepath.Rel(c.baseDir, path)
+		if err != nil {
+			return nil //nolint:nilerr // skip unparseable paths without aborting the walk
+		}
+		key, ok := walkFunc(relativePath)
+		if !ok {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return nil //nolint:nilerr // skip files whose info can't be read
+		}
+		c.adopt(key, info.Size())
+		return nil
+	})
+	if err != nil {
+		warmUpErrs = append(warmUpErrs, err)
+	}
+	if len(warmUpErrs) > 0 {
+		return &WarmUpError{Errs: warmUpErrs}
+	}
+	return nil
+}
+
+func (c *Cache) BaseDir() string {
+	return c.baseDir
+}
+
+func (c *Cache) SetPin(key Key, bytes []byte) (string, func(), error) {
+	var evicted []Key
+	var err error
+	c.mu.Lock()
+	if elem, exists := c.items[key]; exists {
+		err = c.update(elem, key, bytes, key.Path, &evicted)
+	} else {
+		err = c.add(key.Path, key, bytes, &evicted)
+	}
+	if err != nil {
+		c.mu.Unlock()
+		c.notifyEvicted(evicted)
+		return "", nil, err
+	}
+
+	e, ok := c.items[key].Value.(*entry)
+	if !ok {
+		c.mu.Unlock()
+		c.notifyEvicted(evicted)
+		return "", nil, fmt.Errorf("failed to cast cache entry")
+	}
+	e.refCount++
+	path := filepath.Join(c.baseDir, e.key.Path)
+	c.mu.Unlock()
+	c.notifyEvicted(evicted)
+	var released atomic.Bool
+	release := func() {
+		var releaseEvicted []Key
+		if !released.CompareAndSwap(false, true) {
+			return
+		}
+		c.mu.Lock()
+		e.refCount--
+		if e.pendingEvict && e.refCount == 0 {
+			c.removeEntry(e, &releaseEvicted)
+		}
+		c.mu.Unlock()
+		c.notifyEvicted(releaseEvicted)
+	}
+	return path, release, nil
+}

--- a/pkg/cache/diskcache/cache_test.go
+++ b/pkg/cache/diskcache/cache_test.go
@@ -1,0 +1,985 @@
+package diskcache
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCache(t *testing.T, maxSize int64, opts ...CacheOption) *Cache {
+	t.Helper()
+	cache, err := NewCache(t.TempDir(), maxSize, opts...)
+	require.NoError(t, err)
+	return cache
+}
+
+func mustSet(t *testing.T, c *Cache, key Key, data []byte) {
+	t.Helper()
+	require.NoError(t, c.Set(key, data))
+}
+
+func k(name string) Key {
+	return Key{Key: name, Path: name + ".txt"}
+}
+
+func TestNewCache(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		cache, err := NewCache(t.TempDir(), 1024)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1024), cache.maxSize)
+		assert.Equal(t, int64(0), cache.currentSize)
+	})
+
+	t.Run("invalid max size", func(t *testing.T) {
+		cache, err := NewCache(t.TempDir(), -1)
+		assert.Error(t, err)
+		assert.Nil(t, cache)
+	})
+}
+
+func TestCache_Set(t *testing.T) {
+	t.Run("multiple keys", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		mustSet(t, c, k("key1"), []byte("value1"))
+		mustSet(t, c, k("key2"), []byte("value2"))
+
+		assert.Equal(t, int64(12), c.currentSize)
+		assert.Equal(t, 2, c.order.Len())
+
+		content, err := os.ReadFile(filepath.Join(c.baseDir, "key1.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, []byte("value1"), content)
+
+		content, err = os.ReadFile(filepath.Join(c.baseDir, "key2.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, []byte("value2"), content)
+	})
+
+	t.Run("update existing", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		mustSet(t, c, k("key1"), []byte("value1"))
+
+		mustSet(t, c, k("key1"), []byte("value1-updated"))
+
+		assert.Equal(t, int64(len("value1-updated")), c.currentSize)
+		content, err := os.ReadFile(filepath.Join(c.baseDir, "key1.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, []byte("value1-updated"), content)
+	})
+}
+
+func TestCache_Get(t *testing.T) {
+	t.Run("found and not found", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		mustSet(t, c, k("key1"), []byte("value1"))
+
+		found, val := c.Get(k("key1"))
+		assert.True(t, found)
+		assert.Equal(t, []byte("value1"), val)
+
+		found, val = c.Get(k("nonexistent"))
+		assert.False(t, found)
+		assert.Nil(t, val)
+	})
+
+	t.Run("evicts invalid entry", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		key := k("key1")
+		err := os.WriteFile(filepath.Join(c.baseDir, key.Path), []byte("value1"), 0o644)
+		require.NoError(t, err)
+
+		e := &entry{key: key, valid: false}
+		c.order.PushFront(e)
+		c.items[key] = c.order.Front()
+
+		found, val := c.Get(key)
+		assert.False(t, found)
+		assert.Nil(t, val)
+		assert.NotContains(t, c.items, key)
+		assert.Equal(t, 0, c.order.Len())
+	})
+}
+
+func TestSkipWrite(t *testing.T) {
+	t.Run("same hash — skip", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		c.hashFunc = func([]byte) (uint64, error) { return 123, nil }
+		assert.True(t, c.skipWrite([]byte("x"), 123))
+	})
+
+	t.Run("different hash — no skip", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		c.hashFunc = func([]byte) (uint64, error) { return 123, nil }
+		assert.False(t, c.skipWrite([]byte("x"), 456))
+	})
+
+	t.Run("nil hashFunc — no skip", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		assert.False(t, c.skipWrite([]byte("x"), 0))
+	})
+
+	t.Run("hash error — no skip", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		c.hashFunc = func([]byte) (uint64, error) { return 0, assert.AnError }
+		assert.False(t, c.skipWrite([]byte("x"), 0))
+	})
+}
+
+func TestCache_MaxEntrySize(t *testing.T) {
+	t.Run("reject add over limit", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		c.maxEntrySize = 5
+		err := c.Set(k("key1"), []byte("too large"))
+		assert.ErrorIs(t, err, ErrEntryTooLarge)
+		assert.NotContains(t, c.items, k("key1"))
+	})
+
+	t.Run("accept add under limit", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		c.maxEntrySize = 20
+		mustSet(t, c, k("key1"), []byte("small"))
+		assert.Contains(t, c.items, k("key1"))
+	})
+
+	t.Run("reject update over limit, removes entry", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		c.maxEntrySize = 10
+		mustSet(t, c, k("key1"), []byte("small"))
+
+		err := c.Set(k("key1"), []byte("too largeeee"))
+		assert.ErrorIs(t, err, ErrEntryTooLarge)
+		assert.NotContains(t, c.items, k("key1"))
+	})
+}
+
+func TestRemoveEntry(t *testing.T) {
+	t.Run("permission error marks invalid", func(t *testing.T) {
+		testRemoveEntryPermissionError(t)
+	})
+}
+
+func TestCache_EvictFromBack(t *testing.T) {
+	t.Run("evicts LRU until under budget", func(t *testing.T) {
+		c := newTestCache(t, 20)
+		for i := 4; i >= 0; i-- {
+			key := Key{Key: fmt.Sprintf("key%d", i), Path: fmt.Sprintf("file%d.txt", i)}
+			e := &entry{key: key, size: 10, valid: true}
+			c.items[key] = c.order.PushFront(e)
+			c.currentSize += 10
+			os.WriteFile(filepath.Join(c.baseDir, key.Path), []byte("0123456789"), 0o644) //nolint:errcheck
+		}
+
+		c.evictFromBack(c.maxSize, nil, nil)
+
+		assert.LessOrEqual(t, c.currentSize, c.maxSize)
+		assert.Equal(t, 2, c.order.Len())
+		assert.Contains(t, c.items, Key{Key: "key0", Path: "file0.txt"})
+		assert.Contains(t, c.items, Key{Key: "key1", Path: "file1.txt"})
+	})
+
+	t.Run("stops at protected element", func(t *testing.T) {
+		c := newTestCache(t, 10)
+
+		frontKey := Key{Key: "front", Path: "front.txt"}
+		frontElem := c.order.PushFront(&entry{key: frontKey, size: 15, valid: true})
+		c.items[frontKey] = frontElem
+		c.currentSize += 15
+		os.WriteFile(filepath.Join(c.baseDir, "front.txt"), []byte("0123456789abcde"), 0o644) //nolint:errcheck
+
+		backKey := Key{Key: "back", Path: "back.txt"}
+		c.items[backKey] = c.order.PushBack(&entry{key: backKey, size: 10, valid: true})
+		c.currentSize += 10
+		os.WriteFile(filepath.Join(c.baseDir, "back.txt"), []byte("0123456789"), 0o644) //nolint:errcheck
+
+		c.evictFromBack(c.maxSize, frontElem, nil)
+
+		assert.NotContains(t, c.items, backKey)
+		assert.Contains(t, c.items, frontKey)
+		assert.Equal(t, int64(15), c.currentSize)
+	})
+
+	t.Run("skips invalid entries", func(t *testing.T) {
+		c := newTestCache(t, 10)
+
+		validKey := k("valid")
+		validElem := c.order.PushFront(&entry{key: validKey, size: 5, valid: true})
+		c.items[validKey] = validElem
+		c.currentSize += 5
+		os.WriteFile(filepath.Join(c.baseDir, validKey.Path), []byte("12345"), 0o644) //nolint:errcheck
+
+		invalidKey := k("invalid")
+		c.items[invalidKey] = c.order.PushBack(&entry{key: invalidKey, size: 10, valid: false})
+		c.currentSize += 10
+
+		backKey := k("back")
+		c.items[backKey] = c.order.PushBack(&entry{key: backKey, size: 5, valid: true})
+		c.currentSize += 5
+		os.WriteFile(filepath.Join(c.baseDir, backKey.Path), []byte("12345"), 0o644) //nolint:errcheck
+
+		c.evictFromBack(c.maxSize, validElem, nil)
+
+		assert.NotContains(t, c.items, backKey)
+		assert.Contains(t, c.items, invalidKey)
+	})
+
+	t.Run("all invalid — no progress", func(t *testing.T) {
+		c := newTestCache(t, 10)
+		for i := 0; i < 3; i++ {
+			key := Key{Key: fmt.Sprintf("key%d", i), Path: fmt.Sprintf("file%d.txt", i)}
+			c.items[key] = c.order.PushBack(&entry{key: key, size: 10, valid: false})
+			c.currentSize += 10
+		}
+
+		c.evictFromBack(c.maxSize, nil, nil)
+
+		assert.Equal(t, int64(30), c.currentSize)
+		assert.Equal(t, 3, c.order.Len())
+	})
+
+	t.Run("permission error marks invalid", func(t *testing.T) {
+		testEvictFromBackPermissionError(t)
+	})
+
+	t.Run("skips pinned entry and sets pendingEvict", func(t *testing.T) {
+		c := newTestCache(t, 10)
+
+		pinnedKey := k("pinned")
+		pinnedEntry := &entry{key: pinnedKey, size: 15, valid: true, refCount: 1}
+		c.items[pinnedKey] = c.order.PushBack(pinnedEntry)
+		c.currentSize += 15
+		os.WriteFile(filepath.Join(c.baseDir, pinnedKey.Path), []byte("123456789012345"), 0o644) //nolint:errcheck
+
+		c.evictFromBack(c.maxSize, nil, nil)
+
+		// Entry not removed — still in map and list
+		assert.Contains(t, c.items, pinnedKey)
+		assert.Equal(t, 1, c.order.Len())
+		assert.Equal(t, int64(15), c.currentSize)
+		// File still on disk
+		_, err := os.Stat(filepath.Join(c.baseDir, pinnedKey.Path))
+		assert.NoError(t, err)
+		// But marked for deferred eviction
+		assert.True(t, pinnedEntry.pendingEvict)
+	})
+}
+
+func TestCache_Concurrent(t *testing.T) {
+	t.Run("parallel sets evict correctly", func(t *testing.T) {
+		c := newTestCache(t, 10)
+		var wg sync.WaitGroup
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				c.Set(Key{Key: fmt.Sprintf("key_%d", i), Path: fmt.Sprintf("file_%d.txt", i)}, []byte("valuevalue")) //nolint:errcheck
+			}(i)
+		}
+		wg.Wait()
+
+		foundCount := 0
+		for i := 0; i < 10; i++ {
+			if found, _ := c.Get(Key{Key: fmt.Sprintf("key_%d", i), Path: fmt.Sprintf("file_%d.txt", i)}); found {
+				foundCount++
+			}
+		}
+		assert.Equal(t, 1, foundCount)
+	})
+
+	t.Run("parallel sets and gets", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		var wg sync.WaitGroup
+
+		// Writers
+		for i := 0; i < 20; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				key := Key{Key: fmt.Sprintf("k%d", i), Path: fmt.Sprintf("f%d.txt", i)}
+				c.Set(key, []byte(fmt.Sprintf("val%d", i))) //nolint:errcheck
+			}(i)
+		}
+
+		// Readers (concurrent with writers)
+		for i := 0; i < 20; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				key := Key{Key: fmt.Sprintf("k%d", i), Path: fmt.Sprintf("f%d.txt", i)}
+				c.Get(key)
+			}(i)
+		}
+		wg.Wait()
+
+		assert.LessOrEqual(t, c.currentSize, c.maxSize)
+	})
+
+	t.Run("parallel updates same key", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		mustSet(t, c, k("shared"), []byte("initial"))
+
+		var wg sync.WaitGroup
+		for i := 0; i < 50; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				c.Set(k("shared"), []byte(fmt.Sprintf("update-%03d", i))) //nolint:errcheck
+			}(i)
+		}
+		wg.Wait()
+
+		found, val := c.Get(k("shared"))
+		assert.True(t, found)
+		assert.NotEmpty(t, val)
+		assert.Equal(t, 1, c.order.Len())
+	})
+
+	t.Run("parallel sets under pressure", func(t *testing.T) {
+		c := newTestCache(t, 50)
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				key := Key{Key: fmt.Sprintf("k%d", i), Path: fmt.Sprintf("f%d.txt", i)}
+				c.Set(key, []byte(fmt.Sprintf("data-%04d", i))) //nolint:errcheck
+			}(i)
+		}
+		wg.Wait()
+
+		assert.LessOrEqual(t, c.currentSize, c.maxSize)
+		// Verify all remaining entries are readable
+		c.mu.Lock()
+		for key := range c.items {
+			elem := c.items[key]
+			e := elem.Value.(*entry)
+			if e.valid {
+				path := filepath.Join(c.baseDir, key.Path)
+				_, err := os.Stat(path)
+				assert.NoError(t, err, "valid entry %s missing from disk", key.Key)
+			}
+		}
+		c.mu.Unlock()
+	})
+
+	t.Run("mixed set get and update with eviction", func(t *testing.T) {
+		c := newTestCache(t, 100)
+		var wg sync.WaitGroup
+
+		// Seed some entries
+		for i := 0; i < 10; i++ {
+			mustSet(t, c, Key{Key: fmt.Sprintf("seed%d", i), Path: fmt.Sprintf("seed%d.txt", i)}, []byte("seeddata!"))
+		}
+
+		// Hammer with sets, gets, and updates concurrently
+		for i := 0; i < 50; i++ {
+			wg.Add(3)
+			go func(i int) {
+				defer wg.Done()
+				key := Key{Key: fmt.Sprintf("new%d", i), Path: fmt.Sprintf("new%d.txt", i)}
+				c.Set(key, []byte(fmt.Sprintf("newval%04d", i))) //nolint:errcheck
+			}(i)
+			go func(i int) {
+				defer wg.Done()
+				key := Key{Key: fmt.Sprintf("seed%d", i%10), Path: fmt.Sprintf("seed%d.txt", i%10)}
+				c.Get(key) //nolint:errcheck
+			}(i)
+			go func(i int) {
+				defer wg.Done()
+				key := Key{Key: fmt.Sprintf("seed%d", i%10), Path: fmt.Sprintf("seed%d.txt", i%10)}
+				c.Set(key, []byte(fmt.Sprintf("updated%04d", i))) //nolint:errcheck
+			}(i)
+		}
+		wg.Wait()
+
+		assert.LessOrEqual(t, c.currentSize, c.maxSize)
+	})
+}
+
+func TestCache_UpdateOverBudget(t *testing.T) {
+	t.Run("grows entry, evicts others to make room", func(t *testing.T) {
+		c := newTestCache(t, 20)
+		mustSet(t, c, k("key1"), []byte("0123456789")) // 10 bytes
+		mustSet(t, c, k("key2"), []byte("01234"))      // 5 bytes, total=15
+
+		mustSet(t, c, k("key1"), []byte("012345678901234567")) // 18 bytes
+
+		assert.Contains(t, c.items, k("key1"))
+		assert.NotContains(t, c.items, k("key2"))
+		assert.Equal(t, int64(18), c.currentSize)
+	})
+
+	t.Run("grows entry, eviction fails, returns ErrCacheFull", func(t *testing.T) {
+		c := newTestCache(t, 10)
+		mustSet(t, c, k("key1"), []byte("12345")) // 5 bytes
+
+		bk := k("blocker")
+		c.items[bk] = c.order.PushBack(&entry{key: bk, size: 8, valid: false})
+		c.currentSize += 8 // total=13
+
+		err := c.Set(k("key1"), []byte("123456789")) // sizeDiff=4
+		assert.ErrorIs(t, err, ErrCacheFull)
+		assert.NotContains(t, c.items, k("key1"))
+	})
+
+	t.Run("grows entry, evicts others behind it", func(t *testing.T) {
+		c := newTestCache(t, 20)
+		mustSet(t, c, k("key2"), []byte("bbbbbbbbbb")) // 10
+		mustSet(t, c, k("key1"), []byte("aa"))         // 2, total=12
+
+		// key1 grows to 19: sizeDiff=17, 12+17=29>20, target=20-17=3
+		// evictFromBack(3, elem): key2 evicted, currentSize=2<=3, done.
+		mustSet(t, c, k("key1"), []byte("aaaaaaaaaaaaaaaaaaa")) // 19
+
+		assert.Contains(t, c.items, k("key1"))
+		assert.NotContains(t, c.items, k("key2"))
+		found, content := c.Get(k("key1"))
+		assert.True(t, found)
+		assert.Equal(t, []byte("aaaaaaaaaaaaaaaaaaa"), content)
+		assert.LessOrEqual(t, c.currentSize, c.maxSize)
+	})
+
+	t.Run("shrink when over budget — allowed", func(t *testing.T) {
+		c := newTestCache(t, 10)
+		mustSet(t, c, k("key1"), []byte("12345678")) // 8 bytes
+		c.currentSize = 15
+
+		mustSet(t, c, k("key1"), []byte("abc")) // shrink to 3
+
+		assert.Contains(t, c.items, k("key1"))
+		assert.Equal(t, int64(10), c.currentSize)
+	})
+
+	t.Run("same size when over budget — allowed", func(t *testing.T) {
+		c := newTestCache(t, 10)
+		mustSet(t, c, k("key1"), []byte("12345")) // 5 bytes
+		c.currentSize = 12
+
+		err := c.Set(k("key1"), []byte("abcde"))
+		require.NoError(t, err)
+		assert.Contains(t, c.items, k("key1"))
+	})
+}
+
+func TestCache_Get_PendingEvict(t *testing.T) {
+	t.Run("removes entry when sole reader finishes and pendingEvict", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		key := k("key1")
+		mustSet(t, c, key, []byte("value1"))
+
+		// Mark pendingEvict with no other readers — Get will be the sole ref
+		e := c.items[key].Value.(*entry)
+		e.pendingEvict = true
+
+		// Get: refCount 0→1 (read), then 1→0 (done) → triggers removeEntry
+		found, val := c.Get(key)
+		assert.True(t, found)
+		assert.Equal(t, []byte("value1"), val)
+
+		assert.NotContains(t, c.items, key)
+		assert.Equal(t, int64(0), c.currentSize)
+		_, err := os.Stat(filepath.Join(c.baseDir, key.Path))
+		assert.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("does not remove when other readers still hold ref", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		key := k("key1")
+		mustSet(t, c, key, []byte("value1"))
+
+		// Simulate another reader already holding a ref
+		e := c.items[key].Value.(*entry)
+		e.pendingEvict = true
+		e.refCount = 1
+
+		// Get: refCount 1→2 (read), then 2→1 (done) → refCount>0, NOT removed
+		found, val := c.Get(key)
+		assert.True(t, found)
+		assert.Equal(t, []byte("value1"), val)
+
+		assert.Contains(t, c.items, key, "entry should still exist, another reader holds it")
+		assert.Equal(t, int64(6), c.currentSize)
+
+		// Simulate last reader finishing
+		c.mu.Lock()
+		e.refCount--
+		if e.pendingEvict && e.refCount == 0 {
+			c.removeEntry(e, nil)
+		}
+		c.mu.Unlock()
+
+		assert.NotContains(t, c.items, key)
+		assert.Equal(t, int64(0), c.currentSize)
+		_, err := os.Stat(filepath.Join(c.baseDir, key.Path))
+		assert.True(t, os.IsNotExist(err))
+	})
+}
+
+func TestPin(t *testing.T) {
+	t.Run("key doesn't exits", func(t *testing.T) {
+		c := newTestCache(t, 10)
+		path, release, ok := c.Pin(Key{Key: "nonexistent", Path: "nonexistent.txt"})
+		assert.False(t, ok)
+		assert.Empty(t, path)
+		assert.Nil(t, release)
+	})
+
+	t.Run("key exists", func(t *testing.T) {
+		c := newTestCache(t, 10)
+		key := k("key1")
+		mustSet(t, c, key, []byte("value1"))
+
+		path, release, ok := c.Pin(key)
+		assert.True(t, ok)
+		assert.Equal(t, filepath.Join(c.baseDir, key.Path), path)
+		assert.NotNil(t, release)
+
+		// Verify refCount incremented
+		e := c.items[key].Value.(*entry)
+		assert.Equal(t, 1, e.refCount)
+
+		release()
+
+		// Verify refCount decremented
+		assert.Equal(t, 0, e.refCount)
+	})
+
+	t.Run("don't evict if entry pinned", func(t *testing.T) {
+		bytes := []byte("value1")
+		c := newTestCache(t, int64(len(bytes)))
+		key := k("key1")
+		mustSet(t, c, key, bytes)
+
+		path, release, ok := c.Pin(key)
+		assert.Equal(t, filepath.Join(c.baseDir, key.Path), path)
+		require.True(t, ok)
+		require.NotNil(t, release)
+		e := c.items[key].Value.(*entry)
+		assert.Equal(t, 1, e.refCount)
+		assert.Contains(t, c.items, key)
+		// Mark entry as pendingEvict and try to evict it — should skip and set pendingEvict
+
+		c.evictFromBack(c.maxSize-1, nil, nil)
+		assert.True(t, e.pendingEvict)
+		release()
+		assert.NotContains(t, c.items, key)
+	})
+}
+
+func TestOnEvictedCallBack(t *testing.T) {
+	t.Run("called on eviction", func(t *testing.T) {
+		var evictedKeys []Key
+		c := newTestCache(t, 10, WithOnEviction(func(key Key) {
+			evictedKeys = append(evictedKeys, key)
+		}))
+
+		mustSet(t, c, k("key1"), []byte("value1"))
+		mustSet(t, c, k("key2"), []byte("value2")) // should evict key1
+
+		assert.Contains(t, evictedKeys, k("key1"))
+		assert.NotContains(t, evictedKeys, k("key2"))
+	})
+
+	t.Run("called on eviction from back", func(t *testing.T) {
+		var evictedKeys []Key
+		c := newTestCache(t, 10, WithOnEviction(func(key Key) {
+			evictedKeys = append(evictedKeys, key)
+		}))
+
+		for i := 0; i < 5; i++ {
+			key := Key{Key: fmt.Sprintf("key%d", i), Path: fmt.Sprintf("file%d.txt", i)}
+			e := &entry{key: key, size: 10, valid: true}
+			c.currentSize += 10
+			c.items[key] = c.order.PushFront(e)
+		}
+		c.evictFromBack(c.maxSize-1, nil, &evictedKeys)
+		assert.Len(t, evictedKeys, 5)
+	})
+
+	t.Run("test eviction from get", func(t *testing.T) {
+		var evictedKeys []Key
+		c := newTestCache(t, 10, WithOnEviction(func(key Key) {
+			evictedKeys = append(evictedKeys, key)
+		}))
+
+		key := k("key1")
+		mustSet(t, c, key, []byte("value1"))
+
+		// Mark entry as invalid to trigger eviction on Get
+		e := c.items[key].Value.(*entry)
+		e.valid = false
+
+		found, _ := c.Get(key)
+		assert.False(t, found)
+		assert.Contains(t, evictedKeys, key)
+	})
+
+	t.Run("called on update with ErrEntryTooLarge", func(t *testing.T) {
+		var evictedKeys []Key
+		c := newTestCache(t, 1024, WithOnEviction(func(key Key) {
+			evictedKeys = append(evictedKeys, key)
+		}))
+		c.maxEntrySize = 10
+		mustSet(t, c, k("key1"), []byte("small"))
+
+		err := c.Set(k("key1"), []byte("way too large!!"))
+		assert.ErrorIs(t, err, ErrEntryTooLarge)
+		assert.Contains(t, evictedKeys, k("key1"))
+	})
+
+	t.Run("called on update with ErrCacheFull", func(t *testing.T) {
+		var evictedKeys []Key
+		c := newTestCache(t, 10, WithOnEviction(func(key Key) {
+			evictedKeys = append(evictedKeys, key)
+		}))
+		mustSet(t, c, k("key1"), []byte("12345")) // 5 bytes
+
+		// Add invalid blocker that can't be evicted
+		bk := k("blocker")
+		c.items[bk] = c.order.PushBack(&entry{key: bk, size: 8, valid: false})
+		c.currentSize += 8
+
+		err := c.Set(k("key1"), []byte("123456789")) // sizeDiff=4, can't fit
+		assert.ErrorIs(t, err, ErrCacheFull)
+		assert.Contains(t, evictedKeys, k("key1"))
+	})
+
+	t.Run("called on pin release with pendingEvict", func(t *testing.T) {
+		var evictedKeys []Key
+		c := newTestCache(t, 10, WithOnEviction(func(key Key) {
+			evictedKeys = append(evictedKeys, key)
+		}))
+		key := k("key1")
+		mustSet(t, c, key, []byte("value1"))
+
+		_, release, ok := c.Pin(key)
+		require.True(t, ok)
+
+		// Mark pendingEvict while pinned
+		c.mu.Lock()
+		e := c.items[key].Value.(*entry)
+		e.pendingEvict = true
+		c.mu.Unlock()
+
+		assert.Empty(t, evictedKeys, "callback should not fire while pinned")
+
+		release()
+
+		assert.Contains(t, evictedKeys, key, "callback should fire after release")
+	})
+
+	t.Run("not called on permission error", func(t *testing.T) {
+		testOnEvictedNotCalledOnPermissionError(t)
+	})
+
+	t.Run("called for evicted entries on update path, not the updated one", func(t *testing.T) {
+		var evictedKeys []Key
+		c := newTestCache(t, 20, WithOnEviction(func(key Key) {
+			evictedKeys = append(evictedKeys, key)
+		}))
+		mustSet(t, c, k("key1"), []byte("0123456789")) // 10
+		mustSet(t, c, k("key2"), []byte("01234"))      // 5, total=15
+
+		// key1 grows to 18 → evicts key2
+		mustSet(t, c, k("key1"), []byte("012345678901234567"))
+
+		assert.Contains(t, evictedKeys, k("key2"))
+		assert.NotContains(t, evictedKeys, k("key1"))
+	})
+}
+
+func TestDelete(t *testing.T) {
+	t.Run("removes existing key", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		key := k("key1")
+		mustSet(t, c, key, []byte("value1"))
+
+		removed := c.Delete(key)
+		assert.True(t, removed)
+		assert.NotContains(t, c.items, key)
+		_, err := os.Stat(filepath.Join(c.baseDir, key.Path))
+		assert.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("returns false for non-existent key", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		removed := c.Delete(k("nonexistent"))
+		assert.False(t, removed)
+	})
+
+	t.Run("handles permission error gracefully", func(t *testing.T) {
+		testDeletePermissionError(t)
+	})
+
+	t.Run("removes pinned entry and sets pendingEvict", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		key := k("key1")
+		mustSet(t, c, key, []byte("value1"))
+
+		path, release, ok := c.Pin(key)
+		require.True(t, ok)
+		require.NotNil(t, release)
+		assert.Equal(t, filepath.Join(c.baseDir, key.Path), path)
+
+		removed := c.Delete(key)
+		assert.True(t, removed)
+
+		e := c.items[key].Value.(*entry)
+		assert.True(t, e.pendingEvict)
+
+		release()
+
+		assert.NotContains(t, c.items, key)
+	})
+}
+
+func TestAdopt(t *testing.T) {
+	t.Run("adopts existing cache directory", func(t *testing.T) {
+		baseDir := t.TempDir()
+		cache1, err := NewCache(baseDir, 1024)
+		require.NoError(t, err)
+
+		mustSet(t, cache1, k("key1"), []byte("value1"))
+		mustSet(t, cache1, k("key2"), []byte("value2"))
+
+		cache2, err := NewCache(baseDir, 1024)
+		// assert items and order empty before adopt
+		assert.Empty(t, cache2.items)
+		assert.Equal(t, 0, cache2.order.Len())
+
+		key1 := Key{Key: "key1", Path: "key1.txt"}
+		cache2.Adopt(key1)
+		require.NoError(t, err)
+		found, val := cache2.Get(k("key1"))
+		assert.True(t, found)
+		assert.Equal(t, []byte("value1"), val)
+
+		key2 := Key{Key: "key2", Path: "key2.txt"}
+		cache2.Adopt(key2)
+		found, val = cache2.Get(k("key2"))
+		assert.True(t, found)
+		assert.Equal(t, []byte("value2"), val)
+	})
+
+	t.Run("validates entry if entry is invalid", func(t *testing.T) {
+		baseDir := t.TempDir()
+		cache, err := NewCache(baseDir, 1024)
+		require.NoError(t, err)
+
+		mustSet(t, cache, k("key1"), []byte("value1"))
+
+		cache.mu.Lock()
+		e := cache.items[k("key1")].Value.(*entry)
+		e.valid = false
+		cache.mu.Unlock()
+
+		cache.adopt(k("key1"), int64(6))
+		found, _ := cache.Get(k("key1"))
+		assert.True(t, found)
+		// assert entry is now valid
+		assert.True(t, e.valid)
+	})
+}
+
+func TestWarmUp(t *testing.T) {
+	t.Run("loads existing entries into cache, and does not apply sizing limits", func(t *testing.T) {
+		baseDir := t.TempDir()
+		cache, err := NewCache(baseDir, 15)
+		require.NoError(t, err)
+		Key1 := k("key1")
+		Key2 := k("key2")
+		mustSet(t, cache, Key1, []byte("value1"))
+		mustSet(t, cache, Key2, []byte("value2"))
+
+		// Create new cache instance and warm up
+		cache2, err := NewCache(baseDir, 10)
+		require.NoError(t, err)
+		err = cache2.WarmUp(func(path string) (key Key, ok bool) {
+			name := path[:len(path)-len(filepath.Ext(path))]
+			return k(name), true
+		})
+		require.NoError(t, err)
+
+		found, val := cache2.Get(Key1)
+		assert.True(t, found)
+		assert.Equal(t, []byte("value1"), val)
+
+		found, val = cache2.Get(Key2)
+		assert.True(t, found)
+		assert.Equal(t, []byte("value2"), val)
+	})
+}
+
+func TestSetPin(t *testing.T) {
+	t.Run("new entry", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		key := k("key1")
+		data := []byte("value1")
+
+		path, release, err := c.SetPin(key, data)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(c.baseDir, key.Path), path)
+		assert.NotNil(t, release)
+
+		// Verify written to disk
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, data, content)
+
+		// Verify pinned (refCount incremented)
+		e := c.items[key].Value.(*entry)
+		assert.Equal(t, 1, e.refCount)
+		assert.Equal(t, int64(len(data)), c.currentSize)
+
+		release()
+		assert.Equal(t, 0, e.refCount)
+	})
+
+	t.Run("update existing entry", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		key := k("key1")
+		mustSet(t, c, key, []byte("old"))
+
+		path, release, err := c.SetPin(key, []byte("new-value"))
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(c.baseDir, key.Path), path)
+
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("new-value"), content)
+
+		assert.Equal(t, int64(len("new-value")), c.currentSize)
+
+		e := c.items[key].Value.(*entry)
+		assert.Equal(t, 1, e.refCount)
+
+		release()
+		assert.Equal(t, 0, e.refCount)
+	})
+
+	t.Run("entry too large", func(t *testing.T) {
+		c := newTestCache(t, 1024, WithMaxEntrySize(5))
+		key := k("key1")
+
+		path, release, err := c.SetPin(key, []byte("too-large-data"))
+		assert.ErrorIs(t, err, ErrEntryTooLarge)
+		assert.Empty(t, path)
+		assert.Nil(t, release)
+	})
+
+	t.Run("cache full", func(t *testing.T) {
+		c := newTestCache(t, 10)
+		// Fill cache with a pinned entry so eviction can't free space
+		key1 := k("key1")
+		_, release1, err := c.SetPin(key1, []byte("1234567890"))
+		require.NoError(t, err)
+		defer release1()
+
+		key2 := k("key2")
+		path, release, err := c.SetPin(key2, []byte("overflow"))
+		assert.ErrorIs(t, err, ErrCacheFull)
+		assert.Empty(t, path)
+		assert.Nil(t, release)
+	})
+
+	t.Run("evicts LRU to make room", func(t *testing.T) {
+		c := newTestCache(t, 30)
+		mustSet(t, c, k("old1"), []byte("1234567890"))
+		mustSet(t, c, k("old2"), []byte("1234567890"))
+
+		key := k("new")
+		path, release, err := c.SetPin(key, []byte("1234567890-new"))
+		require.NoError(t, err)
+		assert.NotEmpty(t, path)
+		defer release()
+
+		// At least one old entry should have been evicted
+		assert.True(t, c.currentSize <= c.maxSize)
+	})
+
+	t.Run("pinned entry not evicted", func(t *testing.T) {
+		data := []byte("value1")
+		c := newTestCache(t, int64(len(data)))
+		key := k("key1")
+
+		_, release, err := c.SetPin(key, data)
+		require.NoError(t, err)
+
+		// Try to evict — should be blocked by pin
+		c.mu.Lock()
+		c.evictFromBack(0, nil, nil)
+		c.mu.Unlock()
+
+		e := c.items[key].Value.(*entry)
+		assert.True(t, e.pendingEvict)
+		assert.Contains(t, c.items, key)
+
+		// Release the pin — now eviction completes
+		release()
+		assert.NotContains(t, c.items, key)
+	})
+
+	t.Run("release is idempotent", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		key := k("key1")
+
+		_, release, err := c.SetPin(key, []byte("value1"))
+		require.NoError(t, err)
+
+		release()
+		release() // second call should be no-op
+		release() // third call should be no-op
+
+		e := c.items[key].Value.(*entry)
+		assert.Equal(t, 0, e.refCount)
+	})
+
+	t.Run("concurrent SetPin same key", func(t *testing.T) {
+		c := newTestCache(t, 1024)
+		key := k("key1")
+
+		var wg sync.WaitGroup
+		releases := make([]func(), 10)
+		errs := make([]error, 10)
+
+		for i := range 10 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, rel, err := c.SetPin(key, []byte(fmt.Sprintf("value-%d", i)))
+				releases[i] = rel
+				errs[i] = err
+			}()
+		}
+		wg.Wait()
+
+		for i := range 10 {
+			assert.NoError(t, errs[i])
+			if releases[i] != nil {
+				releases[i]()
+			}
+		}
+
+		// Entry should still exist with refCount 0
+		e := c.items[key].Value.(*entry)
+		assert.Equal(t, 0, e.refCount)
+	})
+
+	t.Run("eviction callback fires", func(t *testing.T) {
+		var evictedKeys []Key
+		c := newTestCache(t, 20, WithOnEviction(func(key Key) {
+			evictedKeys = append(evictedKeys, key)
+		}))
+		mustSet(t, c, k("old"), []byte("1234567890"))
+
+		_, release, err := c.SetPin(k("new"), []byte("1234567890-n"))
+		require.NoError(t, err)
+		defer release()
+
+		assert.Contains(t, evictedKeys, k("old"))
+	})
+}

--- a/pkg/cache/diskcache/cache_unix_test.go
+++ b/pkg/cache/diskcache/cache_unix_test.go
@@ -1,0 +1,90 @@
+//go:build !windows
+
+package diskcache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testRemoveEntryPermissionError(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("requires non-root")
+	}
+	c := newTestCache(t, 1024)
+	mustSet(t, c, k("key1"), []byte("data"))
+
+	err := os.Chmod(c.baseDir, 0o555)
+	require.NoError(t, err)
+	t.Cleanup(func() { os.Chmod(c.baseDir, 0o755) }) //nolint:errcheck
+
+	e := c.items[k("key1")].Value.(*entry)
+	c.removeEntry(e, nil)
+
+	assert.False(t, e.valid)
+	assert.Contains(t, c.items, k("key1"))
+}
+
+func testEvictFromBackPermissionError(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("requires non-root")
+	}
+	c := newTestCache(t, 10)
+	key := k("key1")
+	e := &entry{key: key, size: 20, valid: true}
+	c.items[key] = c.order.PushBack(e)
+	c.currentSize += 20
+	os.WriteFile(filepath.Join(c.baseDir, key.Path), []byte("data"), 0o644) //nolint:errcheck
+
+	os.Chmod(c.baseDir, 0o555)                       //nolint:errcheck
+	t.Cleanup(func() { os.Chmod(c.baseDir, 0o755) }) //nolint:errcheck
+
+	c.evictFromBack(c.maxSize, nil, nil)
+
+	assert.Contains(t, c.items, key)
+	assert.False(t, e.valid)
+	assert.Equal(t, int64(20), c.currentSize)
+}
+
+func testOnEvictedNotCalledOnPermissionError(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("requires non-root")
+	}
+	var evictedKeys []Key
+	c := newTestCache(t, 1024, WithOnEviction(func(key Key) {
+		evictedKeys = append(evictedKeys, key)
+	}))
+	key := k("key1")
+	mustSet(t, c, key, []byte("data"))
+
+	os.Chmod(c.baseDir, 0o555)                       //nolint:errcheck
+	t.Cleanup(func() { os.Chmod(c.baseDir, 0o755) }) //nolint:errcheck
+
+	c.mu.Lock()
+	e := c.items[key].Value.(*entry)
+	c.removeEntry(e, nil)
+	c.mu.Unlock()
+
+	assert.Empty(t, evictedKeys, "callback should not fire when os.Remove fails")
+	assert.False(t, e.valid)
+}
+
+func testDeletePermissionError(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("requires non-root")
+	}
+	c := newTestCache(t, 1024)
+	key := k("key1")
+	mustSet(t, c, key, []byte("value1"))
+
+	os.Chmod(c.baseDir, 0o555)                       //nolint:errcheck
+	t.Cleanup(func() { os.Chmod(c.baseDir, 0o755) }) //nolint:errcheck
+}

--- a/pkg/cache/diskcache/rename_unix.go
+++ b/pkg/cache/diskcache/rename_unix.go
@@ -1,0 +1,14 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package diskcache
+
+import "os"
+
+// atomicRename atomically replaces dst with src.
+// On Unix, os.Rename is atomic and overwrites the target.
+func atomicRename(src, dst string) error {
+	return os.Rename(src, dst)
+}

--- a/pkg/cache/diskcache/rename_windows.go
+++ b/pkg/cache/diskcache/rename_windows.go
@@ -1,0 +1,66 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package diskcache
+
+import (
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	// maxRenameRetries is the number of retry attempts for transient Windows errors.
+	maxRenameRetries = 3
+	// renameRetryDelay is the base delay between retries (doubled each attempt).
+	renameRetryDelay = 5 * time.Millisecond
+)
+
+// atomicRename atomically replaces dst with src using MoveFileEx.
+// MOVEFILE_REPLACE_EXISTING allows overwriting an existing target.
+// MOVEFILE_WRITE_THROUGH ensures the operation is flushed to disk.
+// Retries on transient errors (sharing violations, access denied) that
+// occur when antivirus or indexing services hold brief locks on files.
+func atomicRename(src, dst string) error {
+	srcW, err := windows.UTF16PtrFromString(src)
+	if err != nil {
+		return err
+	}
+	dstW, err := windows.UTF16PtrFromString(dst)
+	if err != nil {
+		return err
+	}
+
+	var lastErr error
+	delay := renameRetryDelay
+	for attempt := range maxRenameRetries {
+		lastErr = windows.MoveFileEx(srcW, dstW, windows.MOVEFILE_REPLACE_EXISTING|windows.MOVEFILE_WRITE_THROUGH)
+		if lastErr == nil {
+			return nil
+		}
+		if !isTransientError(lastErr) {
+			return lastErr
+		}
+		if attempt < maxRenameRetries-1 {
+			time.Sleep(delay)
+			delay *= 2
+		}
+	}
+	return lastErr
+}
+
+// isTransientError returns true for Windows errors that are typically
+// caused by brief file locks from antivirus, search indexers, or
+// backup software and are likely to resolve on retry.
+func isTransientError(err error) bool {
+	switch err {
+	case windows.ERROR_SHARING_VIOLATION,
+		windows.ERROR_LOCK_VIOLATION,
+		windows.ERROR_ACCESS_DENIED:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/cache/versionedcache/cache.go
+++ b/pkg/cache/versionedcache/cache.go
@@ -1,0 +1,289 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package versionedcache
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/oakwood-commons/scafctl/pkg/cache/diskcache"
+)
+
+// keySep separates name and platform in the version index key.
+const keySep = "\x00"
+
+// Cache wraps a diskcache.Cache with a semver version index.
+// It maintains a sorted (descending) list of versions per name+platform,
+// kept in sync automatically via the diskcache OnEviction callback.
+type Cache struct {
+	cache    *diskcache.Cache
+	mu       sync.RWMutex
+	versions map[string][]*semver.Version // indexKey -> sorted desc
+}
+
+// New creates a Cache backed by a bounded diskcache.
+// The OnEviction callback is wired internally to keep the version index
+// consistent when the diskcache evicts entries.
+func New(cacheDir string, maxSize int64, opts ...diskcache.CacheOption) (*Cache, error) {
+	vc := &Cache{
+		versions: make(map[string][]*semver.Version),
+	}
+	// Append our eviction callback last so it cannot be overridden by caller opts.
+	// The version index depends on this callback to stay consistent.
+	allOpts := make([]diskcache.CacheOption, 0, len(opts)+1)
+	allOpts = append(allOpts, opts...)
+	allOpts = append(allOpts, diskcache.WithOnEviction(vc.onEvict))
+
+	cache, err := diskcache.NewCache(cacheDir, maxSize, allOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating versioned cache: %w", err)
+	}
+	vc.cache = cache
+	return vc, nil
+}
+
+// Set writes data into the diskcache and adds the version to the index.
+func (vc *Cache) Set(name, version, platform string, data []byte) error {
+	sv, err := semver.NewVersion(version)
+	if err != nil {
+		return fmt.Errorf("invalid semver version %q: %w", version, err)
+	}
+	key := diskKey(name, version, platform)
+	if err := vc.cache.Set(key, data); err != nil {
+		return err
+	}
+	vc.addVersion(name, platform, sv)
+	return nil
+}
+
+// SetPin writes data, pins the entry atomically, and updates the version index.
+// The entry cannot be evicted until the returned release function is called.
+func (vc *Cache) SetPin(name, version, platform string, data []byte) (string, func(), error) {
+	sv, err := semver.NewVersion(version)
+	if err != nil {
+		return "", nil, fmt.Errorf("invalid semver version %q: %w", version, err)
+	}
+	key := diskKey(name, version, platform)
+	path, release, err := vc.cache.SetPin(key, data)
+	if err != nil {
+		return "", nil, err
+	}
+	vc.addVersion(name, platform, sv)
+	return path, release, nil
+}
+
+// Pin marks a cache entry as in-use and returns its on-disk path.
+// The entry cannot be evicted until the returned release function is called.
+// The entry file can however be updated while holding the pin, in which case the path will point to the updated content.
+// Returns ok=false if the entry is not in the cache.
+func (vc *Cache) Pin(name, version, platform string) (path string, release func(), ok bool) {
+	key := diskKey(name, version, platform)
+	return vc.cache.Pin(key)
+}
+
+// Latest returns the highest cached semver version for a name+platform.
+// Returns ok=false if nothing is indexed.
+func (vc *Cache) Latest(name, platform string) (version string, ok bool) {
+	vc.mu.RLock()
+	defer vc.mu.RUnlock()
+	ik := indexKey(name, platform)
+	vs := vc.versions[ik]
+	if len(vs) == 0 {
+		return "", false
+	}
+	return vs[0].Original(), true
+}
+
+// Delete explicitly removes an entry from the diskcache.
+// The version index is updated via the OnEviction callback.
+func (vc *Cache) Delete(name, version, platform string) bool {
+	key := diskKey(name, version, platform)
+	return vc.cache.Delete(key)
+}
+
+// Versions returns all indexed versions for a name+platform, sorted descending.
+// The returned slice is a copy.
+func (vc *Cache) Versions(name, platform string) []string {
+	vc.mu.RLock()
+	defer vc.mu.RUnlock()
+	ik := indexKey(name, platform)
+	vs := vc.versions[ik]
+	out := make([]string, len(vs))
+	for i, v := range vs {
+		out[i] = v.Original()
+	}
+	return out
+}
+
+// BaseDir returns the root directory of the underlying diskcache.
+func (vc *Cache) BaseDir() string {
+	return vc.cache.BaseDir()
+}
+
+// WarmUp scans the cache directory for existing plugin binaries and populates
+// both the diskcache LRU and the version index without reading file contents.
+// Files are adopted into the LRU without triggering eviction — the cache may
+// temporarily exceed maxSize. Eviction occurs naturally on the next Set call.
+func (vc *Cache) WarmUp() error {
+	return vc.cache.WarmUp(func(relativePath string) (diskcache.Key, bool) {
+		name, version, platform, ok := parseRelativePath(relativePath)
+		if !ok {
+			return diskcache.Key{}, false
+		}
+		if sv, err := semver.NewVersion(version); err == nil {
+			vc.addVersion(name, platform, sv)
+		}
+		return diskKey(name, version, platform), true
+	})
+}
+
+// parseRelativePath parses a relative path into its components.
+// Supports two formats:
+//   - 4 segments: "name/version/os-arch/binary" (no registry hash)
+//   - 5 segments: "name/registryHash/version/os-arch/binary" (with registry hash)
+//
+// When a registry hash is present, the returned name is "name/registryHash"
+// (a composite name). Platform is returned as "os/arch".
+func parseRelativePath(relativePath string) (name, version, platform string, ok bool) {
+	// Normalize to forward slashes for cross-platform consistency.
+	normalized := filepath.ToSlash(relativePath)
+	parts := strings.Split(normalized, "/")
+
+	switch len(parts) {
+	case 4:
+		// name/version/os-arch/binary
+		name = parts[0]
+		version = parts[1]
+		fsPlatform := parts[2]
+		binary := parts[3]
+
+		if strings.TrimSuffix(binary, ".exe") != name {
+			return "", "", "", false
+		}
+
+		dashIdx := strings.Index(fsPlatform, "-")
+		if dashIdx <= 0 || dashIdx == len(fsPlatform)-1 {
+			return "", "", "", false
+		}
+		platform = fsPlatform[:dashIdx] + "/" + fsPlatform[dashIdx+1:]
+		return name, version, platform, true
+
+	case 5:
+		// name/registryHash/version/os-arch/binary
+		name = parts[0] + "/" + parts[1] // composite name
+		version = parts[2]
+		fsPlatform := parts[3]
+		binary := parts[4]
+
+		if strings.TrimSuffix(binary, ".exe") != parts[0] {
+			return "", "", "", false
+		}
+
+		dashIdx := strings.Index(fsPlatform, "-")
+		if dashIdx <= 0 || dashIdx == len(fsPlatform)-1 {
+			return "", "", "", false
+		}
+		platform = fsPlatform[:dashIdx] + "/" + fsPlatform[dashIdx+1:]
+		return name, version, platform, true
+
+	default:
+		return "", "", "", false
+	}
+}
+
+// onEvict is the diskcache OnEviction callback. It parses the evicted key
+// and removes the corresponding version from the index.
+func (vc *Cache) onEvict(key diskcache.Key) {
+	name, version, platform, ok := parseDiskKey(key)
+	if !ok {
+		return
+	}
+	sv, err := semver.NewVersion(version)
+	if err != nil {
+		return
+	}
+	vc.removeVersion(name, platform, sv)
+}
+
+// addVersion inserts a semver version into the index in sorted (descending) order.
+// Duplicates are ignored.
+func (vc *Cache) addVersion(name, platform string, v *semver.Version) {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+	ik := indexKey(name, platform)
+	vs := vc.versions[ik]
+	// Binary search for insertion point (sorted descending: greater versions first).
+	idx := sort.Search(len(vs), func(i int) bool {
+		return !vs[i].GreaterThan(v) // vs[i] <= v
+	})
+	// Duplicate check.
+	if idx < len(vs) && vs[idx].Equal(v) {
+		return
+	}
+	vs = append(vs, nil)
+	copy(vs[idx+1:], vs[idx:])
+	vs[idx] = v
+	vc.versions[ik] = vs
+}
+
+// removeVersion removes a semver version from the index.
+func (vc *Cache) removeVersion(name, platform string, v *semver.Version) {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+	ik := indexKey(name, platform)
+	vs := vc.versions[ik]
+	idx := sort.Search(len(vs), func(i int) bool {
+		return !vs[i].GreaterThan(v)
+	})
+	if idx < len(vs) && vs[idx].Equal(v) {
+		vc.versions[ik] = append(vs[:idx], vs[idx+1:]...)
+		if len(vc.versions[ik]) == 0 {
+			delete(vc.versions, ik)
+		}
+	}
+}
+
+// indexKey builds the version index map key.
+func indexKey(name, platform string) string {
+	return name + keySep + platform
+}
+
+// diskKey builds a diskcache.Key from name, version, and platform.
+// The Key field encodes all components for round-tripping via parseDiskKey.
+// The Path field matches the plugin cache layout.
+//
+// When name is a composite "pluginName/registryHash", the path includes the
+// registry hash directory level and the binary name uses just the plugin name:
+//
+//	pluginName/registryHash/version/os-arch/pluginName
+//
+// When name is a plain string, the path is the original 4-segment layout:
+//
+//	name/version/os-arch/name
+func diskKey(name, version, platform string) diskcache.Key {
+	// Platform uses "os/arch" but filesystem uses "os-arch".
+	fsPlatform := strings.ReplaceAll(platform, "/", "-")
+	// Extract the bare plugin name for the binary filename.
+	bareName := name
+	if idx := strings.Index(name, "/"); idx >= 0 {
+		bareName = name[:idx]
+	}
+	return diskcache.Key{
+		Key:  name + keySep + version + keySep + platform,
+		Path: fmt.Sprintf("%s/%s/%s/%s", name, version, fsPlatform, bareName),
+	}
+}
+
+// parseDiskKey extracts name, version, and platform from a diskcache.Key.
+func parseDiskKey(key diskcache.Key) (name, version, platform string, ok bool) {
+	parts := strings.SplitN(key.Key, keySep, 3)
+	if len(parts) != 3 {
+		return "", "", "", false
+	}
+	return parts[0], parts[1], parts[2], true
+}

--- a/pkg/cache/versionedcache/cache_concurrent_test.go
+++ b/pkg/cache/versionedcache/cache_concurrent_test.go
@@ -1,0 +1,201 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+package versionedcache
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/oakwood-commons/scafctl/pkg/cache/diskcache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestCache_ConcurrentSetGetDelete(t *testing.T) {
+	// Large enough for ~30 entries of 10 bytes each to allow eviction churn.
+	vc := newTestCache(t, 512, diskcache.WithFileMode(0o755))
+
+	const (
+		numWriters  = 10
+		numReaders  = 10
+		numPinners  = 5
+		numDeleters = 5
+		opsPerGoro  = 20
+		platform    = "linux/amd64"
+		pluginName  = "race-plugin"
+	)
+
+	data := []byte("0123456789") // 10 bytes per entry
+
+	var g errgroup.Group
+
+	// Writers: each writes a unique set of versions.
+	for w := range numWriters {
+		g.Go(func() error {
+			for i := range opsPerGoro {
+				ver := fmt.Sprintf("%d.%d.0", w, i)
+				if err := vc.Set(pluginName, ver, platform, data); err != nil {
+					return fmt.Errorf("writer %d set %s: %w", w, ver, err)
+				}
+			}
+			return nil
+		})
+	}
+
+	// Readers: call Latest and Versions in a tight loop.
+	for r := range numReaders {
+		g.Go(func() error {
+			for range opsPerGoro {
+				_ = vc.Versions(pluginName, platform)
+				_, _ = vc.Latest(pluginName, platform)
+			}
+			_ = r // suppress unused
+			return nil
+		})
+	}
+
+	// Pinners: pin whatever Latest returns, hold briefly, release.
+	for p := range numPinners {
+		g.Go(func() error {
+			for range opsPerGoro {
+				ver, ok := vc.Latest(pluginName, platform)
+				if !ok {
+					continue
+				}
+				_, release, pinOk := vc.Pin(pluginName, ver, platform)
+				if pinOk {
+					// Simulate brief use of the binary.
+					_ = vc.Versions(pluginName, platform)
+					release()
+				}
+			}
+			_ = p
+			return nil
+		})
+	}
+
+	// Deleters: delete versions they discover via Versions.
+	for d := range numDeleters {
+		g.Go(func() error {
+			for range opsPerGoro {
+				versions := vc.Versions(pluginName, platform)
+				if len(versions) == 0 {
+					continue
+				}
+				// Delete the oldest (last in the descending list).
+				target := versions[len(versions)-1]
+				vc.Delete(pluginName, target, platform)
+			}
+			_ = d
+			return nil
+		})
+	}
+
+	require.NoError(t, g.Wait())
+
+	// Post-condition: Versions must be valid descending semver (no duplicates, sorted).
+	versions := vc.Versions(pluginName, platform)
+	for i := 1; i < len(versions); i++ {
+		prev, _ := semver.NewVersion(versions[i-1])
+		curr, _ := semver.NewVersion(versions[i])
+		assert.True(t, prev.GreaterThan(curr),
+			"versions not sorted descending: %s should be > %s", versions[i-1], versions[i])
+	}
+
+	// Latest must match head of Versions (if any remain).
+	if len(versions) > 0 {
+		latest, ok := vc.Latest(pluginName, platform)
+		assert.True(t, ok)
+		assert.Equal(t, versions[0], latest)
+	}
+}
+
+func TestCache_ConcurrentSetPin(t *testing.T) {
+	// Multiple goroutines SetPin the same version simultaneously.
+	// Only one should write; all should get a valid path + release.
+	vc := newTestCache(t, 4096, diskcache.WithFileMode(0o755))
+
+	const (
+		concurrency = 20
+		platform    = "darwin/arm64"
+		pluginName  = "setpin-race"
+		version     = "1.0.0"
+	)
+
+	data := []byte("concurrent-binary")
+	var successCount atomic.Int32
+
+	var g errgroup.Group
+	for range concurrency {
+		g.Go(func() error {
+			path, release, err := vc.SetPin(pluginName, version, platform, data)
+			if err != nil {
+				return err
+			}
+			defer release()
+			if path != "" {
+				successCount.Add(1)
+			}
+			return nil
+		})
+	}
+
+	require.NoError(t, g.Wait())
+	assert.Equal(t, int32(concurrency), successCount.Load(),
+		"all SetPin calls should succeed with a valid path")
+
+	// Exactly one version indexed.
+	versions := vc.Versions(pluginName, platform)
+	assert.Equal(t, []string{version}, versions)
+}
+
+func BenchmarkCache_MixedOps(b *testing.B) {
+	b.ReportAllocs()
+
+	dir := b.TempDir()
+	vc, err := New(dir, 64*1024, diskcache.WithFileMode(0o755))
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	const platform = "linux/amd64"
+	data := []byte("bench-binary-payload-16b")
+
+	// Pre-seed some versions.
+	for i := range 10 {
+		ver := fmt.Sprintf("0.%d.0", i)
+		if err := vc.Set("bench-plugin", ver, platform, data); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			ver := fmt.Sprintf("1.%d.%d", i/100, i%100)
+			name := "bench-plugin"
+
+			// Set
+			_ = vc.Set(name, ver, platform, data)
+
+			// Latest
+			_, _ = vc.Latest(name, platform)
+
+			// Pin + release
+			if _, release, ok := vc.Pin(name, ver, platform); ok {
+				release()
+			}
+
+			// Delete (every 3rd iteration)
+			if i%3 == 0 {
+				vc.Delete(name, ver, platform)
+			}
+
+			i++
+		}
+	})
+}

--- a/pkg/cache/versionedcache/cache_test.go
+++ b/pkg/cache/versionedcache/cache_test.go
@@ -1,0 +1,390 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+package versionedcache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/cache/diskcache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCache(t *testing.T, maxSize int64, opts ...diskcache.CacheOption) *Cache {
+	t.Helper()
+	vc, err := New(t.TempDir(), maxSize, opts...)
+	require.NoError(t, err)
+	return vc
+}
+
+func TestNew(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		vc := newTestCache(t, 1024)
+		assert.NotNil(t, vc.cache)
+		assert.NotNil(t, vc.versions)
+	})
+
+	t.Run("invalid max size", func(t *testing.T) {
+		_, err := New(t.TempDir(), -1)
+		assert.Error(t, err)
+	})
+}
+
+func TestCache_SetAndPin(t *testing.T) {
+	t.Run("set then pin returns path", func(t *testing.T) {
+		vc := newTestCache(t, 1024)
+		data := []byte("binary-data")
+		require.NoError(t, vc.Set("myplugin", "1.2.3", "darwin/arm64", data))
+
+		path, release, ok := vc.Pin("myplugin", "1.2.3", "darwin/arm64")
+		require.True(t, ok)
+		defer release()
+
+		assert.Contains(t, path, "myplugin/1.2.3/darwin-arm64/myplugin")
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, data, content)
+	})
+
+	t.Run("pin missing entry returns false", func(t *testing.T) {
+		vc := newTestCache(t, 1024)
+		_, _, ok := vc.Pin("missing", "1.0.0", "linux/amd64")
+		assert.False(t, ok)
+	})
+}
+
+func TestCache_Latest(t *testing.T) {
+	t.Run("returns highest version", func(t *testing.T) {
+		vc := newTestCache(t, 4096)
+		require.NoError(t, vc.Set("plugin", "1.0.0", "linux/amd64", []byte("v1")))
+		require.NoError(t, vc.Set("plugin", "2.0.0", "linux/amd64", []byte("v2")))
+		require.NoError(t, vc.Set("plugin", "1.5.0", "linux/amd64", []byte("v15")))
+
+		ver, ok := vc.Latest("plugin", "linux/amd64")
+		require.True(t, ok)
+		assert.Equal(t, "2.0.0", ver)
+	})
+
+	t.Run("different platforms are independent", func(t *testing.T) {
+		vc := newTestCache(t, 4096)
+		require.NoError(t, vc.Set("plugin", "3.0.0", "darwin/arm64", []byte("d3")))
+		require.NoError(t, vc.Set("plugin", "1.0.0", "linux/amd64", []byte("l1")))
+
+		ver, ok := vc.Latest("plugin", "darwin/arm64")
+		require.True(t, ok)
+		assert.Equal(t, "3.0.0", ver)
+
+		ver, ok = vc.Latest("plugin", "linux/amd64")
+		require.True(t, ok)
+		assert.Equal(t, "1.0.0", ver)
+	})
+
+	t.Run("no entries returns false", func(t *testing.T) {
+		vc := newTestCache(t, 1024)
+		_, ok := vc.Latest("missing", "linux/amd64")
+		assert.False(t, ok)
+	})
+}
+
+func TestCache_Remove(t *testing.T) {
+	t.Run("removes entry and updates index", func(t *testing.T) {
+		vc := newTestCache(t, 4096)
+		require.NoError(t, vc.Set("plugin", "1.0.0", "linux/amd64", []byte("v1")))
+		require.NoError(t, vc.Set("plugin", "2.0.0", "linux/amd64", []byte("v2")))
+
+		removed := vc.Delete("plugin", "2.0.0", "linux/amd64")
+		assert.True(t, removed)
+
+		ver, ok := vc.Latest("plugin", "linux/amd64")
+		require.True(t, ok)
+		assert.Equal(t, "1.0.0", ver)
+	})
+
+	t.Run("remove last version cleans up index", func(t *testing.T) {
+		vc := newTestCache(t, 1024)
+		require.NoError(t, vc.Set("plugin", "1.0.0", "linux/amd64", []byte("v1")))
+
+		removed := vc.Delete("plugin", "1.0.0", "linux/amd64")
+		assert.True(t, removed)
+
+		_, ok := vc.Latest("plugin", "linux/amd64")
+		assert.False(t, ok)
+
+		vc.mu.RLock()
+		_, exists := vc.versions[indexKey("plugin", "linux/amd64")]
+		vc.mu.RUnlock()
+		assert.False(t, exists)
+	})
+
+	t.Run("remove nonexistent returns false", func(t *testing.T) {
+		vc := newTestCache(t, 1024)
+		removed := vc.Delete("missing", "1.0.0", "linux/amd64")
+		assert.False(t, removed)
+	})
+}
+
+func TestCache_EvictionUpdatesIndex(t *testing.T) {
+	t.Run("LRU eviction removes version from index", func(t *testing.T) {
+		// maxSize=15 bytes; two entries of 10 bytes each forces eviction.
+		vc := newTestCache(t, 15)
+		require.NoError(t, vc.Set("plugin", "1.0.0", "linux/amd64", []byte("0123456789")))
+		require.NoError(t, vc.Set("plugin", "2.0.0", "linux/amd64", []byte("0123456789")))
+
+		// v1 should have been evicted to make room for v2.
+		_, _, ok := vc.Pin("plugin", "1.0.0", "linux/amd64")
+		assert.False(t, ok)
+
+		ver, ok := vc.Latest("plugin", "linux/amd64")
+		require.True(t, ok)
+		assert.Equal(t, "2.0.0", ver)
+
+		versions := vc.Versions("plugin", "linux/amd64")
+		assert.Equal(t, []string{"2.0.0"}, versions)
+	})
+}
+
+func TestCache_Versions(t *testing.T) {
+	t.Run("returns sorted descending copy", func(t *testing.T) {
+		vc := newTestCache(t, 4096)
+		require.NoError(t, vc.Set("p", "1.0.0", "linux/amd64", []byte("a")))
+		require.NoError(t, vc.Set("p", "3.0.0", "linux/amd64", []byte("c")))
+		require.NoError(t, vc.Set("p", "2.0.0", "linux/amd64", []byte("b")))
+
+		versions := vc.Versions("p", "linux/amd64")
+		assert.Equal(t, []string{"3.0.0", "2.0.0", "1.0.0"}, versions)
+	})
+
+	t.Run("empty for unknown plugin", func(t *testing.T) {
+		vc := newTestCache(t, 1024)
+		versions := vc.Versions("missing", "linux/amd64")
+		assert.Empty(t, versions)
+	})
+}
+
+func TestCache_SetDuplicateVersion(t *testing.T) {
+	vc := newTestCache(t, 4096)
+	require.NoError(t, vc.Set("p", "1.0.0", "linux/amd64", []byte("first")))
+	require.NoError(t, vc.Set("p", "1.0.0", "linux/amd64", []byte("second")))
+
+	versions := vc.Versions("p", "linux/amd64")
+	assert.Equal(t, []string{"1.0.0"}, versions)
+}
+
+func TestCache_SetInvalidSemver(t *testing.T) {
+	vc := newTestCache(t, 1024)
+	err := vc.Set("p", "not-a-version", "linux/amd64", []byte("data"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid semver version")
+
+	// Nothing written to disk.
+	_, _, ok := vc.Pin("p", "not-a-version", "linux/amd64")
+	assert.False(t, ok)
+}
+
+func TestCache_BaseDir(t *testing.T) {
+	dir := t.TempDir()
+	vc, err := New(dir, 1024)
+	require.NoError(t, err)
+	assert.Equal(t, dir, vc.BaseDir())
+}
+
+func TestCache_WithFileMode(t *testing.T) {
+	vc := newTestCache(t, 1024, diskcache.WithFileMode(0o755))
+	require.NoError(t, vc.Set("p", "1.0.0", "linux/amd64", []byte("exec")))
+
+	path, release, ok := vc.Pin("p", "1.0.0", "linux/amd64")
+	require.True(t, ok)
+	defer release()
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&0o111, "file should be executable")
+}
+
+func TestDiskKey(t *testing.T) {
+	t.Run("plain name", func(t *testing.T) {
+		key := diskKey("myplugin", "1.2.3", "darwin/arm64")
+		assert.Equal(t, "myplugin\x001.2.3\x00darwin/arm64", key.Key)
+		assert.Equal(t, "myplugin/1.2.3/darwin-arm64/myplugin", key.Path)
+	})
+
+	t.Run("composite name with registry hash", func(t *testing.T) {
+		key := diskKey("myplugin/a1b2c3d4e5f67890", "1.2.3", "darwin/arm64")
+		assert.Equal(t, "myplugin/a1b2c3d4e5f67890\x001.2.3\x00darwin/arm64", key.Key)
+		assert.Equal(t, "myplugin/a1b2c3d4e5f67890/1.2.3/darwin-arm64/myplugin", key.Path)
+	})
+}
+
+func TestParseDiskKey(t *testing.T) {
+	t.Run("valid key", func(t *testing.T) {
+		key := diskcache.Key{Key: "name\x001.0.0\x00linux/amd64"}
+		name, version, platform, ok := parseDiskKey(key)
+		assert.True(t, ok)
+		assert.Equal(t, "name", name)
+		assert.Equal(t, "1.0.0", version)
+		assert.Equal(t, "linux/amd64", platform)
+	})
+
+	t.Run("malformed key", func(t *testing.T) {
+		key := diskcache.Key{Key: "no-separators"}
+		_, _, _, ok := parseDiskKey(key)
+		assert.False(t, ok)
+	})
+}
+
+func TestCache_FileOnDisk(t *testing.T) {
+	vc := newTestCache(t, 4096)
+	data := []byte("plugin-binary-content")
+	require.NoError(t, vc.Set("auth-handler", "0.5.0", "darwin/arm64", data))
+
+	expected := filepath.Join(vc.BaseDir(), "auth-handler", "0.5.0", "darwin-arm64", "auth-handler")
+	content, err := os.ReadFile(expected)
+	require.NoError(t, err)
+	assert.Equal(t, data, content)
+}
+
+func TestParseRelativePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		wantName string
+		wantVer  string
+		wantPlat string
+		wantOk   bool
+	}{
+		{"valid linux", "myplugin/1.2.3/linux-amd64/myplugin", "myplugin", "1.2.3", "linux/amd64", true},
+		{"valid darwin", "aws-provider/2.0.0/darwin-arm64/aws-provider", "aws-provider", "2.0.0", "darwin/arm64", true},
+		{"valid windows exe", "myplugin/1.0.0/windows-amd64/myplugin.exe", "myplugin", "1.0.0", "windows/amd64", true},
+		{"too few segments", "myplugin/1.0.0/linux-amd64", "", "", "", false},
+		{"too many segments", "a/b/c/d/e/f", "", "", "", false},
+		{"binary mismatch", "myplugin/1.0.0/linux-amd64/other", "", "", "", false},
+		{"no dash in platform", "myplugin/1.0.0/linuxamd64/myplugin", "", "", "", false},
+		{"dash at start", "myplugin/1.0.0/-amd64/myplugin", "", "", "", false},
+		{"dash at end", "myplugin/1.0.0/linux-/myplugin", "", "", "", false},
+		// 5-segment paths with registry hash.
+		{"valid with registry hash", "aws-provider/a1b2c3d4e5f67890/1.5.3/darwin-arm64/aws-provider", "aws-provider/a1b2c3d4e5f67890", "1.5.3", "darwin/arm64", true},
+		{"valid with registry hash windows", "myplugin/deadbeef01234567/2.0.0/windows-amd64/myplugin.exe", "myplugin/deadbeef01234567", "2.0.0", "windows/amd64", true},
+		{"5-segment binary mismatch", "myplugin/hash123/1.0.0/linux-amd64/other", "", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, ver, plat, ok := parseRelativePath(tt.path)
+			assert.Equal(t, tt.wantOk, ok)
+			if ok {
+				assert.Equal(t, tt.wantName, name)
+				assert.Equal(t, tt.wantVer, ver)
+				assert.Equal(t, tt.wantPlat, plat)
+			}
+		})
+	}
+}
+
+func TestCache_WarmUp(t *testing.T) {
+	t.Run("populates index from existing files", func(t *testing.T) {
+		dir := t.TempDir()
+
+		// Pre-create plugin files on disk matching the expected layout.
+		files := map[string][]byte{
+			"plugin-a/1.0.0/linux-amd64/plugin-a":                  []byte("binary-a-1.0"),
+			"plugin-a/2.0.0/linux-amd64/plugin-a":                  []byte("binary-a-2.0"),
+			"plugin-b/0.5.0/darwin-arm64/plugin-b":                 []byte("binary-b-0.5"),
+			"plugin-c/a1b2c3d4e5f67890/1.0.0/linux-amd64/plugin-c": []byte("binary-c-1.0-reg"),
+			"plugin-c/a1b2c3d4e5f67890/2.0.0/linux-amd64/plugin-c": []byte("binary-c-2.0-reg"),
+		}
+		for path, data := range files {
+			full := filepath.Join(dir, filepath.FromSlash(path))
+			require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+			require.NoError(t, os.WriteFile(full, data, 0o755))
+		}
+
+		// Create cache and warm up.
+		vc, err := New(dir, 4096)
+		require.NoError(t, err)
+		require.NoError(t, vc.WarmUp())
+
+		// Version index should be populated.
+		ver, ok := vc.Latest("plugin-a", "linux/amd64")
+		require.True(t, ok)
+		assert.Equal(t, "2.0.0", ver)
+
+		ver, ok = vc.Latest("plugin-b", "darwin/arm64")
+		require.True(t, ok)
+		assert.Equal(t, "0.5.0", ver)
+
+		versions := vc.Versions("plugin-a", "linux/amd64")
+		assert.Equal(t, []string{"2.0.0", "1.0.0"}, versions)
+
+		// Pin should work (file adopted into diskcache).
+		path, release, ok := vc.Pin("plugin-a", "2.0.0", "linux/amd64")
+		require.True(t, ok)
+		defer release()
+		content, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("binary-a-2.0"), content)
+
+		// Registry-hash composite name should also be indexed.
+		ver, ok = vc.Latest("plugin-c/a1b2c3d4e5f67890", "linux/amd64")
+		require.True(t, ok)
+		assert.Equal(t, "2.0.0", ver)
+
+		regVersions := vc.Versions("plugin-c/a1b2c3d4e5f67890", "linux/amd64")
+		assert.Equal(t, []string{"2.0.0", "1.0.0"}, regVersions)
+	})
+
+	t.Run("skips non-matching files", func(t *testing.T) {
+		dir := t.TempDir()
+
+		// Create a file that doesn't match the plugin layout.
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "random"), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "random", "file.txt"), []byte("junk"), 0o644))
+
+		vc, err := New(dir, 1024)
+		require.NoError(t, err)
+		require.NoError(t, vc.WarmUp())
+
+		// No versions indexed.
+		_, ok := vc.Latest("random", "linux/amd64")
+		assert.False(t, ok)
+	})
+
+	t.Run("empty directory", func(t *testing.T) {
+		vc := newTestCache(t, 1024)
+		require.NoError(t, vc.WarmUp())
+		_, ok := vc.Latest("anything", "linux/amd64")
+		assert.False(t, ok)
+	})
+
+	t.Run("over budget after warmup converges on next Set", func(t *testing.T) {
+		dir := t.TempDir()
+
+		// Create 20 bytes of plugins with maxSize=15.
+		files := map[string][]byte{
+			"p/1.0.0/linux-amd64/p": []byte("0123456789"), // 10 bytes
+			"p/2.0.0/linux-amd64/p": []byte("0123456789"), // 10 bytes
+		}
+		for path, data := range files {
+			full := filepath.Join(dir, filepath.FromSlash(path))
+			require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+			require.NoError(t, os.WriteFile(full, data, 0o755))
+		}
+
+		vc, err := New(dir, 15)
+		require.NoError(t, err)
+		require.NoError(t, vc.WarmUp())
+
+		// Both versions are tracked (temporarily over budget).
+		versions := vc.Versions("p", "linux/amd64")
+		assert.Equal(t, []string{"2.0.0", "1.0.0"}, versions)
+
+		// A new Set triggers eviction of the oldest.
+		require.NoError(t, vc.Set("p", "3.0.0", "linux/amd64", []byte("new")))
+
+		// v1 should be evicted, v2 and v3 remain.
+		versions = vc.Versions("p", "linux/amd64")
+		assert.Contains(t, versions, "3.0.0")
+		assert.Contains(t, versions, "2.0.0")
+		assert.NotContains(t, versions, "1.0.0")
+	})
+}

--- a/pkg/catalog/chain_builder.go
+++ b/pkg/catalog/chain_builder.go
@@ -199,7 +199,6 @@ func BuildRemoteCatalogChain(cfg *config.Config, authRegistry *auth.Registry, lo
 	if len(catalogs) == 0 {
 		return nil, fmt.Errorf("no remote catalogs available")
 	}
-
 	return NewChainCatalog(logger, catalogs...)
 }
 

--- a/pkg/cmd/scafctl/auth/handlers_install_test.go
+++ b/pkg/cmd/scafctl/auth/handlers_install_test.go
@@ -74,12 +74,12 @@ func TestCommandHandlersInstall_AlreadyCached(t *testing.T) {
 	cliParams.BinaryName = "testcli"
 
 	// Create the binary at the exact path the cache will look for:
-	// $XDG_CACHE_HOME/testcli/plugins/<cacheKey>/<version>/<platformCacheKey>/<cacheKey>
-	cacheKey := plugin.PluginCacheKey("github", solution.PluginKindAuthHandler)
+	// $XDG_CACHE_HOME/testcli/plugins/<cacheName>/<version>/<platformCacheKey>/<cacheName>
+	cacheName := plugin.PluginCacheKey("github", solution.PluginKindAuthHandler)
 	platform := plugin.CurrentPlatform()
-	binDir := filepath.Join(xdgCache, "testcli", "plugins", cacheKey, "1.0.0", plugin.PlatformCacheKey(platform))
+	binDir := filepath.Join(xdgCache, "testcli", "plugins", cacheName, "1.0.0", plugin.PlatformCacheKey(platform))
 	require.NoError(t, os.MkdirAll(binDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(binDir, cacheKey), []byte("fake"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, cacheName), []byte("fake"), 0o755))
 
 	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
 
@@ -123,11 +123,11 @@ func TestCommandHandlersInstall_ForceBypassesCache(t *testing.T) {
 	cliParams := settings.NewCliParams()
 	cliParams.BinaryName = "testcli"
 
-	cacheKey := plugin.PluginCacheKey("github", solution.PluginKindAuthHandler)
+	cacheName := plugin.PluginCacheKey("github", solution.PluginKindAuthHandler)
 	platform := plugin.CurrentPlatform()
-	binDir := filepath.Join(xdgCache, "testcli", "plugins", cacheKey, "1.0.0", plugin.PlatformCacheKey(platform))
+	binDir := filepath.Join(xdgCache, "testcli", "plugins", cacheName, "1.0.0", plugin.PlatformCacheKey(platform))
 	require.NoError(t, os.MkdirAll(binDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(binDir, cacheKey), []byte("fake"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, cacheName), []byte("fake"), 0o755))
 
 	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
 

--- a/pkg/cmd/scafctl/serve/serve.go
+++ b/pkg/cmd/scafctl/serve/serve.go
@@ -25,6 +25,7 @@ import (
 	sidregistry "github.com/oakwood-commons/scafctl/pkg/serveridentity/registry"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/builder"
 	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/tokenprovider"
@@ -177,14 +178,31 @@ func runServe(ctx context.Context, opts *Options) error {
 	} else {
 		officialReg = official.NewRegistry()
 	}
-
 	// Build plugin fetcher for auto-fetching plugin binaries from catalogs.
 	// Chain construction respects catalog and per-catalog artifact allowlists.
 	var pluginFetcher *plugin.Fetcher
+	var pluginCache *plugin.Cache
+	if !cfg.APIServer.Plugins.DisableDiskCache {
+		cacheMaxSize, sizeErr := pluginCacheMaxSize(cfg)
+		if sizeErr != nil {
+			return fmt.Errorf("invalid plugin cache size: %w", sizeErr)
+		}
+		mc, cacheErr := plugin.NewManagedCache(settings.PluginCacheDirFor(opts.CliParams.BinaryName), cacheMaxSize)
+		if cacheErr != nil {
+			lgr.V(1).Info("managed plugin cache unavailable, falling back to unbounded", "error", cacheErr)
+		} else {
+			if warmErr := mc.WarmUp(); warmErr != nil {
+				lgr.V(1).Info("plugin cache warm-up failed", "error", warmErr)
+			}
+			pluginCache = mc
+		}
+	}
 	if fetcher, fetchErr := prepare.BuildPluginFetcherWithConfig(ctx, prepare.PluginFetcherOverrides{
 		AllowedCatalogs:      catalogNames,
 		ChainAllowedCatalogs: catalogNames,
 		PerCatalogArtifacts:  perCatalog,
+		Cache:                pluginCache,
+		NoCache:              cfg.APIServer.Plugins.DisableDiskCache,
 	}); fetchErr == nil {
 		pluginFetcher = fetcher
 	} else {
@@ -266,6 +284,16 @@ func populateCatalogPolicies(catalogNames []string, perCatalog map[string]catalo
 		}
 	}
 	return perCatalog
+}
+
+// pluginCacheMaxSize returns the configured plugin cache size in bytes.
+// Falls back to settings.DefaultPluginCacheMaxSize when the config field is empty.
+func pluginCacheMaxSize(cfg *config.Config) (int64, error) {
+	raw := cfg.APIServer.Plugins.DiskCacheMaxSize
+	if raw == "" {
+		raw = settings.DefaultPluginCacheMaxSize
+	}
+	return builder.ParseByteSize(raw)
 }
 
 func configurePreloadOptions(perCatalog map[string]catalog.PluginPolicy, preloadOpts []PreLoadOption, catalogName string) []PreLoadOption {
@@ -351,8 +379,19 @@ func preloadOfficialProviders(
 		}
 		lgr.V(0).Info("pre-loading official providers for API server", "providers", names)
 	}
-
+	start := time.Now()
 	fetchResults, fetchErr := fetcher.FetchPlugins(ctx, deps, nil)
+	lgr.V(1).Info("official provider fetch complete", "duration", time.Since(start).String(), "success", fetchErr == nil)
+	// Release cache pins — once RegisterFetchedPlugins execs each binary,
+	// the OS has it mapped in memory and the on-disk file can be evicted.
+	// Placed before the error check so partial results are released on failure.
+	defer func() {
+		for i := range fetchResults {
+			if fetchResults[i].Release != nil {
+				fetchResults[i].Release()
+			}
+		}
+	}()
 	if fetchErr != nil {
 		return nil, fmt.Errorf("fetching official providers: %w", fetchErr)
 	}

--- a/pkg/cmd/scafctl/serve/serve_test.go
+++ b/pkg/cmd/scafctl/serve/serve_test.go
@@ -385,3 +385,53 @@ func TestConfigurePreloadOptions(t *testing.T) {
 		})
 	}
 }
+
+func TestPluginCacheMaxSize(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int64
+		wantErr bool
+	}{
+		{
+			name:  "empty uses default",
+			input: "",
+			want:  512 * 1024 * 1024,
+		},
+		{
+			name:  "explicit MB",
+			input: "256MB",
+			want:  256 * 1024 * 1024,
+		},
+		{
+			name:  "explicit GB",
+			input: "2GB",
+			want:  2 * 1024 * 1024 * 1024,
+		},
+		{
+			name:  "lowercase",
+			input: "128mb",
+			want:  128 * 1024 * 1024,
+		},
+		{
+			name:    "invalid string",
+			input:   "not-a-size",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.APIServer.Plugins.DiskCacheMaxSize = tt.input
+
+			got, err := pluginCacheMaxSize(cfg)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -725,6 +725,13 @@ type APIPluginConfig struct {
 	// fetched from. Catalog names are matched against catalog config entries.
 	// Empty means all configured catalogs are permitted.
 	AllowedCatalogs []string `json:"allowedCatalogs,omitempty" yaml:"allowedCatalogs,omitempty" mapstructure:"allowedCatalogs" doc:"Catalog name allowlist for plugin fetches (empty = allow all configured catalogs)" maxItems:"50"`
+
+	DisableDiskCache bool `json:"disableDiskCache,omitempty" yaml:"disableDiskCache,omitempty" mapstructure:"disableDiskCache" doc:"Disable disk caching for plugins loaded via the API (default: false)"`
+
+	// DiskCacheMaxSize is the maximum total size for the managed plugin disk cache.
+	// Accepts human-readable byte strings (e.g., "512MB", "1GB").
+	// When empty, defaults to settings.DefaultPluginCacheMaxSize (512MB).
+	DiskCacheMaxSize string `json:"diskCacheMaxSize,omitempty" yaml:"diskCacheMaxSize,omitempty" mapstructure:"diskCacheMaxSize" doc:"Maximum size for the plugin binary disk cache (e.g., '512MB', '1GB')" example:"512MB" maxLength:"20"`
 }
 
 // APITLSConfig holds TLS configuration for the API server.

--- a/pkg/plugin/cache.go
+++ b/pkg/plugin/cache.go
@@ -9,29 +9,67 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/cespare/xxhash/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cache/diskcache"
+	"github.com/oakwood-commons/scafctl/pkg/cache/versionedcache"
 	"github.com/oakwood-commons/scafctl/pkg/paths"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
 
-// PluginCache manages a local content-addressed cache of plugin binaries.
+// registryHashPattern matches a 16-character lowercase hex string used as
+// the registry hash directory level. Used to disambiguate registry-hash
+// subdirs from version subdirs when scanning <name>/ contents.
+var registryHashPattern = regexp.MustCompile(`^[0-9a-f]{16}$`)
+
+// Cache manages a local content-addressed cache of plugin binaries.
 //
-// Cache layout:
+// Cache layout (with optional registry hash):
 //
-//	<cacheDir>/<name>/<version>/<os>-<arch>/<name>[.exe]
+//	<cacheDir>/<name>/[<registryHash>/]<version>/<os>-<arch>/<name>[.exe]
 //
+// The registry hash directory level is present only when a plugin is fetched
+// from a catalog. Plugins installed without a catalog omit it.
 // On Windows platforms, the binary has a ".exe" extension.
 //
 // Example:
 //
-//	~/.cache/scafctl/plugins/aws-provider/1.5.3/darwin-arm64/aws-provider
-//	~/.cache/scafctl/plugins/aws-provider/1.5.3/windows-amd64/aws-provider.exe
+//	~/.cache/scafctl/plugins/aws-provider/a1b2c3d4e5f67890/1.5.3/darwin-arm64/aws-provider
+//	~/.cache/scafctl/plugins/my-local-plugin/1.0.0/darwin-arm64/my-local-plugin
 type Cache struct {
 	// dir is the root directory for cached plugin binaries.
 	dir string
+	// managed is the bounded LRU cache with pinning (API server mode).
+	// When nil, the cache operates in unbounded CLI mode.
+	managed *versionedcache.Cache
+}
+
+// CacheOption configures cache operations.
+type CacheOption func(*cacheOpts)
+
+type cacheOpts struct {
+	registryHash string
+}
+
+func applyCacheOpts(opts []CacheOption) cacheOpts {
+	var o cacheOpts
+	for _, opt := range opts {
+		opt(&o)
+	}
+	return o
+}
+
+// WithRegistryHash sets the registry hash directory level for cache lookups.
+// When the hash is empty, this option is a no-op (no registry level is used).
+func WithRegistryHash(hash string) CacheOption {
+	return func(o *cacheOpts) {
+		o.registryHash = hash
+	}
 }
 
 // NewCache creates a new Cache. If cacheDir is empty,
@@ -43,16 +81,64 @@ func NewCache(cacheDir string) *Cache {
 	return &Cache{dir: cacheDir}
 }
 
+// NewManagedCache creates a Cache backed by a bounded LRU with pinning.
+// This is intended for API server mode where concurrent access and eviction
+// control are required. maxSize is the total byte budget for cached binaries.
+// cacheDir should be derived from settings.PluginCacheDirFor(binaryName) to
+// ensure embedders with custom binary names get isolated cache directories.
+func NewManagedCache(cacheDir string, maxSize int64) (*Cache, error) {
+	if cacheDir == "" {
+		cacheDir = settings.PluginCacheDirFor(settings.CliBinaryName)
+	}
+	vc, err := versionedcache.New(cacheDir, maxSize,
+		diskcache.WithFileMode(0o755),
+		diskcache.WithHashFunc(xxhashSum),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating managed plugin cache: %w", err)
+	}
+	return &Cache{dir: cacheDir, managed: vc}, nil
+}
+
 // Dir returns the root cache directory.
 func (c *Cache) Dir() string {
 	return c.dir
 }
 
+// Pin marks a cached plugin binary as in-use and returns its path.
+// The entry cannot be evicted until the returned release function is called.
+// In CLI mode (unbounded), Pin stats the file and returns a no-op release.
+func (c *Cache) Pin(name, version, platform string, opts ...CacheOption) (path string, release func(), ok bool) {
+	o := applyCacheOpts(opts)
+	if c.managed != nil {
+		mn := managedName(name, o.registryHash)
+		return c.managed.Pin(mn, version, platform)
+	}
+	p := c.binaryPath(name, version, platform, o.registryHash)
+	if _, err := os.Stat(p); err != nil {
+		return "", nil, false
+	}
+	return p, func() {}, true
+}
+
+// WarmUp scans the cache directory and populates the LRU and version index.
+// No-op in CLI mode (unbounded cache).
+func (c *Cache) WarmUp() error {
+	if c.managed != nil {
+		return c.managed.WarmUp()
+	}
+	return nil
+}
+
 // Get retrieves the path to a cached plugin binary. Returns the path and
 // true if the binary exists and (optionally) matches the expected digest.
 // If expectedDigest is empty, no digest verification is performed.
-func (c *Cache) Get(name, version, platform, expectedDigest string) (string, bool) {
-	p := c.binaryPath(name, version, platform)
+func (c *Cache) Get(name, version, platform, expectedDigest string, opts ...CacheOption) (string, bool) {
+	o := applyCacheOpts(opts)
+	if c.managed != nil {
+		return c.getManaged(name, version, platform, expectedDigest, o.registryHash)
+	}
+	p := c.binaryPath(name, version, platform, o.registryHash)
 
 	info, err := os.Stat(p)
 	if err != nil || info.IsDir() {
@@ -60,7 +146,7 @@ func (c *Cache) Get(name, version, platform, expectedDigest string) (string, boo
 		// Only attempt migration when the new path genuinely doesn't exist (not for
 		// permission errors or other transient failures).
 		if platformIsWindows(platform) && os.IsNotExist(err) {
-			legacy := c.legacyBinaryPath(name, version, platform)
+			legacy := c.legacyBinaryPath(name, version, platform, o.registryHash)
 			if li, lerr := os.Stat(legacy); lerr == nil && !li.IsDir() {
 				// Rename legacy binary to new .exe path for future lookups.
 				if mkErr := os.MkdirAll(filepath.Dir(p), 0o755); mkErr != nil {
@@ -99,29 +185,71 @@ func (c *Cache) Get(name, version, platform, expectedDigest string) (string, boo
 }
 
 // GetLatestCached returns the path to the newest cached binary for the given
-// name and platform, regardless of version. Returns empty string and false if
-// nothing is cached. This is used as a fallback when catalog version resolution
-// fails (e.g., when running offline).
-func (c *Cache) GetLatestCached(name, platform string) (string, string, bool) {
-	entries, err := os.ReadDir(filepath.Join(c.dir, name))
-	if err != nil {
-		return "", "", false
+// name and platform, regardless of version. When WithRegistryHash is provided,
+// only that registry's versions are searched. Otherwise, all versions across
+// all registry hashes (and the no-registry path) are considered.
+// Returns empty string and false if nothing is cached.
+func (c *Cache) GetLatestCached(name, platform string, opts ...CacheOption) (string, string, bool) {
+	o := applyCacheOpts(opts)
+	if c.managed != nil {
+		return c.getLatestCachedManaged(name, platform, o.registryHash)
+	}
+
+	// Collect version directories to scan.
+	type versionDir struct {
+		version      string
+		registryHash string
+	}
+	var versionDirs []versionDir
+
+	if o.registryHash != "" {
+		// Specific registry hash — scan only that subdir.
+		entries, err := os.ReadDir(filepath.Join(c.dir, name, o.registryHash))
+		if err == nil {
+			for _, e := range entries {
+				if e.IsDir() {
+					versionDirs = append(versionDirs, versionDir{version: e.Name(), registryHash: o.registryHash})
+				}
+			}
+		}
+	} else {
+		// No specific registry hash — scan <name>/ and distinguish hash dirs from version dirs.
+		entries, err := os.ReadDir(filepath.Join(c.dir, name))
+		if err != nil {
+			return "", "", false
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+			dirName := entry.Name()
+			if registryHashPattern.MatchString(dirName) {
+				// This is a registry hash dir — scan its version subdirs.
+				subEntries, err := os.ReadDir(filepath.Join(c.dir, name, dirName))
+				if err != nil {
+					continue
+				}
+				for _, se := range subEntries {
+					if se.IsDir() {
+						versionDirs = append(versionDirs, versionDir{version: se.Name(), registryHash: dirName})
+					}
+				}
+			} else {
+				// Not a hash — treat as a direct version dir (no-registry path).
+				versionDirs = append(versionDirs, versionDir{version: dirName, registryHash: ""})
+			}
+		}
 	}
 
 	var bestSemver *semver.Version
 	var bestVersion string
 	var bestPath string
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		v := entry.Name()
-		p := c.binaryPath(name, v, platform)
+	for _, vd := range versionDirs {
+		p := c.binaryPath(name, vd.version, platform, vd.registryHash)
 		info, err := os.Stat(p)
 		if err != nil || info.IsDir() {
-			// Migration fallback: check legacy path without .exe for older Windows caches.
 			if platformIsWindows(platform) && os.IsNotExist(err) {
-				legacy := c.legacyBinaryPath(name, v, platform)
+				legacy := c.legacyBinaryPath(name, vd.version, platform, vd.registryHash)
 				if li, lerr := os.Stat(legacy); lerr == nil && !li.IsDir() {
 					if mkErr := os.MkdirAll(filepath.Dir(p), 0o755); mkErr == nil {
 						if os.Rename(legacy, p) == nil {
@@ -142,18 +270,18 @@ func (c *Cache) GetLatestCached(name, platform string) (string, string, bool) {
 		if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
 			continue
 		}
-		parsed, parseErr := semver.NewVersion(v)
+		parsed, parseErr := semver.NewVersion(vd.version)
 		if parseErr != nil {
 			// Not a valid semver directory — use lexicographic fallback.
-			if bestSemver == nil && (bestVersion == "" || v > bestVersion) {
-				bestVersion = v
+			if bestSemver == nil && (bestVersion == "" || vd.version > bestVersion) {
+				bestVersion = vd.version
 				bestPath = p
 			}
 			continue
 		}
 		if bestSemver == nil || parsed.GreaterThan(bestSemver) {
 			bestSemver = parsed
-			bestVersion = v
+			bestVersion = vd.version
 			bestPath = p
 		}
 	}
@@ -167,8 +295,12 @@ func (c *Cache) GetLatestCached(name, platform string) (string, string, bool) {
 // Put writes a plugin binary to the cache. It creates the directory
 // structure, writes the data, sets executable permissions, and returns
 // the path to the cached binary.
-func (c *Cache) Put(name, version, platform string, data []byte) (string, error) {
-	p := c.binaryPath(name, version, platform)
+func (c *Cache) Put(name, version, platform string, data []byte, opts ...CacheOption) (string, error) {
+	o := applyCacheOpts(opts)
+	if c.managed != nil {
+		return c.putManaged(name, version, platform, o.registryHash, data)
+	}
+	p := c.binaryPath(name, version, platform, o.registryHash)
 
 	dir := filepath.Dir(p)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -229,17 +361,25 @@ func (c *Cache) Put(name, version, platform string, data []byte) (string, error)
 }
 
 // Digest computes the sha256 digest of a cached plugin binary.
-// Returns the digest in "sha256:<hex>" format.
-func (c *Cache) Digest(name, version, platform string) (string, error) {
-	return fileDigest(c.binaryPath(name, version, platform))
+// Returns the digest in \"sha256:<hex>\" format.
+func (c *Cache) Digest(name, version, platform string, opts ...CacheOption) (string, error) {
+	o := applyCacheOpts(opts)
+	return fileDigest(c.binaryPath(name, version, platform, o.registryHash))
 }
 
 // Remove deletes a cached plugin binary.
-func (c *Cache) Remove(name, version, platform string) error {
-	return os.RemoveAll(filepath.Dir(c.binaryPath(name, version, platform)))
+func (c *Cache) Remove(name, version, platform string, opts ...CacheOption) error {
+	o := applyCacheOpts(opts)
+	if c.managed != nil {
+		mn := managedName(name, o.registryHash)
+		c.managed.Delete(mn, version, platform)
+		return nil
+	}
+	return os.RemoveAll(filepath.Dir(c.binaryPath(name, version, platform, o.registryHash)))
 }
 
 // List returns all cached (name, version, platform) triples.
+// It handles both layouts: with and without a registry hash directory level.
 func (c *Cache) List() ([]CachedPlugin, error) {
 	var results []CachedPlugin
 
@@ -263,37 +403,33 @@ func (c *Cache) List() ([]CachedPlugin, error) {
 		if !nameEntry.IsDir() {
 			continue
 		}
-		versions, err := os.ReadDir(filepath.Join(c.dir, nameEntry.Name()))
+		pluginName := nameEntry.Name()
+		subEntries, err := os.ReadDir(filepath.Join(c.dir, pluginName))
 		if err != nil {
 			continue
 		}
-		for _, versionEntry := range versions {
-			if !versionEntry.IsDir() {
+
+		for _, subEntry := range subEntries {
+			if !subEntry.IsDir() {
 				continue
 			}
-			platforms, err := os.ReadDir(filepath.Join(c.dir, nameEntry.Name(), versionEntry.Name()))
-			if err != nil {
-				continue
-			}
-			for _, platformEntry := range platforms {
-				if !platformEntry.IsDir() {
+
+			if registryHashPattern.MatchString(subEntry.Name()) {
+				// Registry hash dir — versions are one level deeper.
+				regHash := subEntry.Name()
+				versionEntries, err := os.ReadDir(filepath.Join(c.dir, pluginName, regHash))
+				if err != nil {
 					continue
 				}
-				platform := strings.ReplaceAll(platformEntry.Name(), "-", "/")
-				bin := nameEntry.Name()
-				if platformIsWindows(platform) {
-					bin += ".exe"
+				for _, vEntry := range versionEntries {
+					if !vEntry.IsDir() {
+						continue
+					}
+					results = append(results, c.listPlatforms(pluginName, vEntry.Name(), regHash)...)
 				}
-				binaryPath := filepath.Join(c.dir, nameEntry.Name(), versionEntry.Name(), platformEntry.Name(), bin)
-				if info, err := os.Stat(binaryPath); err == nil && !info.IsDir() {
-					results = append(results, CachedPlugin{
-						Name:     nameEntry.Name(),
-						Version:  versionEntry.Name(),
-						Platform: platform,
-						Path:     binaryPath,
-						Size:     info.Size(),
-					})
-				}
+			} else {
+				// No registry hash — subEntry is a version dir directly.
+				results = append(results, c.listPlatforms(pluginName, subEntry.Name(), "")...)
 			}
 		}
 	}
@@ -301,13 +437,53 @@ func (c *Cache) List() ([]CachedPlugin, error) {
 	return results, nil
 }
 
+// listPlatforms scans platform subdirs under a version directory and returns matching CachedPlugin entries.
+func (c *Cache) listPlatforms(name, version, registryHash string) []CachedPlugin {
+	var baseDir string
+	if registryHash != "" {
+		baseDir = filepath.Join(c.dir, name, registryHash, version)
+	} else {
+		baseDir = filepath.Join(c.dir, name, version)
+	}
+
+	platforms, err := os.ReadDir(baseDir)
+	if err != nil {
+		return nil
+	}
+
+	var results []CachedPlugin
+	for _, platformEntry := range platforms {
+		if !platformEntry.IsDir() {
+			continue
+		}
+		platform := strings.ReplaceAll(platformEntry.Name(), "-", "/")
+		bin := name
+		if platformIsWindows(platform) {
+			bin += ".exe"
+		}
+		binaryPath := filepath.Join(baseDir, platformEntry.Name(), bin)
+		if info, err := os.Stat(binaryPath); err == nil && !info.IsDir() {
+			results = append(results, CachedPlugin{
+				Name:         name,
+				Version:      version,
+				Platform:     platform,
+				Path:         binaryPath,
+				Size:         info.Size(),
+				RegistryHash: registryHash,
+			})
+		}
+	}
+	return results
+}
+
 // CachedPlugin describes a cached plugin binary.
 type CachedPlugin struct {
-	Name     string `json:"name" yaml:"name" doc:"Plugin name"`
-	Version  string `json:"version" yaml:"version" doc:"Plugin version"`
-	Platform string `json:"platform" yaml:"platform" doc:"Target platform (os/arch)"`
-	Path     string `json:"path" yaml:"path" doc:"Absolute path to cached binary"`
-	Size     int64  `json:"size" yaml:"size" doc:"Binary size in bytes"`
+	Name         string `json:"name" yaml:"name" doc:"Plugin name"`
+	Version      string `json:"version" yaml:"version" doc:"Plugin version"`
+	Platform     string `json:"platform" yaml:"platform" doc:"Target platform (os/arch)"`
+	Path         string `json:"path" yaml:"path" doc:"Absolute path to cached binary"`
+	Size         int64  `json:"size" yaml:"size" doc:"Binary size in bytes"`
+	RegistryHash string `json:"registryHash,omitempty" yaml:"registryHash,omitempty" doc:"Registry hash directory (empty for local installs)"`
 }
 
 // GetLatestBinary returns the path to the newest cached binary for the given
@@ -364,17 +540,24 @@ func (c *Cache) ListCurrentPlatform() ([]CachedPlugin, error) {
 }
 
 // binaryPath returns the expected path for a cached plugin binary.
+// When registryHash is non-empty, it is inserted as a directory level between name and version.
 // On Windows platforms, the binary name gets a ".exe" extension.
-func (c *Cache) binaryPath(name, version, platform string) string {
+func (c *Cache) binaryPath(name, version, platform, registryHash string) string {
 	bin := name
 	if platformIsWindows(platform) {
 		bin += ".exe"
+	}
+	if registryHash != "" {
+		return filepath.Join(c.dir, name, registryHash, version, PlatformCacheKey(platform), bin)
 	}
 	return filepath.Join(c.dir, name, version, PlatformCacheKey(platform), bin)
 }
 
 // legacyBinaryPath returns the pre-fix path without .exe extension (used for migration).
-func (c *Cache) legacyBinaryPath(name, version, platform string) string {
+func (c *Cache) legacyBinaryPath(name, version, platform, registryHash string) string {
+	if registryHash != "" {
+		return filepath.Join(c.dir, name, registryHash, version, PlatformCacheKey(platform), name)
+	}
 	return filepath.Join(c.dir, name, version, PlatformCacheKey(platform), name)
 }
 
@@ -391,4 +574,137 @@ func fileDigest(path string) (string, error) {
 	}
 	sum := sha256.Sum256(data)
 	return fmt.Sprintf("sha256:%x", sum), nil
+}
+
+// --- Managed mode helpers ---
+
+// xxhashSum computes a non-cryptographic xxHash64 digest for content-dedup.
+// Used by the managed cache to skip redundant disk writes when the binary
+// content has not changed (e.g., re-fetching the same version in enforce mode).
+func xxhashSum(data []byte) (uint64, error) {
+	return xxhash.Sum64(data), nil
+}
+
+// managedName builds the composite name passed to versionedcache.
+// When registryHash is non-empty, the name becomes "name/registryHash"
+// so the versionedcache builds a path with the registry hash directory level.
+func managedName(name, registryHash string) string {
+	if registryHash != "" {
+		return name + "/" + registryHash
+	}
+	return name
+}
+
+// getManaged handles Get() in managed (API server) mode.
+// It uses Pin to verify the entry exists and checks the digest.
+// The pin is released immediately — Get does not hold entries.
+func (c *Cache) getManaged(name, version, platform, expectedDigest, registryHash string) (string, bool) {
+	mn := managedName(name, registryHash)
+	path, release, ok := c.managed.Pin(mn, version, platform)
+	if !ok {
+		return "", false
+	}
+	defer release()
+
+	if expectedDigest != "" {
+		actual, err := fileDigest(path)
+		if err != nil {
+			return "", false
+		}
+		if actual != expectedDigest {
+			return "", false
+		}
+	}
+	return path, true
+}
+
+// GetPin retrieves a cached plugin binary and pins it to prevent eviction.
+// The caller must call release() when done with the binary.
+// In CLI mode (unbounded), the release function is a no-op.
+// This is the atomic alternative to Get()+Pin() which has a TOCTOU gap.
+func (c *Cache) GetPin(name, version, platform, expectedDigest string, opts ...CacheOption) (string, func(), bool) {
+	o := applyCacheOpts(opts)
+	if c.managed != nil {
+		mn := managedName(name, o.registryHash)
+		path, release, ok := c.managed.Pin(mn, version, platform)
+		if !ok {
+			return "", nil, false
+		}
+		if expectedDigest != "" {
+			actual, err := fileDigest(path)
+			if err != nil || actual != expectedDigest {
+				release()
+				return "", nil, false
+			}
+		}
+		return path, release, true
+	}
+	path, ok := c.Get(name, version, platform, expectedDigest, opts...)
+	if !ok {
+		return "", nil, false
+	}
+	return path, func() {}, true
+}
+
+// GetLatestCachedPin returns the newest cached binary and pins it.
+// The caller must call release() when done with the binary.
+// This is the atomic alternative to GetLatestCached()+Pin().
+func (c *Cache) GetLatestCachedPin(name, platform string, opts ...CacheOption) (string, string, func(), bool) {
+	o := applyCacheOpts(opts)
+	if c.managed != nil {
+		mn := managedName(name, o.registryHash)
+		version, ok := c.managed.Latest(mn, platform)
+		if !ok {
+			return "", "", nil, false
+		}
+		path, release, ok := c.managed.Pin(mn, version, platform)
+		if !ok {
+			return "", "", nil, false
+		}
+		return path, version, release, true
+	}
+	path, version, ok := c.GetLatestCached(name, platform, opts...)
+	if !ok {
+		return "", "", nil, false
+	}
+	return path, version, func() {}, true
+}
+
+// getLatestCachedManaged handles GetLatestCached() in managed mode.
+func (c *Cache) getLatestCachedManaged(name, platform, registryHash string) (string, string, bool) {
+	mn := managedName(name, registryHash)
+	version, ok := c.managed.Latest(mn, platform)
+	if !ok {
+		return "", "", false
+	}
+	p := c.binaryPath(name, version, platform, registryHash)
+	if _, err := os.Stat(p); err != nil {
+		return "", "", false
+	}
+	return p, version, true
+}
+
+// putManaged handles Put() in managed mode.
+// Delegates to the versioned cache which handles atomic writes and file mode.
+func (c *Cache) putManaged(name, version, platform, registryHash string, data []byte) (string, error) {
+	mn := managedName(name, registryHash)
+	if err := c.managed.Set(mn, version, platform, data); err != nil {
+		return "", err
+	}
+	return c.binaryPath(name, version, platform, registryHash), nil
+}
+
+// SetPin writes a plugin binary and pins it atomically to prevent eviction
+// between write and use. In CLI mode (unbounded), behaves like Put with a no-op release.
+func (c *Cache) SetPin(name, version, platform string, data []byte, opts ...CacheOption) (string, func(), error) {
+	o := applyCacheOpts(opts)
+	if c.managed != nil {
+		mn := managedName(name, o.registryHash)
+		return c.managed.SetPin(mn, version, platform, data)
+	}
+	path, err := c.Put(name, version, platform, data, opts...)
+	if err != nil {
+		return "", nil, err
+	}
+	return path, func() {}, nil
 }

--- a/pkg/plugin/cache_test.go
+++ b/pkg/plugin/cache_test.go
@@ -4,6 +4,7 @@
 package plugin
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -117,15 +118,15 @@ func TestCache_BinaryPath_WindowsExeExtension(t *testing.T) {
 	cache := NewCache("/tmp/plugins")
 
 	// Windows platform should get .exe extension
-	winPath := cache.binaryPath("myplugin", "1.0.0", "windows/amd64")
+	winPath := cache.binaryPath("myplugin", "1.0.0", "windows/amd64", "")
 	assert.Equal(t, "myplugin.exe", filepath.Base(winPath))
 
 	// Linux platform should NOT get .exe extension
-	linuxPath := cache.binaryPath("myplugin", "1.0.0", "linux/amd64")
+	linuxPath := cache.binaryPath("myplugin", "1.0.0", "linux/amd64", "")
 	assert.Equal(t, "myplugin", filepath.Base(linuxPath))
 
 	// Darwin platform should NOT get .exe extension
-	darwinPath := cache.binaryPath("myplugin", "1.0.0", "darwin/arm64")
+	darwinPath := cache.binaryPath("myplugin", "1.0.0", "darwin/arm64", "")
 	assert.Equal(t, "myplugin", filepath.Base(darwinPath))
 }
 
@@ -224,7 +225,7 @@ func TestCache_Put_RenameRetryAfterConflictingPath(t *testing.T) {
 	version := "1.0.0"
 	platform := "windows/amd64"
 
-	binaryPath := cache.binaryPath(name, version, platform)
+	binaryPath := cache.binaryPath(name, version, platform, "")
 	require.NoError(t, os.MkdirAll(binaryPath, 0o755))
 
 	data := []byte("fresh-binary")
@@ -245,7 +246,7 @@ func TestCache_Put_RenameFailsWhenDestinationIsNonEmptyDir(t *testing.T) {
 	version := "1.0.0"
 	platform := "windows/amd64"
 
-	binaryPath := cache.binaryPath(name, version, platform)
+	binaryPath := cache.binaryPath(name, version, platform, "")
 	require.NoError(t, os.MkdirAll(binaryPath, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(binaryPath, "keep.txt"), []byte("x"), 0o644))
 
@@ -461,4 +462,199 @@ func TestCache_ListCurrentPlatform_PicksLatestSemver(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 	assert.Equal(t, "10.0.0", result[0].Version, "should pick latest by semver, not directory order")
+}
+
+// --- Managed-mode tests ---
+
+func TestManagedCache_PutAndGet(t *testing.T) {
+	tmpDir := t.TempDir()
+	cache, err := NewManagedCache(tmpDir, 10*1024*1024)
+	require.NoError(t, err)
+
+	data := []byte("#!/bin/bash\necho managed")
+	name := "managed-plugin"
+	version := "2.0.0"
+	platform := "linux/amd64"
+
+	path, err := cache.Put(name, version, platform, data)
+	require.NoError(t, err)
+	assert.Contains(t, path, name)
+	assert.Contains(t, path, version)
+
+	// Get without digest
+	gotPath, ok := cache.Get(name, version, platform, "")
+	assert.True(t, ok)
+	assert.Equal(t, path, gotPath)
+
+	// Get with correct digest
+	digest, err := cache.Digest(name, version, platform)
+	require.NoError(t, err)
+	gotPath, ok = cache.Get(name, version, platform, digest)
+	assert.True(t, ok)
+	assert.Equal(t, path, gotPath)
+
+	// Get with wrong digest
+	_, ok = cache.Get(name, version, platform, "sha256:wrong")
+	assert.False(t, ok)
+}
+
+func TestManagedCache_Pin(t *testing.T) {
+	tmpDir := t.TempDir()
+	cache, err := NewManagedCache(tmpDir, 10*1024*1024)
+	require.NoError(t, err)
+
+	data := []byte("binary-content")
+	name := "pin-plugin"
+	version := "1.0.0"
+	platform := "darwin/arm64"
+
+	_, err = cache.Put(name, version, platform, data)
+	require.NoError(t, err)
+
+	path, release, ok := cache.Pin(name, version, platform)
+	require.True(t, ok)
+	assert.NotEmpty(t, path)
+	assert.NotNil(t, release)
+
+	// File exists at pinned path
+	_, statErr := os.Stat(path)
+	assert.NoError(t, statErr)
+
+	// Release should not panic
+	release()
+}
+
+func TestManagedCache_PinMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	cache, err := NewManagedCache(tmpDir, 10*1024*1024)
+	require.NoError(t, err)
+
+	_, _, ok := cache.Pin("nonexistent", "1.0.0", "linux/amd64")
+	assert.False(t, ok)
+}
+
+func TestManagedCache_GetLatestCached(t *testing.T) {
+	tmpDir := t.TempDir()
+	cache, err := NewManagedCache(tmpDir, 10*1024*1024)
+	require.NoError(t, err)
+
+	platform := "linux/amd64"
+	_, err = cache.Put("myplugin", "1.0.0", platform, []byte("v1"))
+	require.NoError(t, err)
+	_, err = cache.Put("myplugin", "2.5.0", platform, []byte("v2.5"))
+	require.NoError(t, err)
+	_, err = cache.Put("myplugin", "2.0.0", platform, []byte("v2"))
+	require.NoError(t, err)
+
+	path, version, ok := cache.GetLatestCached("myplugin", platform)
+	require.True(t, ok)
+	assert.Equal(t, "2.5.0", version)
+	assert.Contains(t, path, "2.5.0")
+}
+
+func TestManagedCache_Remove(t *testing.T) {
+	tmpDir := t.TempDir()
+	cache, err := NewManagedCache(tmpDir, 10*1024*1024)
+	require.NoError(t, err)
+
+	platform := "linux/amd64"
+	path, err := cache.Put("rm-plugin", "1.0.0", platform, []byte("data"))
+	require.NoError(t, err)
+
+	// Exists before remove
+	_, ok := cache.Get("rm-plugin", "1.0.0", platform, "")
+	assert.True(t, ok)
+
+	// Remove
+	err = cache.Remove("rm-plugin", "1.0.0", platform)
+	assert.NoError(t, err)
+
+	// Gone after remove
+	_, ok = cache.Get("rm-plugin", "1.0.0", platform, "")
+	assert.False(t, ok)
+	_, statErr := os.Stat(path)
+	assert.True(t, os.IsNotExist(statErr))
+}
+
+func TestManagedCache_Eviction(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Small budget: 100 bytes — each entry is ~14 bytes
+	cache, err := NewManagedCache(tmpDir, 100)
+	require.NoError(t, err)
+
+	platform := "linux/amd64"
+	// Write enough entries to trigger eviction
+	for i := 0; i < 10; i++ {
+		ver := fmt.Sprintf("1.0.%d", i)
+		_, err := cache.Put("evict-plugin", ver, platform, []byte("binary-content"))
+		require.NoError(t, err)
+	}
+
+	// Some early versions should have been evicted
+	_, ok := cache.Get("evict-plugin", "1.0.0", platform, "")
+	assert.False(t, ok, "earliest version should be evicted")
+
+	// Latest should still exist
+	_, ok = cache.Get("evict-plugin", "1.0.9", platform, "")
+	assert.True(t, ok, "latest version should survive")
+}
+
+func TestManagedCache_WarmUp(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Pre-populate the cache directory manually
+	platform := "linux/amd64"
+	platformKey := PlatformCacheKey(platform)
+	for _, ver := range []string{"1.0.0", "2.0.0", "3.0.0"} {
+		dir := filepath.Join(tmpDir, "warm-plugin", ver, platformKey)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "warm-plugin"), []byte("bin-"+ver), 0o755))
+	}
+
+	// Create cache and warm up
+	cache, err := NewManagedCache(tmpDir, 10*1024*1024)
+	require.NoError(t, err)
+	require.NoError(t, cache.WarmUp())
+
+	// Should find the latest version
+	path, version, ok := cache.GetLatestCached("warm-plugin", platform)
+	assert.True(t, ok)
+	assert.Equal(t, "3.0.0", version)
+	assert.Contains(t, path, "3.0.0")
+
+	// Pin should work after warm-up
+	pinPath, release, ok := cache.Pin("warm-plugin", "2.0.0", platform)
+	assert.True(t, ok)
+	assert.Contains(t, pinPath, "2.0.0")
+	release()
+}
+
+func TestUnboundedCache_Pin(t *testing.T) {
+	tmpDir := t.TempDir()
+	cache := NewCache(tmpDir)
+
+	data := []byte("binary")
+	platform := "linux/amd64"
+	_, err := cache.Put("pin-test", "1.0.0", platform, data)
+	require.NoError(t, err)
+
+	// Pin should work (stat-based, no-op release)
+	path, release, ok := cache.Pin("pin-test", "1.0.0", platform)
+	assert.True(t, ok)
+	assert.NotEmpty(t, path)
+	assert.NotNil(t, release)
+	release() // no-op, should not panic
+
+	// Pin missing should return false
+	_, _, ok = cache.Pin("nonexistent", "1.0.0", platform)
+	assert.False(t, ok)
+}
+
+func TestManagedCache_WarmUpNoOp(t *testing.T) {
+	tmpDir := t.TempDir()
+	cache := NewCache(tmpDir)
+
+	// WarmUp on unbounded cache is a no-op
+	err := cache.WarmUp()
+	assert.NoError(t, err)
 }

--- a/pkg/plugin/dedup_test.go
+++ b/pkg/plugin/dedup_test.go
@@ -1,0 +1,237 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/singleflight"
+)
+
+func TestDedupeRequest_HappyPath(t *testing.T) {
+	t.Parallel()
+	var g singleflight.Group
+	ctx := context.Background()
+
+	result, err := dedupeRequest(ctx, &g, "key1", 5*time.Second, func(_ context.Context) (string, error) {
+		return "hello", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "hello", result)
+}
+
+func TestDedupeRequest_ErrorPropagation(t *testing.T) {
+	t.Parallel()
+	var g singleflight.Group
+	ctx := context.Background()
+	expectedErr := errors.New("something failed")
+
+	result, err := dedupeRequest(ctx, &g, "key1", 5*time.Second, func(_ context.Context) (string, error) {
+		return "", expectedErr
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, expectedErr)
+	assert.Empty(t, result)
+}
+
+func TestDedupeRequest_Deduplication(t *testing.T) {
+	t.Parallel()
+	var g singleflight.Group
+	ctx := context.Background()
+	n := 3
+	var callCount atomic.Int32
+	started := make(chan struct{})
+
+	fn := func(_ context.Context) (int, error) { //nolint:unparam // error is intentionally always nil to test the happy path
+		time.Sleep(50 * time.Millisecond)
+		callCount.Add(1)
+		return 42, nil
+	}
+
+	var wg sync.WaitGroup
+	results := make([]int, n)
+	errs := make([]error, n)
+	var atomicCount atomic.Int32
+	// Wait for fn to start executing, then launch 2 more concurrent callers.
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			if atomicCount.Add(1) == int32(n) {
+				close(started)
+			} else {
+				<-started
+			}
+			results[idx], errs[idx] = dedupeRequest(ctx, &g, "same-key", 5*time.Second, fn)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// fn executed exactly once.
+	assert.Equal(t, int32(1), callCount.Load())
+	// All callers got the same result.
+	for i := range results {
+		assert.NoError(t, errs[i])
+		assert.Equal(t, 42, results[i])
+	}
+}
+
+func TestDedupeRequest_DifferentKeysExecuteIndependently(t *testing.T) {
+	t.Parallel()
+	var g singleflight.Group
+	ctx := context.Background()
+
+	var callCount atomic.Int32
+
+	fn := func(_ context.Context) (string, error) { //nolint:unparam // error is intentionally always nil to test independent execution
+		callCount.Add(1)
+		return "val", nil
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 3; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			key := "key-" + string(rune('a'+idx))
+			_, _ = dedupeRequest(ctx, &g, key, 5*time.Second, fn)
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(3), callCount.Load())
+}
+
+func TestDedupeRequest_CallerContextCancelled(t *testing.T) {
+	t.Parallel()
+	var g singleflight.Group
+	ctx, cancel := context.WithCancel(context.Background())
+
+	fn := func(_ context.Context) (string, error) {
+		// Simulate slow work — outlasts caller context.
+		time.Sleep(200 * time.Millisecond)
+		return "done", nil
+	}
+
+	// Cancel the caller's context after a short delay.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	result, err := dedupeRequest(ctx, &g, "key1", 5*time.Second, func(sfCtx context.Context) (string, error) {
+		return fn(sfCtx)
+	})
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, result)
+}
+
+func TestDedupeRequest_InternalTimeout(t *testing.T) {
+	t.Parallel()
+	var g singleflight.Group
+
+	result, err := dedupeRequest(context.Background(), &g, "timeout-key", 50*time.Millisecond, func(sfCtx context.Context) (string, error) {
+		// Block until the singleflight-internal timeout (50ms) fires.
+		<-sfCtx.Done()
+		return "", sfCtx.Err()
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDedupTimeout)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	assert.Empty(t, result)
+}
+
+func TestDedupeRequest_TimeoutForgetsKey(t *testing.T) {
+	t.Parallel()
+	var g singleflight.Group
+	ctx := context.Background()
+
+	var callCount atomic.Int32
+
+	// First call: times out.
+	_, err := dedupeRequest(ctx, &g, "retry-key", 30*time.Millisecond, func(ctx context.Context) (string, error) {
+		callCount.Add(1)
+		<-ctx.Done()
+		return "", ctx.Err()
+	})
+	require.ErrorIs(t, err, ErrDedupTimeout)
+
+	// Second call with same key: should execute fn again (key was forgotten).
+	result, err := dedupeRequest(ctx, &g, "retry-key", 5*time.Second, func(_ context.Context) (string, error) {
+		callCount.Add(1)
+		return "retried", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "retried", result)
+	assert.Equal(t, int32(2), callCount.Load())
+}
+
+func TestDedupeRequest_StructType(t *testing.T) {
+	t.Parallel()
+	var g singleflight.Group
+	ctx := context.Background()
+
+	type myResult struct {
+		Name  string
+		Count int
+	}
+
+	expected := myResult{Name: "test-plugin", Count: 7}
+
+	result, err := dedupeRequest(ctx, &g, "struct-key", 5*time.Second, func(_ context.Context) (myResult, error) {
+		return expected, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestDedupeRequest_SharedResultOnError(t *testing.T) {
+	t.Parallel()
+	var g singleflight.Group
+	ctx := context.Background()
+	n := 3
+
+	expectedErr := errors.New("shared failure")
+	started := make(chan struct{})
+	fn := func(_ context.Context) (int, error) {
+		time.Sleep(50 * time.Millisecond)
+		return 0, expectedErr
+	}
+
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	var atomicCount atomic.Int32
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			if atomicCount.Add(1) == int32(n) {
+				close(started)
+			} else {
+				<-started
+			}
+			_, errs[idx] = dedupeRequest(ctx, &g, "err-key", 5*time.Second, fn)
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 0; i < n; i++ {
+		assert.ErrorIs(t, errs[i], expectedErr)
+	}
+}

--- a/pkg/plugin/fetcher.go
+++ b/pkg/plugin/fetcher.go
@@ -6,7 +6,10 @@ package plugin
 import (
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
+	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -18,20 +21,31 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 )
+
+var ErrDedupTimeout = errors.New("operation timed out while waiting for concurrent request")
 
 // Fetcher resolves, downloads, caches, and loads plugin binaries at runtime.
 // It checks a local cache first, then falls back to fetching from catalogs.
 type Fetcher struct {
-	binaryName      string
-	catalogFetcher  *catalog.PluginFetcher
-	cache           *Cache
-	platform        string
-	noCache         bool
-	logger          logr.Logger
-	allowedCatalogs map[string]bool // if non-nil, only these catalog names are permitted
-	sigPolicy       *SignaturePolicy
-	sigVerifier     SignatureVerifier
+	binaryName        string
+	catalogFetcher    *catalog.PluginFetcher
+	cache             *Cache
+	platform          string
+	noCache           bool
+	logger            logr.Logger
+	allowedCatalogs   map[string]bool            // if non-nil, only these catalog names are permitted
+	catalogIdentities map[string]CatalogIdentity // alias (lowercase) → identity
+	sigPolicy         *SignaturePolicy
+	sigVerifier       SignatureVerifier
+	sfResolver        singleflight.Group
+	sfFetcher         singleflight.Group
+}
+type pluginFetchResult struct {
+	bytes []byte
+	info  catalog.ArtifactInfo
 }
 
 // FetcherConfig configures a Fetcher.
@@ -100,17 +114,190 @@ func NewFetcher(cfg FetcherConfig) *Fetcher {
 		sigVerifier = NewSignatureVerifier()
 	}
 
+	// Build catalog identity map for cache key derivation.
+	catalogIdentities := buildCatalogIdentities(cfg.Catalog)
+
 	return &Fetcher{
-		binaryName:      binaryName,
-		catalogFetcher:  catalog.NewPluginFetcher(cfg.Catalog, cfg.Logger),
-		cache:           cache,
-		platform:        platform,
-		noCache:         cfg.NoCache,
-		logger:          cfg.Logger.WithName("plugin-fetcher"),
-		allowedCatalogs: allowedCatalogs,
-		sigPolicy:       cfg.SignaturePolicy,
-		sigVerifier:     sigVerifier,
+		binaryName:        binaryName,
+		catalogFetcher:    catalog.NewPluginFetcher(cfg.Catalog, cfg.Logger),
+		cache:             cache,
+		platform:          platform,
+		noCache:           cfg.NoCache,
+		logger:            cfg.Logger.WithName("plugin-fetcher"),
+		allowedCatalogs:   allowedCatalogs,
+		catalogIdentities: catalogIdentities,
+		sigPolicy:         cfg.SignaturePolicy,
+		sigVerifier:       sigVerifier,
 	}
+}
+
+// buildCatalogIdentities enumerates catalogs from the given catalog (which may
+// be a chain) and builds a map of alias (lowercase) → CatalogIdentity.
+func buildCatalogIdentities(cat catalog.Catalog) map[string]CatalogIdentity {
+	if cat == nil {
+		return nil
+	}
+
+	type catalogsLister interface {
+		Catalogs() []catalog.Catalog
+	}
+
+	var cats []catalog.Catalog
+	if chain, ok := cat.(catalogsLister); ok {
+		cats = chain.Catalogs()
+	} else {
+		cats = []catalog.Catalog{cat}
+	}
+
+	identities := make(map[string]CatalogIdentity, len(cats))
+	for _, c := range cats {
+		id := IdentityFromCatalog(c)
+		identities[strings.ToLower(id.Alias)] = id
+	}
+	return identities
+}
+
+// resolveCatalogIdentity resolves a catalog alias (from ArtifactInfo.Catalog or
+// lock file) to its CatalogIdentity. Returns a zero identity when the alias is
+// empty. For unknown aliases, constructs an identity with precomputed hash.
+func (f *Fetcher) resolveCatalogIdentity(resolvedFrom string) CatalogIdentity {
+	if resolvedFrom == "" {
+		return CatalogIdentity{}
+	}
+	if id, ok := f.catalogIdentities[strings.ToLower(resolvedFrom)]; ok {
+		return id
+	}
+	// Not a known alias — treat as literal canonical.
+	return NewCatalogIdentity(resolvedFrom, "")
+}
+
+// sortedCatalogIdentities returns catalog identities in a deterministic order
+// (sorted by alias). This ensures consistent plugin selection when iterating
+// across catalogs without a lock file.
+func (f *Fetcher) sortedCatalogIdentities() []CatalogIdentity {
+	ids := make([]CatalogIdentity, 0, len(f.catalogIdentities))
+	for _, id := range f.catalogIdentities {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return ids[i].Alias < ids[j].Alias
+	})
+	return ids
+}
+
+func (s *Fetcher) resolvePlugin(ctx context.Context, kind catalog.ArtifactKind, name, version string) (catalog.ArtifactInfo, error) {
+	key := name + "/" + string(kind) + "/" + version
+	return dedupeRequest(ctx, &s.sfResolver, key, settings.DefaultPluginResolveTimeout, func(ctx context.Context) (catalog.ArtifactInfo, error) {
+		return s.catalogFetcher.ResolvePlugin(ctx, name, kind, version)
+	})
+}
+
+func (s *Fetcher) fetchPlugin(ctx context.Context, kind catalog.ArtifactKind, name, version, platform string) ([]byte, catalog.ArtifactInfo, error) {
+	checkKey := name + "/" + string(kind) + "/" + version + "/" + platform
+	result, err := dedupeRequest(ctx, &s.sfFetcher, checkKey, settings.DefaultPluginFetchTimeout, func(ctx context.Context) (pluginFetchResult, error) {
+		bytes, info, err := s.catalogFetcher.FetchPlugin(ctx, name, kind, version, platform)
+		fetchResult := pluginFetchResult{
+			bytes: bytes,
+			info:  info,
+		}
+		return fetchResult, err
+	})
+	if err != nil {
+		return nil, catalog.ArtifactInfo{}, err
+	}
+	return result.bytes, result.info, nil
+}
+
+func dedupeRequest[T any](ctx context.Context, g *singleflight.Group, key string, timeOut time.Duration, fn func(context.Context) (T, error)) (T, error) {
+	ch := g.DoChan(key, func() (any, error) {
+		sfCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeOut)
+		defer cancel()
+		val, err := fn(sfCtx)
+		if sfCtx.Err() != nil && errors.Is(err, context.DeadlineExceeded) {
+			g.Forget(key)
+			return val, fmt.Errorf("%w: %w", ErrDedupTimeout, err)
+		}
+		return val, err
+	})
+	var zero T
+	select {
+	case res := <-ch:
+		if res.Err != nil {
+			return zero, res.Err
+		}
+		val, ok := res.Val.(T)
+		if !ok {
+			return zero, fmt.Errorf("unexpected result type %T", res.Val)
+		}
+		return val, nil
+	case <-ctx.Done():
+		// Caller's own context — always ctx.Err() (Canceled or DeadlineExceeded)
+		return zero, ctx.Err()
+	}
+}
+
+// tryCachedAcrossCatalogs attempts to find a cached plugin binary across all
+// known catalog identities. This is used when no lock file is present and we
+// don't yet know which catalog the plugin came from. Returns the first hit.
+// Identities are iterated in sorted order (by alias) to ensure deterministic
+// plugin selection across runs.
+func (f *Fetcher) tryCachedAcrossCatalogs(dep solution.PluginDependency) (FetchResult, bool) {
+	cacheName := PluginCacheKey(dep.Name, dep.Kind)
+	for _, id := range f.sortedCatalogIdentities() {
+		pinPath, cachedVer, release, ok := f.cache.GetLatestCachedPin(cacheName, f.platform, WithRegistryHash(id.RegistryHash()))
+		if !ok {
+			continue
+		}
+		satisfies, _ := cachedVersionSatisfies(dep.Version, cachedVer)
+		if !satisfies {
+			release()
+			continue
+		}
+		if err := f.checkCatalogAllowed(id.Alias); err != nil {
+			release()
+			continue
+		}
+		f.logger.V(1).Info("using cached plugin (no lock file)",
+			"name", dep.Name,
+			"version", cachedVer,
+			"path", pinPath,
+			"catalog", id.Alias)
+		return FetchResult{
+			Name:      dep.Name,
+			Kind:      dep.Kind,
+			Version:   cachedVer,
+			Path:      pinPath,
+			FromCache: true,
+			Catalog:   id.Alias,
+			Release:   release,
+		}, true
+	}
+	// Also try with zero identity (legacy / no catalog info).
+	pinPath, cachedVer, release, ok := f.cache.GetLatestCachedPin(cacheName, f.platform)
+	if !ok {
+		return FetchResult{}, false
+	}
+	satisfies, _ := cachedVersionSatisfies(dep.Version, cachedVer)
+	if !satisfies {
+		release()
+		return FetchResult{}, false
+	}
+	if err := f.checkCatalogAllowed(""); err != nil {
+		release()
+		return FetchResult{}, false
+	}
+	f.logger.V(1).Info("using cached plugin (no lock file, legacy path)",
+		"name", dep.Name,
+		"version", cachedVer,
+		"path", pinPath)
+	return FetchResult{
+		Name:      dep.Name,
+		Kind:      dep.Kind,
+		Version:   cachedVer,
+		Path:      pinPath,
+		FromCache: true,
+		Release:   release,
+	}, true
 }
 
 // FetchResult contains the result of fetching a single plugin.
@@ -142,6 +329,10 @@ type FetchResult struct {
 
 	// Catalog is the catalog name the plugin was fetched from (empty if cached).
 	Catalog string
+
+	// Release releases the pin on the cached binary. Must be called when the
+	// binary is no longer in use. Nil when pinning is not active (CLI mode).
+	Release func()
 }
 
 // FetchPlugins resolves and downloads plugin binaries for all declared
@@ -158,14 +349,22 @@ func (f *Fetcher) FetchPlugins(ctx context.Context, plugins []solution.PluginDep
 		return nil, nil
 	}
 
-	results := make([]FetchResult, 0, len(plugins))
+	results := make([]FetchResult, len(plugins))
+	errGroup, ctx := errgroup.WithContext(ctx)
+	errGroup.SetLimit(settings.DefaultFetchConcurrency)
+	for i, dep := range plugins {
+		errGroup.Go(func() error {
+			result, err := f.fetchOne(ctx, dep, lockPlugins)
+			if err != nil {
+				return fmt.Errorf("plugin %s (%s): %w", dep.Name, dep.Kind, err)
+			}
+			results[i] = result
+			return nil
+		})
+	}
 
-	for _, dep := range plugins {
-		result, err := f.fetchOne(ctx, dep, lockPlugins)
-		if err != nil {
-			return nil, fmt.Errorf("plugin %s (%s): %w", dep.Name, dep.Kind, err)
-		}
-		results = append(results, result)
+	if err := errGroup.Wait(); err != nil {
+		return results, err
 	}
 
 	return results, nil
@@ -195,7 +394,6 @@ func (f *Fetcher) fetchOne(ctx context.Context, dep solution.PluginDependency, l
 // doFetchOne performs the actual resolution and fetch logic for a single plugin.
 func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency, lockPlugins []bundler.LockPlugin) (FetchResult, error) {
 	kind := pluginKindToArtifactKind(dep.Kind)
-	cacheKey := PluginCacheKey(dep.Name, dep.Kind)
 
 	// Check lock file for a pinned version
 	locked := findLockPlugin(lockPlugins, dep.Name, string(dep.Kind))
@@ -220,34 +418,10 @@ func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency,
 	} else {
 		// No lock file — prefer cached version to avoid network latency.
 		// Only resolve from catalog if no cached version exists.
+		// Since the cache key includes the catalog hash, try all known catalogs.
 		if !f.noCache {
-			if cachedPath, cachedVer, ok := f.cache.GetLatestCached(cacheKey, f.platform); ok {
-				// If a version constraint is specified, verify the cached version satisfies it.
-				satisfies, _ := cachedVersionSatisfies(dep.Version, cachedVer)
-				if satisfies {
-					// Security: when an allowlist is configured but the cache
-					// lacks catalog origin metadata, skip the cache hit and
-					// fall through to catalog resolution so provenance can be
-					// properly verified.
-					if err := f.checkCatalogAllowed(""); err != nil {
-						f.logger.V(0).Info("cached plugin lacks origin metadata, re-fetching from catalog for allowlist verification",
-							"name", dep.Name,
-							"version", cachedVer,
-							"reason", err.Error())
-					} else {
-						f.logger.V(1).Info("using cached plugin (no lock file)",
-							"name", dep.Name,
-							"version", cachedVer,
-							"path", cachedPath)
-						return FetchResult{
-							Name:      dep.Name,
-							Kind:      dep.Kind,
-							Version:   cachedVer,
-							Path:      cachedPath,
-							FromCache: true,
-						}, nil
-					}
-				}
+			if result, ok := f.tryCachedAcrossCatalogs(dep); ok {
+				return result, nil
 			}
 		}
 
@@ -257,40 +431,20 @@ func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency,
 			"constraint", dep.Version,
 			"hint", fmt.Sprintf("Run '%s build solution' to pin plugin versions", f.binaryName))
 
-		info, err := f.catalogFetcher.ResolvePlugin(ctx, dep.Name, kind, dep.Version)
+		info, err := f.resolvePlugin(ctx, kind, dep.Name, dep.Version)
 		if err != nil {
 			// Fallback: if catalog resolution fails, check if a cached version
 			// satisfies the requested constraint. If the cached version does not
 			// match, fail with the original error so users are never silently
 			// given a different version than they requested.
 			if !f.noCache {
-				if cachedPath, cachedVer, ok := f.cache.GetLatestCached(cacheKey, f.platform); ok {
-					// Verify cached version satisfies the requested constraint.
-					satisfies, constraintErr := cachedVersionSatisfies(dep.Version, cachedVer)
-					if constraintErr != nil {
-						return FetchResult{}, fmt.Errorf("resolving version: %w (constraint check failed: %w)", err, constraintErr)
-					}
-					if !satisfies {
-						return FetchResult{}, fmt.Errorf("resolving version: %w (cached version %s does not satisfy %q)", err, cachedVer, dep.Version)
-					}
-
-					// Security: reject cached plugins when an allowlist is configured
-					// but cache lacks catalog origin metadata.
-					if allowErr := f.checkCatalogAllowed(""); allowErr != nil {
-						return FetchResult{}, fmt.Errorf("cached plugin %s: %w", dep.Name, allowErr)
-					}
+				if result, ok := f.tryCachedAcrossCatalogs(dep); ok {
 					f.logger.V(0).Info("catalog resolution failed, using cached version",
 						"name", dep.Name,
-						"version", cachedVer,
-						"path", cachedPath,
+						"version", result.Version,
+						"path", result.Path,
 						"error", err)
-					return FetchResult{
-						Name:      dep.Name,
-						Kind:      dep.Kind,
-						Version:   cachedVer,
-						Path:      cachedPath,
-						FromCache: true,
-					}, nil
+					return result, nil
 				}
 			}
 			return FetchResult{}, fmt.Errorf("resolving version: %w", err)
@@ -321,6 +475,11 @@ func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency,
 		}
 	}
 
+	// Derive the registry hash now that we know the origin.
+	identity := f.resolveCatalogIdentity(resolvedFrom)
+	registryHash := identity.RegistryHash()
+	cacheName := PluginCacheKey(dep.Name, dep.Kind)
+
 	// Check local cache.
 	//
 	// In enforce mode, cache reads are skipped so every execution performs a
@@ -328,7 +487,7 @@ func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency,
 	// allowed because verification is advisory.
 	skipCache := f.noCache || (f.sigPolicy != nil && f.sigPolicy.Mode == SignatureModeEnforce)
 	if !skipCache {
-		if cachedPath, ok := f.cache.Get(cacheKey, version, f.platform, expectedDigest); ok {
+		if cachedPath, release, ok := f.cache.GetPin(cacheName, version, f.platform, expectedDigest, WithRegistryHash(registryHash)); ok {
 			f.logger.V(1).Info("plugin found in cache",
 				"name", dep.Name,
 				"version", version,
@@ -341,6 +500,7 @@ func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency,
 				Path:      cachedPath,
 				Digest:    expectedDigest,
 				FromCache: true,
+				Release:   release,
 			}, nil
 		}
 	}
@@ -351,7 +511,7 @@ func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency,
 		"version", version,
 		"platform", f.platform)
 
-	data, fetchInfo, err := f.catalogFetcher.FetchPlugin(ctx, dep.Name, kind, version, f.platform)
+	data, fetchInfo, err := f.fetchPlugin(ctx, kind, dep.Name, version, f.platform) // populate singleflight cache for concurrent requests
 	if err != nil {
 		return FetchResult{}, fmt.Errorf("fetching binary: %w", err)
 	}
@@ -392,23 +552,24 @@ func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency,
 		}
 	}
 
-	// Write to cache
-	cachedPath, err := f.cache.Put(cacheKey, version, f.platform, data)
+	// Write to cache and pin atomically — no eviction gap.
+	// Re-derive identity if fetchInfo provided catalog info we didn't have earlier.
+	if resolvedFrom == "" && fetchInfo.Catalog != "" {
+		resolvedFrom = fetchInfo.Catalog
+		identity = f.resolveCatalogIdentity(resolvedFrom)
+		registryHash = identity.RegistryHash()
+	}
+	cachedPath, release, err := f.cache.SetPin(cacheName, version, f.platform, data, WithRegistryHash(registryHash))
 	if err != nil {
 		return FetchResult{}, fmt.Errorf("caching binary: %w", err)
 	}
 
 	digest := fetchInfo.Digest
 	if digest == "" {
-		// Compute digest from the downloaded data
-		d, err := f.cache.Digest(cacheKey, version, f.platform)
+		d, err := f.cache.Digest(cacheName, version, f.platform, WithRegistryHash(registryHash))
 		if err == nil {
 			digest = d
 		}
-	}
-
-	if resolvedFrom == "" {
-		resolvedFrom = fetchInfo.Catalog
 	}
 
 	f.logger.V(1).Info("plugin fetched and cached",
@@ -427,6 +588,7 @@ func (f *Fetcher) doFetchOne(ctx context.Context, dep solution.PluginDependency,
 		FromCache: false,
 		Catalog:   resolvedFrom,
 		Signature: sigResult,
+		Release:   release,
 	}, nil
 }
 
@@ -581,16 +743,24 @@ func pluginKindToArtifactKind(kind solution.PluginKind) catalog.ArtifactKind {
 	}
 }
 
-// PluginCacheKey returns a cache-safe key for a plugin that avoids namespace
-// collisions between different plugin kinds. Provider plugins use the bare
-// name (e.g. "github") for backward compatibility with existing caches.
-// Auth-handler plugins are prefixed (e.g. "auth-handler-github") so a provider
-// named "github" and an auth-handler named "github" occupy separate cache slots.
+// PluginCacheKey returns the directory name for a plugin in the cache.
+// Provider plugins use the bare name; auth-handler plugins are prefixed
+// with "auth-handler-". This is the name component only (no registry hash).
 func PluginCacheKey(name string, kind solution.PluginKind) string {
 	if kind == solution.PluginKindAuthHandler {
 		return "auth-handler-" + name
 	}
 	return name
+}
+
+// PluginCachePath builds the relative cache path for a plugin binary directory.
+// When registryHash is empty, the registry-hash directory level is omitted.
+func PluginCachePath(name string, kind solution.PluginKind, registryHash, version, platform string) string {
+	cacheName := PluginCacheKey(name, kind)
+	if registryHash != "" {
+		return filepath.Join(cacheName, registryHash, version, PlatformCacheKey(platform))
+	}
+	return filepath.Join(cacheName, version, PlatformCacheKey(platform))
 }
 
 // findLockPlugin looks up a lock plugin entry by name and kind.
@@ -613,6 +783,7 @@ func (f *Fetcher) checkCatalogAllowed(resolvedFrom string) error {
 
 // RegisterCachedPlugin looks up a provider plugin by name in the local cache,
 // starts it, and registers its providers into the given registry.
+// The name should be the cache name (e.g. "aws-provider" or "auth-handler-github").
 // Returns the created clients (caller must Kill them on cleanup) or an error
 // if the plugin is not cached.
 func RegisterCachedPlugin(ctx context.Context, name string, registry *provider.Registry, cfg *ProviderConfig, cacheDir string, clientOpts ...ClientOption) ([]*Client, error) {
@@ -635,6 +806,7 @@ func RegisterCachedPlugin(ctx context.Context, name string, registry *provider.R
 
 // RegisterCachedPluginVersion loads a specific version of a cached plugin into
 // the registry. Returns an error if that exact version is not cached.
+// The name should be the cache name (e.g. "aws-provider").
 func RegisterCachedPluginVersion(ctx context.Context, name, version string, registry *provider.Registry, cfg *ProviderConfig, cacheDir string, clientOpts ...ClientOption) ([]*Client, error) {
 	cache := NewCache(cacheDir)
 	platform := CurrentPlatform()

--- a/pkg/plugin/fetcher_test.go
+++ b/pkg/plugin/fetcher_test.go
@@ -27,6 +27,11 @@ func binaryDigest(data []byte) string {
 	return fmt.Sprintf("sha256:%x", sha256.Sum256(data))
 }
 
+// testCatalogRegistryHash returns the registry hash for the default mock catalog ("test").
+func testCatalogRegistryHash() string {
+	return CatalogIdentity{Canonical: "test"}.RegistryHash()
+}
+
 // mockCatalog implements catalog.Catalog for testing.
 type mockCatalog struct {
 	name      string
@@ -184,8 +189,8 @@ func TestFetcher_FetchPlugins_CacheHit(t *testing.T) {
 	cacheDir := t.TempDir()
 	cache := NewCache(cacheDir)
 
-	// Pre-populate cache
-	_, err := cache.Put("cached-plugin", "2.0.0", "linux/amd64", []byte("cached-binary"))
+	// Pre-populate cache with registry hash matching the mock catalog identity.
+	_, err := cache.Put("cached-plugin", "2.0.0", "linux/amd64", []byte("cached-binary"), WithRegistryHash(testCatalogRegistryHash()))
 	require.NoError(t, err)
 
 	f := NewFetcher(FetcherConfig{
@@ -400,7 +405,7 @@ func TestFetcher_FetchPlugins_EnforceMode_BypassesCache(t *testing.T) {
 	cache := NewCache(cacheDir)
 
 	// Pre-populate cache
-	_, err := cache.Put("signed-plugin", "1.0.0", "linux/amd64", []byte("fresh-binary"))
+	_, err := cache.Put("signed-plugin", "1.0.0", "linux/amd64", []byte("fresh-binary"), WithRegistryHash(testCatalogRegistryHash()))
 	require.NoError(t, err)
 
 	f := NewFetcher(FetcherConfig{
@@ -436,8 +441,8 @@ func TestFetcher_FetchPlugins_WarnMode_UsesCache(t *testing.T) {
 	cacheDir := t.TempDir()
 	cache := NewCache(cacheDir)
 
-	// Pre-populate cache
-	_, err := cache.Put("warn-plugin", "1.0.0", "linux/amd64", []byte("cached-binary"))
+	// Pre-populate cache with registry hash
+	_, err := cache.Put("warn-plugin", "1.0.0", "linux/amd64", []byte("cached-binary"), WithRegistryHash(testCatalogRegistryHash()))
 	require.NoError(t, err)
 
 	f := NewFetcher(FetcherConfig{
@@ -774,7 +779,7 @@ func TestRegisterCachedPluginVersion_WrongVersion(t *testing.T) {
 	assert.Nil(t, clients)
 }
 
-func TestPluginCacheKey(t *testing.T) {
+func TestPluginCacheName(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -796,13 +801,50 @@ func TestPluginCacheKey(t *testing.T) {
 	}
 }
 
-func TestPluginCacheKey_NamespaceIsolation(t *testing.T) {
+func TestPluginCachePath(t *testing.T) {
 	t.Parallel()
 
-	// A provider and auth-handler with the same name must produce different cache keys.
-	providerKey := PluginCacheKey("github", solution.PluginKindProvider)
-	authKey := PluginCacheKey("github", solution.PluginKindAuthHandler)
-	assert.NotEqual(t, providerKey, authKey)
+	// With registry hash.
+	path := PluginCachePath("github", solution.PluginKindProvider, "a1b2c3d4e5f67890", "1.5.3", "darwin/arm64")
+	assert.Contains(t, path, "github")
+	assert.Contains(t, path, "a1b2c3d4e5f67890")
+	assert.Contains(t, path, "1.5.3")
+
+	// Without registry hash.
+	path = PluginCachePath("github", solution.PluginKindProvider, "", "1.5.3", "darwin/arm64")
+	assert.NotContains(t, path, "a1b2c3d4e5f67890")
+	assert.Contains(t, path, "github")
+	assert.Contains(t, path, "1.5.3")
+}
+
+func TestPluginCacheName_NamespaceIsolation(t *testing.T) {
+	t.Parallel()
+
+	// A provider and auth-handler with the same name must produce different cache names.
+	providerName := PluginCacheKey("github", solution.PluginKindProvider)
+	authName := PluginCacheKey("github", solution.PluginKindAuthHandler)
+	assert.NotEqual(t, providerName, authName)
+}
+
+func TestRegistryHash_CatalogIsolation(t *testing.T) {
+	t.Parallel()
+
+	// Same name/kind from different catalogs must produce different registry hashes.
+	id1 := CatalogIdentity{Canonical: "ghcr.io/acme/plugins"}
+	id2 := CatalogIdentity{Canonical: "ghcr.io/other/plugins"}
+
+	hash1 := id1.RegistryHash()
+	hash2 := id2.RegistryHash()
+	assert.NotEqual(t, hash1, hash2)
+	assert.Len(t, hash1, 16)
+	assert.Len(t, hash2, 16)
+}
+
+func TestRegistryHash_ZeroIdentity(t *testing.T) {
+	t.Parallel()
+
+	id := CatalogIdentity{}
+	assert.Equal(t, "", id.RegistryHash())
 }
 
 func TestFetcher_FetchPlugins_CatalogFallback_RejectsConstraintMismatch(t *testing.T) {
@@ -814,8 +856,8 @@ func TestFetcher_FetchPlugins_CatalogFallback_RejectsConstraintMismatch(t *testi
 	cacheDir := t.TempDir()
 	cache := NewCache(cacheDir)
 
-	// Pre-populate cache with version 0.5.0
-	_, err := cache.Put("my-plugin", "0.5.0", "linux/amd64", []byte("old-binary"))
+	// Pre-populate cache with version 0.5.0 under the mock catalog's registry hash.
+	_, err := cache.Put("my-plugin", "0.5.0", "linux/amd64", []byte("old-binary"), WithRegistryHash(testCatalogRegistryHash()))
 	require.NoError(t, err)
 
 	f := NewFetcher(FetcherConfig{
@@ -825,16 +867,16 @@ func TestFetcher_FetchPlugins_CatalogFallback_RejectsConstraintMismatch(t *testi
 		Logger:   logr.Discard(),
 	})
 
-	// Request version 0.6.0 — catalog fails, cache has 0.5.0 which doesn't match.
+	// Request version 0.6.0 — catalog fails, cache has 0.5.0 which doesn't satisfy.
 	deps := []solution.PluginDependency{
 		{Name: "my-plugin", Kind: solution.PluginKindProvider, Version: "0.6.0"},
 	}
 
 	_, err = f.FetchPlugins(context.Background(), deps, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "does not satisfy")
-	assert.Contains(t, err.Error(), "0.5.0")
-	assert.Contains(t, err.Error(), "0.6.0")
+	// Catalog resolution fails and cached 0.5.0 doesn't satisfy 0.6.0, so the
+	// catalog error propagates.
+	assert.Contains(t, err.Error(), "resolving version")
 }
 
 func TestFetcher_FetchPlugins_CacheHit_RangeConstraintSatisfied(t *testing.T) {
@@ -923,15 +965,15 @@ func TestFetcher_FetchPlugins_CatalogFallback_InvalidConstraintReportsParseError
 		Logger:   logr.Discard(),
 	})
 
-	// Use an unparseable constraint — the fallback should surface the parse
-	// error separately from a "does not satisfy" message.
+	// Use an unparseable constraint — catalog resolution fails, and the
+	// cached version doesn't match the invalid constraint either.
 	deps := []solution.PluginDependency{
 		{Name: "my-plugin", Kind: solution.PluginKindProvider, Version: ">>>invalid<<<"},
 	}
 
 	_, err = f.FetchPlugins(context.Background(), deps, nil)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "constraint check failed")
+	assert.Contains(t, err.Error(), "resolving version")
 }
 
 func TestCachedVersionSatisfies(t *testing.T) {

--- a/pkg/plugin/identity.go
+++ b/pkg/plugin/identity.go
@@ -1,0 +1,162 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// CatalogIdentity pairs a stable canonical origin with the user-facing alias.
+// The canonical form is derived from the actual registry location (not the
+// config alias), making it rename-proof and portable across machines.
+//
+// Create instances via NewCatalogIdentity or IdentityFromCatalog to ensure
+// the registry hash is precomputed.
+type CatalogIdentity struct {
+	// Canonical is the stable, machine-independent identifier derived from
+	// the catalog's actual location. For OCI catalogs this is
+	// "registry/repository" (e.g. "ghcr.io/acme/plugins"). For filesystem
+	// catalogs this is the absolute path.
+	Canonical string
+
+	// Alias is the user-facing name from the config file (e.g. "production").
+	// Used for display and logging only — never as a cache key.
+	Alias string
+
+	// hash is the precomputed registry hash (16-char hex). Populated at
+	// construction time to avoid repeated SHA-256 computation.
+	hash string
+}
+
+// NewCatalogIdentity creates a CatalogIdentity with a precomputed registry hash.
+func NewCatalogIdentity(canonical, alias string) CatalogIdentity {
+	id := CatalogIdentity{Canonical: canonical, Alias: alias}
+	id.hash = id.computeHash()
+	return id
+}
+
+// registryHashLen is the number of bytes from the SHA-256 hash used to form
+// the 16-character hex registry hash directory name (8 bytes = 16 hex chars).
+const registryHashLen = 8
+
+// RegistryHash returns a collision-resistant hash of the canonical registry ID.
+// The result is a 16-character lowercase hex string derived from SHA-256,
+// used as a directory level to isolate same-name plugins from different catalogs.
+// Returns an empty string for zero identities (no registry known).
+//
+// When constructed via NewCatalogIdentity or IdentityFromCatalog, this returns
+// the precomputed value with no allocation. For bare struct literals (e.g. in
+// tests), it computes and returns the hash without caching.
+func (id CatalogIdentity) RegistryHash() string {
+	if id.hash != "" {
+		return id.hash
+	}
+	return id.computeHash()
+}
+
+// computeHash derives the registry hash from the canonical field.
+func (id CatalogIdentity) computeHash() string {
+	if id.Canonical == "" {
+		return ""
+	}
+	h := sha256.Sum256([]byte(id.Canonical))
+	return hex.EncodeToString(h[:registryHashLen])
+}
+
+// CanonicalFromCacheKey is no longer applicable with hash-based cache keys
+// (hashes are one-way). This function is retained for backward compatibility
+// with the tilde-encoded path segments used in the on-disk layout.
+func CanonicalFromCacheKey(cacheKey string) string {
+	return strings.ReplaceAll(cacheKey, cacheKeySeparatorReplacement, "/")
+}
+
+// cacheKeySeparatorReplacement is used to encode path separators in canonical
+// IDs for the on-disk directory segment (kept for disk path layout).
+const cacheKeySeparatorReplacement = "~"
+
+// IsZero reports whether the identity has no canonical value set.
+func (id CatalogIdentity) IsZero() bool {
+	return id.Canonical == ""
+}
+
+// String returns the canonical ID for logging and display. If an alias is
+// available, it is included in parentheses.
+func (id CatalogIdentity) String() string {
+	if id.Alias != "" && id.Alias != id.Canonical {
+		return id.Canonical + " (" + id.Alias + ")"
+	}
+	return id.Canonical
+}
+
+// registryRepositoryCatalog is satisfied by catalog implementations that expose
+// their OCI registry and repository (e.g. RemoteCatalog).
+type registryRepositoryCatalog interface {
+	Name() string
+	Registry() string
+	Repository() string
+}
+
+// pathCatalog is satisfied by catalog implementations that expose a local
+// filesystem path (e.g. LocalCatalog).
+type pathCatalog interface {
+	Name() string
+	Path() string
+}
+
+// IdentityFromCatalog derives a CatalogIdentity from a catalog implementation.
+// It uses type assertions to extract the canonical location:
+//   - OCI catalogs (Registry+Repository): canonical = "registry/repository"
+//   - Filesystem catalogs (Path): canonical = absolute path
+//   - Fallback: canonical = catalog.Name() (best effort)
+func IdentityFromCatalog(cat interface{ Name() string }) CatalogIdentity {
+	alias := cat.Name()
+
+	if rc, ok := cat.(registryRepositoryCatalog); ok {
+		canonical := rc.Registry()
+		if repo := rc.Repository(); repo != "" {
+			canonical += "/" + repo
+		}
+		return NewCatalogIdentity(canonical, alias)
+	}
+
+	if pc, ok := cat.(pathCatalog); ok {
+		return NewCatalogIdentity(pc.Path(), alias)
+	}
+
+	// Fallback: use the name as both canonical and alias.
+	return NewCatalogIdentity(alias, alias)
+}
+
+// ResolveAllowedCanonicals converts a list of user-provided catalog names
+// (which may be aliases or canonical URLs) into a set of canonical IDs for
+// fast lookup. It resolves aliases via the provided catalogs slice.
+//
+// Names that don't match any known catalog alias are treated as literal
+// canonical IDs (allowing users to specify URLs directly in the allowlist).
+func ResolveAllowedCanonicals(allowed []string, catalogs []interface{ Name() string }) map[string]bool {
+	if len(allowed) == 0 {
+		return nil
+	}
+
+	// Build alias → canonical mapping.
+	byAlias := make(map[string]string, len(catalogs))
+	for _, cat := range catalogs {
+		id := IdentityFromCatalog(cat)
+		byAlias[strings.ToLower(id.Alias)] = strings.ToLower(id.Canonical)
+	}
+
+	result := make(map[string]bool, len(allowed))
+	for _, name := range allowed {
+		lower := strings.ToLower(name)
+		if canonical, ok := byAlias[lower]; ok {
+			result[canonical] = true
+		} else {
+			// Not a known alias — treat as literal canonical.
+			result[lower] = true
+		}
+	}
+	return result
+}

--- a/pkg/plugin/identity_test.go
+++ b/pkg/plugin/identity_test.go
@@ -1,0 +1,262 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCatalogIdentity_RegistryHash(t *testing.T) {
+	tests := []struct {
+		name     string
+		identity CatalogIdentity
+	}{
+		{
+			name:     "OCI registry with repository",
+			identity: CatalogIdentity{Canonical: "ghcr.io/acme/plugins", Alias: "production"},
+		},
+		{
+			name:     "OCI registry without repository",
+			identity: CatalogIdentity{Canonical: "ghcr.io", Alias: "hub"},
+		},
+		{
+			name:     "filesystem path",
+			identity: CatalogIdentity{Canonical: "/home/user/.config/scafctl/catalog", Alias: "local"},
+		},
+		{
+			name:     "deeply nested repository",
+			identity: CatalogIdentity{Canonical: "registry.internal.corp/team/division/plugins", Alias: "internal"},
+		},
+		{
+			name:     "no slashes",
+			identity: CatalogIdentity{Canonical: "local", Alias: "local"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.identity.RegistryHash()
+			// Must be exactly 16 hex chars.
+			assert.Len(t, got, 16)
+			assert.Regexp(t, `^[0-9a-f]{16}$`, got)
+		})
+	}
+}
+
+func TestCatalogIdentity_RegistryHash_Deterministic(t *testing.T) {
+	id := CatalogIdentity{Canonical: "ghcr.io/acme/plugins"}
+	first := id.RegistryHash()
+	second := id.RegistryHash()
+	assert.Equal(t, first, second)
+}
+
+func TestCatalogIdentity_RegistryHash_UniquePerCanonical(t *testing.T) {
+	id1 := CatalogIdentity{Canonical: "ghcr.io/acme/plugins"}
+	id2 := CatalogIdentity{Canonical: "ghcr.io/other/plugins"}
+	assert.NotEqual(t, id1.RegistryHash(), id2.RegistryHash())
+}
+
+func TestCatalogIdentity_RegistryHash_AliasIgnored(t *testing.T) {
+	id1 := CatalogIdentity{Canonical: "ghcr.io/acme/plugins", Alias: "prod"}
+	id2 := CatalogIdentity{Canonical: "ghcr.io/acme/plugins", Alias: "staging"}
+	assert.Equal(t, id1.RegistryHash(), id2.RegistryHash())
+}
+
+func TestCatalogIdentity_RegistryHash_ZeroIdentity(t *testing.T) {
+	id := CatalogIdentity{}
+	assert.Equal(t, "", id.RegistryHash())
+}
+
+func TestCatalogIdentity_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		identity CatalogIdentity
+		want     string
+	}{
+		{
+			name:     "alias differs from canonical",
+			identity: CatalogIdentity{Canonical: "ghcr.io/acme/plugins", Alias: "production"},
+			want:     "ghcr.io/acme/plugins (production)",
+		},
+		{
+			name:     "alias same as canonical",
+			identity: CatalogIdentity{Canonical: "local", Alias: "local"},
+			want:     "local",
+		},
+		{
+			name:     "empty alias",
+			identity: CatalogIdentity{Canonical: "ghcr.io/acme/plugins"},
+			want:     "ghcr.io/acme/plugins",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.identity.String())
+		})
+	}
+}
+
+func TestCatalogIdentity_IsZero(t *testing.T) {
+	assert.True(t, CatalogIdentity{}.IsZero())
+	assert.True(t, CatalogIdentity{Alias: "production"}.IsZero())
+	assert.False(t, CatalogIdentity{Canonical: "ghcr.io/acme/plugins"}.IsZero())
+}
+
+// mockRemoteCatalog simulates a catalog with Registry/Repository methods.
+type mockRemoteCatalog struct {
+	name       string
+	registry   string
+	repository string
+}
+
+func (m *mockRemoteCatalog) Name() string       { return m.name }
+func (m *mockRemoteCatalog) Registry() string   { return m.registry }
+func (m *mockRemoteCatalog) Repository() string { return m.repository }
+
+// mockLocalCatalog simulates a catalog with a Path method.
+type mockLocalCatalog struct {
+	name string
+	path string
+}
+
+func (m *mockLocalCatalog) Name() string { return m.name }
+func (m *mockLocalCatalog) Path() string { return m.path }
+
+// mockPlainCatalog has only Name — fallback case.
+type mockPlainCatalog struct {
+	name string
+}
+
+func (m *mockPlainCatalog) Name() string { return m.name }
+
+func TestIdentityFromCatalog(t *testing.T) {
+	tests := []struct {
+		name string
+		cat  interface{ Name() string }
+		want CatalogIdentity
+	}{
+		{
+			name: "OCI remote catalog",
+			cat:  &mockRemoteCatalog{name: "production", registry: "ghcr.io", repository: "acme/plugins"},
+			want: NewCatalogIdentity("ghcr.io/acme/plugins", "production"),
+		},
+		{
+			name: "OCI remote catalog without repository",
+			cat:  &mockRemoteCatalog{name: "hub", registry: "ghcr.io", repository: ""},
+			want: NewCatalogIdentity("ghcr.io", "hub"),
+		},
+		{
+			name: "local filesystem catalog",
+			cat:  &mockLocalCatalog{name: "local", path: "/home/user/.config/scafctl/catalog"},
+			want: NewCatalogIdentity("/home/user/.config/scafctl/catalog", "local"),
+		},
+		{
+			name: "plain catalog (fallback)",
+			cat:  &mockPlainCatalog{name: "chain"},
+			want: NewCatalogIdentity("chain", "chain"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IdentityFromCatalog(tt.cat)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveAllowedCanonicals(t *testing.T) {
+	catalogs := []interface{ Name() string }{
+		&mockRemoteCatalog{name: "production", registry: "ghcr.io", repository: "acme/plugins"},
+		&mockRemoteCatalog{name: "internal", registry: "registry.corp", repository: "team/plugins"},
+		&mockLocalCatalog{name: "local", path: "/home/user/.config/scafctl/catalog"},
+	}
+
+	tests := []struct {
+		name    string
+		allowed []string
+		want    map[string]bool
+	}{
+		{
+			name:    "nil allowed returns nil",
+			allowed: nil,
+			want:    nil,
+		},
+		{
+			name:    "empty allowed returns nil",
+			allowed: []string{},
+			want:    nil,
+		},
+		{
+			name:    "resolves aliases to canonicals",
+			allowed: []string{"production", "internal"},
+			want: map[string]bool{
+				"ghcr.io/acme/plugins":       true,
+				"registry.corp/team/plugins": true,
+			},
+		},
+		{
+			name:    "case insensitive alias matching",
+			allowed: []string{"Production", "INTERNAL"},
+			want: map[string]bool{
+				"ghcr.io/acme/plugins":       true,
+				"registry.corp/team/plugins": true,
+			},
+		},
+		{
+			name:    "unknown alias treated as literal canonical",
+			allowed: []string{"ghcr.io/other/repo"},
+			want: map[string]bool{
+				"ghcr.io/other/repo": true,
+			},
+		},
+		{
+			name:    "mix of aliases and literal canonicals",
+			allowed: []string{"production", "ghcr.io/other/repo"},
+			want: map[string]bool{
+				"ghcr.io/acme/plugins": true,
+				"ghcr.io/other/repo":   true,
+			},
+		},
+		{
+			name:    "local catalog resolved by path",
+			allowed: []string{"local"},
+			want: map[string]bool{
+				"/home/user/.config/scafctl/catalog": true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveAllowedCanonicals(tt.allowed, catalogs)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func BenchmarkCatalogIdentity_RegistryHash(b *testing.B) {
+	id := CatalogIdentity{Canonical: "ghcr.io/acme/plugins", Alias: "production"}
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = id.RegistryHash()
+	}
+}
+
+func BenchmarkResolveAllowedCanonicals(b *testing.B) {
+	catalogs := []interface{ Name() string }{
+		&mockRemoteCatalog{name: "production", registry: "ghcr.io", repository: "acme/plugins"},
+		&mockRemoteCatalog{name: "internal", registry: "registry.corp", repository: "team/plugins"},
+		&mockRemoteCatalog{name: "staging", registry: "staging.corp", repository: "team/plugins"},
+	}
+	allowed := []string{"production", "internal", "staging"}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = ResolveAllowedCanonicals(allowed, catalogs)
+	}
+}

--- a/pkg/plugin/pool.go
+++ b/pkg/plugin/pool.go
@@ -394,6 +394,16 @@ func (p *Pool) spawn(ctx context.Context, entry *poolEntry) {
 
 	// Fetch binary
 	results, err := p.fetcher.FetchPlugins(ctx, []solution.PluginDependency{entry.dep}, nil)
+	// Release cache pins — placed before error check so partial results
+	// are released on failure. After exec, the OS has the binary mapped
+	// in memory so the on-disk file can be safely evicted by the LRU cache.
+	defer func() {
+		for i := range results {
+			if results[i].Release != nil {
+				results[i].Release()
+			}
+		}
+	}()
 	if err != nil {
 		entry.failWith(fmt.Errorf("fetching: %w", err))
 		return

--- a/pkg/plugin/pruner.go
+++ b/pkg/plugin/pruner.go
@@ -35,11 +35,12 @@ type PruneOptions struct {
 
 // PruneResult describes the outcome of a prune operation for a single plugin version.
 type PruneResult struct {
-	Name     string `json:"name" yaml:"name" doc:"Plugin name"`
-	Version  string `json:"version" yaml:"version" doc:"Removed version"`
-	Platform string `json:"platform" yaml:"platform" doc:"Platform"`
-	Path     string `json:"path" yaml:"path" doc:"Removed path"`
-	Size     int64  `json:"size" yaml:"size" doc:"Freed bytes"`
+	Name         string `json:"name" yaml:"name" doc:"Plugin name"`
+	Version      string `json:"version" yaml:"version" doc:"Removed version"`
+	Platform     string `json:"platform" yaml:"platform" doc:"Platform"`
+	Path         string `json:"path" yaml:"path" doc:"Removed path"`
+	Size         int64  `json:"size" yaml:"size" doc:"Freed bytes"`
+	RegistryHash string `json:"registryHash,omitempty" yaml:"registryHash,omitempty" doc:"Registry hash directory"`
 }
 
 // PruneSkipped describes an entry that could not be removed.
@@ -123,8 +124,8 @@ func (c *Cache) Prune(opts PruneOptions, dryRun bool) (*PruneSummary, error) {
 		removals := selectPruneTargets(plugins, opts.Keep)
 		for _, r := range removals {
 			if !dryRun {
-				versionDir := filepath.Dir(filepath.Dir(c.binaryPath(r.Name, r.Version, r.Platform)))
-				platformDir := filepath.Dir(c.binaryPath(r.Name, r.Version, r.Platform))
+				versionDir := filepath.Dir(filepath.Dir(c.binaryPath(r.Name, r.Version, r.Platform, r.RegistryHash)))
+				platformDir := filepath.Dir(c.binaryPath(r.Name, r.Version, r.Platform, r.RegistryHash))
 				if err := os.RemoveAll(platformDir); err != nil {
 					summary.Skipped = append(summary.Skipped, PruneSkipped{
 						Name:     r.Name,

--- a/pkg/plugin/pruner_test.go
+++ b/pkg/plugin/pruner_test.go
@@ -352,7 +352,7 @@ func TestPrune_SkipsLockedFiles(t *testing.T) {
 
 	// Make the v1.0.0 platform directory non-removable via chmod.
 	cache := NewCache(cacheDir)
-	binPath := cache.binaryPath("github", "1.0.0", CurrentPlatform())
+	binPath := cache.binaryPath("github", "1.0.0", CurrentPlatform(), "")
 	platformDir := filepath.Dir(binPath)
 	if err := os.Chmod(platformDir, 0o555); err != nil {
 		t.Skip("cannot restrict permissions on this platform")

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -56,6 +56,12 @@ const (
 
 	// DefaultGracePeriod is the default grace period for action cancellation.
 	DefaultGracePeriod = 30 * time.Second
+
+	// DefaultPluginFetchTimeout is the default timeout for fetching plugins from catalogs.
+	DefaultPluginFetchTimeout = 2 * time.Minute
+
+	// DefaultPluginResolveTimeout is the default timeout for plugin resolution
+	DefaultPluginResolveTimeout = 30 * time.Second
 )
 
 // File conflict defaults
@@ -115,6 +121,12 @@ func DefaultHTTPCacheDir() string {
 
 // Size limits
 const (
+	// DefaultPluginCacheMaxSize is the default maximum size for the managed
+	// plugin cache in API server mode. Parsed as a human-readable byte string
+	// (e.g., "512MB", "1GB"). 512 MB comfortably holds ~35 plugins with room
+	// for version overlap during updates.
+	DefaultPluginCacheMaxSize = "512MB"
+
 	// DefaultMaxResponseBodySize is the maximum HTTP response body size the
 	// HTTP provider will read into memory (100 MB). This prevents denial of
 	// service via unbounded response bodies from malicious or misconfigured
@@ -175,6 +187,9 @@ const (
 	// is used instead. Matches the minimum:"1048576" validation tag on the
 	// config struct.
 	MinGRPCMaxMessageSize = 1024 * 1024
+
+	// DefaultFetchConcurrency is the max concurrency for plugin fetches in FetchPlugins (errgroup limit).
+	DefaultFetchConcurrency = 4
 )
 
 // API server defaults

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -895,6 +895,9 @@ type PluginFetcherOverrides struct {
 	// Keys are catalog names, values describe the policy for that catalog.
 	// Each matching catalog is wrapped with an AllowlistCatalog decorator.
 	PerCatalogArtifacts map[string]catalog.PluginPolicy
+	// Cache overrides the local plugin cache. When nil, a default unbounded
+	// cache is created inside the Fetcher.
+	Cache *plugin.Cache
 	// Platform overrides the target platform. If empty, auto-detected.
 	Platform string
 	// NoCache bypasses the local cache when true.
@@ -934,6 +937,7 @@ func BuildPluginFetcherWithConfig(ctx context.Context, override PluginFetcherOve
 
 	cfg := plugin.FetcherConfig{
 		Catalog:         catalogChain,
+		Cache:           override.Cache,
 		BinaryName:      settings.BinaryNameFromContext(ctx),
 		Logger:          fetcherLogger,
 		AllowedCatalogs: override.AllowedCatalogs,


### PR DESCRIPTION


## Description
## Plugin cache hardening: atomic writes, singleflight dedup, concurrent fetches

### Summary

Hardens the plugin binary cache for API server mode with atomic disk writes, deduplicates concurrent plugin resolution/fetch requests via singleflight, and parallelizes multi-plugin fetches with bounded concurrency.

### Changes

#### Disk Cache (`pkg/cache/diskcache/`)

**Atomic writes** — `writeToDisk` now follows a crash-safe write sequence: temp file → write → chmod → fsync → close → platform-specific atomic rename. Previously it used a bare `os.Rename` which is not atomic on Windows when the destination exists.

- **`rename_unix.go`** — trivial `os.Rename` wrapper (POSIX guarantees atomicity)
- **`rename_windows.go`** — `MoveFileEx` with `MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH`, plus retry (3 attempts, exponential backoff starting at 5ms) for transient `ERROR_SHARING_VIOLATION` / `ERROR_LOCK_VIOLATION` errors caused by antivirus or file indexers

**`SetPin` method** — New method that writes and pins an entry atomically under a single lock acquisition. Eliminates the TOCTOU gap where an entry could be evicted between a `Set()` and `Pin()` call in API server mode. In CLI mode, the release function is a no-op.

9 subtests added covering: new entry, update existing, entry too large, cache full, LRU eviction, pinned entry protection, idempotent release, concurrent SetPin on same key, and eviction callback firing.

#### Pin Release Semantics

Both `Pin` and `SetPin` return a `release` function that the caller must invoke when the binary is no longer needed. The release function has the following properties:

- **Idempotent** — guarded by `atomic.Bool` CAS (`CompareAndSwap(false, true)`). Calling release multiple times is safe; only the first call decrements `refCount`.
- **Deferred eviction** — when `release()` fires and `refCount` drops to zero, if the entry was marked `pendingEvict` during the pin's lifetime (another goroutine tried to evict it while pinned), `removeEntry` runs immediately inside the release to clean up the entry and delete the file from disk.
- **Eviction notification** — eviction callbacks (`OnEviction`) are fired *outside* the mutex to avoid deadlocks with the versioned cache's index lock. The release function collects evicted keys under the lock, then calls `notifyEvicted` after unlocking.
- **CLI mode no-op** — in unbounded CLI mode (`managed == nil`), `SetPin` and `GetPin` return `func() {}`. There is no eviction in CLI mode, so no refCount tracking is needed. All callers can unconditionally call `release()` without checking the mode.
- **Ownership transfer** — the pin is acquired inside `SetPin`/`Pin`/`GetPin` and returned to the caller. The caller owns the release and must ensure it is called (typically via `defer`). In the API server's `pool.go` and `serve.go`, release is deferred immediately after `FetchPlugins` returns. In CLI-only code paths (`prepare.go`), release is a no-op so the absence of an explicit defer is safe today.

#### Versioned Cache (`pkg/cache/versionedcache/`)

The versioned cache is a semver-aware layer on top of the disk cache, used exclusively in API server mode (managed cache). It maintains an in-memory index of all cached versions per name+platform, sorted in descending semver order for O(1) latest-version lookup.

**`SetPin` method** — New method that delegates to `diskcache.SetPin` for atomic write+pin, then updates the semver version index. This is used by the plugin fetcher to cache a freshly downloaded binary and pin it in one step, guaranteeing no eviction gap between write and use.

**Index consistency** — The version index stays in sync through two mechanisms:
- On write: `Set()` / `SetPin()` parse the version string via `semver.NewVersion()` and insert it into the sorted index using binary search
- On eviction: The diskcache `OnEviction` callback (`onEvict`) parses the evicted key and removes the version from the index. This callback is wired internally in `New()` and appended last so it cannot be overridden by caller-provided options.

**Composite name support** — When a plugin is fetched from a catalog, the cache key uses a composite name (`"pluginName/registryHash"`) so that the same plugin from different registries occupies separate index entries. The `parseRelativePath` function handles both 4-segment (`name/version/os-arch/binary`) and 5-segment (`name/registryHash/version/os-arch/binary`) layouts.

**WarmUp** — On API server startup, `WarmUp()` walks the cache directory, parses each file path into name/version/platform components, adopts entries into the LRU without triggering eviction (the cache may temporarily exceed `maxSize`), and populates the semver index. Eviction occurs naturally on the next `Set()` call.

#### Singleflight Deduplication (`pkg/plugin/fetcher.go`)

Concurrent requests for the same plugin (same name/kind/version/platform) are coalesced into a single in-flight operation via `golang.org/x/sync/singleflight`. Applied to both `resolvePlugin` (catalog resolution) and `fetchPlugin` (binary download).

The generic `dedupeRequest[T]` helper uses `DoChan` (non-blocking) with `context.WithoutCancel` so that one caller's context cancellation does not abort the shared request. Each operation has its own timeout (`DefaultPluginResolveTimeout`, `DefaultPluginFetchTimeout`). Timed-out keys are forgotten from the singleflight group to allow retry.

#### Concurrent Plugin Fetches (`pkg/plugin/fetcher.go`)

`FetchPlugins` now resolves dependencies concurrently using `errgroup.WithContext` with `SetLimit(4)` (configurable via `settings.DefaultFetchConcurrency`). Results use index-based assignment into a pre-allocated slice, avoiding mutex contention.

#### Plugin Cache (`pkg/plugin/cache.go`)

The plugin cache is the high-level API consumed by the fetcher. It operates in two modes:

- **CLI mode** (`NewCache`) — unbounded, direct filesystem operations, no eviction. `SetPin` delegates to `Put` and returns a no-op release.
- **API server mode** (`NewManagedCache`) — bounded LRU backed by versioned cache → disk cache. `SetPin` delegates to `versionedcache.SetPin` which delegates to `diskcache.SetPin`, returning a real release function that decrements `refCount`.

The full write+pin path in API server mode:

```
plugin.Cache.SetPin()
  → versionedcache.Cache.SetPin()  (validates semver, updates version index)
    → diskcache.Cache.SetPin()     (write + pin under single mutex, returns release)
```

#### Documentation (`docs/design/api-plugin-cache`)

Updated to reflect code changes:

- `CachedPlugin` struct: added `RegistryHash` field
- `versionedcache.New` signature: corrected parameter type to `diskcache.CacheOption`
- Disk Cache layer description: clarified write mechanism (temp + fsync + platform-specific rename)
- Windows Support section: documented `MoveFileEx` flags and transient error retry behavior

### Breaking Changes

None. `SetPin` is a new method at all three layers. All existing public APIs retain their signatures.

### Dependencies

- `golang.org/x/sync/singleflight` (already in go.mod)
- `golang.org/x/sync/errgroup` (already in go.mod)
- `golang.org/x/sys/windows` v0.44.0 (already in go.mod, used by `rename_windows.go`)

Brief description of the changes.

## Related Issues

Closes #

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My commits follow conventional commit format
- [ ] I have added/updated tests for my changes
- [x] `go test ./...` passes
- [ ] `task lint` passes
- [ ] I have signed off my commits (`git commit -s -S`)
