### PR TITLE
feat(resolver): add validate command and non-fatal validation diagnostics

### DIFF
--- a/docs/tutorials/mcp-server-tutorial.md
+++ b/docs/tutorials/mcp-server-tutorial.md
@@ -723,7 +723,7 @@ The AI calls `inspect_solution` with `path: "solution.yaml"` and the response in
 | `list_providers` | List all providers with capability and category filtering |
 | `list_solutions` | List solutions from the local catalog with name filtering |
 | `preview_action` | Preview what each action in a workflow would do WITHOUT executing — shows materialized inputs, deferred values, phases, dependencies, and cross-section references (`crossSectionRefs`) for finally actions reading main-section results |
-| `preview_resolvers` | Execute a solution's resolver chain and return each resolver's resolved value, output schema, and source positions. Use `resolver` param to focus on a single resolver and its dependencies |
+| `preview_resolvers` | Execute a solution's resolver chain and return each resolver's resolved value, output schema, and source positions. Use `resolver` param to focus on a single resolver and its dependencies. Validation failures are non-fatal by default: resolved values are returned alongside a `diagnostics` list and `valid: false`. Set `strict: true` to report an error result on validation failure (values are still included) |
 | `render_solution` | Render action, resolver, or action-deps graphs as structured JSON |
 | `run_solution_tests` | Execute functional tests defined in a solution and return structured results. Use `verbose=true` for full assertion details |
 | `scaffold_solution` | Generate a complete skeleton solution YAML from parameters — name, description, features, and providers |

--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -456,9 +456,11 @@ Output:
 
 ## Skipping Phases
 
-Resolvers execute through three ordered phases: **resolve → transform → validate**. You can skip phases to inspect intermediate values — particularly useful when validation blocks output and you need to see what was actually resolved.
+Resolvers execute through three ordered phases: **resolve -> transform -> validate**. You can skip phases to inspect intermediate values, or rely on the non-fatal validation behavior described below to see resolved values even when validation fails.
 
-Create a file called `phases-demo.yaml`. This example resolves a port number, transforms it by adding `8000`, then validates the result is within the valid port range. The input value of `60000` is intentionally too high — after the transform, the result (`68000`) exceeds the valid range:
+> **Validation is non-fatal in `run resolver`.** Because `run resolver` is an inspection and troubleshooting command, validation failures never withhold the produced values. The resolved values are still printed, validation diagnostics are written to stderr, and the command exits `0`. To make validation failures exit non-zero (for example, in CI), pass `--fail-on-validation`. To gate on validation as the primary intent, use the dedicated [`scafctl validate resolver`](#validate-resolver) command, which presets fatal validation.
+
+Create a file called `phases-demo.yaml`. This example resolves a port number, transforms it by adding `8000`, then validates the result is within the valid port range. The input value of `60000` is intentionally too high -- after the transform, the result (`68000`) exceeds the valid range:
 
 ```yaml
 apiVersion: scafctl.io/v1
@@ -488,7 +490,7 @@ spec:
               message: "Port must be between 1024 and 65535"
 ```
 
-Running the resolver fails because the transformed value (`68000`) exceeds the valid port range:
+Running the resolver reports a validation failure because the transformed value (`68000`) exceeds the valid port range -- but the value is still shown:
 
 {{< tabs "run-resolver-tutorial-cmd-9" >}}
 {{% tab "Bash" %}}
@@ -503,17 +505,44 @@ scafctl run resolver -f phases-demo.yaml -o json
 {{% /tab %}}
 {{< /tabs >}}
 
-Output:
+Output (values on stdout, exit `0`):
+
+```json
+{
+  "port": 68000
+}
+```
+
+Diagnostics on stderr:
 
 ```
-❌ resolver execution failed: ... validation: Port must be between 1024 and 65535
+Warning: 1 resolver(s) failed validation:
+  - port: Port must be between 1024 and 65535
+(values shown above; pass --fail-on-validation to exit non-zero)
 ```
 
-The validation error blocks the output entirely — you can't see the resolved value.
+You can see the resolved value (`68000`) directly, and the diagnostic explains why it is invalid -- no flags required.
+
+To make validation failures exit non-zero, add `--fail-on-validation`:
+
+{{< tabs "run-resolver-tutorial-cmd-9b" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl run resolver -f phases-demo.yaml -o json --fail-on-validation
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl run resolver -f phases-demo.yaml -o json --fail-on-validation
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+The values are still printed, the diagnostics still appear on stderr, but the command now exits `2` (validation failed).
 
 ### Skip Validation
 
-Use `--skip-validation` to bypass the validation phase and see the actual value:
+Use `--skip-validation` to bypass the validation phase entirely (no diagnostics, no validation work):
 
 {{< tabs "run-resolver-tutorial-cmd-10" >}}
 {{% tab "Bash" %}}
@@ -536,7 +565,7 @@ Output:
 }
 ```
 
-Now you can see the problem: the transform added `8000` to `60000`, producing `68000` which exceeds the valid port range. Without `--skip-validation`, this value would be hidden behind the error.
+Now you can see the problem: the transform added `8000` to `60000`, producing `68000` which exceeds the valid port range. Unlike the default non-fatal behavior, `--skip-validation` produces no validation diagnostics at all.
 
 ### Skip Transform (and Validation)
 
@@ -567,6 +596,27 @@ This reveals the provider returned `60000` — confirming the root cause is the 
 
 > [!WARNING]
 > **Note**: `--skip-transform` implies `--skip-validation` because validating a pre-transform value is misleading — validation rules are written against the expected final shape.
+
+---
+
+## Validate Resolver
+
+When your primary intent is to **gate on validation** rather than inspect values, use the dedicated `scafctl validate resolver` command. It behaves like `run resolver` but presets fatal validation: validation failures exit `2` (validation failed). It is equivalent to `run resolver --fail-on-validation`, expressed as a first-class verb for clarity in scripts and CI pipelines.
+
+{{< tabs "run-resolver-tutorial-cmd-validate" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl validate resolver -f phases-demo.yaml -o json
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl validate resolver -f phases-demo.yaml -o json
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+The resolved values are still printed and diagnostics still appear on stderr, but the command exits `2` when any resolver fails validation. Use `run resolver` for day-to-day troubleshooting (exit `0`) and `validate resolver` when a non-zero exit on validation failure is the goal.
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -228,7 +228,7 @@ Standalone demo files in the root examples directory:
 |------|-------------|
 | [resolver-demo.yaml](resolver-demo.yaml) | Interactive resolver demonstration |
 | [resolver-stress-demo.yaml](resolver-stress-demo.yaml) | Performance testing with many resolvers |
-| [resolver-validation-failures-demo.yaml](resolver-validation-failures-demo.yaml) | Demonstrates validation error handling |
+| [resolver-validation-failures-demo.yaml](resolver-validation-failures-demo.yaml) | Validation error handling; non-fatal by default (`--fail-on-validation` or `validate resolver` to exit non-zero) |
 
 ---
 

--- a/examples/resolver-validation-failures-demo.yaml
+++ b/examples/resolver-validation-failures-demo.yaml
@@ -1,4 +1,11 @@
 # Run: scafctl run resolver -f resolver-validation-failures-demo.yaml
+#
+# Validation is non-fatal in `run resolver`: the resolved values are still
+# printed on stdout, validation diagnostics are written to stderr, and the
+# command exits 0. To make validation failures exit non-zero (e.g. in CI):
+#   scafctl run resolver -f resolver-validation-failures-demo.yaml --fail-on-validation
+# Or use the dedicated validation gate, which presets fatal validation (exit 2):
+#   scafctl validate resolver -f resolver-validation-failures-demo.yaml
 
 apiVersion: scafctl.io/v1
 kind: Solution
@@ -13,6 +20,10 @@ metadata:
   description: |
     Intentional validation failure scenarios for testing and learning.
     Shows how scafctl reports different types of validation failures.
+
+    Validation is non-fatal in `run resolver`: resolved values are still shown,
+    diagnostics go to stderr, and the command exits 0. Pass --fail-on-validation
+    (or use `scafctl validate resolver`) to exit non-zero on validation failure.
 
 spec:
   resolvers:

--- a/pkg/celexp/refs.go
+++ b/pkg/celexp/refs.go
@@ -42,7 +42,9 @@ func (e Expression) GetVariablesWithPrefix(ctx context.Context, prefix string) (
 	if factory != nil {
 		env, err = factory(ctx)
 	} else {
-		env, err = cel.NewEnv()
+		// Enable optional types so optional access (_.?name, _[?"name"]) parses
+		// even when no extension factory is registered (e.g. white-box tests).
+		env, err = cel.NewEnv(cel.OptionalTypes())
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
@@ -125,7 +127,9 @@ func (e Expression) RequiredVariables(ctx context.Context) ([]string, error) {
 	if factory != nil {
 		env, err = factory(ctx)
 	} else {
-		env, err = cel.NewEnv()
+		// Enable optional types so optional access (_.?name, _[?"name"]) parses
+		// even when no extension factory is registered (e.g. white-box tests).
+		env, err = cel.NewEnv(cel.OptionalTypes())
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
@@ -216,15 +220,21 @@ func extractVariablesWithPrefix(expr *exprpb.Expr, prefix string, vars map[strin
 		// Process function calls and their arguments
 		call := expr.GetCallExpr()
 
-		// Handle bracket/index access: _["resolverName"] is parsed as a CallExpr
-		// with function "_[_]", where args[0] is the map operand and args[1] is the key.
-		if useSelect && call.GetFunction() == "_[_]" && len(call.GetArgs()) == 2 {
-			operand := call.GetArgs()[0]
-			key := call.GetArgs()[1]
-			if operand.GetIdentExpr() != nil && operand.GetIdentExpr().GetName() == baseIdent {
-				// Check if the key is a string constant (e.g., _["resolverName"])
-				if key.GetConstExpr() != nil && key.GetConstExpr().GetStringValue() != "" {
-					vars[key.GetConstExpr().GetStringValue()] = struct{}{}
+		// Handle index and optional access, all of which are parsed as a CallExpr
+		// with args[0] the operand and args[1] the field/key string constant:
+		//   _["resolverName"]  -> function "_[_]"   (bracket index)
+		//   _.?resolverName    -> function "_?._"   (optional select)
+		//   _[?"resolverName"] -> function "_[?_]"  (optional index)
+		if useSelect && len(call.GetArgs()) == 2 {
+			switch call.GetFunction() {
+			case "_[_]", "_?._", "_[?_]":
+				operand := call.GetArgs()[0]
+				key := call.GetArgs()[1]
+				if operand.GetIdentExpr() != nil && operand.GetIdentExpr().GetName() == baseIdent {
+					// Check if the key is a string constant (e.g., _["resolverName"])
+					if key.GetConstExpr() != nil && key.GetConstExpr().GetStringValue() != "" {
+						vars[key.GetConstExpr().GetStringValue()] = struct{}{}
+					}
 				}
 			}
 		}

--- a/pkg/celexp/refs_test.go
+++ b/pkg/celexp/refs_test.go
@@ -261,6 +261,31 @@ func TestGetUnderscoreVariables_EdgeCases(t *testing.T) {
 			expected:   []string{"user"},
 		},
 		{
+			name:       "optional select",
+			expression: `_.?platformProfileID`,
+			expected:   []string{"platformProfileID"},
+		},
+		{
+			name:       "optional select with method chain",
+			expression: `_.?platformProfileID.orValue("")`,
+			expected:   []string{"platformProfileID"},
+		},
+		{
+			name:       "optional select mixed with plain select",
+			expression: `_.?platformProfileID.orValue("") + _.moduleSource`,
+			expected:   []string{"moduleSource", "platformProfileID"},
+		},
+		{
+			name:       "optional index bracket notation",
+			expression: `_[?"my-resolver"]`,
+			expected:   []string{"my-resolver"},
+		},
+		{
+			name:       "optional select inside map literal",
+			expression: `{"a": _.?platformProfileID.orValue(""), "b": _.moduleSource}`,
+			expected:   []string{"moduleSource", "platformProfileID"},
+		},
+		{
 			name:       "unclosed parenthesis",
 			expression: "_.value + (_.other",
 			wantError:  true,

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -39,6 +39,7 @@ import (
 	solutioncmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/solution"
 	statecmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/state"
 	testcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/test"
+	validatecmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/validate"
 	vendorcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/vendor"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/version"
 	"github.com/oakwood-commons/scafctl/pkg/config"
@@ -838,6 +839,7 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 	cCmd.AddCommand(withGroup(groupCore, render.CommandRender(cliParams, ioStreams, binaryName)))
 	cCmd.AddCommand(withGroup(groupCore, lint.CommandLint(cliParams, ioStreams, binaryName)))
 	cCmd.AddCommand(withGroup(groupCore, testcmd.CommandTest(cliParams, ioStreams, binaryName)))
+	cCmd.AddCommand(withGroup(groupCore, validatecmd.CommandValidate(cliParams, ioStreams, binaryName)))
 
 	// Inspection Commands — explore and understand solutions
 	cCmd.AddCommand(withGroup(groupInspect, get.CommandGet(cliParams, ioStreams, binaryName)))

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -200,6 +200,14 @@ type sharedResolverOptions struct {
 	// declare them explicitly in bundle.plugins.
 	Strict bool
 
+	// nonFatalValidation, when true, makes executeResolvers treat resolver
+	// validation-only failures as non-fatal: it returns the populated values
+	// and resolver context alongside the error instead of discarding them.
+	// Resolve- and transform-phase failures remain fatal. Set only by
+	// inspection commands (run resolver, validate resolver), never by run
+	// solution / run action which keep validation as a hard gate.
+	nonFatalValidation bool
+
 	// kvx output integration (shared flags)
 	flags.KvxOutputFlags
 
@@ -491,7 +499,7 @@ func (o *sharedResolverOptions) executeResolvers(
 	if progressCallback != nil {
 		executorOpts = append(executorOpts, resolver.WithProgressCallback(progressCallback))
 	}
-	if resolverCfg.ValidateAll {
+	if resolverCfg.ValidateAll || o.nonFatalValidation {
 		executorOpts = append(executorOpts, resolver.WithValidateAll(true))
 	}
 	if o.SkipValidation {
@@ -540,26 +548,30 @@ func (o *sharedResolverOptions) executeResolvers(
 
 	// Execute resolvers
 	resultCtx, err := executor.Execute(ctx, resolvers, params)
-	if err != nil {
+
+	// Retrieve the resolver context with results. It is populated even on
+	// failure, so fetch it before deciding how to handle the error.
+	resolverCtx, ctxOK := resolver.FromContext(resultCtx)
+	if !ctxOK {
 		if progress != nil {
 			progress.Wait()
 		}
-		return nil, nil, fmt.Errorf("resolver execution failed: %w", err)
-	}
-
-	// Get resolver context with results
-	resolverCtx, ok := resolver.FromContext(resultCtx)
-	if !ok {
-		if progress != nil {
-			progress.Wait()
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolver execution failed: %w", err)
 		}
 		return nil, nil, fmt.Errorf("failed to retrieve resolver results")
 	}
 
-	// Build resolver data map
+	// Build resolver data map. In non-fatal mode, also include partial values
+	// captured by resolvers that failed validation so they remain inspectable.
 	for name := range sol.Spec.Resolvers {
 		result, ok := resolverCtx.GetResult(name)
-		if ok && result.Status == resolver.ExecutionStatusSuccess {
+		if !ok {
+			continue
+		}
+		if result.Status == resolver.ExecutionStatusSuccess {
+			resolverData[name] = result.Value
+		} else if o.nonFatalValidation && result.Value != nil {
 			resolverData[name] = result.Value
 		}
 	}
@@ -567,6 +579,19 @@ func (o *sharedResolverOptions) executeResolvers(
 	// Wait for progress bars to complete
 	if progress != nil {
 		progress.Wait()
+	}
+
+	if err != nil {
+		// In non-fatal mode, return the populated values and context alongside
+		// the error so the caller can render values plus diagnostics instead of
+		// aborting -- but only for pure validation failures. Resolve- and
+		// transform-phase failures (where no value exists) remain fatal and
+		// discard partial results so the caller surfaces a hard failure. In
+		// fatal mode (run solution / run action), all errors are fatal.
+		if o.nonFatalValidation && execute.IsValidationOnlyFailure(err) {
+			return resolverData, resolverCtx, fmt.Errorf("resolver execution failed: %w", err)
+		}
+		return nil, nil, fmt.Errorf("resolver execution failed: %w", err)
 	}
 
 	lgr.V(1).Info("resolver execution complete", "resolvedCount", len(resolverData))

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -73,6 +73,11 @@ type ResolverOptions struct {
 	// ShowExecution includes the __execution metadata in output.
 	ShowExecution bool
 
+	// FailOnValidation makes the command exit with a non-zero status when any
+	// resolver fails validation. By default, validation failures are reported as
+	// non-fatal diagnostics (values are still shown) and the command exits 0.
+	FailOnValidation bool
+
 	// DynamicArgs are resolver parameters from positional key=value syntax
 	// (e.g. env=prod region=us-east-1, captured from positional args containing '=').
 	DynamicArgs []string
@@ -268,7 +273,89 @@ Examples:
 	cCmd.Flags().StringVar(&options.SnapshotFile, "snapshot-file", "", "Snapshot output file (required with --snapshot)")
 	cCmd.Flags().BoolVar(&options.Redact, "redact", false, "Redact sensitive values in snapshot")
 	cCmd.Flags().BoolVar(&options.ShowExecution, "show-execution", false, "Include __execution metadata (phases, timing, dependencies, providers) in output")
+	cCmd.Flags().BoolVar(&options.FailOnValidation, "fail-on-validation", false, "Exit non-zero when any resolver fails validation (by default validation failures are non-fatal diagnostics)")
 	cCmd.Flags().StringArrayVar(&options.Actions, "action", nil, "Scope resolver output to the resolvers consumed by this action (repeatable)")
+
+	setResolverHelpFunc(cCmd)
+
+	return cCmd
+}
+
+// CommandValidateResolver creates the 'validate resolver' subcommand. It reuses
+// the resolver execution machinery but always treats validation failures as
+// fatal (exit code 2), making it a validation gate suitable for CI. Unlike
+// 'run resolver', it does not expose graph/snapshot modes — its sole purpose is
+// to validate resolver outputs and report failures.
+func CommandValidateResolver(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	options := &ResolverOptions{FailOnValidation: true}
+
+	cfg := runCommandConfig{
+		cliParams: cliParams,
+		ioStreams: ioStreams,
+		path:      path,
+		runner:    options,
+		getOutputFn: func() string {
+			return options.Output
+		},
+		setIOStreamFn: func(ios *terminal.IOStreams, cli *settings.Run) {
+			options.BinaryName = cli.BinaryName
+			options.IOStreams = ios
+			options.CliParams = cli
+		},
+	}
+
+	cCmd := &cobra.Command{
+		Use:     "resolver [resolver-name...] [key=value...]",
+		Aliases: []string{"res", "resolvers"},
+		Short:   "Validate resolvers and fail when validation does not pass",
+		Long: strings.ReplaceAll(`Validate a solution's resolvers and exit non-zero on validation failure.
+
+This command executes the resolvers (resolve, transform, and validate phases)
+and reports any validation failures as errors. Unlike 'run resolver', which
+treats validation failures as non-fatal diagnostics and exits 0, this command
+exits with code 2 when any resolver fails validation. Use it as a validation
+gate in CI pipelines or pre-commit checks.
+
+Resolved values are still printed so failures can be inspected. Input
+parameters and solution sources work exactly as in 'run resolver'.
+
+`+ResolverParametersHelp+`
+
+EXIT CODES:
+  0  All resolvers validated successfully
+  1  Resolver execution failed
+  2  Validation failed
+  3  Invalid solution (cycle/parse error)
+  4  File not found
+
+Examples:
+  # Validate all resolvers (auto-discovery)
+  scafctl validate resolver
+
+  # Validate resolvers from a solution file
+  scafctl validate resolver -f ./my-solution.yaml
+
+  # Validate with parameters
+  scafctl validate resolver -f ./my-solution.yaml env=prod region=us-east1
+
+  # Validate specific resolvers (with their dependencies)
+  scafctl validate resolver db config -f ./my-solution.yaml`, settings.CliBinaryName, cliParams.BinaryName),
+		Args: cobra.ArbitraryArgs,
+		PreRun: func(cCmd *cobra.Command, args []string) {
+			options.flagsChanged = make(map[string]bool)
+			cCmd.Flags().Visit(func(f *pflag.Flag) {
+				options.flagsChanged[f.Name] = true
+			})
+			fileExplicit := options.flagsChanged["file"]
+			parseResolverArgs(args, options, fileExplicit)
+		},
+		RunE:         makeRunEFunc(cfg, "resolver"),
+		SilenceUsage: true,
+	}
+
+	addSharedResolverFlags(cCmd, &options.sharedResolverOptions)
+	cCmd.Flags().BoolVar(&options.ShowExecution, "show-execution", false, "Include __execution metadata (phases, timing, dependencies, providers) in output")
+	cCmd.Flags().StringArrayVar(&options.Actions, "action", nil, "Scope validation to the resolvers consumed by this action (repeatable)")
 
 	setResolverHelpFunc(cCmd)
 
@@ -528,20 +615,28 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		o.sharedResolverOptions.SkipTransform = true
 	}
 
+	// run resolver is an inspection command: validation failures must never
+	// withhold the produced values. Enable non-fatal mode so executeResolvers
+	// returns partial values plus diagnostics instead of aborting.
+	o.nonFatalValidation = true
+
 	// Track timing
 	start := time.Now()
 
 	// Execute resolvers
-	resolverData, resolverCtx, err := o.executeResolvers(ctx, sol, resolvers, params, reg)
-	if err != nil {
-		return o.exitWithCode(ctx, err, exitcode.GeneralError)
+	resolverData, resolverCtx, execErr := o.executeResolvers(ctx, sol, resolvers, params, reg)
+	if execErr != nil && resolverCtx == nil {
+		// A hard failure occurred before any values could be produced
+		// (e.g., phase build error). Abort with the error.
+		return o.exitWithCode(ctx, execErr, exitcode.GeneralError)
 	}
 
 	elapsed := time.Since(start)
 
 	// State lifecycle: save merged parameters and check immutable values
-	// after successful resolver execution.
-	if stateMgr != nil && stateData != nil {
+	// after successful resolver execution. Skip the save when validation failed
+	// so invalid values are never persisted.
+	if stateMgr != nil && stateData != nil && execErr == nil {
 		solMeta := buildStateSolutionMeta(sol)
 		if saveErr := stateMgr.Save(ctx, stateData, resolverCtx, resolvers, params, resolverData, solMeta); saveErr != nil {
 			return o.exitWithCode(ctx, fmt.Errorf("state save: %w", saveErr), exitcode.GeneralError)
@@ -586,12 +681,70 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		results["__execution"] = executionData
 	}
 
+	// Surface non-fatal validation diagnostics on stderr so the resolved values
+	// (on stdout) remain useful for troubleshooting and machine consumption.
+	if execErr != nil {
+		o.renderValidationDiagnostics(ctx, execErr)
+	}
+
 	// When -o test: generate a functional test definition instead of normal output.
 	if o.Output == "test" {
 		return o.generateTestOutput(ctx, []string{"run", "resolver"}, o.Names, results)
 	}
 
-	return o.writeResolverOutput(ctx, results, o.BinaryName+" run resolver")
+	if err := o.writeResolverOutput(ctx, results, o.BinaryName+" run resolver"); err != nil {
+		return err
+	}
+
+	// In non-fatal mode the values are always shown. When --fail-on-validation
+	// is set, exit non-zero so CI/gating callers detect the failure.
+	if execErr != nil && o.FailOnValidation {
+		return exitcode.WithCode(execErr, exitcode.ValidationFailed)
+	}
+
+	return nil
+}
+
+// renderValidationDiagnostics writes a human-readable summary of resolver
+// validation-only failures to stderr. It is used by the non-fatal inspection
+// path so the resolved values on stdout are not polluted. Resolve- and
+// transform-phase failures remain fatal and are reported earlier.
+func (o *ResolverOptions) renderValidationDiagnostics(ctx context.Context, execErr error) {
+	w := writer.FromContext(ctx)
+	if w == nil {
+		// Fall back to a writer built from the command's IO streams so
+		// diagnostics are still emitted when the caller did not seed a writer
+		// into the context (e.g. embedders or direct Run invocations).
+		if o.IOStreams != nil {
+			cliParams := o.CliParams
+			if cliParams == nil {
+				// Writer methods dereference cliParams; default it so direct
+				// ResolverOptions.Run() calls outside the cobra wiring do not panic.
+				cliParams = &settings.Run{}
+			}
+			w = writer.New(o.IOStreams, cliParams)
+		} else {
+			return
+		}
+	}
+
+	diags := execute.DiagnosticsFromError(execErr)
+	if len(diags) == 0 {
+		w.WarnStderrf("resolver validation failed: %v", execErr)
+		return
+	}
+
+	w.WarnStderrf("%d resolver(s) failed validation:", len(diags))
+	for _, d := range diags {
+		if d.Resolver != "" {
+			w.PlainStderrf("  - %s: %s", d.Resolver, d.Message)
+		} else {
+			w.PlainStderrf("  - %s", d.Message)
+		}
+	}
+	if !o.FailOnValidation {
+		w.PlainStderrf("(values shown above; pass --fail-on-validation to exit non-zero)")
+	}
 }
 
 // showResolverGraph renders the resolver dependency graph without executing providers
@@ -628,6 +781,10 @@ func (o *ResolverOptions) showResolverSnapshot(
 		o.sharedResolverOptions.SkipTransform = true
 	}
 
+	// Capture the snapshot even when validation fails: non-fatal mode keeps the
+	// populated resolver context so the snapshot reflects partial values.
+	o.nonFatalValidation = true
+
 	start := time.Now()
 
 	// Execute resolvers
@@ -639,6 +796,9 @@ func (o *ResolverOptions) showResolverSnapshot(
 		lgr.V(1).Info("resolver execution completed with errors", "error", err)
 		status = resolver.ExecutionStatusFailed
 		// Continue to capture snapshot even with errors
+	}
+	if resolverCtx == nil {
+		resolverCtx = resolver.NewContext()
 	}
 
 	// Re-inject resolver context into context.Context for CaptureSnapshot

--- a/pkg/cmd/scafctl/run/resolver_test.go
+++ b/pkg/cmd/scafctl/run/resolver_test.go
@@ -3202,3 +3202,44 @@ func TestResolverOptions_Run_CatalogFallbackNotFiredForMalformedSolution(t *test
 	// The fallback should NOT have consumed the first name as a catalog ref.
 	assert.NotEqual(t, "ford-proxy", opts.File, "fallback should NOT fire for a malformed solution.yaml")
 }
+
+func TestResolverOptions_renderValidationDiagnostics_NilCliParamsNoPanic(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{
+		In:     nil,
+		Out:    &stdout,
+		ErrOut: &stderr,
+	}
+
+	// CliParams is intentionally nil to mirror direct ResolverOptions.Run()
+	// invocations outside the cobra wiring. The fallback writer must default
+	// cli params so Writer methods do not panic on a nil dereference.
+	opts := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams: streams,
+			CliParams: nil,
+		},
+	}
+
+	// No writer seeded into the context forces the IOStreams fallback path.
+	ctx := context.Background()
+
+	assert.NotPanics(t, func() {
+		opts.renderValidationDiagnostics(ctx, assert.AnError)
+	})
+	assert.Contains(t, stderr.String(), "failed validation")
+}
+
+func TestResolverOptions_renderValidationDiagnostics_NoIOStreamsNoPanic(t *testing.T) {
+	t.Parallel()
+
+	// Without a context writer and without IOStreams there is nowhere to write,
+	// so the function must return without panicking.
+	opts := &ResolverOptions{}
+
+	assert.NotPanics(t, func() {
+		opts.renderValidationDiagnostics(context.Background(), assert.AnError)
+	})
+}

--- a/pkg/cmd/scafctl/run/validate_resolver_test.go
+++ b/pkg/cmd/scafctl/run/validate_resolver_test.go
@@ -1,0 +1,138 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/staticprovider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/validationprovider"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testRegistryWithValidation returns a registry with the static and validation
+// providers, used for exercising validation-failure behavior.
+func testRegistryWithValidation(t *testing.T) *provider.Registry {
+	t.Helper()
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(staticprovider.New()))
+	require.NoError(t, reg.Register(validationprovider.NewValidationProvider()))
+	return reg
+}
+
+const failingValidationSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: validation-exit-test
+  version: 1.0.0
+spec:
+  resolvers:
+    name:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Bob"
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: "^Alice$"
+              message: "name must be Alice"
+`
+
+func newResolverOptions(t *testing.T, solutionPath string, stdout, stderr *bytes.Buffer) *ResolverOptions {
+	t.Helper()
+	streams := &terminal.IOStreams{In: nil, Out: stdout, ErrOut: stderr}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	return &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistryWithValidation(t),
+		},
+	}
+}
+
+func TestResolverOptions_Run_ValidationNonFatalByDefault(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(failingValidationSolution), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	opts := newResolverOptions(t, solutionPath, &stdout, &stderr)
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	err := opts.Run(ctx)
+
+	require.NoError(t, err, "validation failure must be non-fatal by default (exit 0)")
+	assert.Contains(t, stdout.String(), "Bob", "resolved value must still be shown")
+	assert.Contains(t, stderr.String(), "failed validation", "diagnostics must be rendered to stderr")
+}
+
+func TestResolverOptions_Run_FailOnValidationExitsNonZero(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(failingValidationSolution), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	opts := newResolverOptions(t, solutionPath, &stdout, &stderr)
+	opts.FailOnValidation = true
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	err := opts.Run(ctx)
+
+	require.Error(t, err, "--fail-on-validation must produce an error on validation failure")
+	assert.Equal(t, exitcode.ValidationFailed, exitcode.GetCode(err))
+	assert.Contains(t, stdout.String(), "Bob", "resolved value must still be shown even when failing")
+}
+
+func TestCommandValidateResolver(t *testing.T) {
+	t.Parallel()
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateResolver(cliParams, streams, "")
+
+	assert.Equal(t, "resolver [resolver-name...] [key=value...]", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+	// The validate command does not expose the fail-on-validation toggle —
+	// it is always fatal.
+	assert.Nil(t, cmd.Flags().Lookup("fail-on-validation"))
+	assert.NotNil(t, cmd.Flags().Lookup("file"))
+	assert.NotNil(t, cmd.Flags().Lookup("resolver"))
+}
+
+func TestCommandValidateResolver_EmbedderBinaryName(t *testing.T) {
+	t.Parallel()
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+
+	cmd := CommandValidateResolver(cliParams, streams, "")
+	assert.Contains(t, cmd.Long, "mycli validate resolver", "help text must use the embedder binary name")
+}

--- a/pkg/cmd/scafctl/validate/validate.go
+++ b/pkg/cmd/scafctl/validate/validate.go
@@ -1,0 +1,36 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/run"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/cobra"
+)
+
+// CommandValidate creates the 'validate' command that validates solution
+// artifacts and exits non-zero when validation fails.
+func CommandValidate(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	cCmd := &cobra.Command{
+		Use:   "validate",
+		Short: fmt.Sprintf("Validate %s solution artifacts and fail on validation errors", path),
+		Long: `Validate executes a solution's artifacts and exits non-zero when validation fails.
+
+Unlike the 'run' commands, which surface validation failures as non-fatal
+diagnostics, 'validate' treats them as errors. Use it as a validation gate in
+CI pipelines or pre-commit checks.
+
+SUBCOMMANDS:
+  resolver  Validate resolvers (resolve, transform, and validate phases)`,
+		SilenceUsage: true,
+	}
+
+	validatePath := fmt.Sprintf("%s/%s", path, cCmd.Use)
+	cCmd.AddCommand(run.CommandValidateResolver(cliParams, ioStreams, validatePath))
+
+	return cCmd
+}

--- a/pkg/cmd/scafctl/validate/validate_test.go
+++ b/pkg/cmd/scafctl/validate/validate_test.go
@@ -1,0 +1,45 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandValidate(t *testing.T) {
+	t.Parallel()
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidate(cliParams, streams, "scafctl")
+
+	assert.Equal(t, "validate", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+
+	// The resolver subcommand must be wired up.
+	var resolverCmd bool
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "resolver" {
+			resolverCmd = true
+		}
+	}
+	require.True(t, resolverCmd, "validate must register the resolver subcommand")
+}
+
+func TestCommandValidate_EmbedderBinaryName(t *testing.T) {
+	t.Parallel()
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+
+	cmd := CommandValidate(cliParams, streams, "mycli")
+	assert.Contains(t, cmd.Short, "mycli")
+}

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -1011,8 +1010,11 @@ func lintTemplateUnderscorePrefix(tmpl, location string, result *Result) {
 }
 
 // validateCELSyntax checks if a CEL expression is syntactically valid.
+// The env enables cel.OptionalTypes() so that optional access syntax
+// (_.?name, _[?"name"]) parses successfully, matching the env used by the
+// reference collector and runtime evaluation in pkg/celexp.
 func validateCELSyntax(expr string) error {
-	env, err := cel.NewEnv()
+	env, err := cel.NewEnv(cel.OptionalTypes())
 	if err != nil {
 		return err
 	}
@@ -1045,97 +1047,52 @@ func validateTemplateSyntax(tmpl string) error {
 func collectReferencedResolvers(sol *solution.Solution) map[string]bool {
 	refs := make(map[string]bool)
 
-	resolverRefPattern := regexp.MustCompile(`_\.([a-zA-Z_][a-zA-Z0-9_]*)|__resolvers\.([a-zA-Z_][a-zA-Z0-9_]*)`)
-
+	// Walk every ValueRef and condition in the solution, extracting resolver
+	// references via the same AST-based logic used to build the dependency graph.
+	// This recognizes plain (_.name), bracket (_["name"]), and optional
+	// (_.?name, _[?"name"]) CEL access, Go-template references, and nested
+	// literals, and applies go-template data-scope exclusions -- keeping the
+	// unused-resolver rule consistent with actual dependency resolution.
 	_ = walk.Walk(sol, &walk.Visitor{
 		ValueRef: func(_ string, vr *spec.ValueRef) error {
-			if vr.Resolver != nil {
-				refs[*vr.Resolver] = true
-			}
-			if vr.Expr != nil {
-				scanExpressionForResolverRefs(string(*vr.Expr), resolverRefPattern, refs)
-			}
-			if vr.Tmpl != nil {
-				// Use the Go template AST to extract references, which handles
-				// both {{ .resolverName }} and {{ ._.resolverName }} patterns.
-				tmplRefs, err := gotmpl.GetGoTemplateReferences(string(*vr.Tmpl), "", "")
-				if err == nil {
-					for _, ref := range tmplRefs {
-						// Skip scoped references inside {{ with }}/{{ range }} bodies
-						if ref.Scoped {
-							continue
-						}
-
-						name := resolverRefs.ExtractResolverName(ref.Path)
-						if name != "" {
-							refs[name] = true
-						}
-					}
-				}
-				// Also scan with regex as a fallback
-				scanExpressionForResolverRefs(string(*vr.Tmpl), resolverRefPattern, refs)
-			}
-			if vr.Literal != nil {
-				scanLiteralForResolverRefs(vr.Literal, resolverRefPattern, refs)
-			}
+			resolver.ExtractRefsFromValueRef(vr, refs)
 			return nil
 		},
 		Condition: func(_, _ string, expr *celexp.Expression) error {
-			scanExpressionForResolverRefs(string(*expr), resolverRefPattern, refs)
+			resolver.ExtractRefsFromValueRef(&spec.ValueRef{Expr: expr}, refs)
 			return nil
 		},
 	})
 
+	// A resolver named in another resolver's dependsOn array is used, even when
+	// it is not referenced by any expression or template. The walker does not
+	// visit dependsOn, so collect those references explicitly.
+	if sol.Spec.Resolvers != nil {
+		for _, r := range sol.Spec.Resolvers {
+			if r == nil {
+				continue
+			}
+			for _, dep := range r.DependsOn {
+				if dep != "" {
+					refs[dep] = true
+				}
+			}
+		}
+	}
+
+	// State configuration (enabled, backend inputs, saveOverrides) can reference
+	// resolvers. The walker does not traverse state, so scan it explicitly.
+	if sol.State != nil {
+		resolver.ExtractRefsFromValueRef(sol.State.Enabled, refs)
+		for _, vr := range sol.State.Backend.Inputs {
+			resolver.ExtractRefsFromValueRef(vr, refs)
+		}
+		for _, vr := range sol.State.Backend.SaveOverrides {
+			resolver.ExtractRefsFromValueRef(vr, refs)
+		}
+	}
+
 	return refs
-}
-
-// scanLiteralForResolverRefs scans literal values (maps, slices) for nested
-// resolver references, expressions, and templates. Nested maps with a single
-// "rslvr", "expr", or "tmpl" key are treated as resolver references.
-func scanLiteralForResolverRefs(v any, pattern *regexp.Regexp, refs map[string]bool) {
-	switch val := v.(type) {
-	case string:
-		// Scan plain string literals for _.resolverName patterns.
-		// This catches CEL expression inputs (e.g., `expression: "has(_.foo)"`),
-		// Go template inputs, and any other string that may reference resolvers.
-		scanExpressionForResolverRefs(val, pattern, refs)
-	case map[string]any:
-		// Check if this map itself is a resolver reference
-		if rslvr, ok := val["rslvr"]; ok {
-			if name, ok := rslvr.(string); ok {
-				refs[name] = true
-			}
-		}
-		if expr, ok := val["expr"]; ok {
-			if s, ok := expr.(string); ok {
-				scanExpressionForResolverRefs(s, pattern, refs)
-			}
-		}
-		if tmpl, ok := val["tmpl"]; ok {
-			if s, ok := tmpl.(string); ok {
-				scanExpressionForResolverRefs(s, pattern, refs)
-			}
-		}
-		// Recurse into nested values
-		for _, child := range val {
-			scanLiteralForResolverRefs(child, pattern, refs)
-		}
-	case []any:
-		for _, item := range val {
-			scanLiteralForResolverRefs(item, pattern, refs)
-		}
-	}
-}
-
-func scanExpressionForResolverRefs(expr string, pattern *regexp.Regexp, refs map[string]bool) {
-	matches := pattern.FindAllStringSubmatch(expr, -1)
-	for _, match := range matches {
-		for i := 1; i < len(match); i++ {
-			if match[i] != "" {
-				refs[match[i]] = true
-			}
-		}
-	}
 }
 
 // collectTemplateFileResolverRefs scans external template files on disk

--- a/pkg/lint/lint_extra_test.go
+++ b/pkg/lint/lint_extra_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
 	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/oakwood-commons/scafctl/pkg/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -97,6 +98,10 @@ func TestValidateCELSyntax_Valid(t *testing.T) {
 	assert.NoError(t, validateCELSyntax("1 + 1"))
 	assert.NoError(t, validateCELSyntax("_.myResolver"))
 	assert.NoError(t, validateCELSyntax("'hello' + ' world'"))
+	// Optional access syntax must parse -- the env enables cel.OptionalTypes()
+	// to match the reference collector and runtime evaluation.
+	assert.NoError(t, validateCELSyntax(`_.?optionalDep.orValue("")`))
+	assert.NoError(t, validateCELSyntax(`_[?"optionalDep"].orValue("")`))
 }
 
 func TestValidateCELSyntax_Invalid(t *testing.T) {
@@ -556,6 +561,118 @@ func TestLintResolvers_CELExpressionInputNotFlaggedUnused(t *testing.T) {
 				"unixResult referenced in CEL expression should not be flagged unused")
 		}
 	}
+}
+
+func TestLintResolvers_OptionalAccessNotFlaggedUnused(t *testing.T) {
+	// A resolver referenced only via optional access (_.?name) must NOT be
+	// flagged as unused -- the AST-based collector recognizes optional select.
+	optExpr := celexp.Expression(`_.?optionalDep.orValue("")`)
+
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("static", nil)))
+	require.NoError(t, reg.Register(newFakeProvider("cel", nil)))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"optionalDep": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{Provider: "static"}},
+			},
+		},
+		"consumer": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{
+					Provider: "cel",
+					Inputs: map[string]*spec.ValueRef{
+						"expression": {Expr: &optExpr},
+					},
+				}},
+			},
+		},
+	}
+
+	referencedResolvers := collectReferencedResolvers(sol)
+	assert.True(t, referencedResolvers["optionalDep"],
+		"optional access _.?optionalDep should mark optionalDep as referenced")
+
+	result := &Result{}
+	lintResolvers(sol, result, reg, referencedResolvers)
+	for _, f := range result.Findings {
+		if f.RuleName == "unused-resolver" {
+			assert.NotContains(t, f.Message, "optionalDep",
+				"optionalDep referenced via optional access should not be flagged unused")
+		}
+	}
+}
+
+func TestLintResolvers_DependsOnCountedAsUsage(t *testing.T) {
+	// A resolver referenced only via another resolver's dependsOn must NOT be
+	// flagged as unused.
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("static", nil)))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"base": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{Provider: "static"}},
+			},
+		},
+		"dependent": {
+			DependsOn: []string{"base"},
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{Provider: "static"}},
+			},
+		},
+	}
+
+	referencedResolvers := collectReferencedResolvers(sol)
+	assert.True(t, referencedResolvers["base"],
+		"dependsOn membership should mark base as referenced")
+
+	result := &Result{}
+	lintResolvers(sol, result, reg, referencedResolvers)
+	for _, f := range result.Findings {
+		if f.RuleName == "unused-resolver" {
+			assert.NotContains(t, f.Message, "base",
+				"base referenced via dependsOn should not be flagged unused")
+		}
+	}
+}
+
+func TestLintResolvers_StateReferenceCountedAsUsage(t *testing.T) {
+	// Resolvers referenced only from the state block (saveOverrides rslvr and a
+	// backend input expression) must NOT be flagged as unused.
+	branch := "featureBranch"
+	pathExpr := celexp.Expression("_.statePath")
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"featureBranch": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{Provider: "static"}},
+			},
+		},
+		"statePath": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{{Provider: "static"}},
+			},
+		},
+	}
+	sol.State = &state.Config{
+		Enabled: &spec.ValueRef{Literal: true},
+		Backend: state.Backend{
+			Provider:      "github",
+			Inputs:        map[string]*spec.ValueRef{"path": {Expr: &pathExpr}},
+			SaveOverrides: map[string]*spec.ValueRef{"branch": {Resolver: &branch}},
+		},
+	}
+
+	referencedResolvers := collectReferencedResolvers(sol)
+	assert.True(t, referencedResolvers["featureBranch"],
+		"saveOverrides rslvr reference should mark featureBranch as referenced")
+	assert.True(t, referencedResolvers["statePath"],
+		"backend input expr reference should mark statePath as referenced")
 }
 
 func TestLintResolvers_HyphenatedName(t *testing.T) {

--- a/pkg/mcp/output_schemas.go
+++ b/pkg/mcp/output_schemas.go
@@ -191,6 +191,22 @@ var outputSchemaPreviewResolvers = json.RawMessage(`{
 			"description": "Map of resolver name to resolved value or error",
 			"additionalProperties": {}
 		},
+		"valid": {
+			"type": "boolean",
+			"description": "False when one or more resolvers failed validation (see diagnostics)"
+		},
+		"diagnostics": {
+			"type": "array",
+			"description": "Non-fatal validation-only diagnostics. Present when valid is false; resolved values are still returned. Resolve/transform failures return an error result instead.",
+			"items": {
+				"type": "object",
+				"properties": {
+					"resolver": { "type": "string" },
+					"phase": { "type": "integer" },
+					"message": { "type": "string" }
+				}
+			}
+		},
 		"summary": {
 			"type": "object",
 			"properties": {

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -127,7 +127,7 @@ func (s *Server) registerSolutionTools() {
 
 	// preview_resolvers
 	previewResolversTool := mcp.NewTool("preview_resolvers",
-		mcp.WithDescription("Execute a solution's resolver chain and return each resolver's resolved value. This is the 'does it actually work?' step between writing YAML and running the full solution. Shows the resolved value, type, and status for every resolver. Accepts optional input parameters for parameter-type resolvers. Use the 'resolver' parameter to debug a single resolver and see its resolve/transform/validate pipeline in detail."),
+		mcp.WithDescription("Execute a solution's resolver chain and return each resolver's resolved value. This is the 'does it actually work?' step between writing YAML and running the full solution. Shows the resolved value, type, and status for every resolver. Accepts optional input parameters for parameter-type resolvers. Use the 'resolver' parameter to debug a single resolver and see its resolve/transform/validate pipeline in detail. Validation failures are non-fatal by default: resolved values are still returned alongside a 'diagnostics' list so you can troubleshoot. Set 'strict' to true to have the tool report an error when validation fails (values are still included)."),
 		mcp.WithTitleAnnotation("Preview Resolvers"),
 		mcp.WithToolIcons(toolIcons["solution"]),
 		mcp.WithReadOnlyHintAnnotation(false),
@@ -144,6 +144,9 @@ func (s *Server) registerSolutionTools() {
 		),
 		mcp.WithString("resolver",
 			mcp.Description("Debug a single resolver by name. Returns detailed pipeline info (resolve, transform, validate phases) for just this resolver and its dependencies."),
+		),
+		mcp.WithBoolean("strict",
+			mcp.Description("Report an error result when any resolver fails validation. The resolved values and diagnostics are still included. Default: false (validation failures are non-fatal)."),
 		),
 		mcp.WithString("output_dir",
 			mcp.Description("Target directory for action output. Included for path preview purposes — resolvers always use CWD regardless of this setting."),
@@ -776,8 +779,12 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 	}
 
 	cfg := execute.ResolverExecutionConfigFromContext(ctx)
+	// Validation failures must not withhold resolved values: enable non-fatal
+	// mode so resolver execution returns partial values plus diagnostics.
+	cfg.NonFatalValidation = true
 	// Check if we're debugging a single resolver
 	resolverFilter := request.GetString("resolver", "")
+	strict := request.GetBool("strict", false)
 
 	// Send progress notifications during execution
 	progress := newProgressReporter(s, request)
@@ -900,7 +907,19 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 			}
 		}
 
-		if val, ok := result.Data[name]; ok {
+		if res, ok := result.Context.GetResult(name); ok {
+			preview.Value = res.Value
+			switch res.Status {
+			case resolver.ExecutionStatusSuccess:
+				preview.Status = "resolved"
+			case resolver.ExecutionStatusFailed:
+				preview.Status = "failed"
+			case resolver.ExecutionStatusSkipped:
+				preview.Status = "skipped"
+			default:
+				preview.Status = "unresolved"
+			}
+		} else if val, ok := result.Data[name]; ok {
 			preview.Value = val
 			preview.Status = "resolved"
 		} else {
@@ -941,6 +960,29 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 	// This lets AI agents understand execution order without re-parsing the YAML.
 	if planRaw, ok := result.Context.Get(celexp.VarPlan); ok {
 		response["plan"] = planRaw
+	}
+
+	// Surface non-fatal validation diagnostics so agents can troubleshoot while
+	// still seeing the resolved values. When strict is requested, report the
+	// result as an error (values remain included for context).
+	diags := execute.DiagnosticsFromError(result.Diagnostics)
+	if len(diags) > 0 {
+		response["diagnostics"] = diags
+		response["valid"] = false
+		if strict {
+			result2, jsonErr := mcp.NewToolResultJSON(response)
+			if jsonErr != nil {
+				return nil, jsonErr
+			}
+			result2.IsError = true
+			result2.Content = append(result2.Content,
+				mcp.NewResourceLink("solution://"+path, "Solution YAML", "Raw solution YAML content", "application/x-yaml"),
+				mcp.NewResourceLink("solution://"+path+"/graph", "Dependency Graph", "Resolver dependency graph", "application/json"),
+			)
+			return result2, nil
+		}
+	} else {
+		response["valid"] = true
 	}
 
 	result2, err := mcp.NewToolResultJSON(response)

--- a/pkg/mcp/tools_solution_test.go
+++ b/pkg/mcp/tools_solution_test.go
@@ -635,6 +635,110 @@ spec:
 		assert.Equal(t, float64(2), derivedPlan["phase"], "derived should be in phase 2")
 		assert.Equal(t, float64(1), derivedPlan["dependencyCount"], "derived should have 1 dependency")
 	})
+
+	t.Run("validation failure is non-fatal by default and includes values plus diagnostics", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		solFile := filepath.Join(tmpDir, "badval.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: badval
+  version: 1.0.0
+spec:
+  resolvers:
+    name:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Bob"
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: "^Alice$"
+              message: "name must be Alice"
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_resolvers"
+		request.Params.Arguments = map[string]any{
+			"path": solFile,
+		}
+
+		result, err := srv.handlePreviewResolvers(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError, "validation failure must be non-fatal by default")
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+
+		assert.Equal(t, false, parsed["valid"], "valid should be false when validation fails")
+		diagnostics, ok := parsed["diagnostics"].([]any)
+		require.True(t, ok, "diagnostics should be present")
+		assert.NotEmpty(t, diagnostics)
+
+		resolvers := parsed["resolvers"].(map[string]any)
+		name := resolvers["name"].(map[string]any)
+		assert.Equal(t, "Bob", name["value"], "partial value must still be returned")
+		assert.Equal(t, "failed", name["status"])
+	})
+
+	t.Run("strict mode reports error but still includes values", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		solFile := filepath.Join(tmpDir, "badval-strict.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: badval-strict
+  version: 1.0.0
+spec:
+  resolvers:
+    name:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Bob"
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: "^Alice$"
+              message: "name must be Alice"
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_resolvers"
+		request.Params.Arguments = map[string]any{
+			"path":   solFile,
+			"strict": true,
+		}
+
+		result, err := srv.handlePreviewResolvers(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError, "strict mode must report an error on validation failure")
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+
+		assert.Equal(t, false, parsed["valid"])
+		resolvers := parsed["resolvers"].(map[string]any)
+		name := resolvers["name"].(map[string]any)
+		assert.Equal(t, "Bob", name["value"], "values must still be included in strict mode")
+	})
 }
 
 func TestHandleGetRunCommand(t *testing.T) {

--- a/pkg/resolver/graph.go
+++ b/pkg/resolver/graph.go
@@ -234,6 +234,18 @@ func ExtractRefsFromValueRefs(inputs map[string]*ValueRef) []string {
 	return result
 }
 
+// ExtractRefsFromValueRef extracts all resolver names referenced by a single
+// ValueRef, accumulating them into the provided deps set. It handles direct
+// resolver references, CEL expressions, Go templates, and nested literal values
+// using the same AST-based logic the dependency graph uses. Passing a nil ref or
+// deps map is a no-op (deps must be non-nil to collect results).
+func ExtractRefsFromValueRef(ref *ValueRef, deps map[string]bool) {
+	if deps == nil {
+		return
+	}
+	extractDepsFromValueRef(ref, deps)
+}
+
 // extractDepsFromLiteral recursively extracts dependencies from literal values
 // that may contain CEL expression strings or Go template syntax
 func extractDepsFromLiteral(literal any, deps map[string]bool) {

--- a/pkg/resolver/graph_test.go
+++ b/pkg/resolver/graph_test.go
@@ -678,6 +678,21 @@ func TestExtractDepsFromExpression(t *testing.T) {
 			want: []string{"env", "region"},
 		},
 		{
+			name: "optional select",
+			expr: `_.?platformProfileID.orValue("")`,
+			want: []string{"platformProfileID"},
+		},
+		{
+			name: "optional select mixed with plain select",
+			expr: `_.?optionalDep.orValue("") + _.plainDep`,
+			want: []string{"optionalDep", "plainDep"},
+		},
+		{
+			name: "optional index bracket notation",
+			expr: `_[?"my-resolver"].orValue("")`,
+			want: []string{"my-resolver"},
+		},
+		{
 			name: "invalid expression (should not panic)",
 			expr: "this is not valid CEL",
 			want: []string{},
@@ -956,6 +971,54 @@ func TestBuildGraph(t *testing.T) {
 				// Verify stats
 				assert.Equal(t, 2, graph.Stats.TotalResolvers)
 				assert.Equal(t, 2, graph.Stats.TotalPhases)
+			},
+		},
+		{
+			name: "dependency via optional access expression",
+			resolvers: []*Resolver{
+				{
+					Name: "base",
+					Type: TypeString,
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{
+							{
+								Provider: "static",
+								Inputs: map[string]*ValueRef{
+									"value": {Literal: "base"},
+								},
+							},
+						},
+					},
+				},
+				{
+					Name: "dependent",
+					Type: TypeString,
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{
+							{
+								Provider: "cel",
+								Inputs: map[string]*ValueRef{
+									"value": {Expr: celExpPtr(`_.?base.orValue("")`)},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+			validate: func(t *testing.T, graph *Graph) {
+				require.Equal(t, 2, len(graph.Nodes))
+				// Optional access _.?base must produce a dependency edge so that
+				// base is ordered before dependent.
+				require.Equal(t, 2, len(graph.Phases))
+				assert.Equal(t, 1, len(graph.Edges))
+
+				phaseOf := make(map[string]int)
+				for _, n := range graph.Nodes {
+					phaseOf[n.Name] = n.Phase
+				}
+				assert.Less(t, phaseOf["base"], phaseOf["dependent"],
+					"base must resolve before dependent when referenced via optional access")
 			},
 		},
 		{
@@ -1471,6 +1534,68 @@ func TestExtractRefsFromValueRefs(t *testing.T) {
 			assert.Equal(t, tt.want, gotMap)
 		})
 	}
+}
+
+func TestExtractRefsFromValueRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ref  *ValueRef
+		want map[string]bool
+	}{
+		{
+			name: "nil ref is a no-op",
+			ref:  nil,
+			want: map[string]bool{},
+		},
+		{
+			name: "direct resolver reference",
+			ref:  &ValueRef{Resolver: stringPtr("environment")},
+			want: map[string]bool{"environment": true},
+		},
+		{
+			name: "cel expression reference",
+			ref:  &ValueRef{Expr: celExpPtr("_.config.host + ':' + string(_.config.port)")},
+			want: map[string]bool{"config": true},
+		},
+		{
+			name: "template reference",
+			ref:  &ValueRef{Tmpl: tmplPtr("Hello {{ ._.username }}")},
+			want: map[string]bool{"username": true},
+		},
+		{
+			name: "nested literal map reference",
+			ref: &ValueRef{Literal: map[string]any{
+				"APP_NAME": map[string]any{"rslvr": "appName"},
+			}},
+			want: map[string]bool{"appName": true},
+		},
+		{
+			name: "literal value produces no refs",
+			ref:  &ValueRef{Literal: "static"},
+			want: map[string]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			deps := make(map[string]bool)
+			ExtractRefsFromValueRef(tt.ref, deps)
+			assert.Equal(t, tt.want, deps)
+		})
+	}
+}
+
+func TestExtractRefsFromValueRef_NilDepsIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	// A nil deps map must be a no-op and must not panic, even with a
+	// non-nil ref that would otherwise produce dependencies.
+	assert.NotPanics(t, func() {
+		ExtractRefsFromValueRef(&ValueRef{Resolver: stringPtr("environment")}, nil)
+	})
 }
 
 func TestExtractRefsFromValueRefs_NestedValueRefMaps(t *testing.T) {

--- a/pkg/solution/execute/execute.go
+++ b/pkg/solution/execute/execute.go
@@ -7,6 +7,7 @@ package execute
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -94,16 +95,135 @@ type ResolverExecutionConfig struct {
 
 	// SkipTransform skips resolver transforms.
 	SkipTransform bool `json:"skipTransform,omitempty" yaml:"skipTransform,omitempty" doc:"Skip resolver transforms"`
+
+	// NonFatalValidation, when true, treats resolver validation-only failures
+	// as non-fatal: the populated values are returned alongside structured
+	// diagnostics (ResolverExecutionResult.Diagnostics) instead of aborting
+	// with an error. Resolve- and transform-phase failures (where no value
+	// could be produced) remain fatal. This is used by inspection and
+	// troubleshooting paths (run resolver, preview_resolvers) so that resolver
+	// output remains useful even when validation fails. It implies validate-all
+	// semantics so that all reachable resolvers populate their values.
+	NonFatalValidation bool `json:"nonFatalValidation,omitempty" yaml:"nonFatalValidation,omitempty" doc:"Treat validation failures as non-fatal and return partial values with diagnostics"`
 }
 
 // ResolverExecutionResult holds the structured output of resolver execution.
 type ResolverExecutionResult struct {
-	// Data contains the resolved values keyed by resolver name.
+	// Data contains the resolved values keyed by resolver name. When
+	// NonFatalValidation is enabled, this also includes partial values produced
+	// by resolvers that failed validation (their value is captured post-transform
+	// before the validate phase rejects it).
 	Data map[string]any `json:"data" yaml:"data" doc:"Resolved values"`
 
 	// Context is the resolver execution context with full metadata.
-	// Only available when execution succeeds.
 	Context *resolver.Context `json:"-" yaml:"-"`
+
+	// Diagnostics holds the resolver validation or execution error collected
+	// when NonFatalValidation is enabled. It is nil when execution was clean.
+	// Use DiagnosticsFromError to convert it into a structured list.
+	Diagnostics error `json:"-" yaml:"-"`
+}
+
+// ResolverDiagnostic describes a single resolver validation or execution
+// failure surfaced during a non-fatal inspection run.
+type ResolverDiagnostic struct {
+	// Resolver is the name of the resolver that failed. It may be empty when
+	// the failure is not attributable to a specific resolver.
+	Resolver string `json:"resolver,omitempty" yaml:"resolver,omitempty" doc:"Name of the resolver that failed"`
+
+	// Phase is the execution phase number where the failure occurred (0 when unknown).
+	Phase int `json:"phase,omitempty" yaml:"phase,omitempty" doc:"Phase number where the failure occurred"`
+
+	// Message is the human-readable failure description.
+	Message string `json:"message" yaml:"message" doc:"Human-readable failure message"`
+}
+
+// DiagnosticsFromError converts a resolver execution error into a structured
+// list of per-resolver diagnostics. It understands AggregatedExecutionError
+// (validate-all mode) and AggregatedValidationError, and falls back to a single
+// generic diagnostic for any other error. Returns nil when err is nil.
+func DiagnosticsFromError(err error) []ResolverDiagnostic {
+	if err == nil {
+		return nil
+	}
+
+	var aggExec *resolver.AggregatedExecutionError
+	if errors.As(err, &aggExec) {
+		diags := make([]ResolverDiagnostic, 0, len(aggExec.Errors))
+		for _, fr := range aggExec.Errors {
+			if fr == nil {
+				continue
+			}
+			msg := fr.ErrMessage
+			if msg == "" && fr.Err != nil {
+				msg = fr.Err.Error()
+			}
+			diags = append(diags, ResolverDiagnostic{
+				Resolver: fr.ResolverName,
+				Phase:    fr.Phase,
+				Message:  msg,
+			})
+		}
+		return diags
+	}
+
+	var aggVal *resolver.AggregatedValidationError
+	if errors.As(err, &aggVal) {
+		return []ResolverDiagnostic{{
+			Resolver: aggVal.ResolverName,
+			Message:  aggVal.Error(),
+		}}
+	}
+
+	return []ResolverDiagnostic{{Message: err.Error()}}
+}
+
+// isValidationFailure reports whether a single resolver failure originated from
+// the validate phase. Resolve- and transform-phase failures (where no value
+// could be produced) return false so callers keep treating them as fatal.
+func isValidationFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	var aggVal *resolver.AggregatedValidationError
+	if errors.As(err, &aggVal) {
+		return true
+	}
+	var execErr *resolver.ExecutionError
+	if errors.As(err, &execErr) {
+		return execErr.Phase == "validate"
+	}
+	return false
+}
+
+// IsValidationOnlyFailure reports whether every failure contained in err is a
+// validation failure. It returns false when err contains any non-validation
+// failure (such as a resolve- or transform-phase error) so those remain fatal.
+// Non-fatal inspection mode only suppresses pure validation failures.
+func IsValidationOnlyFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	var aggExec *resolver.AggregatedExecutionError
+	if errors.As(err, &aggExec) {
+		if len(aggExec.Errors) == 0 {
+			return false
+		}
+		sawFailure := false
+		for _, fr := range aggExec.Errors {
+			if fr == nil {
+				continue
+			}
+			sawFailure = true
+			if !isValidationFailure(fr.Err) {
+				return false
+			}
+		}
+		// If every entry was nil there is no concrete failure to classify, so
+		// do not treat the aggregated error as validation-only.
+		return sawFailure
+	}
+	return isValidationFailure(err)
 }
 
 // Resolvers runs the resolver execution pipeline on the given solution.
@@ -151,7 +271,7 @@ func Resolvers(
 	if cfg.MaxValueSize > 0 {
 		executorOpts = append(executorOpts, resolver.WithMaxValueSize(cfg.MaxValueSize))
 	}
-	if cfg.ValidateAll {
+	if cfg.ValidateAll || cfg.NonFatalValidation {
 		executorOpts = append(executorOpts, resolver.WithValidateAll(true))
 	}
 	if cfg.SkipValidation {
@@ -166,23 +286,51 @@ func Resolvers(
 	ctx = ApplySolutionCELCostLimit(ctx, sol)
 
 	// Execute resolvers
-	resultCtx, err := executor.Execute(ctx, resolvers, params)
-	if err != nil {
-		return nil, fmt.Errorf("resolver execution failed: %w", err)
-	}
+	resultCtx, execErr := executor.Execute(ctx, resolvers, params)
 
-	// Get resolver context with results
+	// Get resolver context with results. This is populated even on failure, so
+	// retrieve it before deciding how to handle execErr.
 	resolverCtx, ok := resolver.FromContext(resultCtx)
 	if !ok {
+		// Execution failed before a resolver context could be established
+		// (e.g., phase build failure). Surface the underlying error.
+		if execErr != nil {
+			return nil, fmt.Errorf("resolver execution failed: %w", execErr)
+		}
 		return nil, fmt.Errorf("failed to retrieve resolver results")
 	}
 
-	// Build resolver data map
+	// Build resolver data map. In non-fatal mode, also include partial values
+	// captured by resolvers that failed validation so callers can inspect them.
 	for name := range sol.Spec.Resolvers {
 		result, ok := resolverCtx.GetResult(name)
-		if ok && result.Status == resolver.ExecutionStatusSuccess {
+		if !ok {
+			continue
+		}
+		if result.Status == resolver.ExecutionStatusSuccess {
+			resolverData[name] = result.Value
+		} else if cfg.NonFatalValidation && result.Value != nil {
 			resolverData[name] = result.Value
 		}
+	}
+
+	if execErr != nil {
+		if cfg.NonFatalValidation && IsValidationOnlyFailure(execErr) {
+			// Non-fatal: return the populated values plus diagnostics instead of
+			// aborting, so the inspection path remains useful. Only pure
+			// validation failures are suppressed; resolve/transform failures
+			// (where no value exists) remain fatal below.
+			if lgr != nil {
+				lgr.V(1).Info("resolver execution completed with validation diagnostics",
+					"resolvedCount", len(resolverData))
+			}
+			return &ResolverExecutionResult{
+				Data:        resolverData,
+				Context:     resolverCtx,
+				Diagnostics: execErr,
+			}, nil
+		}
+		return nil, fmt.Errorf("resolver execution failed: %w", execErr)
 	}
 
 	if lgr != nil {

--- a/pkg/solution/execute/nonfatal_test.go
+++ b/pkg/solution/execute/nonfatal_test.go
@@ -1,0 +1,227 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package execute
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/solution/inspect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeSolution writes the given YAML to a temp solution file and returns its path.
+func writeSolution(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	solFile := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solFile, []byte(content), 0o600))
+	return solFile
+}
+
+func TestDiagnosticsFromError(t *testing.T) {
+	t.Run("nil error returns nil", func(t *testing.T) {
+		assert.Nil(t, DiagnosticsFromError(nil))
+	})
+
+	t.Run("aggregated execution error maps each failed resolver", func(t *testing.T) {
+		aggErr := &resolver.AggregatedExecutionError{
+			Errors: []*resolver.FailedResolver{
+				{ResolverName: "a", Phase: 1, ErrMessage: "boom a"},
+				{ResolverName: "b", Phase: 2, Err: errors.New("boom b")},
+				nil, // nil entries are skipped
+			},
+		}
+
+		diags := DiagnosticsFromError(aggErr)
+		require.Len(t, diags, 2)
+		assert.Equal(t, "a", diags[0].Resolver)
+		assert.Equal(t, 1, diags[0].Phase)
+		assert.Equal(t, "boom a", diags[0].Message)
+		assert.Equal(t, "b", diags[1].Resolver)
+		assert.Equal(t, 2, diags[1].Phase)
+		assert.Equal(t, "boom b", diags[1].Message)
+	})
+
+	t.Run("generic error falls back to single diagnostic", func(t *testing.T) {
+		diags := DiagnosticsFromError(errors.New("something broke"))
+		require.Len(t, diags, 1)
+		assert.Empty(t, diags[0].Resolver)
+		assert.Equal(t, "something broke", diags[0].Message)
+	})
+}
+
+const badValidationSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: badval
+  version: 0.0.1
+spec:
+  resolvers:
+    name:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Bob"
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: "^Alice$"
+              message: "name must be Alice"
+`
+
+func TestResolvers_NonFatalValidation(t *testing.T) {
+	ctx := context.Background()
+	reg, err := builtin.DefaultRegistry(ctx)
+	require.NoError(t, err)
+
+	solFile := writeSolution(t, badValidationSolution)
+	sol, err := inspect.LoadSolution(ctx, solFile)
+	require.NoError(t, err)
+
+	t.Run("non-fatal returns partial values plus diagnostics and no error", func(t *testing.T) {
+		cfg := ResolverExecutionConfig{
+			Timeout:            ResolverExecutionConfigFromContext(ctx).Timeout,
+			PhaseTimeout:       ResolverExecutionConfigFromContext(ctx).PhaseTimeout,
+			NonFatalValidation: true,
+		}
+
+		result, err := Resolvers(ctx, sol, nil, reg, cfg)
+		require.NoError(t, err, "non-fatal mode must not return an error on validation failure")
+		require.NotNil(t, result)
+		assert.Equal(t, "Bob", result.Data["name"], "partial value must still be returned")
+		require.Error(t, result.Diagnostics, "diagnostics must be populated on validation failure")
+
+		diags := DiagnosticsFromError(result.Diagnostics)
+		require.NotEmpty(t, diags)
+		assert.Equal(t, "name", diags[0].Resolver)
+	})
+
+	t.Run("fatal mode returns error on validation failure", func(t *testing.T) {
+		cfg := ResolverExecutionConfig{
+			Timeout:      ResolverExecutionConfigFromContext(ctx).Timeout,
+			PhaseTimeout: ResolverExecutionConfigFromContext(ctx).PhaseTimeout,
+		}
+
+		_, err := Resolvers(ctx, sol, nil, reg, cfg)
+		require.Error(t, err, "default (fatal) mode must return an error on validation failure")
+	})
+}
+
+const resolvePhaseFailureSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: resolvefail
+  version: 0.0.1
+spec:
+  resolvers:
+    data:
+      resolve:
+        with:
+          - provider: solution
+            inputs:
+              file: "./nonexistent.yaml"
+`
+
+func TestResolvers_NonFatalValidation_ResolvePhaseStaysFatal(t *testing.T) {
+	ctx := context.Background()
+	reg, err := builtin.DefaultRegistry(ctx)
+	require.NoError(t, err)
+
+	solFile := writeSolution(t, resolvePhaseFailureSolution)
+	sol, err := inspect.LoadSolution(ctx, solFile)
+	require.NoError(t, err)
+
+	cfg := ResolverExecutionConfig{
+		Timeout:            ResolverExecutionConfigFromContext(ctx).Timeout,
+		PhaseTimeout:       ResolverExecutionConfigFromContext(ctx).PhaseTimeout,
+		NonFatalValidation: true,
+	}
+
+	_, err = Resolvers(ctx, sol, nil, reg, cfg)
+	require.Error(t, err, "resolve-phase failures must remain fatal even in non-fatal mode")
+}
+
+func TestIsValidationOnlyFailure(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		assert.False(t, IsValidationOnlyFailure(nil))
+	})
+
+	t.Run("aggregated validation error is validation-only", func(t *testing.T) {
+		err := &resolver.AggregatedExecutionError{
+			Errors: []*resolver.FailedResolver{
+				{ResolverName: "a", Phase: 1, Err: &resolver.AggregatedValidationError{ResolverName: "a"}},
+			},
+		}
+		assert.True(t, IsValidationOnlyFailure(err))
+	})
+
+	t.Run("validate-phase execution error is validation-only", func(t *testing.T) {
+		err := &resolver.AggregatedExecutionError{
+			Errors: []*resolver.FailedResolver{
+				{ResolverName: "a", Phase: 1, Err: &resolver.ExecutionError{ResolverName: "a", Phase: "validate"}},
+			},
+		}
+		assert.True(t, IsValidationOnlyFailure(err))
+	})
+
+	t.Run("resolve-phase execution error is not validation-only", func(t *testing.T) {
+		err := &resolver.AggregatedExecutionError{
+			Errors: []*resolver.FailedResolver{
+				{ResolverName: "a", Phase: 1, Err: &resolver.ExecutionError{ResolverName: "a", Phase: "resolve"}},
+			},
+		}
+		assert.False(t, IsValidationOnlyFailure(err))
+	})
+
+	t.Run("mixed failures are not validation-only", func(t *testing.T) {
+		err := &resolver.AggregatedExecutionError{
+			Errors: []*resolver.FailedResolver{
+				{ResolverName: "a", Phase: 1, Err: &resolver.AggregatedValidationError{ResolverName: "a"}},
+				{ResolverName: "b", Phase: 1, Err: &resolver.ExecutionError{ResolverName: "b", Phase: "resolve"}},
+			},
+		}
+		assert.False(t, IsValidationOnlyFailure(err))
+	})
+
+	t.Run("empty aggregated error is not validation-only", func(t *testing.T) {
+		assert.False(t, IsValidationOnlyFailure(&resolver.AggregatedExecutionError{}))
+	})
+
+	t.Run("aggregated error with only nil entries is not validation-only", func(t *testing.T) {
+		// A non-empty Errors slice whose entries are all nil has no concrete
+		// failure to classify, so it must not be treated as validation-only.
+		err := &resolver.AggregatedExecutionError{
+			Errors: []*resolver.FailedResolver{nil, nil},
+		}
+		assert.False(t, IsValidationOnlyFailure(err))
+	})
+
+	t.Run("aggregated error with nils and one validation failure is validation-only", func(t *testing.T) {
+		err := &resolver.AggregatedExecutionError{
+			Errors: []*resolver.FailedResolver{
+				nil,
+				{ResolverName: "a", Phase: 1, Err: &resolver.AggregatedValidationError{ResolverName: "a"}},
+			},
+		}
+		assert.True(t, IsValidationOnlyFailure(err))
+	})
+
+	t.Run("bare validation error is validation-only", func(t *testing.T) {
+		assert.True(t, IsValidationOnlyFailure(&resolver.AggregatedValidationError{ResolverName: "a"}))
+	})
+
+	t.Run("bare generic error is not validation-only", func(t *testing.T) {
+		assert.False(t, IsValidationOnlyFailure(errors.New("boom")))
+	})
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1250,6 +1251,50 @@ func TestIntegration_RunResolver_GraphMermaid(t *testing.T) {
 
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "graph")
+}
+
+func TestIntegration_Validate_Help(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "validate", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	// Top-level validate command help advertises the resolver subcommand.
+	assert.Contains(t, stdout, "Validate")
+	assert.Contains(t, stdout, "resolver")
+}
+
+func TestIntegration_ValidateResolver_Help(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "validate", "resolver", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "resolver")
+	assert.Contains(t, stdout, "--file")
+}
+
+func TestIntegration_ValidateResolver_Passes(t *testing.T) {
+	t.Parallel()
+	// A solution with no validation failures exits 0.
+	_, _, exitCode := runScafctl(t,
+		"validate", "resolver",
+		"-f", "examples/resolver-demo.yaml",
+		"-o", "json",
+	)
+
+	assert.Equal(t, 0, exitCode)
+}
+
+func TestIntegration_ValidateResolver_FailsNonZero(t *testing.T) {
+	t.Parallel()
+	// The validate gate presets fatal validation, so a solution with validation
+	// failures must exit non-zero (ValidationFailed == 2).
+	_, _, exitCode := runScafctl(t,
+		"validate", "resolver",
+		"-f", "examples/resolver-validation-failures-demo.yaml",
+		"-o", "json",
+	)
+
+	assert.Equal(t, exitcode.ValidationFailed, exitCode)
 }
 
 func TestIntegration_RunResolver_GraphJSON(t *testing.T) {

--- a/tests/integration/solutions/edge-cases/validation-failures/solution.yaml
+++ b/tests/integration/solutions/edge-cases/validation-failures/solution.yaml
@@ -82,19 +82,32 @@ spec:
           - expression: '__output.validValue == "good"'
 
       regex-failure:
-        description: Verify regex validation failure
+        description: Verify regex validation failure exits non-zero with --fail-on-validation
         command: [run, resolver]
-        args: ["invalidRegex"]
+        args: ["invalidRegex", "--fail-on-validation"]
         tags: [edge-case, validation, negative]
         expectFailure: true
         assertions:
           - expression: __exitCode != 0
             message: "Should fail validation"
 
-      expression-failure:
-        description: Verify CEL expression validation failure
+      regex-failure-non-fatal:
+        description: Verify regex validation failure is non-fatal by default (value still shown)
         command: [run, resolver]
-        args: ["invalidExpression"]
+        args: ["invalidRegex", "-o", "json"]
+        tags: [edge-case, validation]
+        assertions:
+          - expression: __exitCode == 0
+            message: "run resolver must be non-fatal by default"
+          - expression: '__output.invalidRegex == "BAD_VALUE!"'
+            message: "Partial value must still be shown despite validation failure"
+          - expression: '__stderr.contains("failed validation")'
+            message: "Validation diagnostics must appear on stderr"
+
+      expression-failure:
+        description: Verify CEL expression validation failure exits non-zero with --fail-on-validation
+        command: [run, resolver]
+        args: ["invalidExpression", "--fail-on-validation"]
         tags: [edge-case, validation, negative]
         expectFailure: true
         assertions:
@@ -102,11 +115,36 @@ spec:
             message: "Should fail validation"
 
       not-match-failure:
-        description: Verify notMatch validation failure
+        description: Verify notMatch validation failure exits non-zero with --fail-on-validation
         command: [run, resolver]
-        args: ["invalidNotMatch"]
+        args: ["invalidNotMatch", "--fail-on-validation"]
         tags: [edge-case, validation, negative]
         expectFailure: true
         assertions:
           - expression: __exitCode != 0
             message: "Should fail validation"
+
+      validate-resolver-passes:
+        description: Verify 'validate resolver' exits 0 when validation passes
+        command: [validate, resolver]
+        args: ["validValue", "-o", "json"]
+        tags: [edge-case, validation, smoke]
+        assertions:
+          - expression: __exitCode == 0
+            message: "validate resolver must exit 0 when validation passes"
+          - expression: '__output.validValue == "good"'
+            message: "Resolved value must still be shown"
+
+      validate-resolver-fails:
+        description: Verify 'validate resolver' exits 2 (validation failed) on failure
+        command: [validate, resolver]
+        args: ["invalidRegex", "-o", "json"]
+        tags: [edge-case, validation, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode == 2
+            message: "validate resolver must exit 2 on validation failure"
+          - expression: '__output.invalidRegex == "BAD_VALUE!"'
+            message: "Resolved value must still be shown despite validation failure"
+          - expression: '__stderr.contains("failed validation")'
+            message: "Validation diagnostics must appear on stderr"

--- a/tests/integration/solutions/resolvers/messages/solution.yaml
+++ b/tests/integration/solutions/resolvers/messages/solution.yaml
@@ -78,7 +78,7 @@ spec:
       static-custom-error:
         description: Verify static custom error message overrides default
         command: [run, resolver, invalidPortStatic]
-        args: ["-o", "json"]
+        args: ["-o", "json", "--fail-on-validation"]
         tags: [resolver, messages, negative]
         expectFailure: true
         assertions:
@@ -89,7 +89,7 @@ spec:
       cel-custom-error:
         description: Verify CEL-based custom error message includes dynamic content
         command: [run, resolver, invalidPortCel]
-        args: ["-o", "json"]
+        args: ["-o", "json", "--fail-on-validation"]
         tags: [resolver, messages, negative]
         expectFailure: true
         assertions:

--- a/tests/integration/solutions/resolvers/split-resolver-validation/solution.yaml
+++ b/tests/integration/solutions/resolvers/split-resolver-validation/solution.yaml
@@ -130,7 +130,7 @@ spec:
       non-200-fails-with-message:
         description: Raw resolver validation fails on a non-200 upstream response
         extends: [_base]
-        args: ["userMissingRaw"]
+        args: ["userMissingRaw", "--fail-on-validation"]
         tags: [negative]
         expectFailure: true
         assertions:


### PR DESCRIPTION
- cli: add `validate` command with a `validate resolver` subcommand that executes resolvers as a validation gate, exiting non-zero (code 2) when any resolver fails validation -- suitable for CI and pre-commit checks
- cli(run resolver): treat validation failures as non-fatal by default -- resolved values print on stdout while diagnostics go to stderr; add `--fail-on-validation` to exit non-zero for gating callers
- execute: add NonFatalValidation mode that returns partial values plus structured ResolverDiagnostic list instead of aborting; only pure validation failures are suppressed, resolve/transform failures stay fatal
- mcp(preview_resolvers): return resolved values alongside a `diagnostics` list and `valid` flag when validation fails; add `strict` input to report an error result; document new output schema fields
- celexp: enable CEL optional types so optional access (`_.?name`, `_[?"name"]`) parses, and recognize optional select/index in reference extraction
- resolver: export ExtractRefsFromValueRef helper for AST-based reference collection
- lint: collect resolver references via the dependency-graph AST logic instead of regex, and include dependsOn and state references so the unused-resolver rule matches actual resolution
- run resolver/validate: skip state save when validation fails so invalid values are never persisted