### PR TITLE
feat(auth)!: emit raw tokens by default and add kubectl exec-credential

### DIFF
--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -1859,7 +1859,16 @@ spec:
 
 ## Getting Tokens for Debugging
 
-The `auth token` command retrieves a valid access token for debugging:
+The `auth token` command retrieves a valid access token for debugging. By
+default it prints the **raw token value** to stdout so it composes cleanly with
+shell scripts, `curl`, and tools like `kubectl`:
+
+> [!IMPORTANT]
+> **Breaking change:** `auth token` now prints the raw token by default. Earlier
+> versions printed a masked table and required `--raw` for the token value. The
+> `--raw` flag is still accepted as an explicit alias. Use `-o json` or
+> `-o yaml` to get the structured metadata object (handler, scope, expiry)
+> instead of the bare token.
 
 {{< tabs "auth-tutorial-cmd-47" >}}
 {{% tab "Bash" %}}
@@ -1896,12 +1905,14 @@ scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform"
 
 ### Example Output
 
+The default output is the raw token value, ready to pipe or assign:
+
 ```
-Handler   Scope                                       Token                Expires
-entra     https://graph.microsoft.com/.default        eyJ0eXAi...****      2026-02-04 16:30:00
+eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiI...
 ```
 
-The token is masked in table output for security. Use JSON output to get the full token:
+Use JSON (or YAML) output to get the structured metadata object instead of the
+bare token:
 
 {{< tabs "auth-tutorial-cmd-48" >}}
 {{% tab "Bash" %}}
@@ -2056,6 +2067,74 @@ scafctl auth token github --curl
 ```
 {{% /tab %}}
 {{< /tabs >}}
+
+### Kubernetes ExecCredential (kubectl / oc)
+
+Use `--exec-credential` to emit a Kubernetes `ExecCredential` JSON object so
+`scafctl` can act as a [client-go credential plugin][k8s-exec] for `kubectl` and
+`oc`. This lets a cluster reuse the same scafctl-managed identity you already
+logged in with -- no separate kubeconfig token to rotate:
+
+{{< tabs "auth-tutorial-exec-credential" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl auth token entra --scope "<cluster-scope>/.default" --exec-credential
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl auth token entra --scope "<cluster-scope>/.default" --exec-credential
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Output (the `status.token` is consumed by kubectl; `expirationTimestamp` lets
+kubectl cache the token until it expires):
+
+```json
+{
+  "apiVersion": "client.authentication.k8s.io/v1",
+  "kind": "ExecCredential",
+  "status": {
+    "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiI...",
+    "expirationTimestamp": "2026-02-04T16:30:00Z"
+  }
+}
+```
+
+When `kubectl` invokes the plugin it sets the `KUBERNETES_EXEC_INFO`
+environment variable. scafctl **auto-detects** this: if `KUBERNETES_EXEC_INFO`
+is present and you have not requested another render mode (`--raw`, `--curl`,
+`--export`) or an explicit `-o` format, `auth token` emits an `ExecCredential`
+automatically. scafctl also echoes back the `apiVersion` requested in
+`KUBERNETES_EXEC_INFO`, so both `client.authentication.k8s.io/v1` and
+`client.authentication.k8s.io/v1beta1` clients are supported.
+
+Wire it into your kubeconfig under `users[].user.exec`:
+
+```yaml
+users:
+  - name: my-cluster-user
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1
+        command: scafctl
+        args:
+          - auth
+          - token
+          - entra
+          - --scope
+          - "<cluster-scope>/.default"
+          - --exec-credential
+        # Forwards KUBERNETES_EXEC_INFO so scafctl can echo the apiVersion.
+        provideClusterInfo: true
+        interactiveMode: IfAvailable
+```
+
+For a complete, copy-pasteable walkthrough see the
+[kubectl exec credential example](../../examples/auth/kubectl-exec-credential.md).
+
+[k8s-exec]: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
 
 ### Decoding the JWT (Header + Payload)
 

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -9,10 +9,10 @@ This directory contains examples and cheat-sheets for the `scafctl auth` command
 ### Login
 
 ```bash
-# Entra ID (browser OAuth + PKCE — default)
+# Entra ID (browser OAuth + PKCE -- default)
 scafctl auth login entra
 
-# GitHub (browser OAuth + PKCE — default)
+# GitHub (browser OAuth + PKCE -- default)
 scafctl auth login github
 
 # GCP (browser OAuth)
@@ -27,7 +27,7 @@ scafctl auth login github --flow github-app         # requires GitHub App creden
 scafctl auth login gcp --flow service-principal     # requires GOOGLE_APPLICATION_CREDENTIALS
 scafctl auth login gcp --flow gcloud-adc            # uses existing gcloud ADC file
 
-# Idempotent — skip if already authenticated (safe for scripts and CI)
+# Idempotent -- skip if already authenticated (safe for scripts and CI)
 scafctl auth login entra --skip-if-authenticated
 scafctl auth login github --skip-if-authenticated
 scafctl auth login gcp --skip-if-authenticated
@@ -56,11 +56,11 @@ scafctl auth diagnose
 Output example:
 ```
 ✅ [ok]   auth registry: registered handlers: [entra gcp github]
-⚠️  [warn] config file: config file not found — using built-in defaults
-✅ [ok]   env GITHUB_TOKEN: GitHub personal access token — set
+⚠️  [warn] config file: config file not found -- using built-in defaults
+✅ [ok]   env GITHUB_TOKEN: GitHub personal access token -- set
 ✅ [ok]   entra: authenticated: authenticated as "user@example.com", expires in 58m
 ⚠️  [warn] entra: token cache: 3 cached token(s), 1 expired
-⚠️  [warn] github: not authenticated — run 'scafctl auth login github'
+⚠️  [warn] github: not authenticated -- run 'scafctl auth login github'
 
 ⚠️ Diagnostics complete: 3 warning(s), 5 ok (no failures)
 ```
@@ -87,7 +87,7 @@ Get structured output for CI pipelines:
 scafctl auth diagnose -o json
 ```
 
-> The `clock-skew` check compares your system clock against an external time source and warns if the skew exceeds 5 minutes — a common but easy-to-miss cause of token validation failures.
+> The `clock-skew` check compares your system clock against an external time source and warns if the skew exceeds 5 minutes -- a common but easy-to-miss cause of token validation failures.
 
 ---
 
@@ -145,7 +145,7 @@ scafctl auth list entra --purge-expired
 ```
 
 The `getTokenCommand` column shows the exact `scafctl auth token` command to
-retrieve each access token — copy-paste it directly into your terminal.
+retrieve each access token -- copy-paste it directly into your terminal.
 
 ---
 
@@ -184,7 +184,7 @@ scafctl auth token entra --scope "https://graph.microsoft.com/.default" \
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" \
     --curl --curl-url "https://graph.microsoft.com/v1.0/me" | bash
 
-# No URL — uses <URL> placeholder for inspection
+# No URL -- uses <URL> placeholder for inspection
 scafctl auth token github --curl
 ```
 
@@ -193,10 +193,10 @@ scafctl auth token github --curl
 `--decode` shows both the JWT **header** (algorithm, key ID) and the **payload** (claims):
 
 ```bash
-# Table format — immediately readable
+# Table format -- immediately readable
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode
 
-# JSON format — pipe to jq for filtering
+# JSON format -- pipe to jq for filtering
 scafctl auth token entra --scope "https://graph.microsoft.com/.default" --decode -o json \
     | jq '{alg: .header.alg, kid: .header.kid, upn: .payload.upn, expires: .payload.exp_human, roles: .payload.roles}'
 ```
@@ -210,6 +210,21 @@ Unix timestamp fields (`exp`, `iat`, `nbf`, `auth_time`) automatically get a
 scafctl auth token entra --scope "https://management.azure.com/.default" --clip
 # ✓ Token copied to clipboard (expires in 58m42s).
 ```
+
+### Kubernetes ExecCredential (kubectl / oc)
+
+Emit a client-go `ExecCredential` so kubectl/oc reuse your scafctl identity:
+
+```bash
+scafctl auth token entra --scope "<cluster-scope>/.default" --exec-credential
+```
+
+scafctl auto-detects `KUBERNETES_EXEC_INFO` and emits the envelope even without
+the flag. See [kubectl-exec-credential.md](kubectl-exec-credential.md) for the
+full kubeconfig wiring.
+
+> Note: `auth token` prints the **raw token by default**; `--raw` remains an
+> explicit alias. Use `-o json`/`-o yaml` for the structured metadata object.
 
 ---
 
@@ -264,6 +279,7 @@ scafctl auth handlers remove entra
 
 ## Related
 
-- [Auth Tutorial](../../docs/tutorials/auth-tutorial.md) — full walkthrough
-- [HTTP Provider with Entra](../providers/http-entra.yaml) — example HTTP call with Entra auth
-- [GitHub API Provider](../providers/github-api.yaml) — example GitHub API call
+- [Auth Tutorial](../../docs/tutorials/auth-tutorial.md) -- full walkthrough
+- [kubectl Exec Credential](kubectl-exec-credential.md) -- use scafctl as a Kubernetes credential plugin
+- [HTTP Provider with Entra](../providers/http-entra.yaml) -- example HTTP call with Entra auth
+- [GitHub API Provider](../providers/github-api.yaml) -- example GitHub API call

--- a/examples/auth/credential-helper-setup.md
+++ b/examples/auth/credential-helper-setup.md
@@ -58,6 +58,28 @@ Place the symlink in a custom directory:
 scafctl credential-helper install --bin-dir /usr/local/bin --docker
 ```
 
+## How the Helper Is Installed (Unix vs. Windows)
+
+`credential-helper install` makes scafctl discoverable to Docker/Podman as
+`docker-credential-scafctl`. The mechanism differs by platform:
+
+- **Unix (Linux, macOS):** a `docker-credential-scafctl` **symlink** is created
+  in the bin directory pointing at the scafctl binary.
+- **Windows:** symlinks usually require elevation, so scafctl writes an
+  elevation-free **forwarding shim** named `docker-credential-scafctl.cmd`
+  instead. The shim simply forwards to `scafctl credential-helper <verb>`. If a
+  symlink cannot be created on Unix either, scafctl falls back to the same shim.
+
+```powershell
+# Windows
+scafctl credential-helper install --bin-dir "$env:USERPROFILE\bin" --docker
+```
+
+> The bin directory must be on your `PATH` so Docker/Podman can locate the
+> helper. On Windows the `.cmd` extension must be present in `PATHEXT` (it is by
+> default). `scafctl credential-helper uninstall` removes the symlink or the
+> managed shim; it refuses to delete a path it did not create.
+
 ## Direct Protocol Usage
 
 Test the credential helper directly (useful for debugging):

--- a/examples/auth/kubectl-exec-credential.md
+++ b/examples/auth/kubectl-exec-credential.md
@@ -1,0 +1,99 @@
+# kubectl / oc Exec Credential Plugin
+
+Use scafctl as a Kubernetes [client-go credential plugin][k8s-exec] so `kubectl`
+and `oc` reuse the same scafctl-managed identity you already logged in with. No
+separate cluster token to mint or rotate -- scafctl returns a fresh access token
+on demand and tells kubectl when it expires.
+
+## How It Works
+
+When `kubectl` needs a credential it executes the configured command and reads a
+JSON `ExecCredential` from stdout. `scafctl auth token <handler>
+--exec-credential` emits exactly that envelope:
+
+```json
+{
+  "apiVersion": "client.authentication.k8s.io/v1",
+  "kind": "ExecCredential",
+  "status": {
+    "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiI...",
+    "expirationTimestamp": "2026-02-04T16:30:00Z"
+  }
+}
+```
+
+kubectl caches the token until `expirationTimestamp`, then re-invokes scafctl.
+
+## Prerequisites
+
+Log in once with the handler your cluster trusts (Entra shown here):
+
+```bash
+scafctl auth login entra
+```
+
+## Configure kubeconfig
+
+Add an `exec` user to your kubeconfig and bind it to the cluster context:
+
+```yaml
+apiVersion: v1
+kind: Config
+clusters:
+  - name: my-cluster
+    cluster:
+      server: https://my-cluster.example.com:6443
+contexts:
+  - name: my-context
+    context:
+      cluster: my-cluster
+      user: my-cluster-user
+current-context: my-context
+users:
+  - name: my-cluster-user
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1
+        command: scafctl
+        args:
+          - auth
+          - token
+          - entra
+          - --scope
+          - "<cluster-scope>/.default"
+          - --exec-credential
+        # Forwards KUBERNETES_EXEC_INFO so scafctl echoes the requested apiVersion.
+        provideClusterInfo: true
+        interactiveMode: IfAvailable
+```
+
+Replace `<cluster-scope>` with the audience/scope your cluster's OIDC config
+expects (for example an Entra application ID URI).
+
+## Auto-Detection
+
+You can also drop `--exec-credential` from the args. When kubectl invokes the
+plugin it sets the `KUBERNETES_EXEC_INFO` environment variable; scafctl detects
+it and emits an `ExecCredential` automatically -- as long as no other render
+flag (`--raw`, `--curl`, `--export`) or explicit `-o` format is requested.
+
+scafctl echoes back whichever `apiVersion` kubectl sends, so both
+`client.authentication.k8s.io/v1` and `client.authentication.k8s.io/v1beta1`
+clients work without changes.
+
+## Verify
+
+Force a manual run to confirm the JSON envelope before pointing kubectl at it:
+
+```bash
+KUBERNETES_EXEC_INFO='{"apiVersion":"client.authentication.k8s.io/v1"}' \
+  scafctl auth token entra --scope "<cluster-scope>/.default"
+```
+
+Then exercise it through kubectl:
+
+```bash
+kubectl --context my-context get pods
+```
+
+[k8s-exec]: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins

--- a/pkg/auth/execcredential/execcredential.go
+++ b/pkg/auth/execcredential/execcredential.go
@@ -1,0 +1,93 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package execcredential builds Kubernetes client-go ExecCredential payloads
+// from scafctl auth tokens. It deliberately hand-rolls the tiny JSON schema so
+// that scafctl core never imports client-go.
+//
+// The ExecCredential is the response format of a kubectl/oc exec credential
+// plugin: kubectl invokes the plugin, the plugin prints this JSON to stdout,
+// and kubectl reads status.token as the bearer token for the API server.
+// See https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
+package execcredential
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+const (
+	// Kind is the ExecCredential resource kind.
+	Kind = "ExecCredential"
+
+	// DefaultAPIVersion is the client.authentication.k8s.io API version used
+	// when kubectl does not advertise one via KUBERNETES_EXEC_INFO.
+	DefaultAPIVersion = "client.authentication.k8s.io/v1"
+
+	// ExecInfoEnv is the environment variable kubectl sets when it invokes an
+	// exec credential plugin. Its presence signals that exec-credential output
+	// is expected even without an explicit flag.
+	ExecInfoEnv = "KUBERNETES_EXEC_INFO"
+
+	// apiVersionPrefix guards against echoing an unrelated apiVersion parsed
+	// from the exec info payload.
+	apiVersionPrefix = "client.authentication.k8s.io/"
+)
+
+// ExecCredential is the client-go credential plugin response envelope.
+type ExecCredential struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Status     Status `json:"status"`
+}
+
+// Status carries the bearer token and its optional expiry.
+type Status struct {
+	Token               string `json:"token"`
+	ExpirationTimestamp string `json:"expirationTimestamp,omitempty"`
+}
+
+// NewWithAPIVersion builds an ExecCredential with an explicit API version.
+// An empty apiVersion falls back to DefaultAPIVersion.
+func NewWithAPIVersion(apiVersion, token string, expiresAt time.Time) ExecCredential {
+	if apiVersion == "" {
+		apiVersion = DefaultAPIVersion
+	}
+	ec := ExecCredential{
+		APIVersion: apiVersion,
+		Kind:       Kind,
+		Status:     Status{Token: token},
+	}
+	if !expiresAt.IsZero() {
+		ec.Status.ExpirationTimestamp = expiresAt.UTC().Format(time.RFC3339)
+	}
+	return ec
+}
+
+// JSON marshals the ExecCredential to its on-the-wire JSON form.
+func (e ExecCredential) JSON() ([]byte, error) {
+	return json.Marshal(e)
+}
+
+// APIVersionFromExecInfo extracts the client.authentication.k8s.io API version
+// that kubectl requested from a KUBERNETES_EXEC_INFO payload. It returns
+// DefaultAPIVersion when the payload is empty, unparseable, or advertises an
+// apiVersion outside the client.authentication.k8s.io group. Echoing the
+// requested version keeps the plugin compatible with both v1 and v1beta1
+// clusters without importing client-go.
+func APIVersionFromExecInfo(execInfo string) string {
+	if execInfo == "" {
+		return DefaultAPIVersion
+	}
+	var parsed struct {
+		APIVersion string `json:"apiVersion"`
+	}
+	if err := json.Unmarshal([]byte(execInfo), &parsed); err != nil {
+		return DefaultAPIVersion
+	}
+	if !strings.HasPrefix(parsed.APIVersion, apiVersionPrefix) {
+		return DefaultAPIVersion
+	}
+	return parsed.APIVersion
+}

--- a/pkg/auth/execcredential/execcredential_test.go
+++ b/pkg/auth/execcredential/execcredential_test.go
@@ -1,0 +1,134 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package execcredential
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewWithAPIVersion_Expiry(t *testing.T) {
+	t.Parallel()
+
+	expiry := time.Date(2026, 6, 24, 15, 4, 5, 0, time.UTC)
+	tests := []struct {
+		name          string
+		token         string
+		expiresAt     time.Time
+		wantExpiry    string
+		wantHasExpiry bool
+	}{
+		{
+			name:          "with expiry",
+			token:         "abc123",
+			expiresAt:     expiry,
+			wantExpiry:    "2026-06-24T15:04:05Z",
+			wantHasExpiry: true,
+		},
+		{
+			name:          "zero expiry omits timestamp",
+			token:         "abc123",
+			expiresAt:     time.Time{},
+			wantHasExpiry: false,
+		},
+		{
+			name:          "non-UTC expiry normalized to UTC",
+			token:         "abc123",
+			expiresAt:     time.Date(2026, 6, 24, 11, 4, 5, 0, time.FixedZone("EST", -4*3600)),
+			wantExpiry:    "2026-06-24T15:04:05Z",
+			wantHasExpiry: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ec := NewWithAPIVersion(DefaultAPIVersion, tt.token, tt.expiresAt)
+			assert.Equal(t, DefaultAPIVersion, ec.APIVersion)
+			assert.Equal(t, Kind, ec.Kind)
+			assert.Equal(t, tt.token, ec.Status.Token)
+			if tt.wantHasExpiry {
+				assert.Equal(t, tt.wantExpiry, ec.Status.ExpirationTimestamp)
+			} else {
+				assert.Empty(t, ec.Status.ExpirationTimestamp)
+			}
+		})
+	}
+}
+
+func TestNewWithAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		apiVersion string
+		want       string
+	}{
+		{name: "explicit v1beta1", apiVersion: "client.authentication.k8s.io/v1beta1", want: "client.authentication.k8s.io/v1beta1"},
+		{name: "empty falls back to default", apiVersion: "", want: DefaultAPIVersion},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ec := NewWithAPIVersion(tt.apiVersion, "tok", time.Time{})
+			assert.Equal(t, tt.want, ec.APIVersion)
+		})
+	}
+}
+
+func TestJSON(t *testing.T) {
+	t.Parallel()
+
+	ec := NewWithAPIVersion(DefaultAPIVersion, "eyJtoken", time.Date(2026, 6, 24, 15, 4, 5, 0, time.UTC))
+	data, err := ec.JSON()
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, DefaultAPIVersion, decoded["apiVersion"])
+	assert.Equal(t, Kind, decoded["kind"])
+
+	status, ok := decoded["status"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "eyJtoken", status["token"])
+	assert.Equal(t, "2026-06-24T15:04:05Z", status["expirationTimestamp"])
+}
+
+func TestJSON_ZeroExpiryOmitsField(t *testing.T) {
+	t.Parallel()
+
+	ec := NewWithAPIVersion(DefaultAPIVersion, "tok", time.Time{})
+	data, err := ec.JSON()
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "expirationTimestamp")
+}
+
+func TestAPIVersionFromExecInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		execInfo string
+		want     string
+	}{
+		{name: "empty", execInfo: "", want: DefaultAPIVersion},
+		{name: "invalid json", execInfo: "{not json", want: DefaultAPIVersion},
+		{name: "v1", execInfo: `{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential"}`, want: "client.authentication.k8s.io/v1"},
+		{name: "v1beta1", execInfo: `{"apiVersion":"client.authentication.k8s.io/v1beta1"}`, want: "client.authentication.k8s.io/v1beta1"},
+		{name: "unrelated group rejected", execInfo: `{"apiVersion":"v1"}`, want: DefaultAPIVersion},
+		{name: "missing apiVersion", execInfo: `{"kind":"ExecCredential"}`, want: DefaultAPIVersion},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, APIVersionFromExecInfo(tt.execInfo))
+		})
+	}
+}

--- a/pkg/cmd/scafctl/auth/token.go
+++ b/pkg/cmd/scafctl/auth/token.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/atotto/clipboard"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/auth/execcredential"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -37,17 +39,21 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 		curl         bool
 		curlURL      string
 		exportToken  bool
+		execCred     bool
 		profile      string
 	)
 
 	cmd := &cobra.Command{
 		Use:   "token <handler>",
-		Short: "Get an access token (for debugging)",
+		Short: "Get an access token",
 		Long: strings.ReplaceAll(heredoc.Doc(`
 			Get an access token from an auth handler.
 
-			This command is primarily for debugging and testing. It retrieves
-			a valid access token from the specified handler.
+			By default it prints the raw access token to stdout, which is
+			convenient for scripting (command substitution, environment variables,
+			Authorization headers). Use -o json|yaml for the full token metadata
+			object, or a render flag (--export, --curl, --exec-credential) to shape
+			the token for a specific tool.
 
 			For handlers that support per-request scopes (e.g., Entra), the --scope
 			flag is required and specifies which resource scope to request.
@@ -95,6 +101,9 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 
 			  # Emit a ready-to-run curl command with the token injected
 			  scafctl auth token entra --scope "https://management.azure.com/.default" --curl --curl-url "https://management.azure.com/subscriptions?api-version=2020-01-01"
+
+			  # Emit a Kubernetes ExecCredential (for a kubeconfig exec credential plugin)
+			  scafctl auth token entra --scope "https://management.azure.com/.default" --exec-credential
 
 			  # Export the token as a shell variable (eval-compatible)
 			  eval $(scafctl auth token gcp --scope "https://www.googleapis.com/auth/cloud-platform" --export)
@@ -191,6 +200,34 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				return exitcode.WithCode(err, exitcode.GeneralError)
 			}
 
+			// Kubernetes exec-credential: emit a client-go ExecCredential. Explicit
+			// via --exec-credential, or auto-detected when kubectl invokes this binary
+			// as an exec plugin (KUBERNETES_EXEC_INFO set) and no other render mode or
+			// explicit output format was requested.
+			execInfo := os.Getenv(execcredential.ExecInfoEnv)
+			wantExecCred := execCred
+			if !wantExecCred && execInfo != "" &&
+				!rawToken && !clip && !exportToken && !curl && !decode &&
+				!outputFlags.FormatExplicit && !outputFlags.Interactive &&
+				outputFlags.Expression == "" {
+				wantExecCred = true
+			}
+			if wantExecCred {
+				cred := execcredential.NewWithAPIVersion(
+					execcredential.APIVersionFromExecInfo(execInfo),
+					token.AccessToken,
+					token.ExpiresAt,
+				)
+				data, marshalErr := cred.JSON()
+				if marshalErr != nil {
+					marshalErr = fmt.Errorf("failed to encode exec credential: %w", marshalErr)
+					w.Errorf("%v", marshalErr)
+					return exitcode.WithCode(marshalErr, exitcode.GeneralError)
+				}
+				w.Plainln(string(data))
+				return nil
+			}
+
 			if rawToken {
 				w.Plainln(token.AccessToken)
 				return nil
@@ -267,6 +304,13 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				return outputOpts.Write(decoded)
 			}
 
+			// Default output is the raw token for scriptability. The structured
+			// metadata object is opt-in via -o / --interactive / --expression.
+			if !outputFlags.FormatExplicit && !outputFlags.Interactive && outputFlags.Expression == "" {
+				w.Plainln(token.AccessToken)
+				return nil
+			}
+
 			result := map[string]any{
 				"handler":     handlerName,
 				"flow":        string(token.Flow),
@@ -305,6 +349,7 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 	cmd.Flags().BoolVar(&curl, "curl", false, "Emit a ready-to-run curl command with the token injected")
 	cmd.Flags().StringVar(&curlURL, "curl-url", "", "URL to embed in the --curl output (default: '<URL>' placeholder)")
 	cmd.Flags().BoolVar(&exportToken, "export", false, fmt.Sprintf("Output a shell export statement: eval $(%s auth token ... --export)", cliParams.BinaryName))
+	cmd.Flags().BoolVar(&execCred, "exec-credential", false, "Emit a Kubernetes client-go ExecCredential JSON (for kubectl/oc exec credential plugins; auto-detected when KUBERNETES_EXEC_INFO is set)")
 	cmd.Flags().StringVar(&profile, "profile", "", "Named profile for isolated credential storage (e.g. work, personal)")
 	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
 

--- a/pkg/cmd/scafctl/auth/token_test.go
+++ b/pkg/cmd/scafctl/auth/token_test.go
@@ -4,7 +4,9 @@
 package auth
 
 import (
+	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -129,9 +131,10 @@ func TestCommandToken_GitHubSuccessWithoutScope(t *testing.T) {
 	require.Len(t, mock.GetTokenCalls, 1)
 	assert.Equal(t, "", mock.GetTokenCalls[0].Scope)
 
+	// Default output is the raw token (scriptable), not the metadata object.
 	output := buf.String()
-	assert.Contains(t, output, "handler")
-	assert.Contains(t, output, "github")
+	assert.Equal(t, "gho_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx", strings.TrimSpace(output))
+	assert.NotContains(t, output, "handler")
 }
 
 func TestCommandToken_Success(t *testing.T) {
@@ -161,15 +164,11 @@ func TestCommandToken_Success(t *testing.T) {
 	require.Len(t, mock.GetTokenCalls, 1)
 	assert.Equal(t, "https://graph.microsoft.com/.default", mock.GetTokenCalls[0].Scope)
 
-	// Verify output includes all fields
+	// Default output is the raw access token for scriptability.
 	output := buf.String()
-	assert.Contains(t, output, "handler")
-	assert.Contains(t, output, "entra")
-	assert.Contains(t, output, "scope")
-	assert.Contains(t, output, "graph.microsoft.com")
-	assert.Contains(t, output, "tokenType")
-	assert.Contains(t, output, "Bearer")
-	assert.Contains(t, output, "accessToken") // Full token is present, not masked
+	assert.Equal(t, "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBP", strings.TrimSpace(output))
+	assert.NotContains(t, output, "tokenType")
+	assert.NotContains(t, output, "handler")
 }
 
 func TestCommandToken_JSONOutput(t *testing.T) {
@@ -325,4 +324,158 @@ func TestCommandToken_ShortToken(t *testing.T) {
 	output := buf.String()
 	assert.Contains(t, output, "short")
 	assert.NotContains(t, output, "...")
+}
+
+// decodeExecCredential parses the command output as an ExecCredential JSON.
+func decodeExecCredential(t *testing.T, output string) map[string]any {
+	t.Helper()
+	var ec map[string]any
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &ec))
+	return ec
+}
+
+func TestCommandToken_ExecCredential(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	expiry := time.Now().Add(time.Hour).UTC()
+	mock := newEntraMock()
+	mock.SetToken(&auth.Token{
+		AccessToken: "eyJexec-cred-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   expiry,
+		Scope:       "https://graph.microsoft.com/.default",
+	})
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandToken(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra", "--scope", "https://graph.microsoft.com/.default", "--exec-credential"})
+
+	require.NoError(t, cmd.Execute())
+
+	ec := decodeExecCredential(t, buf.String())
+	assert.Equal(t, "client.authentication.k8s.io/v1", ec["apiVersion"])
+	assert.Equal(t, "ExecCredential", ec["kind"])
+	status, ok := ec["status"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "eyJexec-cred-token", status["token"])
+	assert.Equal(t, expiry.Format(time.RFC3339), status["expirationTimestamp"])
+}
+
+func TestCommandToken_ExecCredentialAutoDetect(t *testing.T) {
+	t.Setenv("KUBERNETES_EXEC_INFO", `{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential","spec":{}}`)
+
+	ctx, buf := newTestContext(t)
+
+	mock := newEntraMock()
+	mock.SetToken(&auth.Token{
+		AccessToken: "auto-detected-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		Scope:       "https://graph.microsoft.com/.default",
+	})
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandToken(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	// No --exec-credential flag: presence of KUBERNETES_EXEC_INFO triggers it.
+	cmd.SetArgs([]string{"entra", "--scope", "https://graph.microsoft.com/.default"})
+
+	require.NoError(t, cmd.Execute())
+
+	ec := decodeExecCredential(t, buf.String())
+	status, ok := ec["status"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "auto-detected-token", status["token"])
+}
+
+func TestCommandToken_ExecCredentialEchoesAPIVersion(t *testing.T) {
+	t.Setenv("KUBERNETES_EXEC_INFO", `{"apiVersion":"client.authentication.k8s.io/v1beta1","kind":"ExecCredential","spec":{}}`)
+
+	ctx, buf := newTestContext(t)
+
+	mock := newEntraMock()
+	mock.SetToken(&auth.Token{
+		AccessToken: "beta-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		Scope:       "https://graph.microsoft.com/.default",
+	})
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandToken(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra", "--scope", "https://graph.microsoft.com/.default", "--exec-credential"})
+
+	require.NoError(t, cmd.Execute())
+
+	ec := decodeExecCredential(t, buf.String())
+	assert.Equal(t, "client.authentication.k8s.io/v1beta1", ec["apiVersion"])
+}
+
+func TestCommandToken_ExplicitFormatBeatsExecInfo(t *testing.T) {
+	t.Setenv("KUBERNETES_EXEC_INFO", `{"apiVersion":"client.authentication.k8s.io/v1"}`)
+
+	ctx, buf := newTestContext(t)
+
+	mock := newEntraMock()
+	mock.SetToken(&auth.Token{
+		AccessToken: "explicit-json-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		Scope:       "https://graph.microsoft.com/.default",
+	})
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandToken(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	// Explicit -o json must win over KUBERNETES_EXEC_INFO auto-detect.
+	cmd.SetArgs([]string{"entra", "--scope", "https://graph.microsoft.com/.default", "-o", "json"})
+
+	require.NoError(t, cmd.Execute())
+
+	output := buf.String()
+	assert.Contains(t, output, "tokenType")
+	assert.NotContains(t, output, "ExecCredential")
+}
+
+func TestCommandToken_ExpressionBeatsExecInfo(t *testing.T) {
+	t.Setenv("KUBERNETES_EXEC_INFO", `{"apiVersion":"client.authentication.k8s.io/v1"}`)
+
+	ctx, buf := newTestContext(t)
+
+	mock := newEntraMock()
+	mock.SetToken(&auth.Token{
+		AccessToken: "expression-token",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(time.Hour),
+		Scope:       "https://graph.microsoft.com/.default",
+	})
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandToken(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	// An explicit -e/--expression must win over KUBERNETES_EXEC_INFO auto-detect.
+	cmd.SetArgs([]string{"entra", "--scope", "https://graph.microsoft.com/.default", "-e", "_.handler"})
+
+	require.NoError(t, cmd.Execute())
+
+	output := buf.String()
+	assert.Contains(t, output, "entra")
+	assert.NotContains(t, output, "ExecCredential")
 }

--- a/pkg/cmd/scafctl/credentialhelper/install.go
+++ b/pkg/cmd/scafctl/credentialhelper/install.go
@@ -5,7 +5,9 @@ package credentialhelper
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -21,6 +23,29 @@ import (
 const (
 	// defaultBinDir is the default directory for the symlink.
 	defaultBinDir = "~/.local/bin"
+)
+
+// shimSignature marks forwarding shims that this command generated,
+// so uninstall can safely distinguish them from unrelated user files.
+const shimSignature = "scafctl-managed forwarding shim"
+
+// shimSignatureLinePOSIX and shimSignatureLineWindows are the exact comment
+// lines embedded in generated shims. isManagedShim matches one of these lines
+// exactly so an unrelated file cannot be mistaken for a managed shim.
+const (
+	shimSignatureLinePOSIX   = "# " + shimSignature
+	shimSignatureLineWindows = "REM " + shimSignature
+)
+
+// shimHeaderScanBytes bounds how much of a candidate file isManagedShim reads
+// when searching for the signature line. Generated shims carry the signature on
+// the second line, so a small header is always sufficient.
+const shimHeaderScanBytes = 512
+
+// Install methods reported by installHelper.
+const (
+	methodSymlink = "symlink"
+	methodShim    = "shim"
 )
 
 // credHelperName returns the Docker credential helper symlink name for the given binary.
@@ -39,11 +64,13 @@ func commandInstall(_ *terminal.IOStreams, path string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: fmt.Sprintf("Install %s as a Docker/Podman credential helper", path),
-		Long: fmt.Sprintf(`Creates a %s symlink and optionally configures
+		Long: fmt.Sprintf(`Installs a %s credential helper and optionally configures
 Docker or Podman to use %s as the credential store.
 
-The symlink is placed in --bin-dir (default ~/.local/bin) and must be on
-your PATH for Docker/Podman to discover it.`, credHelperName(path), path),
+On Unix a symlink is created in --bin-dir (default ~/.local/bin). On Windows,
+or when a symlink cannot be created without elevation, an elevation-free
+forwarding shim is written instead. Either way --bin-dir must be on your PATH
+for Docker/Podman to discover the helper.`, credHelperName(path), path),
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -65,12 +92,14 @@ your PATH for Docker/Podman to discover it.`, credHelperName(path), path),
 				return fmt.Errorf("create bin directory %s: %w", resolvedBinDir, err)
 			}
 
-			// Create (or replace) the symlink
-			linkPath := filepath.Join(resolvedBinDir, helperName)
-			if err := createSymlink(scafctlPath, linkPath); err != nil {
-				return fmt.Errorf("create symlink: %w", err)
+			// Install the helper: a symlink on Unix, or an elevation-free forwarding
+			// shim on Windows (or as a fallback when symlinking is not permitted).
+			linkPath := filepath.Join(resolvedBinDir, credHelperFileName(path, runtime.GOOS))
+			method, err := installHelper(scafctlPath, linkPath, runtime.GOOS)
+			if err != nil {
+				return fmt.Errorf("install credential helper: %w", err)
 			}
-			w.Successf("Created symlink %s -> %s\n", linkPath, scafctlPath)
+			w.Successf("Created %s %s -> %s\n", method, linkPath, scafctlPath)
 
 			// Optionally configure Docker
 			if docker {
@@ -95,7 +124,7 @@ your PATH for Docker/Podman to discover it.`, credHelperName(path), path),
 		},
 	}
 
-	cmd.Flags().StringVar(&binDir, "bin-dir", defaultBinDir, "Directory for the credential helper symlink")
+	cmd.Flags().StringVar(&binDir, "bin-dir", defaultBinDir, "Directory for the credential helper symlink or shim")
 	cmd.Flags().BoolVar(&docker, "docker", false, "Update ~/.docker/config.json")
 	cmd.Flags().BoolVar(&podman, "podman", false, "Update Podman containers/auth.json")
 	cmd.Flags().StringVar(&registry, "registry", "", "Configure per-registry credHelper instead of global credsStore")
@@ -114,7 +143,7 @@ func commandUninstall(_ *terminal.IOStreams, path string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "uninstall",
 		Short: fmt.Sprintf("Remove %s credential helper integration", path),
-		Long: fmt.Sprintf(`Removes the %s symlink and optionally removes
+		Long: fmt.Sprintf(`Removes the %s symlink or managed shim and optionally removes
 %s entries from Docker or Podman configuration.`, credHelperName(path), path),
 		Args:          cobra.NoArgs,
 		SilenceUsage:  true,
@@ -124,24 +153,34 @@ func commandUninstall(_ *terminal.IOStreams, path string) *cobra.Command {
 			w := writer.FromContext(ctx)
 
 			resolvedBinDir := expandHome(binDir)
-			linkPath := filepath.Join(resolvedBinDir, credHelperName(path))
+			linkPath := filepath.Join(resolvedBinDir, credHelperFileName(path, runtime.GOOS))
 
-			// Remove symlink only when the path is actually a symlink.
-			// Refusing to remove regular files mirrors the safety checks in createSymlink.
+			// Remove the installed helper. Symlinks (Unix) are removed directly;
+			// regular files are removed only when they are a managed forwarding shim,
+			// so an unrelated file the user placed here is never deleted.
 			info, err := os.Lstat(linkPath)
-			if os.IsNotExist(err) {
-				w.Successf("Removed symlink %s\n", linkPath)
-			} else {
-				if err != nil {
-					return fmt.Errorf("stat symlink %s: %w", linkPath, err)
-				}
-				if info.Mode()&os.ModeSymlink == 0 {
-					return fmt.Errorf("refusing to remove non-symlink path %s", linkPath)
-				}
+			switch {
+			case os.IsNotExist(err):
+				w.Successf("Nothing to remove at %s\n", linkPath)
+			case err != nil:
+				return fmt.Errorf("stat %s: %w", linkPath, err)
+			case info.Mode()&os.ModeSymlink != 0:
 				if err := os.Remove(linkPath); err != nil {
 					return fmt.Errorf("remove symlink %s: %w", linkPath, err)
 				}
 				w.Successf("Removed symlink %s\n", linkPath)
+			default:
+				managed, shimErr := isManagedShim(linkPath)
+				if shimErr != nil {
+					return fmt.Errorf("inspect %s: %w", linkPath, shimErr)
+				}
+				if !managed {
+					return fmt.Errorf("refusing to remove non-symlink path %s", linkPath)
+				}
+				if err := os.Remove(linkPath); err != nil {
+					return fmt.Errorf("remove shim %s: %w", linkPath, err)
+				}
+				w.Successf("Removed shim %s\n", linkPath)
 			}
 
 			// Optionally clean Docker config
@@ -166,7 +205,7 @@ func commandUninstall(_ *terminal.IOStreams, path string) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&binDir, "bin-dir", defaultBinDir, "Directory where the symlink was installed")
+	cmd.Flags().StringVar(&binDir, "bin-dir", defaultBinDir, "Directory where the symlink or shim was installed")
 	cmd.Flags().BoolVar(&docker, "docker", false, fmt.Sprintf("Remove %s entries from ~/.docker/config.json", path))
 	cmd.Flags().BoolVar(&podman, "podman", false, fmt.Sprintf("Remove %s entries from Podman containers/auth.json", path))
 	cmd.Flags().StringVar(&registry, "registry", "", "Remove per-registry credHelper instead of global credsStore")
@@ -206,6 +245,105 @@ func createSymlink(target, linkPath string) error {
 	}
 
 	return os.Symlink(target, linkPath)
+}
+
+// credHelperFileName returns the on-disk file name for the credential helper.
+// On Windows the helper is a ".cmd" shim so that Go's exec.LookPath (honoring
+// PATHEXT) can discover it; elsewhere it is the bare alias name used by the
+// symlink.
+func credHelperFileName(binaryName, goos string) string {
+	name := credHelperName(binaryName)
+	if goos == "windows" {
+		return name + ".cmd"
+	}
+	return name
+}
+
+// installHelper installs the credential helper at linkPath, returning the method
+// used (methodSymlink or methodShim). On Windows it always writes a forwarding
+// shim (symlinks require elevation). On Unix it prefers a symlink and falls back
+// to a shim when symlink creation is not permitted.
+func installHelper(target, linkPath, goos string) (string, error) {
+	if goos == "windows" {
+		if err := writeShim(target, linkPath, goos); err != nil {
+			return "", err
+		}
+		return methodShim, nil
+	}
+	if err := createSymlink(target, linkPath); err != nil {
+		if shimErr := writeShim(target, linkPath, goos); shimErr != nil {
+			return "", fmt.Errorf("symlink failed (%w) and shim fallback failed: %w", err, shimErr)
+		}
+		return methodShim, nil
+	}
+	return methodSymlink, nil
+}
+
+// shimContent returns the forwarding-shim script body for the given OS. The shim
+// delegates to the resolved binary's "credential-helper" subcommand and carries
+// a signature line so uninstall can recognize files it generated.
+func shimContent(target, goos string) string {
+	if goos == "windows" {
+		return "@echo off\r\n" + shimSignatureLineWindows + "\r\n\"" + target + "\" credential-helper %*\r\n"
+	}
+	return "#!/bin/sh\n" + shimSignatureLinePOSIX + "\nexec \"" + target + "\" credential-helper \"$@\"\n"
+}
+
+// writeShim writes a forwarding shim at shimPath pointing to target. An existing
+// symlink or a previously generated managed shim is replaced; any other regular
+// file is left untouched and an error is returned, so an unrelated helper the
+// user placed at this path is never clobbered.
+func writeShim(target, shimPath, goos string) error {
+	if _, err := exec.LookPath(target); err != nil {
+		return fmt.Errorf("target %s is not executable: %w", target, err)
+	}
+	if fi, err := os.Lstat(shimPath); err == nil {
+		if fi.Mode()&os.ModeSymlink == 0 {
+			managed, mErr := isManagedShim(shimPath)
+			if mErr != nil {
+				return fmt.Errorf("inspect existing %s: %w", shimPath, mErr)
+			}
+			if !managed {
+				return fmt.Errorf("%s exists and is not a managed shim", shimPath)
+			}
+		}
+		if err := os.Remove(shimPath); err != nil {
+			return fmt.Errorf("remove existing %s: %w", shimPath, err)
+		}
+	}
+	mode := os.FileMode(0o755)
+	if goos == "windows" {
+		mode = 0o644
+	}
+	if err := os.WriteFile(shimPath, []byte(shimContent(target, goos)), mode); err != nil {
+		return fmt.Errorf("write shim %s: %w", shimPath, err)
+	}
+	return nil
+}
+
+// isManagedShim reports whether path is a forwarding shim generated by this
+// command, identified by an exact signature line within the file header. Only a
+// bounded header is read, so large unrelated files are cheap to reject and
+// cannot be mis-identified by an incidental substring match deeper in the file.
+func isManagedShim(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	header := make([]byte, shimHeaderScanBytes)
+	n, err := io.ReadFull(f, header)
+	if err != nil && !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
+		return false, fmt.Errorf("read %s: %w", path, err)
+	}
+	for _, line := range strings.Split(string(header[:n]), "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == shimSignatureLinePOSIX || line == shimSignatureLineWindows {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // expandHome replaces a leading ~ with the user's home directory.

--- a/pkg/cmd/scafctl/credentialhelper/install_test.go
+++ b/pkg/cmd/scafctl/credentialhelper/install_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -327,4 +328,321 @@ func TestFindScafctlBinary(t *testing.T) {
 	assert.NotEmpty(t, path)
 	// Should be an absolute path
 	assert.True(t, filepath.IsAbs(path), "binary path should be absolute, got %s", path)
+}
+
+func TestCredHelperFileName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		binaryName string
+		goos       string
+		want       string
+	}{
+		{name: "linux default", binaryName: "scafctl", goos: "linux", want: "docker-credential-scafctl"},
+		{name: "darwin default", binaryName: "scafctl", goos: "darwin", want: "docker-credential-scafctl"},
+		{name: "windows default", binaryName: "scafctl", goos: "windows", want: "docker-credential-scafctl.cmd"},
+		{name: "embedder unix", binaryName: "mycli", goos: "linux", want: "docker-credential-mycli"},
+		{name: "embedder windows", binaryName: "mycli", goos: "windows", want: "docker-credential-mycli.cmd"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, credHelperFileName(tt.binaryName, tt.goos))
+		})
+	}
+}
+
+func TestShimContent(t *testing.T) {
+	t.Parallel()
+
+	const target = "/usr/local/bin/scafctl"
+
+	unix := shimContent(target, "linux")
+	assert.Contains(t, unix, "#!/bin/sh")
+	assert.Contains(t, unix, shimSignature)
+	assert.Contains(t, unix, `exec "`+target+`" credential-helper "$@"`)
+
+	win := shimContent(target, "windows")
+	assert.Contains(t, win, "@echo off")
+	assert.Contains(t, win, shimSignature)
+	assert.Contains(t, win, `"`+target+`" credential-helper %*`)
+	assert.Contains(t, win, "\r\n", "windows shim should use CRLF line endings")
+}
+
+func TestWriteShimAndIsManagedShim(t *testing.T) {
+	target, err := os.Executable()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	shimPath := filepath.Join(dir, "shim.sh")
+
+	require.NoError(t, writeShim(target, shimPath, "linux"))
+
+	data, err := os.ReadFile(shimPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), shimSignature)
+	assert.Contains(t, string(data), target)
+
+	managed, err := isManagedShim(shimPath)
+	require.NoError(t, err)
+	assert.True(t, managed, "generated shim should be recognized as managed")
+
+	// A foreign regular file must not be recognized as a managed shim.
+	foreign := filepath.Join(dir, "foreign")
+	require.NoError(t, os.WriteFile(foreign, []byte("not a shim"), 0o644))
+	managed, err = isManagedShim(foreign)
+	require.NoError(t, err)
+	assert.False(t, managed, "unrelated file should not be a managed shim")
+}
+
+func TestWriteShim_ReplacesManagedShim(t *testing.T) {
+	target, err := os.Executable()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	shimPath := filepath.Join(dir, "shim.sh")
+
+	// A previously generated managed shim may be replaced.
+	require.NoError(t, writeShim(target, shimPath, "linux"))
+	require.NoError(t, writeShim(target, shimPath, "linux"))
+
+	data, err := os.ReadFile(shimPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), shimSignature)
+}
+
+func TestWriteShim_RefusesForeignFile(t *testing.T) {
+	target, err := os.Executable()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	shimPath := filepath.Join(dir, "shim.sh")
+	require.NoError(t, os.WriteFile(shimPath, []byte("user data"), 0o644))
+
+	err = writeShim(target, shimPath, "linux")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a managed shim")
+
+	// The unrelated file must be left untouched.
+	data, err := os.ReadFile(shimPath)
+	require.NoError(t, err)
+	assert.Equal(t, "user data", string(data))
+}
+
+func TestWriteShim_ReplacesSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation may require elevated privilege on Windows")
+	}
+	target, err := os.Executable()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	shimPath := filepath.Join(dir, "shim.sh")
+	require.NoError(t, os.Symlink(filepath.FromSlash("/nonexistent"), shimPath))
+
+	require.NoError(t, writeShim(target, shimPath, "linux"))
+
+	data, err := os.ReadFile(shimPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), shimSignature)
+}
+
+func TestWriteShim_NonExecutableTarget(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "does-not-exist")
+	shimPath := filepath.Join(dir, "shim.sh")
+
+	err := writeShim(target, shimPath, "linux")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not executable")
+}
+
+func TestIsManagedShim_MatchesWindowsSignatureLine(t *testing.T) {
+	dir := t.TempDir()
+	shimPath := filepath.Join(dir, "shim.cmd")
+	require.NoError(t, os.WriteFile(shimPath, []byte(shimContent("target.exe", "windows")), 0o644))
+
+	managed, err := isManagedShim(shimPath)
+	require.NoError(t, err)
+	assert.True(t, managed, "generated windows shim should be recognized as managed")
+}
+
+func TestIsManagedShim_RejectsSignatureBeyondHeader(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "large")
+
+	// Place the signature far past the bounded header so it must not match.
+	content := strings.Repeat("x", shimHeaderScanBytes+64) + "\n" + shimSignatureLinePOSIX + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	managed, err := isManagedShim(path)
+	require.NoError(t, err)
+	assert.False(t, managed, "signature outside the scanned header must not match")
+}
+
+func TestIsManagedShim_RejectsSubstringWithoutExactLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "incidental")
+
+	// The signature text appears, but never as a standalone comment line.
+	content := "prefix " + shimSignature + " suffix on the same line\n"
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+
+	managed, err := isManagedShim(path)
+	require.NoError(t, err)
+	assert.False(t, managed, "incidental substring must not be treated as a managed shim")
+}
+
+func TestIsManagedShim_EmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty")
+	require.NoError(t, os.WriteFile(path, nil, 0o644))
+
+	managed, err := isManagedShim(path)
+	require.NoError(t, err)
+	assert.False(t, managed, "empty file is not a managed shim")
+}
+
+func TestIsManagedShim_MissingFile(t *testing.T) {
+	managed, err := isManagedShim(filepath.Join(t.TempDir(), "missing"))
+	require.Error(t, err)
+	assert.False(t, managed)
+}
+
+func TestInstallHelper(t *testing.T) {
+	target, err := os.Executable()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	linkPath := filepath.Join(dir, credHelperFileName("scafctl", runtime.GOOS))
+
+	method, err := installHelper(target, linkPath, runtime.GOOS)
+	require.NoError(t, err)
+
+	if runtime.GOOS == "windows" {
+		assert.Equal(t, "shim", method)
+	} else {
+		assert.Equal(t, "symlink", method)
+	}
+
+	_, err = os.Lstat(linkPath)
+	require.NoError(t, err, "installed helper should exist at %s", linkPath)
+}
+
+func TestInstallHelper_Windows(t *testing.T) {
+	target, err := os.Executable()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	linkPath := filepath.Join(dir, credHelperFileName("scafctl", "windows"))
+
+	method, err := installHelper(target, linkPath, "windows")
+	require.NoError(t, err)
+	assert.Equal(t, "shim", method)
+
+	data, err := os.ReadFile(linkPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), shimSignature)
+	assert.True(t, strings.HasSuffix(linkPath, ".cmd"))
+}
+
+func TestCommandUninstall_RemovesManagedShim(t *testing.T) {
+	target, err := os.Executable()
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	shimPath := filepath.Join(dir, credHelperFileName("scafctl", runtime.GOOS))
+	require.NoError(t, writeShim(target, shimPath, runtime.GOOS))
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := commandUninstall(ioStreams, "scafctl")
+	cmd.SetContext(newInstallTestCtx())
+	cmd.SetArgs([]string{"--bin-dir", dir})
+
+	require.NoError(t, cmd.Execute())
+
+	_, statErr := os.Stat(shimPath)
+	assert.True(t, os.IsNotExist(statErr), "managed shim should be removed")
+}
+
+func TestCommandInstall_RunE(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation may require elevated privilege on Windows")
+	}
+	binDir := t.TempDir()
+	dockerDir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dockerDir)
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := commandInstall(ioStreams, "scafctl")
+	cmd.SetContext(newInstallTestCtx())
+	cmd.SetArgs([]string{"--bin-dir", binDir, "--docker"})
+
+	require.NoError(t, cmd.Execute())
+
+	// Helper installed.
+	linkPath := filepath.Join(binDir, credHelperFileName("scafctl", runtime.GOOS))
+	_, err := os.Lstat(linkPath)
+	require.NoError(t, err, "credential helper should be installed at %s", linkPath)
+
+	// Docker config updated with global credsStore.
+	cfg, err := readContainerConfig(filepath.Join(dockerDir, "config.json"))
+	require.NoError(t, err)
+	assert.Equal(t, "scafctl", cfg["credsStore"])
+}
+
+func TestCommandInstall_RunE_Registry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation may require elevated privilege on Windows")
+	}
+	binDir := t.TempDir()
+	dockerDir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dockerDir)
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := commandInstall(ioStreams, "scafctl")
+	cmd.SetContext(newInstallTestCtx())
+	cmd.SetArgs([]string{"--bin-dir", binDir, "--docker", "--registry", "ghcr.io"})
+
+	require.NoError(t, cmd.Execute())
+
+	cfg, err := readContainerConfig(filepath.Join(dockerDir, "config.json"))
+	require.NoError(t, err)
+	credHelpers, ok := cfg["credHelpers"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "scafctl", credHelpers["ghcr.io"])
+}
+
+func TestCommandInstallUninstall_DockerRoundTrip(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation may require elevated privilege on Windows")
+	}
+	binDir := t.TempDir()
+	dockerDir := t.TempDir()
+	t.Setenv("DOCKER_CONFIG", dockerDir)
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	install := commandInstall(ioStreams, "scafctl")
+	install.SetContext(newInstallTestCtx())
+	install.SetArgs([]string{"--bin-dir", binDir, "--docker"})
+	require.NoError(t, install.Execute())
+
+	uninstall := commandUninstall(ioStreams, "scafctl")
+	uninstall.SetContext(newInstallTestCtx())
+	uninstall.SetArgs([]string{"--bin-dir", binDir, "--docker"})
+	require.NoError(t, uninstall.Execute())
+
+	// Helper removed.
+	linkPath := filepath.Join(binDir, credHelperFileName("scafctl", runtime.GOOS))
+	_, statErr := os.Lstat(linkPath)
+	assert.True(t, os.IsNotExist(statErr), "credential helper should be removed")
+
+	// Docker credsStore cleaned.
+	cfg, err := readContainerConfig(filepath.Join(dockerDir, "config.json"))
+	require.NoError(t, err)
+	_, hasCredsStore := cfg["credsStore"]
+	assert.False(t, hasCredsStore, "credsStore should be removed from docker config")
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2017,6 +2017,12 @@ func TestIntegration_AuthTokenHelp(t *testing.T) {
 	assert.Contains(t, stdout, "--scope")
 	assert.Contains(t, stdout, "--min-valid-for")
 	assert.Contains(t, stdout, "--force-refresh")
+	// Render-mode flags and the raw-by-default behavior must be documented.
+	assert.Contains(t, stdout, "--raw")
+	assert.Contains(t, stdout, "--curl")
+	assert.Contains(t, stdout, "--export")
+	assert.Contains(t, stdout, "--exec-credential")
+	assert.Contains(t, stdout, "prints the raw access token")
 }
 
 func TestIntegration_AuthMigrateHelp(t *testing.T) {
@@ -8470,7 +8476,7 @@ func TestIntegration_CredentialHelperInstallHelp(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "credential-helper", "install", "--help")
 	assert.Equal(t, 0, exitCode)
-	assert.Contains(t, stdout, "docker-credential-scafctl symlink")
+	assert.Contains(t, stdout, "docker-credential-scafctl credential helper")
 	assert.Contains(t, stdout, "--bin-dir")
 	assert.Contains(t, stdout, "--docker")
 	assert.Contains(t, stdout, "--podman")
@@ -8481,10 +8487,37 @@ func TestIntegration_CredentialHelperUninstallHelp(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "credential-helper", "uninstall", "--help")
 	assert.Equal(t, 0, exitCode)
-	assert.Contains(t, stdout, "docker-credential-scafctl symlink")
+	assert.Contains(t, stdout, "docker-credential-scafctl symlink or managed shim")
 	assert.Contains(t, stdout, "--bin-dir")
 	assert.Contains(t, stdout, "--docker")
 	assert.Contains(t, stdout, "--podman")
+}
+
+// TestIntegration_CredentialHelperInstallUninstall exercises the real install
+// and uninstall flow against a temp bin directory. On POSIX a symlink is
+// created; the Windows shim path is covered by unit tests in the
+// credentialhelper package.
+func TestIntegration_CredentialHelperInstallUninstall(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink install path is POSIX-only; Windows shim is covered by unit tests")
+	}
+
+	binDir := t.TempDir()
+	helperPath := filepath.Join(binDir, "docker-credential-scafctl")
+
+	stdout, stderr, exitCode := runScafctl(t, "credential-helper", "install", "--bin-dir", binDir)
+	require.Equal(t, 0, exitCode, "install should succeed: stdout=%q stderr=%q", stdout, stderr)
+
+	info, err := os.Lstat(helperPath)
+	require.NoError(t, err, "helper should be created at %s", helperPath)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink, "helper should be a symlink on POSIX")
+
+	_, _, exitCode = runScafctl(t, "credential-helper", "uninstall", "--bin-dir", binDir)
+	assert.Equal(t, 0, exitCode, "uninstall should succeed")
+
+	_, statErr := os.Lstat(helperPath)
+	assert.True(t, os.IsNotExist(statErr), "helper should be removed after uninstall")
 }
 
 func TestIntegration_CredentialHelperGetNotFound(t *testing.T) {


### PR DESCRIPTION
Make `auth token` print the raw access token by default for clean scripting, add a Kubernetes client-go ExecCredential output mode, and fall back to an elevation-free forwarding shim when the credential helper cannot be symlinked (Windows).

- auth token now prints the raw token by default; -o json|yaml returns the structured metadata object. --raw is kept as an explicit alias
- add --exec-credential to emit a client.authentication.k8s.io ExecCredential, auto-detected when KUBERNETES_EXEC_INFO is set, and echo the apiVersion kubectl requests (v1 / v1beta1)
- add pkg/auth/execcredential to build the envelope without importing client-go
- credential-helper install writes a managed .cmd/sh forwarding shim when symlinking is unavailable; uninstall only removes shims it generated (signature-guarded)
- document the kubectl exec credential plugin flow and the raw-default change; add a kubeconfig example and integration coverage

BREAKING CHANGE: `auth token` now prints the raw access token to stdout by default instead of a masked table. Use -o json or -o yaml for the structured metadata object.

Closes #542
Relates to #536