### PR TITLE
feat(credentialhelper): make Docker credential helper usable by embedders

### DIFF
--- a/docs/tutorials/credential-helper-tutorial.md
+++ b/docs/tutorials/credential-helper-tutorial.md
@@ -134,10 +134,26 @@ The credential helper protocol uses four stdin/stdout commands:
 
 When Docker calls `get`, scafctl checks credentials in this order:
 
-1. **credhelper namespace** -- credentials stored via `docker login` (through scafctl)
-2. **Native credential store** -- credentials stored via `scafctl catalog login`
+1. **Dynamic token resolution** -- infers the auth handler for the registry and
+   mints a fresh token from it (auto-refreshing via a stored refresh token when
+   available)
+2. **credhelper namespace** -- credentials stored via `docker login` (through scafctl)
+3. **Native credential store** -- credentials stored via `scafctl catalog login`
 
-This means credentials from either source are available to Docker.
+This means credentials from any source are available to Docker.
+
+> **Note:** `get` runs as a non-interactive subprocess (no TTY). If the inferred
+> auth handler has no valid token and can only refresh through an interactive
+> login, dynamic resolution cannot complete inside the helper. scafctl emits an
+> actionable error naming the exact command to run, for example:
+>
+> ```json
+> {
+>   "message": "no valid credentials for https://ghcr.io: run 'scafctl auth login github' to re-authenticate (interactive login cannot run inside a credential-helper subprocess)"
+> }
+> ```
+>
+> Run the named `auth login` once; subsequent `get` calls then refresh silently.
 
 ## Using with Podman/Buildah
 
@@ -184,9 +200,38 @@ scafctl catalog login ghcr.io --username oauth2 --password @- < token.txt
 docker pull ghcr.io/your-org/your-image:latest
 ```
 
-## Uninstall
+## Embedding scafctl in another CLI
 
-Remove the credential helper integration:
+scafctl is consumable as a library by downstream CLIs that ship their own
+binary name. The credential helper works for embedders with **no extra wiring**:
+when the binary is invoked under a `docker-credential-<name>` alias, the shared
+root command automatically routes the helper verb into the `credential-helper`
+command tree.
+
+If you build your CLI via the shared `scafctl.Root(...)` constructor, you get
+this for free -- `credential-helper install` creates a
+`docker-credential-<yourbinary>` symlink, and Docker/Podman invoking it just
+works.
+
+For a fully custom `main` that does not use `scafctl.Root`, call the exported,
+side-effect-free dispatch helper at the very top of `main`:
+
+```go
+import "github.com/oakwood-commons/scafctl/pkg/credentialhelper"
+
+func main() {
+    // Route docker-credential-<name> <verb> into "credential-helper <verb>".
+    if rewritten, isAlias := credentialhelper.RewriteAliasArgs(os.Args); isAlias {
+        rootCmd.SetArgs(rewritten[1:]) // SetArgs excludes the program name
+    }
+    // ... normal command execution ...
+}
+```
+
+The actionable `get` error (see [How It Works](#how-it-works)) is derived from
+your configured binary name, so it names `your-binary auth login <handler>`.
+
+## Uninstall
 
 ```bash
 # Remove symlink and Docker config entry

--- a/pkg/cmd/scafctl/credentialhelper/credentialhelper.go
+++ b/pkg/cmd/scafctl/credentialhelper/credentialhelper.go
@@ -9,6 +9,7 @@ package credentialhelper
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -104,7 +105,7 @@ func commandGet() *cobra.Command {
 			}
 			cred, err := helper.Get(cmd.Context(), string(input))
 			if err != nil {
-				return writeError(os.Stdout, err.Error())
+				return writeError(os.Stdout, formatGetError(cmd.Context(), err))
 			}
 			return json.NewEncoder(os.Stdout).Encode(cred) //nolint:gosec // G117: required by Docker credential helper protocol
 		},
@@ -194,4 +195,22 @@ func writeError(w io.Writer, message string) error {
 	resp := credentialhelper.ErrorResponse{Message: message}
 	_ = json.NewEncoder(w).Encode(resp)
 	return exitcode.WithCode(fmt.Errorf("%s", message), exitcode.GeneralError)
+}
+
+// formatGetError renders the message written to the credential-helper error
+// response. When the failure is a ReauthRequiredError — a handler was inferred
+// but no usable token could be acquired non-interactively — it produces an
+// actionable hint naming the exact `auth login` command to run, derived from
+// the configured binary name so embedders get the correct command too.
+func formatGetError(ctx context.Context, err error) string {
+	var reauth *credentialhelper.ReauthRequiredError
+	if errors.As(err, &reauth) {
+		bin := settings.BinaryNameFromContext(ctx)
+		return fmt.Sprintf(
+			"no valid credentials for %s: run '%s auth login %s' to re-authenticate "+
+				"(interactive login cannot run inside a credential-helper subprocess)",
+			reauth.ServerURL, bin, reauth.Handler,
+		)
+	}
+	return err.Error()
 }

--- a/pkg/cmd/scafctl/credentialhelper/credentialhelper_test.go
+++ b/pkg/cmd/scafctl/credentialhelper/credentialhelper_test.go
@@ -5,7 +5,10 @@ package credentialhelper
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/credentialhelper"
@@ -63,6 +66,33 @@ func TestCommandGet_Structure(t *testing.T) {
 	assert.Equal(t, "get", cmd.Use)
 	assert.True(t, cmd.SilenceUsage)
 	assert.True(t, cmd.SilenceErrors)
+}
+
+func TestFormatGetError(t *testing.T) {
+	t.Run("reauth error yields actionable hint with binary name", func(t *testing.T) {
+		ctx := settings.IntoContext(context.Background(), &settings.Run{BinaryName: "mybin"})
+		err := &credentialhelper.ReauthRequiredError{
+			Handler:   "github",
+			ServerURL: "https://ghcr.io",
+		}
+		msg := formatGetError(ctx, err)
+		assert.Contains(t, msg, "mybin auth login github")
+		assert.Contains(t, msg, "https://ghcr.io")
+		assert.Contains(t, msg, "credential-helper subprocess")
+	})
+
+	t.Run("reauth error wrapped in chain is detected", func(t *testing.T) {
+		ctx := context.Background() // no settings -> default binary name
+		base := &credentialhelper.ReauthRequiredError{Handler: "entra", ServerURL: "acr.azurecr.io"}
+		wrapped := fmt.Errorf("get failed: %w", base)
+		msg := formatGetError(ctx, wrapped)
+		assert.Contains(t, msg, settings.CliBinaryName+" auth login entra")
+	})
+
+	t.Run("plain error returns its message verbatim", func(t *testing.T) {
+		msg := formatGetError(context.Background(), errors.New("credentials not found"))
+		assert.Equal(t, "credentials not found", msg)
+	})
 }
 
 func TestCommandStore_Structure(t *testing.T) {

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -42,6 +42,7 @@ import (
 	vendorcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/vendor"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/version"
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/credentialhelper"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/metrics"
@@ -891,6 +892,17 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 				_ = telShutdown(shutCtx)
 			}
 		})
+	}
+
+	// When the binary is invoked under a docker-credential-<name> alias (the
+	// symlink created by `credential-helper install`), rewrite the arguments so
+	// the helper verb routes into the credential-helper command tree. This makes
+	// scafctl — and any embedder building the CLI via Root — a working Docker/
+	// Podman credential helper with no extra wiring. os.Args[0] carries the alias
+	// name as exec'd; cobra otherwise ignores it. SetArgs expects args without
+	// the program name, so pass rewritten[1:].
+	if rewritten, isAlias := credentialhelper.RewriteAliasArgs(os.Args); isAlias {
+		cCmd.SetArgs(rewritten[1:])
 	}
 
 	return cCmd, cleanup

--- a/pkg/credentialhelper/credentialhelper.go
+++ b/pkg/credentialhelper/credentialhelper.go
@@ -90,12 +90,14 @@ func (h *Helper) Get(ctx context.Context, serverURL string) (*Credential, error)
 
 	// Try dynamic resolution first — this returns a fresh token from the
 	// auth handler, avoiding stale bridged credentials.
+	var resolverErr error
 	if h.tokenResolver != nil {
 		cred, err := h.tokenResolver.Resolve(ctx, serverURL)
 		if err == nil && cred != nil {
 			return cred, nil
 		}
-		// Fall through to stored credentials on any error.
+		// Remember the resolver error; fall through to stored credentials.
+		resolverErr = err
 	}
 
 	// Check credhelper: namespace next
@@ -120,6 +122,15 @@ func (h *Helper) Get(ctx context.Context, serverURL string) (*Credential, error)
 				Secret:    native.Password,
 			}, nil
 		}
+	}
+
+	// No stored fallback was found. When dynamic resolution failed because the
+	// inferred handler needs an interactive re-login, surface that typed error
+	// so the caller can render an actionable message instead of a bare
+	// "credentials not found".
+	var reauth *ReauthRequiredError
+	if errors.As(resolverErr, &reauth) {
+		return nil, reauth
 	}
 
 	return nil, fmt.Errorf("credentials not found")

--- a/pkg/credentialhelper/dispatch.go
+++ b/pkg/credentialhelper/dispatch.go
@@ -1,0 +1,60 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package credentialhelper
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+const (
+	// AliasPrefix is the basename prefix Docker/Podman use when invoking a
+	// credential helper binary (e.g. "docker-credential-scafctl").
+	AliasPrefix = "docker-credential-"
+
+	// CommandName is the cobra subcommand path that implements the helper
+	// protocol verbs (get/store/erase/list).
+	CommandName = "credential-helper"
+)
+
+// RewriteAliasArgs detects whether the process was invoked under a
+// docker-credential-<name> alias and, if so, returns a copy of argv rewritten
+// so the helper verb routes into the "credential-helper <verb>" command tree.
+//
+// Docker/Podman invoke a credential helper as:
+//
+//	docker-credential-<name> get      # server URL on stdin, JSON cred on stdout
+//	docker-credential-<name> store
+//	docker-credential-<name> erase
+//	docker-credential-<name> list
+//
+// The binary's argv therefore looks like {"docker-credential-<name>", "get"},
+// which a normal cobra root command cannot route (there is no top-level "get").
+// RewriteAliasArgs turns that into {"docker-credential-<name>", "credential-helper", "get"}.
+//
+// The returned slice preserves the input shape: element 0 is the original
+// program name (argv[0]), and the helper subcommand is inserted ahead of the
+// verb. Callers wiring this into cobra should pass rewritten[1:] to
+// (*cobra.Command).SetArgs, since cobra expects args without the program name.
+//
+// When the process was not invoked under an alias, RewriteAliasArgs returns the
+// original argv unchanged and isHelperAlias=false. The function is pure and has
+// no side effects, making it safe to call at the very top of main.
+func RewriteAliasArgs(argv []string) (rewritten []string, isHelperAlias bool) {
+	if len(argv) == 0 {
+		return argv, false
+	}
+	base := filepath.Base(argv[0])
+	// Strip a Windows executable suffix so docker-credential-mybin.exe matches.
+	base = strings.TrimSuffix(base, ".exe")
+	if !strings.HasPrefix(base, AliasPrefix) {
+		return argv, false
+	}
+
+	out := make([]string, 0, len(argv)+1)
+	out = append(out, argv[0])
+	out = append(out, CommandName)
+	out = append(out, argv[1:]...)
+	return out, true
+}

--- a/pkg/credentialhelper/dispatch_test.go
+++ b/pkg/credentialhelper/dispatch_test.go
@@ -1,0 +1,101 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package credentialhelper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRewriteAliasArgs(t *testing.T) {
+	tests := []struct {
+		name          string
+		argv          []string
+		wantRewritten []string
+		wantAlias     bool
+	}{
+		{
+			name:          "empty argv",
+			argv:          nil,
+			wantRewritten: nil,
+			wantAlias:     false,
+		},
+		{
+			name:          "non-alias binary",
+			argv:          []string{"/usr/local/bin/scafctl", "credential-helper", "get"},
+			wantRewritten: []string{"/usr/local/bin/scafctl", "credential-helper", "get"},
+			wantAlias:     false,
+		},
+		{
+			name:          "alias get",
+			argv:          []string{"/home/u/.local/bin/docker-credential-scafctl", "get"},
+			wantRewritten: []string{"/home/u/.local/bin/docker-credential-scafctl", "credential-helper", "get"},
+			wantAlias:     true,
+		},
+		{
+			name:          "alias store",
+			argv:          []string{"docker-credential-scafctl", "store"},
+			wantRewritten: []string{"docker-credential-scafctl", "credential-helper", "store"},
+			wantAlias:     true,
+		},
+		{
+			name:          "alias erase",
+			argv:          []string{"docker-credential-scafctl", "erase"},
+			wantRewritten: []string{"docker-credential-scafctl", "credential-helper", "erase"},
+			wantAlias:     true,
+		},
+		{
+			name:          "alias list",
+			argv:          []string{"docker-credential-scafctl", "list"},
+			wantRewritten: []string{"docker-credential-scafctl", "credential-helper", "list"},
+			wantAlias:     true,
+		},
+		{
+			name:          "alias with no verb",
+			argv:          []string{"docker-credential-scafctl"},
+			wantRewritten: []string{"docker-credential-scafctl", "credential-helper"},
+			wantAlias:     true,
+		},
+		{
+			name:          "embedder binary name",
+			argv:          []string{"/opt/mybin/docker-credential-mybin", "get"},
+			wantRewritten: []string{"/opt/mybin/docker-credential-mybin", "credential-helper", "get"},
+			wantAlias:     true,
+		},
+		{
+			name:          "windows exe suffix",
+			argv:          []string{"docker-credential-mybin.exe", "get"},
+			wantRewritten: []string{"docker-credential-mybin.exe", "credential-helper", "get"},
+			wantAlias:     true,
+		},
+		{
+			name:          "unknown verb still routed",
+			argv:          []string{"docker-credential-scafctl", "bogus"},
+			wantRewritten: []string{"docker-credential-scafctl", "credential-helper", "bogus"},
+			wantAlias:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRewritten, gotAlias := RewriteAliasArgs(tt.argv)
+			assert.Equal(t, tt.wantAlias, gotAlias)
+			assert.Equal(t, tt.wantRewritten, gotRewritten)
+		})
+	}
+}
+
+// TestRewriteAliasArgs_DoesNotMutateInput ensures the input slice is not
+// modified in place when an alias is detected.
+func TestRewriteAliasArgs_DoesNotMutateInput(t *testing.T) {
+	argv := []string{"docker-credential-scafctl", "get"}
+	original := make([]string, len(argv))
+	copy(original, argv)
+
+	_, isAlias := RewriteAliasArgs(argv)
+
+	assert.True(t, isAlias)
+	assert.Equal(t, original, argv, "input argv must not be mutated")
+}

--- a/pkg/credentialhelper/resolver.go
+++ b/pkg/credentialhelper/resolver.go
@@ -41,6 +41,30 @@ func NewAuthTokenResolver(registry *auth.Registry, opts ...ResolverOption) *Auth
 	return r
 }
 
+// ReauthRequiredError indicates that an auth handler was successfully inferred
+// for a registry, but acquiring a fresh token failed — typically because the
+// stored token is missing or expired and the handler can only refresh through
+// an interactive login. Interactive login cannot run inside a non-interactive
+// credential-helper subprocess, so the user must run `auth login` beforehand.
+//
+// Callers can detect this via errors.As to render an actionable message that
+// names the exact handler to re-authenticate.
+type ReauthRequiredError struct {
+	// Handler is the inferred auth handler name (e.g. "github", "entra").
+	Handler string
+	// ServerURL is the registry server URL that was being resolved.
+	ServerURL string
+	// Err is the underlying failure from the token bridge.
+	Err error
+}
+
+func (e *ReauthRequiredError) Error() string {
+	return fmt.Sprintf("no valid token for registry %q via auth handler %q: %v", e.ServerURL, e.Handler, e.Err)
+}
+
+// Unwrap exposes the underlying error for errors.Is/As chains.
+func (e *ReauthRequiredError) Unwrap() error { return e.Err }
+
 // Resolve infers the auth handler for serverURL, resolves the active profile,
 // and returns fresh credentials. Returns an error if no handler can be inferred
 // or the handler is not registered/authenticated.
@@ -66,7 +90,14 @@ func (r *AuthTokenResolver) Resolve(ctx context.Context, serverURL string) (*Cre
 	scope := catalog.InferDefaultScope(host)
 	username, password, err := catalog.BridgeAuthToRegistry(ctx, handlerName, host, scope)
 	if err != nil {
-		return nil, fmt.Errorf("bridge auth for %q: %w", serverURL, err)
+		// A handler was inferred but no usable token could be acquired. Surface
+		// a typed error so the credential-helper get command can emit an
+		// actionable "run <binary> auth login <handler>" message.
+		return nil, &ReauthRequiredError{
+			Handler:   handlerName,
+			ServerURL: serverURL,
+			Err:       fmt.Errorf("bridge auth for %q: %w", serverURL, err),
+		}
 	}
 
 	return &Credential{

--- a/pkg/credentialhelper/resolver_test.go
+++ b/pkg/credentialhelper/resolver_test.go
@@ -6,6 +6,7 @@ package credentialhelper
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -105,6 +106,52 @@ func TestHelperGet_DynamicResolution(t *testing.T) {
 		got, err := helper.Get(context.Background(), "ghcr.io")
 		require.NoError(t, err)
 		assert.Equal(t, "stored-token", got.Secret, "nil credential should fall through")
+	})
+
+	t.Run("reauth error surfaced when no fallback", func(t *testing.T) {
+		t.Parallel()
+		store := secrets.NewMockStore()
+		resolver := &mockResolver{err: &ReauthRequiredError{
+			Handler:   "github",
+			ServerURL: "ghcr.io",
+			Err:       fmt.Errorf("bridge auth for %q: token expired", "ghcr.io"),
+		}}
+		helper := New(store, WithTokenResolver(resolver))
+
+		_, err := helper.Get(context.Background(), "ghcr.io")
+		require.Error(t, err)
+		var reauth *ReauthRequiredError
+		require.ErrorAs(t, err, &reauth, "reauth error should be surfaced, not masked as 'credentials not found'")
+		assert.Equal(t, "github", reauth.Handler)
+		assert.Equal(t, "ghcr.io", reauth.ServerURL)
+	})
+
+	t.Run("reauth error masked by stored fallback", func(t *testing.T) {
+		t.Parallel()
+		store := secrets.NewMockStore()
+		cred := Credential{ServerURL: "ghcr.io", Username: "stored-user", Secret: "stored-token"}
+		data, _ := json.Marshal(cred)
+		store.Data["credhelper:ghcr.io"] = data
+
+		resolver := &mockResolver{err: &ReauthRequiredError{Handler: "github", ServerURL: "ghcr.io"}}
+		helper := New(store, WithTokenResolver(resolver))
+
+		got, err := helper.Get(context.Background(), "ghcr.io")
+		require.NoError(t, err, "a usable stored credential should win over a reauth hint")
+		assert.Equal(t, "stored-token", got.Secret)
+	})
+
+	t.Run("plain resolver error stays credentials not found", func(t *testing.T) {
+		t.Parallel()
+		store := secrets.NewMockStore()
+		resolver := &mockResolver{err: fmt.Errorf("no auth handler for registry")}
+		helper := New(store, WithTokenResolver(resolver))
+
+		_, err := helper.Get(context.Background(), "unknown.io")
+		require.Error(t, err)
+		var reauth *ReauthRequiredError
+		assert.False(t, errors.As(err, &reauth))
+		assert.Contains(t, err.Error(), "credentials not found")
 	})
 }
 
@@ -257,6 +304,11 @@ func TestAuthTokenResolver_Resolve(t *testing.T) {
 		_, err := resolver.Resolve(ctx, "ghcr.io")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "bridge auth")
+
+		var reauth *ReauthRequiredError
+		require.ErrorAs(t, err, &reauth, "a failed token bridge should yield a ReauthRequiredError")
+		assert.Equal(t, "github", reauth.Handler)
+		assert.Equal(t, "ghcr.io", reauth.ServerURL)
 	})
 
 	t.Run("custom handler via config", func(t *testing.T) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -8509,6 +8509,91 @@ func TestIntegration_CredentialHelperListEmpty(t *testing.T) {
 	}
 }
 
+// runCredHelperSymlink invokes the integration binary through a
+// docker-credential-<name> symlink, mirroring how Docker/Podman exec a
+// credential helper. It returns stdout, stderr, and the exit code.
+func runCredHelperSymlink(t *testing.T, aliasName, stdin, verb string) (stdout, stderr string, exitCode int) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink dispatch test is POSIX-only")
+	}
+
+	linkDir := t.TempDir()
+	linkPath := filepath.Join(linkDir, aliasName)
+	require.NoError(t, os.Symlink(binaryPath, linkPath))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, linkPath, verb)
+	cmd.Dir = findProjectRoot()
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err := cmd.Run()
+	stdout = outBuf.String()
+	stderr = errBuf.String()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("failed to run credential helper symlink: %v", err)
+		}
+	}
+	return stdout, stderr, exitCode
+}
+
+// TestIntegration_CredentialHelperSymlinkDispatch verifies that invoking the
+// binary under a docker-credential-<name> alias routes into the
+// credential-helper command tree (Problem 1 in issue #540). Without the
+// argv[0] dispatch, cobra would fail with "unknown command \"get\"".
+func TestIntegration_CredentialHelperSymlinkDispatch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("get routes via scafctl alias", func(t *testing.T) {
+		t.Parallel()
+		stdout, stderr, exitCode := runCredHelperSymlink(t, "docker-credential-scafctl", "https://unknown.registry.io", "get")
+
+		assert.NotContains(t, stderr, "unknown command", "argv[0] dispatch should route get into credential-helper")
+		assert.NotEqual(t, 0, exitCode, "unknown registry should fail")
+
+		var errResp map[string]string
+		require.NoError(t, json.Unmarshal([]byte(stdout), &errResp), "stdout should be a JSON error response, got: %q / stderr: %q", stdout, stderr)
+		assert.Contains(t, errResp["message"], "credentials not found")
+	})
+
+	t.Run("embedder binary name also routes", func(t *testing.T) {
+		t.Parallel()
+		// The dispatch keys off the docker-credential- prefix, not the binary
+		// suffix, so an embedder alias routes the same way.
+		stdout, stderr, exitCode := runCredHelperSymlink(t, "docker-credential-myembedder", "https://unknown.registry.io", "get")
+
+		assert.NotContains(t, stderr, "unknown command")
+		assert.NotEqual(t, 0, exitCode)
+
+		var errResp map[string]string
+		require.NoError(t, json.Unmarshal([]byte(stdout), &errResp), "stdout should be JSON, got: %q / stderr: %q", stdout, stderr)
+		assert.Contains(t, errResp["message"], "credentials not found")
+	})
+
+	t.Run("list routes and returns valid JSON", func(t *testing.T) {
+		t.Parallel()
+		stdout, stderr, exitCode := runCredHelperSymlink(t, "docker-credential-scafctl", "", "list")
+
+		assert.NotContains(t, stderr, "unknown command", "argv[0] dispatch should route list into credential-helper")
+		if exitCode == 0 {
+			var result map[string]string
+			require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+			assert.NotNil(t, result)
+		}
+	})
+}
+
 // ============================================================================
 // Plugin Execution Integration Tests
 // ============================================================================


### PR DESCRIPTION
Enable scafctl-embedding CLIs to act as Docker/Podman credential helpers with no extra wiring, and surface an actionable re-login hint when a registry token has expired.

- Add RewriteAliasArgs to route docker-credential-<name> <verb> into the credential-helper command tree via argv[0] dispatch
- Auto-wire alias dispatch in Root() so any embedder built on the shared root command works as a credential helper out of the box
- Add typed ReauthRequiredError so a failed token bridge is distinguished from a missing credential
- Surface ReauthRequiredError from Helper.Get when no stored fallback exists, instead of a bare "credentials not found"
- Render an actionable get error naming the exact "<binary> auth login <handler>" command, derived from the configured binary name
- Document embedder integration and the re-login flow in the tutorial
- Cover dispatch, reauth surfacing, and symlink routing with unit and integration tests

Closes #540