### PR TITLE
feat: add HTTP status acceptance, conditional validation, lint and template helpers

### DIFF
--- a/.github/skills/go-template-patterns/SKILL.md
+++ b/.github/skills/go-template-patterns/SKILL.md
@@ -133,7 +133,8 @@ All [Sprig v3](http://masterminds.github.io/sprig/) functions are available:
 
 ```gotemplate
 {{cel "_.name.upperAscii()"}}   <!-- Inline CEL evaluation -->
-{{toHcl .config}}               <!-- Convert to HCL format -->
+{{toHcl .config}}               <!-- Convert to HCL body (attributes + blocks) -->
+{{toHclValue .bindings}}        <!-- Convert to HCL value expression (RHS of =) -->
 {{fromYaml .yamlString}}        <!-- Parse YAML string to object -->
 {{toYaml .data}}                <!-- Convert to YAML string -->
 {{slugify .title}}              <!-- URL-safe slug -->

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -1941,16 +1941,54 @@ Output:
 ["repo:a:ref:main", "repo:b:ref:main"]
 ```
 
-A top-level list of maps still renders as repeated HCL blocks, so `toHcl` picks
-the right shape automatically based on the list's element types.
+A keyed list of maps (a list nested under a map key) renders as repeated HCL
+blocks, which is the idiomatic Terraform pattern:
+
+```gotemplate
+{{ dict "ingress" (list (dict "port" 80) (dict "port" 443)) | toHcl }}
+```
+
+```hcl
+ingress {
+  port = 80
+}
+ingress {
+  port = 443
+}
+```
+
+A *keyless* top-level list of maps has no key to act as a block label, so it
+cannot be a valid HCL body. `toHcl` renders it as a tuple of object literals
+instead.
+
+### Rendering HCL Values with toHclValue
+
+`toHcl` generates an HCL *body* (bare attributes and blocks), which is what you
+want when rendering a whole `.tf`/`.tfvars` file. When you need a value on the
+right-hand side of an assignment, use `toHclValue`. It always renders a valid
+HCL value expression: maps become inline object literals and lists of objects
+become tuples of object literals.
+
+```gotemplate
+labels   = {{ dict "env" "prod" "tier" "web" | toHclValue }}
+bindings = {{ list (dict "ns" "y1" "sa" "x1") (dict "ns" "y2" "sa" "x2") | toHclValue }}
+```
+
+Output:
+
+```hcl
+labels   = { env = "prod", tier = "web" }
+bindings = [{ ns = "y1", sa = "x1" }, { ns = "y2", sa = "x2" }]
+```
 
 ### What You Learned
 
-- **`toHcl`** — Converts maps, lists, and primitives into HCL syntax.
-- **Nested structures** — Maps within maps render as nested HCL blocks.
+- **`toHcl`** -- Converts maps, lists, and primitives into an HCL body.
+- **`toHclValue`** -- Renders an HCL value expression for the right-hand side of an assignment (object literals and tuples of objects).
+- **Nested structures** -- Maps within maps render as nested HCL blocks.
 - **Top-level scalar lists** -- Render as a bare HCL array (`["a", "b"]`); empty lists render as `[]`.
-- **Combined with Sprig** — Use `indent` (from Sprig) to properly nest the generated HCL.
-- **Terraform workflows** — Generate provider blocks, resource definitions, and variable files from structured data.
+- **Combined with Sprig** -- Use `indent` (from Sprig) to properly nest the generated HCL.
+- **Terraform workflows** -- Generate provider blocks, resource definitions, and variable files from structured data.
 
 ---
 

--- a/docs/tutorials/resolver-tutorial.md
+++ b/docs/tutorials/resolver-tutorial.md
@@ -661,6 +661,70 @@ Output:
 
 Both validation errors are reported together rather than failing on the first one.
 
+### Example: Conditional Validation Rule
+
+Each rule in `validate.with` can carry its own `when` condition. When the
+condition evaluates to `false`, that single rule is skipped while the other
+rules still run. The condition can reference `__self` (the resolved value) and
+any other resolver via `_`. This is useful when a rule only applies to certain
+values -- for example, only enforcing a strict pattern in production.
+
+Create a file called `conditional-validation.yaml`:
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: conditional-validation
+  version: 1.0.0
+
+spec:
+  resolvers:
+    appName:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            onError: continue
+            inputs:
+              key: appName
+          - provider: static
+            inputs:
+              value: my-app
+      validate:
+        with:
+          # Always enforced: lowercase, alphanumeric with hyphens.
+          - provider: validation
+            inputs:
+              match: "^[a-z0-9-]+$"
+              message: "Name must be lowercase alphanumeric with hyphens"
+          # Only enforced in production: must start with "prod-".
+          - provider: validation
+            when:
+              expr: "_.environment == 'production'"
+            inputs:
+              match: "^prod-"
+              message: "Production app names must start with 'prod-'"
+
+    environment:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            onError: continue
+            inputs:
+              key: env
+          - provider: static
+            inputs:
+              value: development
+```
+
+In `development` (the default), the second rule is skipped, so `my-app` passes.
+In `production`, the second rule runs and a name without the `prod-` prefix
+fails. Put the `when` on the individual rule inside `validate.with`, not on the
+`validate` phase as a whole (a phase-level `validate.when` gates every rule at
+once).
+
 ---
 
 ## Conditional Execution
@@ -985,9 +1049,68 @@ Output (body and headers will vary):
   "api_data": {
     "body": "...",
     "headers": { "...": "..." },
-    "statusCode": 200
+    "statusCode": 200,
+    "success": true
   }
 }
+```
+
+The `success` field is `true` for any `2xx` status by default. A non-2xx
+response (for example `404`) does **not** raise an error -- the resolver still
+produces a value with `success: false` so you can branch on it in a transform or
+a downstream resolver.
+
+### Accepting Non-2xx Status Codes
+
+Sometimes a non-2xx status is a normal result. For example, a lookup that
+returns `404` when a resource does not yet exist. Use `acceptableStatusCodes` to
+declare which statuses count as successful. Each entry may be an exact integer
+(`200`), a class shorthand (`"2xx"`), or an inclusive range (`"200-204"`):
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: optional-lookup
+  version: 1.0.0
+
+spec:
+  resolvers:
+    existing:
+      type: any
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://api.example.com/users/maybe-missing
+              method: GET
+              autoParseJson: true
+              acceptableStatusCodes: [200, 404]
+```
+
+With `acceptableStatusCodes` set, a `404` yields `success: true` and the body is
+still returned (and parsed when `autoParseJson` is enabled). Any status outside
+the set -- such as `500` -- fails the source, which lets an `onError: continue`
+policy fall back to the next source:
+
+```yaml
+spec:
+  resolvers:
+    config:
+      type: any
+      resolve:
+        with:
+          # Fails on any status other than 2xx or 404, falling through below.
+          - provider: http
+            onError: continue
+            inputs:
+              url: https://api.example.com/config
+              method: GET
+              autoParseJson: true
+              acceptableStatusCodes: [200, 404]
+          - provider: static
+            inputs:
+              value: { fallback: true }
 ```
 
 ### With Authentication

--- a/docs/tutorials/run-provider-tutorial.md
+++ b/docs/tutorials/run-provider-tutorial.md
@@ -311,22 +311,22 @@ key is close to a valid one (a likely typo), a suggestion is included:
 ```bash
 # Typo in key name
 scafctl run provider http urll=https://example.com
-# Error: provider "http" does not accept input "urll" — did you mean "url"? (valid inputs: authProvider, autoParseJson, body, headers, method, pagination, poll, retry, scope, timeout, url)
+# Error: provider "http" does not accept input "urll" — did you mean "url"? (valid inputs: acceptableStatusCodes, authProvider, autoParseJson, body, headers, method, pagination, poll, retry, scope, timeout, url)
 
 # Completely unknown key
 scafctl run provider http unknown=value
-# Error: provider "http" does not accept input "unknown" (valid inputs: authProvider, autoParseJson, body, headers, method, pagination, poll, retry, scope, timeout, url)
+# Error: provider "http" does not accept input "unknown" (valid inputs: acceptableStatusCodes, authProvider, autoParseJson, body, headers, method, pagination, poll, retry, scope, timeout, url)
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
 # Typo in key name
 scafctl run provider http urll=https://example.com
-# Error: provider "http" does not accept input "urll" — did you mean "url"? (valid inputs: authProvider, autoParseJson, body, headers, method, pagination, poll, retry, scope, timeout, url)
+# Error: provider "http" does not accept input "urll" — did you mean "url"? (valid inputs: acceptableStatusCodes, authProvider, autoParseJson, body, headers, method, pagination, poll, retry, scope, timeout, url)
 
 # Completely unknown key
 scafctl run provider http unknown=value
-# Error: provider "http" does not accept input "unknown" (valid inputs: authProvider, autoParseJson, body, headers, method, pagination, poll, retry, scope, timeout, url)
+# Error: provider "http" does not accept input "unknown" (valid inputs: acceptableStatusCodes, authProvider, autoParseJson, body, headers, method, pagination, poll, retry, scope, timeout, url)
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -630,6 +630,7 @@ At the end of the standard help text, you'll see a section like:
 
 ```
 Provider Inputs (http):
+  acceptableStatusCodes  array         Status codes treated as successful (e.g. [200, 404], "2xx", "200-204")
   authProvider   string                Authentication provider to use for this request
   autoParseJson  boolean               When true and the response Content-Type is application/json, automatically parse the body into a structured object
   body           string                Request body for POST/PUT/PATCH requests

--- a/examples/providers/README.md
+++ b/examples/providers/README.md
@@ -37,6 +37,7 @@ scafctl run resolver -f examples/providers/http-get.yaml
 |------|-------------|
 | [http-get.yaml](http-get.yaml) | Simple HTTP GET request |
 | [http-autoparse.yaml](http-autoparse.yaml) | Auto-parse JSON responses |
+| [http-acceptable-status.yaml](http-acceptable-status.yaml) | Treat selected non-2xx statuses as successful (acceptableStatusCodes) |
 | [http-empty-body.yaml](http-empty-body.yaml) | Non-JSON and empty response bodies |
 | [http-poll.yaml](http-poll.yaml) | Polling until a condition is met |
 | [http-entra.yaml](http-entra.yaml) | Microsoft Graph API with Entra auth |

--- a/examples/providers/http-acceptable-status.yaml
+++ b/examples/providers/http-acceptable-status.yaml
@@ -1,0 +1,73 @@
+# Run: scafctl run solution -f examples/providers/http-acceptable-status.yaml
+# Run: scafctl run resolver -f examples/providers/http-acceptable-status.yaml -o json
+
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: http-acceptable-status-example
+  displayName: HTTP Acceptable Status Codes Example
+  category: providers
+  tags:
+    - http
+    - provider-example
+  description: |
+    Treat selected non-2xx statuses as successful with acceptableStatusCodes.
+    Each output carries a 'success' flag (true for any 2xx by default). Entries
+    may be exact integers (404), class shorthands ("4xx"), or inclusive ranges
+    ("400-404"). Any status outside the set fails the source, which an
+    onError: continue policy can turn into a fallback.
+
+spec:
+  resolvers:
+    # Default behavior: a 404 is NOT an error, but success is false.
+    defaultStatus:
+      description: A 404 returns without error; success is false (only 2xx is successful)
+      type: any
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://httpbin.org/status/404
+              method: GET
+
+    # Exact codes: 404 counts as success alongside 2xx.
+    acceptExact:
+      description: 404 treated as success via an exact acceptableStatusCodes entry
+      type: any
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://httpbin.org/status/404
+              method: GET
+              acceptableStatusCodes: [200, 404]
+
+    # Class shorthand: any 4xx counts as success.
+    acceptClass:
+      description: 404 treated as success via the "4xx" class shorthand
+      type: any
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://httpbin.org/status/404
+              method: GET
+              acceptableStatusCodes: ["2xx", "4xx"]
+
+    # Strict set + fallback: a 500 is not acceptable, so the source fails and
+    # onError: continue falls through to the static value.
+    strictWithFallback:
+      description: An unacceptable 500 fails the source and falls back to a static value
+      type: any
+      resolve:
+        with:
+          - provider: http
+            onError: continue
+            inputs:
+              url: https://httpbin.org/status/500
+              method: GET
+              acceptableStatusCodes: [200, 404]
+          - provider: static
+            inputs:
+              value: fallback-value

--- a/examples/resolvers/README.md
+++ b/examples/resolvers/README.md
@@ -28,6 +28,7 @@ This directory contains practical examples demonstrating various resolver patter
 | [transform-pipeline.yaml](transform-pipeline.yaml) | Multi-step data transformation |
 | [foreach-filter.yaml](foreach-filter.yaml) | ForEach in resolve phase with filter to strip nil results |
 | [validation.yaml](validation.yaml) | Input validation patterns |
+| [validation-conditional-rule.yaml](validation-conditional-rule.yaml) | Rule-level when to skip a validate rule conditionally |
 | [split-resolver-validation.yaml](split-resolver-validation.yaml) | Validate a raw upstream response, then reshape downstream |
 
 ### CEL Expressions
@@ -44,7 +45,7 @@ This directory contains practical examples demonstrating various resolver patter
 
 | Example | Description |
 |---------|-------------|
-| [go-template-extensions.yaml](go-template-extensions.yaml) | Custom extension functions: toHcl, toYaml, fromYaml |
+| [go-template-extensions.yaml](go-template-extensions.yaml) | Custom extension functions: toHcl, toHclValue, toYaml, fromYaml |
 | [go-template-sprig.yaml](go-template-sprig.yaml) | Sprig template functions (strings, type conversion, etc.) |
 | [go-template-ignored-blocks.yaml](go-template-ignored-blocks.yaml) | Using scafctl:ignore blocks to skip template rendering |
 

--- a/examples/resolvers/go-template-extensions.yaml
+++ b/examples/resolvers/go-template-extensions.yaml
@@ -12,9 +12,9 @@ metadata:
     - template
   description: |
     Custom Go template extension functions provided by scafctl. Covers
-    toHcl for HCL generation and toYaml/fromYaml/mustToYaml/mustFromYaml
-    for YAML serialization. The data input merges fields into the root
-    template context.
+    toHcl/toHclValue for HCL generation and toYaml/fromYaml/mustToYaml/
+    mustFromYaml for YAML serialization. The data input merges fields into
+    the root template context.
 
 spec:
   resolvers:
@@ -147,6 +147,61 @@ spec:
                     protocol: "-1"
                     cidr_blocks:
                       - 0.0.0.0/0
+
+    # ─────────────────────────────────────────────
+    # toHclValue - Render an HCL value expression (RHS of an assignment)
+    # ─────────────────────────────────────────────
+    # toHcl renders an HCL *body* (bare attributes and blocks) for a whole
+    # .tf/.tfvars file. toHclValue renders a *value expression* for the
+    # right-hand side of an assignment: maps become inline object literals
+    # and lists of objects become tuples of object literals.
+
+    tohclvalue_object:
+      description: "toHclValue - Map to an inline HCL object literal"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohclvalue-object
+              template: |
+                labels = {{ .labels | toHclValue }}
+              data:
+                labels:
+                  env: prod
+                  tier: web
+
+    tohclvalue_list_of_objects:
+      description: "toHclValue - List of objects to a tuple of object literals"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohclvalue-list-of-objects
+              template: |
+                bindings = {{ .bindings | toHclValue }}
+              data:
+                bindings:
+                  - ns: y1
+                    sa: x1
+                  - ns: y2
+                    sa: x2
+
+    tohclvalue_scalar_list:
+      description: "toHclValue - Scalar list to an HCL tuple"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohclvalue-scalar-list
+              template: |
+                tags = {{ .tags | toHclValue }}
+              data:
+                tags:
+                  - web
+                  - prod
 
     # ─────────────────────────────────────────────
     # COMBINED - toHcl with Sprig functions

--- a/examples/resolvers/validation-conditional-rule.yaml
+++ b/examples/resolvers/validation-conditional-rule.yaml
@@ -1,0 +1,64 @@
+# Run: scafctl run resolver -f examples/resolvers/validation-conditional-rule.yaml
+# Run: scafctl run resolver -f examples/resolvers/validation-conditional-rule.yaml -r env=production -r appName=web
+#
+# Demonstrates a rule-level 'when' on a validate rule. When the condition is
+# false, that single rule is skipped while the other rules still run. The
+# condition can reference __self (the resolved value) and any other resolver
+# via _.
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: validation-conditional-rule
+  displayName: Conditional Validation Rule
+  category: resolvers
+  tags:
+    - resolver-example
+    - validation
+    - conditional
+  description: |
+    A validate rule can carry its own 'when' condition. A false condition skips
+    only that rule, not the whole validate phase. Here a strict production-only
+    rule is enforced only when the environment is production.
+
+spec:
+  resolvers:
+    environment:
+      description: Deployment environment (defaults to development)
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            onError: continue
+            inputs:
+              key: env
+          - provider: static
+            inputs:
+              value: development
+
+    appName:
+      description: Application name with an environment-gated naming rule
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            onError: continue
+            inputs:
+              key: appName
+          - provider: static
+            inputs:
+              value: my-app
+      validate:
+        with:
+          # Always enforced: lowercase alphanumeric with hyphens.
+          - provider: validation
+            inputs:
+              match: "^[a-z0-9-]+$"
+              message: "Name must be lowercase alphanumeric with hyphens"
+          # Only enforced in production: name must start with "prod-".
+          - provider: validation
+            when:
+              expr: "_.environment == 'production'"
+            inputs:
+              match: "^prod-"
+              message: "Production app names must start with 'prod-'"

--- a/pkg/gotmpl/README.md
+++ b/pkg/gotmpl/README.md
@@ -615,6 +615,33 @@ Converts a Go object into HCL (HashiCorp Configuration Language) format:
 // ["repo:a:ref:main", "repo:b:ref:main"]
 ```
 
+`toHcl` generates an HCL *body* (bare attributes and blocks), which is what you
+want when rendering a whole `.tf`/`.tfvars` file. For the right-hand side of an
+assignment, use `toHclValue` instead.
+
+##### toHclValue
+
+Converts a Go object into an HCL *value expression* suitable for the right-hand
+side of an assignment. Maps become object literals, and lists of objects become
+tuples of object literals:
+
+```go
+// Maps become inline object literals:
+{{ dict "env" "prod" "tier" "web" | toHclValue }}
+// Output:
+// { env = "prod", tier = "web" }
+
+// Lists of objects become tuples of object literals:
+bindings = {{ list (dict "ns" "y1" "sa" "x1") (dict "ns" "y2" "sa" "x2") | toHclValue }}
+// Output:
+// bindings = [{ ns = "y1", sa = "x1" }, { ns = "y2", sa = "x2" }]
+
+// Scalars and scalar lists render the same as toHcl:
+tags = {{ list "web" "prod" | toHclValue }}
+// Output:
+// tags = ["web", "prod"]
+```
+
 ##### toYaml
 
 Encodes a Go value as a YAML string:

--- a/pkg/gotmpl/ext/ext.go
+++ b/pkg/gotmpl/ext/ext.go
@@ -72,6 +72,7 @@ func Custom() gotmpl.ExtFunctionList {
 	return gotmpl.ExtFunctionList{
 		// HCL functions
 		hcl.ToHclFunc(),
+		hcl.ToHclValueFunc(),
 
 		// DNS / slugify functions
 		dns.SlugifyFunc(),

--- a/pkg/gotmpl/ext/hcl/hcl.go
+++ b/pkg/gotmpl/ext/hcl/hcl.go
@@ -52,6 +52,46 @@ func ToHclFunc() gotmpl.ExtFunction {
 	}
 }
 
+// ToHclValueFunc returns an ExtFunction that converts a Go object into an HCL
+// value expression.
+//
+// Unlike toHcl (which renders a map as an HCL body of bare attributes and blocks
+// for generating .tf/.tfvars file bodies), toHclValue always renders a valid HCL
+// value expression suitable for the right-hand side of an assignment: scalars
+// become literals, lists become tuples ([...]), maps become object literals
+// ({ k = v, ... }), and lists of objects become tuples of object literals
+// ([{ ... }, ...]).
+//
+// Example usage in a Go template:
+//
+//	labels = {{ .labels | toHclValue }}
+//	bindings = {{ .wifBindings | toHclValue }}
+func ToHclValueFunc() gotmpl.ExtFunction {
+	return gotmpl.ExtFunction{
+		Name:        "toHclValue",
+		Description: "Converts a Go object into an HCL value expression for the right-hand side of an assignment. Scalars become literals, lists become tuples, maps become object literals, and lists of objects become tuples of object literals. Use toHcl instead to generate an HCL file body of bare attributes and blocks.",
+		Custom:      true,
+		Links:       []string{"https://github.com/hashicorp/hcl"},
+		Examples: []gotmpl.Example{
+			{
+				Description: "Convert a map to an HCL object literal",
+				Template:    `labels = {{ dict "env" "prod" "tier" "web" | toHclValue }}`,
+			},
+			{
+				Description: "Convert a list of objects to an HCL tuple of object literals",
+				Template:    `bindings = {{ .wifBindings | toHclValue }}`,
+			},
+			{
+				Description: "Convert a scalar list to an HCL tuple",
+				Template:    `tags = {{ list "web" "prod" | toHclValue }}`,
+			},
+		},
+		Func: template.FuncMap{
+			"toHclValue": ToHclValue,
+		},
+	}
+}
+
 // ToHcl converts a Go object to its HCL string representation.
 //
 // For example:
@@ -87,6 +127,43 @@ func ToHcl(obj any) (string, error) {
 	return buf.String(), nil
 }
 
+// ToHclValue converts a Go object to a valid HCL value expression.
+//
+// Unlike ToHcl, a map is rendered as an inline object literal ({ k = v, ... })
+// rather than a bare body, so the result is always valid on the right-hand side
+// of an HCL assignment.
+//
+// For example:
+//
+//	obj := []any{map[string]any{"ns": "y1"}, map[string]any{"ns": "y2"}}
+//	ToHclValue(obj) // returns: [{ ns = "y1" }, { ns = "y2" }]
+//
+// Parameters:
+//
+//	obj any: The Go object to convert. Supports structs, maps, slices, and primitives.
+//
+// Returns:
+//
+//	string: The HCL value expression for the Go object.
+//	error: An error if the conversion fails.
+func ToHclValue(obj any) (string, error) {
+	if obj == nil {
+		return "null", nil
+	}
+
+	normalized, err := normalize(obj)
+	if err != nil {
+		return "", fmt.Errorf("toHclValue: failed to normalize input: %w", err)
+	}
+
+	var buf strings.Builder
+	if err := writeHclValue(&buf, normalized); err != nil {
+		return "", fmt.Errorf("toHclValue: %w", err)
+	}
+
+	return buf.String(), nil
+}
+
 // normalize converts any Go value to a JSON-friendly representation
 // (map[string]any, []any, or primitives) via JSON round-trip.
 func normalize(obj any) (any, error) {
@@ -104,12 +181,21 @@ func normalize(obj any) (any, error) {
 }
 
 // writeHcl recursively writes HCL-formatted output for a normalized value.
+//
+// A top-level map is rendered as an HCL body (bare attributes and nested
+// blocks), which is the common case for generating .tf/.tfvars file bodies. A
+// top-level list of objects has no key to act as a block label, so it cannot be
+// a valid body; it is rendered as a tuple of object literals ([{ ... }, ...]).
+// To render an arbitrary value as an HCL value expression (for the right-hand
+// side of an assignment), use ToHclValue instead.
 func writeHcl(buf *strings.Builder, value any, indent int) error {
 	switch v := value.(type) {
 	case map[string]any:
 		return writeHclMap(buf, v, indent)
 	case []any:
-		return writeHclList(buf, v, indent)
+		// A keyless top-level list cannot be an HCL body; render it as a value
+		// expression (scalar tuple or tuple of object literals).
+		return writeHclListValue(buf, v)
 	default:
 		// Scalar at top level — emit as a bare HCL literal
 		buf.WriteString(formatHclValue(v))
@@ -157,7 +243,7 @@ func writeHclMap(buf *strings.Builder, m map[string]any, indent int) error {
 			} else {
 				// Simple list becomes an HCL list attribute
 				fmt.Fprintf(buf, "%s%s = ", prefix, key)
-				if err := writeHclListValue(buf, v, indent); err != nil {
+				if err := writeHclListValue(buf, v); err != nil {
 					return err
 				}
 				buf.WriteString("\n")
@@ -172,43 +258,60 @@ func writeHclMap(buf *strings.Builder, m map[string]any, indent int) error {
 	return nil
 }
 
-// writeHclList writes a top-level list. Lists of maps/objects are rendered as
-// blocks; lists of scalars are rendered as a bare HCL array (["a", "b"]).
-func writeHclList(buf *strings.Builder, list []any, indent int) error {
-	if len(list) == 0 {
-		buf.WriteString("[]")
+// writeHclValue writes any normalized value as an HCL value expression: scalars
+// become literals, lists become tuples ([...]), and maps become object literals
+// ({ k = v, ... }). Unlike writeHcl, a map is never rendered as a bare body, so
+// the result is always valid on the right-hand side of an assignment.
+func writeHclValue(buf *strings.Builder, value any) error {
+	switch v := value.(type) {
+	case map[string]any:
+		return writeHclObjectLiteral(buf, v)
+	case []any:
+		return writeHclListValue(buf, v)
+	default:
+		buf.WriteString(formatHclValue(v))
 		return nil
 	}
-
-	if isListOfMaps(list) {
-		for _, item := range list {
-			itemMap, ok := item.(map[string]any)
-			if !ok {
-				return fmt.Errorf("expected map in list of maps, got %T", item)
-			}
-			if err := writeHclMap(buf, itemMap, indent); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
-	// Top-level scalar list — emit as a bare HCL array.
-	return writeHclListValue(buf, list, indent)
 }
 
-// writeHclListValue writes a list value in HCL list syntax: [val1, val2, ...]
-func writeHclListValue(buf *strings.Builder, list []any, _ int) error {
+// writeHclObjectLiteral writes a map as an inline HCL object literal:
+// { key = value, ... }. Keys are sorted for deterministic output.
+func writeHclObjectLiteral(buf *strings.Builder, m map[string]any) error {
+	if len(m) == 0 {
+		buf.WriteString("{}")
+		return nil
+	}
+
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	buf.WriteString("{ ")
+	for i, key := range keys {
+		if i > 0 {
+			buf.WriteString(", ")
+		}
+		fmt.Fprintf(buf, "%s = ", key)
+		if err := writeHclValue(buf, m[key]); err != nil {
+			return err
+		}
+	}
+	buf.WriteString(" }")
+	return nil
+}
+
+// writeHclListValue writes a list as an HCL tuple: [val1, val2, ...]. Elements
+// may be scalars, nested lists, or maps (rendered as object literals).
+func writeHclListValue(buf *strings.Builder, list []any) error {
 	buf.WriteString("[")
 	for i, item := range list {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		switch item.(type) {
-		case map[string]any:
-			return fmt.Errorf("mixed lists with nested objects are not supported in HCL list syntax; use blocks instead")
-		default:
-			buf.WriteString(formatHclValue(item))
+		if err := writeHclValue(buf, item); err != nil {
+			return err
 		}
 	}
 	buf.WriteString("]")

--- a/pkg/gotmpl/ext/hcl/hcl_test.go
+++ b/pkg/gotmpl/ext/hcl/hcl_test.go
@@ -251,9 +251,11 @@ func TestToHcl_TopLevelListOfMaps(t *testing.T) {
 		map[string]any{"name": "b"},
 	}
 
+	// A keyless top-level list of objects cannot be a valid HCL body, so toHcl
+	// renders it as a tuple of object literals instead of bare attribute lines.
 	result, err := ToHcl(input)
 	require.NoError(t, err)
-	assert.Equal(t, "name = \"a\"\nname = \"b\"\n", result)
+	assert.Equal(t, `[{ name = "a" }, { name = "b" }]`, result)
 }
 
 func TestToHcl_ComplexExample(t *testing.T) {
@@ -285,6 +287,78 @@ func TestToHclFunc_Metadata(t *testing.T) {
 	assert.NotEmpty(t, fn.Examples)
 	assert.NotEmpty(t, fn.Links)
 	assert.Contains(t, fn.Func, "toHcl")
+}
+
+func TestToHclValueFunc_Metadata(t *testing.T) {
+	fn := ToHclValueFunc()
+	assert.Equal(t, "toHclValue", fn.Name)
+	assert.True(t, fn.Custom)
+	assert.NotEmpty(t, fn.Description)
+	assert.NotEmpty(t, fn.Examples)
+	assert.NotEmpty(t, fn.Links)
+	assert.Contains(t, fn.Func, "toHclValue")
+}
+
+func TestToHclValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected string
+	}{
+		{"nil", nil, "null"},
+		{"string", "hello", `"hello"`},
+		{"bool", true, "true"},
+		{"integer", float64(42), "42"},
+		{"scalar list", []any{"web", "prod"}, `["web", "prod"]`},
+		{"number list", []any{float64(80), float64(443)}, "[80, 443]"},
+		{"empty list", []any{}, "[]"},
+		{"empty map", map[string]any{}, "{}"},
+		{
+			name:     "object literal",
+			input:    map[string]any{"env": "prod", "tier": "web"},
+			expected: `{ env = "prod", tier = "web" }`,
+		},
+		{
+			name: "list of objects",
+			input: []any{
+				map[string]any{"ns": "y1", "sa": "x1"},
+				map[string]any{"ns": "y2", "sa": "x2"},
+			},
+			expected: `[{ ns = "y1", sa = "x1" }, { ns = "y2", sa = "x2" }]`,
+		},
+		{
+			name: "nested object and list",
+			input: map[string]any{
+				"labels": map[string]any{"env": "prod"},
+				"ports":  []any{float64(80), float64(443)},
+			},
+			expected: `{ labels = { env = "prod" }, ports = [80, 443] }`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ToHclValue(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestToHclValue_Struct(t *testing.T) {
+	type binding struct {
+		Namespace string `json:"namespace"`
+		Account   string `json:"account"`
+	}
+
+	input := []any{
+		binding{Namespace: "ns1", Account: "sa1"},
+		binding{Namespace: "ns2", Account: "sa2"},
+	}
+
+	result, err := ToHclValue(input)
+	require.NoError(t, err)
+	assert.Equal(t, `[{ account = "sa1", namespace = "ns1" }, { account = "sa2", namespace = "ns2" }]`, result)
 }
 
 func TestToHcl_StringEscaping(t *testing.T) {

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -162,6 +162,29 @@ func (r *Result) addFinding(severity SeverityLevel, category, location, message,
 	r.Findings = append(r.Findings, f)
 }
 
+// parameterProviderName is the name of the built-in parameter provider, whose
+// source fails at runtime when the named CLI parameter is missing and no
+// 'default' input is declared.
+const parameterProviderName = "parameter"
+
+// parameterDefaultInput is the input key the parameter provider treats as a
+// fallback value (presence of the key, regardless of value, counts).
+const parameterDefaultInput = "default"
+
+// isUnconditionalSource reports whether a resolve source always runs -- it has
+// no 'when' condition, or a 'when' that is literally "true".
+func isUnconditionalSource(step resolver.ProviderSource) bool {
+	return step.When == nil || step.When.Expr == nil || strings.TrimSpace(string(*step.When.Expr)) == "true"
+}
+
+// parameterSourceHasDefault reports whether a parameter provider source
+// declares a 'default' input. The parameter provider treats the presence of the
+// 'default' key (any value) as a fallback.
+func parameterSourceHasDefault(step resolver.ProviderSource) bool {
+	_, ok := step.Inputs[parameterDefaultInput]
+	return ok
+}
+
 func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Registry, referencedResolvers map[string]bool) {
 	if sol.Spec.Resolvers == nil {
 		return
@@ -258,6 +281,35 @@ func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Re
 						"all resolve sources have 'when' conditions with no unconditional fallback; resolver will fail if no condition is met",
 						"Add a source without a 'when' condition (e.g. a static provider) as a fallback",
 						"missing-fallback-source")
+				}
+			}
+
+			// Warn if the resolver relies on an unconditional 'parameter' source
+			// with no 'default' and has no other unconditional source guaranteed
+			// to produce a value. Such a resolver passes lint but fails at runtime
+			// with "parameter not provided" when the CLI parameter is absent.
+			if len(res.Resolve.With) > 0 {
+				unconditionalParamWithoutDefault := false
+				hasGuaranteedFallback := false
+				for _, step := range res.Resolve.With {
+					if !isUnconditionalSource(step) {
+						continue
+					}
+					if step.Provider == parameterProviderName {
+						if parameterSourceHasDefault(step) {
+							hasGuaranteedFallback = true
+						} else {
+							unconditionalParamWithoutDefault = true
+						}
+					} else {
+						hasGuaranteedFallback = true
+					}
+				}
+				if unconditionalParamWithoutDefault && !hasGuaranteedFallback {
+					result.addFinding(SeverityWarning, "structure", location+".resolve",
+						"resolver depends on a 'parameter' source with no 'default' and no unconditional fallback; it will fail at runtime if the parameter is not supplied",
+						"Add a 'default' to the parameter source, or add an unconditional fallback source (e.g. a static provider)",
+						"parameter-missing-default")
 				}
 			}
 		}

--- a/pkg/lint/lint_extra_test.go
+++ b/pkg/lint/lint_extra_test.go
@@ -865,6 +865,133 @@ func TestLintResolvers_MissingFallbackSource_NoResolvePhase(t *testing.T) {
 	}
 }
 
+// ---- parameter-missing-default ----
+
+func filterByRule(findings []*Finding) []*Finding {
+	var out []*Finding
+	for _, f := range findings {
+		if f.RuleName == "parameter-missing-default" {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func TestLintResolvers_ParameterMissingDefault_Fires(t *testing.T) {
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("parameter", nil)))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"environment": {
+			Description: "param with no default and no fallback",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*spec.ValueRef{
+						"key": {Literal: "environment"},
+					}},
+				},
+			},
+		},
+	}
+
+	result := &Result{}
+	lintResolvers(sol, result, reg, map[string]bool{"environment": true})
+
+	findings := filterByRule(result.Findings)
+	require.Len(t, findings, 1)
+	assert.Equal(t, SeverityWarning, findings[0].Severity)
+	assert.Equal(t, "resolvers.environment.resolve", findings[0].Location)
+	assert.Contains(t, findings[0].Message, "no 'default'")
+}
+
+func TestLintResolvers_ParameterMissingDefault_HasDefault(t *testing.T) {
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("parameter", nil)))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"environment": {
+			Description: "param with default",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*spec.ValueRef{
+						"key":     {Literal: "environment"},
+						"default": {Literal: "development"},
+					}},
+				},
+			},
+		},
+	}
+
+	result := &Result{}
+	lintResolvers(sol, result, reg, map[string]bool{"environment": true})
+
+	assert.Empty(t, filterByRule(result.Findings),
+		"should not warn when the parameter source declares a default")
+}
+
+func TestLintResolvers_ParameterMissingDefault_HasUnconditionalFallback(t *testing.T) {
+	exprCond := celexp.Expression("_.useParam == true")
+
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("parameter", nil)))
+	require.NoError(t, reg.Register(newFakeProvider("static", nil)))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"environment": {
+			Description: "param with static fallback",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "parameter", When: &resolver.Condition{Expr: &exprCond}, Inputs: map[string]*spec.ValueRef{
+						"key": {Literal: "environment"},
+					}},
+					{Provider: "static", Inputs: map[string]*spec.ValueRef{
+						"value": {Literal: "development"},
+					}},
+				},
+			},
+		},
+	}
+
+	result := &Result{}
+	lintResolvers(sol, result, reg, map[string]bool{"environment": true})
+
+	assert.Empty(t, filterByRule(result.Findings),
+		"should not warn when an unconditional non-parameter fallback exists")
+}
+
+func TestLintResolvers_ParameterMissingDefault_AllConditional(t *testing.T) {
+	exprCond := celexp.Expression("_.useParam == true")
+
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("parameter", nil)))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"environment": {
+			Description: "conditional param only",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "parameter", When: &resolver.Condition{Expr: &exprCond}, Inputs: map[string]*spec.ValueRef{
+						"key": {Literal: "environment"},
+					}},
+				},
+			},
+		},
+	}
+
+	result := &Result{}
+	lintResolvers(sol, result, reg, map[string]bool{"environment": true})
+
+	// The all-conditional case is covered by missing-fallback-source; the
+	// parameter-missing-default rule only targets unconditional parameter
+	// sources to avoid duplicate findings.
+	assert.Empty(t, filterByRule(result.Findings),
+		"should not warn for a conditional parameter source (handled by missing-fallback-source)")
+}
+
 // ---- hyphensToCamelCase ----
 
 func TestHyphensToCamelCase(t *testing.T) {

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -316,6 +316,17 @@ var KnownRules = map[string]RuleMeta{
 			"# Problem: all sources are conditional\nresolve:\n  with:\n    - provider: http\n      when:\n        expr: '_.authenticated == true'\n    - provider: http\n      when:\n        expr: '_.fallbackEnabled == true'\n\n# Fix: add unconditional fallback\nresolve:\n  with:\n    - provider: http\n      when:\n        expr: '_.authenticated == true'\n    - provider: static\n      inputs:\n        value: default-value",
 		},
 	},
+	"parameter-missing-default": {
+		Rule:        "parameter-missing-default",
+		Severity:    string(SeverityWarning),
+		Category:    "structure",
+		Description: "A resolver depends on an unconditional 'parameter' source that has no 'default', and there is no other unconditional source guaranteed to produce a value.",
+		Why:         "The 'parameter' provider fails at runtime with 'parameter not provided' when the CLI parameter is absent and no 'default' is set. Such a resolver passes lint but fails the moment it runs without the parameter. Adding a 'default' (or an unconditional fallback source) guarantees the resolver always produces a value.",
+		Fix:         "Add a 'default' input to the parameter source, or add an unconditional fallback source (e.g. a static provider) after it in resolve.with.",
+		Examples: []string{
+			"# Problem: parameter source with no default and no fallback\nresolve:\n  with:\n    - provider: parameter\n      inputs:\n        key: environment\n\n# Fix: add a default\nresolve:\n  with:\n    - provider: parameter\n      inputs:\n        key: environment\n        default: development",
+		},
+	},
 	"null-resolver": {
 		Rule:        "null-resolver",
 		Severity:    string(SeverityError),

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 49 rules — update this when new rules are added
-	assert.Equal(t, 49, len(KnownRules), "expected 49 known lint rules")
+	// We expect exactly 50 rules — update this when new rules are added
+	assert.Equal(t, 50, len(KnownRules), "expected 50 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/provider/builtin/httpprovider/http.go
+++ b/pkg/provider/builtin/httpprovider/http.go
@@ -30,10 +30,13 @@ const (
 
 // Field name constants for input/output map keys.
 const (
-	fieldURL     = "url"
-	fieldMethod  = "method"
-	fieldHeaders = "headers"
-	fieldBody    = "body"
+	fieldURL                   = "url"
+	fieldMethod                = "method"
+	fieldHeaders               = "headers"
+	fieldBody                  = "body"
+	fieldStatusCode            = "statusCode"
+	fieldSuccess               = "success"
+	fieldAcceptableStatusCodes = "acceptableStatusCodes"
 )
 
 // retryConfig holds retry configuration for HTTP requests.
@@ -254,29 +257,34 @@ func NewHTTPProvider() *HTTPProvider {
 					schemahelper.WithExample("https://graph.microsoft.com/.default"),
 					schemahelper.WithMaxLength(*ptrs.IntPtr(500))),
 				"autoParseJson": schemahelper.BoolProp("When true and the response Content-Type is application/json, automatically parse the body into a structured object instead of returning it as a raw string. This allows direct field access in downstream CEL expressions (e.g., _.myApi.body.items) without manual parsing."),
+				fieldAcceptableStatusCodes: schemahelper.ArrayProp("Status codes treated as successful. Each entry may be an integer (200), a class shorthand (\"2xx\"), or an inclusive range (\"200-204\"). When set, any response whose status is not acceptable causes the request to fail (which the source-level onError policy can turn into a fallback). When omitted, only 2xx responses are successful and non-2xx responses are returned without error.",
+					schemahelper.WithItems(&jsonschema.Schema{Types: []string{"integer", "string"}}),
+					schemahelper.WithExample([]any{200, 201, "2xx"})),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
-					"statusCode": schemahelper.IntProp("HTTP response status code (last page when paginating)", schemahelper.WithExample(200)),
-					fieldBody:    schemahelper.AnyProp("Response body. By default (or when the response Content-Type is not JSON, or the body is empty) this is the raw response string; an empty response yields an empty string (\"\"). When autoParseJson is true and the Content-Type is JSON and the body is non-empty, it is the parsed JSON object. When paginating with collectPath, contains the JSON array of all collected items"),
-					fieldHeaders: schemahelper.AnyProp("Response headers (last page when paginating)"),
-					"pages":      schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
-					"totalItems": schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),
+					fieldSuccess:    schemahelper.BoolProp("Whether the response status is considered successful. When acceptableStatusCodes is set, true only for those codes; otherwise true for any 2xx status."),
+					fieldStatusCode: schemahelper.IntProp("HTTP response status code (last page when paginating)", schemahelper.WithExample(200)),
+					fieldBody:       schemahelper.AnyProp("Response body. By default (or when the response Content-Type is not JSON, or the body is empty) this is the raw response string; an empty response yields an empty string (\"\"). When autoParseJson is true and the Content-Type is JSON and the body is non-empty, it is the parsed JSON object. When paginating with collectPath, contains the JSON array of all collected items"),
+					fieldHeaders:    schemahelper.AnyProp("Response headers (last page when paginating)"),
+					"pages":         schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
+					"totalItems":    schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),
 				}),
 				provider.CapabilityTransform: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
-					"statusCode": schemahelper.IntProp("HTTP response status code (last page when paginating)", schemahelper.WithExample(200)),
-					fieldBody:    schemahelper.AnyProp("Response body. By default (or when the response Content-Type is not JSON, or the body is empty) this is the raw response string; an empty response yields an empty string (\"\"). When autoParseJson is true and the Content-Type is JSON and the body is non-empty, it is the parsed JSON object. When paginating with collectPath, contains the JSON array of all collected items"),
-					fieldHeaders: schemahelper.AnyProp("Response headers (last page when paginating)"),
-					"pages":      schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
-					"totalItems": schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),
+					fieldSuccess:    schemahelper.BoolProp("Whether the response status is considered successful. When acceptableStatusCodes is set, true only for those codes; otherwise true for any 2xx status."),
+					fieldStatusCode: schemahelper.IntProp("HTTP response status code (last page when paginating)", schemahelper.WithExample(200)),
+					fieldBody:       schemahelper.AnyProp("Response body. By default (or when the response Content-Type is not JSON, or the body is empty) this is the raw response string; an empty response yields an empty string (\"\"). When autoParseJson is true and the Content-Type is JSON and the body is non-empty, it is the parsed JSON object. When paginating with collectPath, contains the JSON array of all collected items"),
+					fieldHeaders:    schemahelper.AnyProp("Response headers (last page when paginating)"),
+					"pages":         schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
+					"totalItems":    schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),
 				}),
 				provider.CapabilityAction: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
-					"success":    schemahelper.BoolProp("Whether the HTTP request completed successfully (2xx status)"),
-					"statusCode": schemahelper.IntProp("HTTP response status code (last page when paginating)", schemahelper.WithExample(200)),
-					fieldBody:    schemahelper.AnyProp("Response body. By default (or when the response Content-Type is not JSON, or the body is empty) this is the raw response string; an empty response yields an empty string (\"\"). When autoParseJson is true and the Content-Type is JSON and the body is non-empty, it is the parsed JSON object. When paginating with collectPath, contains the JSON array of all collected items"),
-					fieldHeaders: schemahelper.AnyProp("Response headers (last page when paginating)"),
-					"pages":      schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
-					"totalItems": schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),
+					fieldSuccess:    schemahelper.BoolProp("Whether the response status is considered successful. When acceptableStatusCodes is set, true only for those codes; otherwise true for any 2xx status."),
+					fieldStatusCode: schemahelper.IntProp("HTTP response status code (last page when paginating)", schemahelper.WithExample(200)),
+					fieldBody:       schemahelper.AnyProp("Response body. By default (or when the response Content-Type is not JSON, or the body is empty) this is the raw response string; an empty response yields an empty string (\"\"). When autoParseJson is true and the Content-Type is JSON and the body is non-empty, it is the parsed JSON object. When paginating with collectPath, contains the JSON array of all collected items"),
+					fieldHeaders:    schemahelper.AnyProp("Response headers (last page when paginating)"),
+					"pages":         schemahelper.IntProp("Number of pages fetched (only present when pagination is configured)", schemahelper.WithExample(3)),
+					"totalItems":    schemahelper.IntProp("Total number of items collected across all pages (only present when pagination is configured)", schemahelper.WithExample(150)),
 				}),
 				provider.CapabilityState: schemahelper.ObjectSchema([]string{"success"}, map[string]*jsonschema.Schema{
 					"success": schemahelper.BoolProp("Whether the state operation succeeded"),
@@ -325,6 +333,16 @@ inputs:
   url: "https://api.example.com/health"
   method: GET
   timeout: 5`,
+				},
+				{
+					Name:        "Treat additional status codes as successful",
+					Description: "Accept a 404 alongside 2xx responses so a missing resource is a normal result instead of an error. Entries may be integers (200), class shorthands (\"2xx\"), or ranges (\"200-204\"). Any status outside the set fails the request, which an onError fallback can handle.",
+					YAML: `name: lookup-optional
+provider: http
+inputs:
+  url: "https://api.example.com/users/maybe-missing"
+  method: GET
+  acceptableStatusCodes: [200, 404]`,
 				},
 				{
 					Name:        "Request with Entra authentication",
@@ -488,9 +506,10 @@ func (p *HTTPProvider) Execute(ctx context.Context, input any) (*provider.Output
 	if provider.DryRunFromContext(ctx) {
 		return &provider.Output{
 			Data: map[string]any{
-				"statusCode": 200,
-				fieldBody:    "[DRY-RUN] Request not executed",
-				fieldHeaders: map[string]any{},
+				fieldSuccess:    true,
+				fieldStatusCode: 200,
+				fieldBody:       "[DRY-RUN] Request not executed",
+				fieldHeaders:    map[string]any{},
 			},
 		}, nil
 	}
@@ -575,6 +594,14 @@ func (p *HTTPProvider) Execute(ctx context.Context, input any) (*provider.Output
 		return nil, fmt.Errorf("%s: %w", ProviderName, err)
 	}
 
+	// Parse acceptable status codes. When configured, a response whose status is
+	// not acceptable causes the request to fail; when unconfigured, only 2xx is
+	// treated as successful and non-2xx responses are returned without error.
+	acc, err := parseAcceptableStatusCodes(inputs)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", ProviderName, err)
+	}
+
 	httpClient := httpc.NewClient(httpcCfg)
 
 	autoParseJSON, _ := inputs["autoParseJson"].(bool)
@@ -584,12 +611,12 @@ func (p *HTTPProvider) Execute(ctx context.Context, input any) (*provider.Output
 		if pagCfg.BodyTemplate != "" && !methodSupportsBody(method) {
 			return nil, fmt.Errorf("%s: pagination bodyTemplate requires method POST, PUT, or PATCH (got %q)", ProviderName, method)
 		}
-		return p.executePaginated(ctx, httpClient, method, urlStr, bodyContent, headers, pagCfg, autoParseJSON)
+		return p.executePaginated(ctx, httpClient, method, urlStr, bodyContent, headers, pagCfg, autoParseJSON, acc)
 	}
 
 	// Build the execute function for potential polling
 	executeFunc := func() (*provider.Output, error) {
-		return p.execute(ctx, httpClient, method, urlStr, bodyContent, headers, autoParseJSON)
+		return p.execute(ctx, httpClient, method, urlStr, bodyContent, headers, autoParseJSON, acc)
 	}
 
 	// If polling is configured, wrap execution in a poll loop
@@ -654,6 +681,7 @@ func (p *HTTPProvider) execute(
 	method, urlStr, bodyContent string,
 	headers map[string]any,
 	autoParseJSON bool,
+	acc statusAcceptance,
 ) (*provider.Output, error) {
 	lgr := logger.FromContext(ctx)
 
@@ -715,6 +743,14 @@ func (p *HTTPProvider) execute(
 
 	lgr.V(1).Info("provider execution completed", "provider", ProviderName, "statusCode", resp.StatusCode)
 
+	// Determine whether the status is acceptable. When acceptableStatusCodes is
+	// configured and the status is not acceptable, fail so the source-level
+	// onError policy can decide whether to fall back or propagate.
+	success := acc.isSuccess(resp.StatusCode)
+	if acc.configured && !success {
+		return nil, fmt.Errorf("%s: response status %d is not in acceptableStatusCodes (%s)", ProviderName, resp.StatusCode, acc.describe())
+	}
+
 	// Determine response body value
 	var bodyValue any = string(respBody)
 	if autoParseJSON && isJSONContentType(resp.Header.Get("Content-Type")) && len(respBody) > 0 {
@@ -727,9 +763,10 @@ func (p *HTTPProvider) execute(
 
 	return &provider.Output{
 		Data: map[string]any{
-			"statusCode": resp.StatusCode,
-			fieldBody:    bodyValue,
-			fieldHeaders: respHeaders,
+			fieldSuccess:    success,
+			fieldStatusCode: resp.StatusCode,
+			fieldBody:       bodyValue,
+			fieldHeaders:    respHeaders,
 		},
 	}, nil
 }

--- a/pkg/provider/builtin/httpprovider/http_test.go
+++ b/pkg/provider/builtin/httpprovider/http_test.go
@@ -301,6 +301,114 @@ func TestHTTPProvider_Execute_500(t *testing.T) {
 	assert.Contains(t, data["body"], "Internal Server Error")
 }
 
+func TestHTTPProvider_Execute_Success_Default2xx(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	output, err := p.Execute(ctx, map[string]any{"url": server.URL})
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	assert.Equal(t, true, data[fieldSuccess])
+	assert.Equal(t, 200, data["statusCode"])
+}
+
+func TestHTTPProvider_Execute_Default2xx_NonSuccess(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("nope"))
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	// Without acceptableStatusCodes a 404 must not error but success is false.
+	output, err := p.Execute(ctx, map[string]any{"url": server.URL})
+	require.NoError(t, err)
+
+	data := output.Data.(map[string]any)
+	assert.Equal(t, false, data[fieldSuccess])
+	assert.Equal(t, 404, data["statusCode"])
+}
+
+func TestHTTPProvider_Execute_AcceptableStatusCodes_Allows404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	cases := []struct {
+		name    string
+		entries []any
+	}{
+		{name: "exact int", entries: []any{200, 404}},
+		{name: "class shorthand", entries: []any{"2xx", "4xx"}},
+		{name: "range", entries: []any{"400-404"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := p.Execute(ctx, map[string]any{
+				"url":                      server.URL,
+				fieldAcceptableStatusCodes: tc.entries,
+			})
+			require.NoError(t, err)
+			data := output.Data.(map[string]any)
+			assert.Equal(t, true, data[fieldSuccess])
+			assert.Equal(t, 404, data["statusCode"])
+		})
+	}
+}
+
+func TestHTTPProvider_Execute_AcceptableStatusCodes_ErrorsOnUnacceptable(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"url":                      server.URL,
+		fieldAcceptableStatusCodes: []any{200, "2xx"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is not in acceptableStatusCodes")
+}
+
+func TestHTTPProvider_Execute_AcceptableStatusCodes_InvalidConfig(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"url":                      server.URL,
+		fieldAcceptableStatusCodes: []any{"not-a-code"},
+	})
+	require.Error(t, err)
+}
+
 func TestHTTPProvider_Execute_MultipleHeaderValues(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/provider/builtin/httpprovider/pagination.go
+++ b/pkg/provider/builtin/httpprovider/pagination.go
@@ -281,6 +281,7 @@ func (p *HTTPProvider) executePaginated(
 	headers map[string]any,
 	pagCfg *paginationConfig,
 	autoParseJSON bool,
+	acc statusAcceptance,
 ) (*provider.Output, error) {
 	lgr := logger.FromContext(ctx)
 
@@ -315,6 +316,12 @@ func (p *HTTPProvider) executePaginated(
 			return nil, fmt.Errorf("%s: page %d request failed: %w", ProviderName, pageCount, err)
 		}
 		lastResponse = resp
+
+		// When acceptableStatusCodes is configured, fail on the first page whose
+		// status is not acceptable so the source-level onError policy applies.
+		if acc.configured && !acc.isSuccess(resp.StatusCode) {
+			return nil, fmt.Errorf("%s: page %d response status %d is not in acceptableStatusCodes (%s)", ProviderName, pageCount, resp.StatusCode, acc.describe())
+		}
 
 		// Parse body as JSON for CEL evaluation
 		var bodyData any
@@ -461,7 +468,7 @@ func (p *HTTPProvider) executePaginated(
 	lgr.V(1).Info("pagination finished", "totalPages", pageCount, "totalItems", len(allItems))
 
 	// Build output
-	return p.buildPaginatedOutput(lastResponse, allItems, pageCount, autoParseJSON)
+	return p.buildPaginatedOutput(lastResponse, allItems, pageCount, autoParseJSON, acc)
 }
 
 // doRequest performs a single HTTP request and returns the parsed response.
@@ -933,7 +940,7 @@ func (p *HTTPProvider) evaluateBodyTemplate(
 // structured []any value, matching the behaviour of non-paginated requests with
 // autoParseJson: true. When false (the default) the body is serialized to a
 // JSON string for backward compatibility.
-func (p *HTTPProvider) buildPaginatedOutput(lastResponse *paginatedResponse, items []any, pageCount int, autoParseJSON bool) (*provider.Output, error) {
+func (p *HTTPProvider) buildPaginatedOutput(lastResponse *paginatedResponse, items []any, pageCount int, autoParseJSON bool, acc statusAcceptance) (*provider.Output, error) {
 	var bodyValue any
 	if autoParseJSON {
 		// Return the items as a structured value so downstream CEL expressions
@@ -967,6 +974,7 @@ func (p *HTTPProvider) buildPaginatedOutput(lastResponse *paginatedResponse, ite
 
 	return &provider.Output{
 		Data: map[string]any{
+			fieldSuccess: acc.isSuccess(lastStatusCode),
 			"statusCode": lastStatusCode,
 			"body":       bodyValue,
 			"headers":    lastHeaders,

--- a/pkg/provider/builtin/httpprovider/status.go
+++ b/pkg/provider/builtin/httpprovider/status.go
@@ -1,0 +1,185 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package httpprovider
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// statusAcceptance decides whether an HTTP response status code is considered
+// successful. It is built from the optional acceptableStatusCodes input.
+//
+// When the input is not configured, a status is successful only if it is a 2xx
+// code (the conventional default). When configured, a status is successful only
+// if it matches one of the supplied exact codes, class shorthands (e.g. "2xx"),
+// or inclusive ranges (e.g. "200-204").
+type statusAcceptance struct {
+	configured bool
+	exact      map[int]struct{}
+	classes    map[int]struct{} // first digit of the code, e.g. 2 for any 2xx
+	ranges     [][2]int         // inclusive [lo, hi] ranges
+}
+
+// isSuccess reports whether the given status code should be treated as a
+// successful response.
+func (s statusAcceptance) isSuccess(code int) bool {
+	if !s.configured {
+		return code >= 200 && code < 300
+	}
+	return s.matches(code)
+}
+
+// matches reports whether the code satisfies any configured exact code, class,
+// or range. It is only meaningful when configured is true.
+func (s statusAcceptance) matches(code int) bool {
+	if _, ok := s.exact[code]; ok {
+		return true
+	}
+	if _, ok := s.classes[code/100]; ok {
+		return true
+	}
+	for _, r := range s.ranges {
+		if code >= r[0] && code <= r[1] {
+			return true
+		}
+	}
+	return false
+}
+
+// describe returns a human-readable summary of the acceptable codes for use in
+// error messages. The output is sorted so the message is deterministic.
+func (s statusAcceptance) describe() string {
+	exactCodes := make([]int, 0, len(s.exact))
+	for code := range s.exact {
+		exactCodes = append(exactCodes, code)
+	}
+	sort.Ints(exactCodes)
+
+	classes := make([]int, 0, len(s.classes))
+	for class := range s.classes {
+		classes = append(classes, class)
+	}
+	sort.Ints(classes)
+
+	ranges := make([][2]int, len(s.ranges))
+	copy(ranges, s.ranges)
+	sort.Slice(ranges, func(i, j int) bool {
+		if ranges[i][0] != ranges[j][0] {
+			return ranges[i][0] < ranges[j][0]
+		}
+		return ranges[i][1] < ranges[j][1]
+	})
+
+	parts := make([]string, 0, len(exactCodes)+len(classes)+len(ranges))
+	for _, code := range exactCodes {
+		parts = append(parts, strconv.Itoa(code))
+	}
+	for _, class := range classes {
+		parts = append(parts, fmt.Sprintf("%dxx", class))
+	}
+	for _, r := range ranges {
+		parts = append(parts, fmt.Sprintf("%d-%d", r[0], r[1]))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// parseAcceptableStatusCodes builds a statusAcceptance from the provider inputs.
+// It returns an unconfigured statusAcceptance (configured == false) when the
+// acceptableStatusCodes input is absent or empty, preserving the default
+// behaviour where only 2xx responses are considered successful and non-2xx
+// responses are returned without error.
+//
+// Each entry may be an integer (200), a class shorthand string ("2xx"), an
+// inclusive range string ("200-204"), or a status code as a string ("404").
+func parseAcceptableStatusCodes(inputs map[string]any) (statusAcceptance, error) {
+	raw, ok := inputs[fieldAcceptableStatusCodes]
+	if !ok || raw == nil {
+		return statusAcceptance{}, nil
+	}
+
+	list, ok := raw.([]any)
+	if !ok {
+		return statusAcceptance{}, fmt.Errorf("%s must be an array, got %T", fieldAcceptableStatusCodes, raw)
+	}
+
+	acc := statusAcceptance{
+		configured: true,
+		exact:      make(map[int]struct{}),
+		classes:    make(map[int]struct{}),
+	}
+
+	for _, item := range list {
+		switch v := item.(type) {
+		case int:
+			acc.addExact(v)
+		case int64:
+			acc.addExact(int(v))
+		case float64:
+			if v != math.Trunc(v) {
+				return statusAcceptance{}, fmt.Errorf("%s entry %v must be a whole number", fieldAcceptableStatusCodes, v)
+			}
+			acc.addExact(int(v))
+		case string:
+			if err := acc.addStringEntry(v); err != nil {
+				return statusAcceptance{}, err
+			}
+		default:
+			return statusAcceptance{}, fmt.Errorf("%s entries must be integers or strings, got %T", fieldAcceptableStatusCodes, item)
+		}
+	}
+
+	// An explicitly empty list is treated as unconfigured so it does not reject
+	// every response.
+	if len(acc.exact) == 0 && len(acc.classes) == 0 && len(acc.ranges) == 0 {
+		return statusAcceptance{}, nil
+	}
+
+	return acc, nil
+}
+
+func (s *statusAcceptance) addExact(code int) {
+	s.exact[code] = struct{}{}
+}
+
+// addStringEntry parses a single string entry: a class shorthand ("2xx"), an
+// inclusive range ("200-204"), or a plain status code ("404").
+func (s *statusAcceptance) addStringEntry(entry string) error {
+	e := strings.TrimSpace(strings.ToLower(entry))
+	if e == "" {
+		return fmt.Errorf("%s entry must not be empty", fieldAcceptableStatusCodes)
+	}
+
+	// Class shorthand, e.g. "2xx" (first digit 1-5 followed by "xx").
+	if len(e) == 3 && e[1] == 'x' && e[2] == 'x' && e[0] >= '1' && e[0] <= '5' {
+		s.classes[int(e[0]-'0')] = struct{}{}
+		return nil
+	}
+
+	// Inclusive range, e.g. "200-204".
+	if strings.Contains(e, "-") {
+		parts := strings.SplitN(e, "-", 2)
+		lo, err1 := strconv.Atoi(strings.TrimSpace(parts[0]))
+		hi, err2 := strconv.Atoi(strings.TrimSpace(parts[1]))
+		if err1 != nil || err2 != nil {
+			return fmt.Errorf("invalid %s range %q", fieldAcceptableStatusCodes, entry)
+		}
+		if lo > hi {
+			return fmt.Errorf("invalid %s range %q: start is greater than end", fieldAcceptableStatusCodes, entry)
+		}
+		s.ranges = append(s.ranges, [2]int{lo, hi})
+		return nil
+	}
+
+	// Plain status code as a string.
+	code, err := strconv.Atoi(e)
+	if err != nil {
+		return fmt.Errorf("invalid %s entry %q: expected an integer, class shorthand (e.g. \"2xx\"), or range (e.g. \"200-204\")", fieldAcceptableStatusCodes, entry)
+	}
+	s.addExact(code)
+	return nil
+}

--- a/pkg/provider/builtin/httpprovider/status_test.go
+++ b/pkg/provider/builtin/httpprovider/status_test.go
@@ -1,0 +1,152 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package httpprovider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseAcceptableStatusCodes_Unconfigured(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		inputs map[string]any
+	}{
+		{name: "absent", inputs: map[string]any{}},
+		{name: "nil value", inputs: map[string]any{fieldAcceptableStatusCodes: nil}},
+		{name: "empty list", inputs: map[string]any{fieldAcceptableStatusCodes: []any{}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			acc, err := parseAcceptableStatusCodes(tt.inputs)
+			require.NoError(t, err)
+			assert.False(t, acc.configured)
+			// Unconfigured: only 2xx is successful.
+			assert.True(t, acc.isSuccess(200))
+			assert.True(t, acc.isSuccess(204))
+			assert.False(t, acc.isSuccess(404))
+			assert.False(t, acc.isSuccess(500))
+		})
+	}
+}
+
+func TestParseAcceptableStatusCodes_Entries(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		entries  []any
+		success  []int
+		notMatch []int
+	}{
+		{
+			name:     "exact ints",
+			entries:  []any{200, 404},
+			success:  []int{200, 404},
+			notMatch: []int{201, 500},
+		},
+		{
+			name:     "float codes from json",
+			entries:  []any{float64(200), float64(202)},
+			success:  []int{200, 202},
+			notMatch: []int{201, 404},
+		},
+		{
+			name:     "string code",
+			entries:  []any{"404"},
+			success:  []int{404},
+			notMatch: []int{200},
+		},
+		{
+			name:     "class shorthand",
+			entries:  []any{"2xx", "4xx"},
+			success:  []int{200, 204, 299, 400, 404, 499},
+			notMatch: []int{300, 500},
+		},
+		{
+			name:     "inclusive range",
+			entries:  []any{"200-204"},
+			success:  []int{200, 202, 204},
+			notMatch: []int{199, 205},
+		},
+		{
+			name:     "mixed",
+			entries:  []any{200, "2xx", "400-404"},
+			success:  []int{200, 250, 400, 404},
+			notMatch: []int{405, 500},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			acc, err := parseAcceptableStatusCodes(map[string]any{fieldAcceptableStatusCodes: tt.entries})
+			require.NoError(t, err)
+			assert.True(t, acc.configured)
+			for _, code := range tt.success {
+				assert.Truef(t, acc.isSuccess(code), "expected %d to be successful", code)
+			}
+			for _, code := range tt.notMatch {
+				assert.Falsef(t, acc.isSuccess(code), "expected %d to not be successful", code)
+			}
+		})
+	}
+}
+
+func TestParseAcceptableStatusCodes_Errors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		inputs map[string]any
+	}{
+		{name: "not an array", inputs: map[string]any{fieldAcceptableStatusCodes: "2xx"}},
+		{name: "unsupported entry type", inputs: map[string]any{fieldAcceptableStatusCodes: []any{true}}},
+		{name: "non-integer float", inputs: map[string]any{fieldAcceptableStatusCodes: []any{float64(200.5)}}},
+		{name: "empty string entry", inputs: map[string]any{fieldAcceptableStatusCodes: []any{""}}},
+		{name: "invalid range", inputs: map[string]any{fieldAcceptableStatusCodes: []any{"200-abc"}}},
+		{name: "reversed range", inputs: map[string]any{fieldAcceptableStatusCodes: []any{"500-200"}}},
+		{name: "invalid token", inputs: map[string]any{fieldAcceptableStatusCodes: []any{"okay"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := parseAcceptableStatusCodes(tt.inputs)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestStatusAcceptance_Describe(t *testing.T) {
+	t.Parallel()
+
+	acc, err := parseAcceptableStatusCodes(map[string]any{fieldAcceptableStatusCodes: []any{200}})
+	require.NoError(t, err)
+	assert.Equal(t, "200", acc.describe())
+}
+
+func TestStatusAcceptance_DescribeDeterministic(t *testing.T) {
+	t.Parallel()
+
+	// Entries are intentionally provided out of order across exact codes,
+	// classes, and ranges to verify the output is sorted and stable.
+	inputs := map[string]any{
+		fieldAcceptableStatusCodes: []any{404, 200, "5xx", "2xx", "500-504", "200-204"},
+	}
+	acc, err := parseAcceptableStatusCodes(inputs)
+	require.NoError(t, err)
+
+	want := "200, 404, 2xx, 5xx, 200-204, 500-504"
+	// Call repeatedly to confirm map iteration order does not affect output.
+	for range 5 {
+		assert.Equal(t, want, acc.describe())
+	}
+}

--- a/pkg/resolver/executor.go
+++ b/pkg/resolver/executor.go
@@ -1535,6 +1535,19 @@ func (e *Executor) executeValidatePhase(ctx context.Context, resolverName string
 
 	// Run ALL validation rules and collect failures
 	for i, validation := range phase.With {
+		// Check rule-level when condition (with __self so conditions can
+		// reference the resolved value). A false condition skips the rule.
+		if validation.When != nil {
+			shouldExecute, err := e.evaluateConditionWithSelf(ctx, validation.When, value)
+			if err != nil {
+				return providerCallCount, fmt.Errorf("failed to evaluate validate rule %d when condition: %w", i+1, err)
+			}
+			if !shouldExecute {
+				lgr.V(1).Info("skipping validate rule due to when condition", "rule", i+1)
+				continue
+			}
+		}
+
 		// Execute validation provider with __self set to value being validated
 		_, err := e.executeProviderWithSelf(ctx, validation.Provider, validation.Inputs, value)
 		providerCallCount++

--- a/pkg/resolver/executor_test.go
+++ b/pkg/resolver/executor_test.go
@@ -1772,6 +1772,67 @@ func TestExecutor_ValidatePhase_WhenWithSelf(t *testing.T) {
 	})
 }
 
+func TestExecutor_ValidatePhase_PerRuleWhen(t *testing.T) {
+	registry := newMockRegistry()
+
+	require.NoError(t, registry.Register(&mockProvider{
+		name: "static",
+		executeFunc: func(_ context.Context, inputs map[string]any) (*provider.Output, error) {
+			return &provider.Output{Data: inputs["value"]}, nil
+		},
+	}))
+	require.NoError(t, registry.Register(&mockProvider{
+		name: "validation",
+		executeFunc: func(_ context.Context, inputs map[string]any) (*provider.Output, error) {
+			return nil, fmt.Errorf("validation failed: %v", inputs["message"])
+		},
+	}))
+
+	newResolver := func(value string, ruleWhen *Condition) []*Resolver {
+		return []*Resolver{
+			{
+				Name: "myParam",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{Provider: "static", Inputs: map[string]*ValueRef{"value": {Literal: value}}},
+					},
+				},
+				Validate: &ValidatePhase{
+					With: []ProviderValidation{
+						{
+							Provider: "validation",
+							When:     ruleWhen,
+							Inputs:   map[string]*ValueRef{"message": {Literal: "rule fired"}},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("rule runs when condition is true", func(t *testing.T) {
+		executor := NewExecutor(registry)
+		when := celexp.Expression(`__self == "prod"`)
+		_, err := executor.Execute(context.Background(), newResolver("prod", &Condition{Expr: &when}), nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rule fired")
+	})
+
+	t.Run("rule skipped when condition is false", func(t *testing.T) {
+		executor := NewExecutor(registry)
+		when := celexp.Expression(`__self == "prod"`)
+		_, err := executor.Execute(context.Background(), newResolver("dev", &Condition{Expr: &when}), nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid when condition surfaces an error", func(t *testing.T) {
+		executor := NewExecutor(registry)
+		when := celexp.Expression(`this is not valid cel ((`)
+		_, err := executor.Execute(context.Background(), newResolver("prod", &Condition{Expr: &when}), nil)
+		require.Error(t, err)
+	})
+}
+
 // ─── Write Operation Guard Tests ─────────────────────────────────────────────
 
 // mockWriteClassifierProvider returns a Descriptor with WriteOperations populated.

--- a/pkg/resolver/graph.go
+++ b/pkg/resolver/graph.go
@@ -598,6 +598,11 @@ func extractDepsFromValidatePhase(phase *ValidatePhase, deps map[string]bool, lo
 
 	// Extract from each validation rule
 	for _, validation := range phase.With {
+		// Extract from the rule-level when condition
+		if validation.When != nil && validation.When.Expr != nil {
+			extractDepsFromExpression(string(*validation.When.Expr), deps)
+		}
+
 		// Try provider-specific extraction first
 		if extractDepsFromProviderInputs(validation.Provider, validation.Inputs, deps, lookup) {
 			// Still extract from message even if provider handled inputs

--- a/pkg/resolver/graph_render_test.go
+++ b/pkg/resolver/graph_render_test.go
@@ -525,6 +525,23 @@ func TestExtractDepsFromValidatePhase_WithWhen(t *testing.T) {
 	assert.Contains(t, deps, "invalid")
 }
 
+func TestExtractDepsFromValidatePhase_RuleLevelWhen(t *testing.T) {
+	deps := make(map[string]bool)
+	phase := &ValidatePhase{
+		With: []ProviderValidation{
+			{
+				Provider: "validation",
+				When:     &Condition{Expr: celExpPtr("_.environment == 'prod'")},
+				Inputs: map[string]*ValueRef{
+					"rule": {Expr: celExpPtr("__self != ''")},
+				},
+			},
+		},
+	}
+	extractDepsFromValidatePhase(phase, deps, nil)
+	assert.Contains(t, deps, "environment")
+}
+
 func TestGraph_FindNode_NotFound(t *testing.T) {
 	graph := &Graph{
 		Nodes: []*GraphNode{

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -235,5 +235,6 @@ type ProviderTransform struct {
 type ProviderValidation struct {
 	Provider string               `json:"provider" yaml:"provider" doc:"Provider name" example:"validation" maxLength:"100" pattern:"^[a-zA-Z][a-zA-Z0-9_-]*$" patternDescription:"Must start with a letter, followed by letters, numbers, underscores, or hyphens"`
 	Inputs   map[string]*ValueRef `json:"inputs,omitempty" yaml:"inputs,omitempty" doc:"Provider inputs" required:"false"`
+	When     *Condition           `json:"when,omitempty" yaml:"when,omitempty" doc:"Rule-level condition; the rule is skipped when this evaluates to false"`
 	Message  *ValueRef            `json:"message,omitempty" yaml:"message,omitempty" doc:"Error message on validation failure"`
 }

--- a/tests/integration/solutions/providers/go-template-extensions/solution.yaml
+++ b/tests/integration/solutions/providers/go-template-extensions/solution.yaml
@@ -333,6 +333,24 @@ spec:
               name: tohcl-empty-list
               template: '{{ list | toHcl }}'
 
+    toHclValueListOfObjects:
+      description: toHclValue renders a list of objects as a tuple of object literals
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohcl-value-list-of-objects
+              template: 'bindings = {{ list (dict "ns" "y1" "sa" "x1") (dict "ns" "y2" "sa" "x2") | toHclValue }}'
+
+    toHclValueObject:
+      description: toHclValue renders a map as an inline HCL object literal
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: tohcl-value-object
+              template: 'labels = {{ dict "env" "prod" "tier" "web" | toHclValue }}'
+
     # ─────────────────────────────────────────────
     # Custom YAML Functions (toYaml, fromYaml, mustToYaml, mustFromYaml)
     # ─────────────────────────────────────────────
@@ -652,6 +670,22 @@ spec:
         assertions:
           - expression: '__output.toHclEmptyList.contains("[]")'
             message: "Empty list should render as []"
+
+      tohcl-value-list-of-objects:
+        description: Verify toHclValue renders a list of objects as a tuple of object literals
+        extends: [_base]
+        tags: [custom, toHclValue, hcl]
+        assertions:
+          - expression: '__output.toHclValueListOfObjects.contains("[{ ns = \"y1\", sa = \"x1\" }, { ns = \"y2\", sa = \"x2\" }]")'
+            message: "List of objects should render as a tuple of object literals"
+
+      tohcl-value-object:
+        description: Verify toHclValue renders a map as an inline HCL object literal
+        extends: [_base]
+        tags: [custom, toHclValue, hcl]
+        assertions:
+          - expression: '__output.toHclValueObject.contains("{ env = \"prod\", tier = \"web\" }")'
+            message: "Map should render as an inline HCL object literal"
 
       # Custom YAML function tests
       toyaml-simple:

--- a/tests/integration/solutions/providers/http/solution.yaml
+++ b/tests/integration/solutions/providers/http/solution.yaml
@@ -46,6 +46,44 @@ spec:
                 expr: "_.mockBaseUrl + '/api/missing'"
               method: GET
 
+    acceptable404:
+      description: 404 treated as success via acceptableStatusCodes (exact codes)
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/api/missing'"
+              method: GET
+              autoParseJson: true
+              acceptableStatusCodes: [200, 404]
+
+    acceptable4xxClass:
+      description: 404 treated as success via acceptableStatusCodes (class shorthand)
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/api/missing'"
+              method: GET
+              acceptableStatusCodes: ["2xx", "4xx"]
+
+    acceptableStrictFallback:
+      description: Unacceptable status fails the source, falling back to a static value
+      resolve:
+        with:
+          - provider: http
+            onError: continue
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/api/missing'"
+              method: GET
+              acceptableStatusCodes: [200]
+          - provider: static
+            inputs:
+              value: fallback-value
+
     customHeaders:
       description: GET request with custom response headers
       resolve:
@@ -184,6 +222,37 @@ spec:
             message: "Missing endpoint should return 404"
           - expression: __output.notFoundEndpoint.body.contains("not found")
             message: "404 body should contain error message"
+          - expression: __output.notFoundEndpoint.success == false
+            message: "404 is not successful by default (only 2xx)"
+
+      acceptable-status-codes-exact:
+        description: Verify acceptableStatusCodes lets an exact 404 count as success
+        extends: [_base]
+        tags: [acceptableStatusCodes]
+        assertions:
+          - expression: __output.acceptable404.statusCode == 404
+            message: "Endpoint should return 404"
+          - expression: __output.acceptable404.success == true
+            message: "404 should be successful when listed in acceptableStatusCodes"
+          - expression: __output.acceptable404.body.error == "not found"
+            message: "Body should still be parsed when status is acceptable"
+
+      acceptable-status-codes-class:
+        description: Verify acceptableStatusCodes class shorthand (4xx) counts as success
+        extends: [_base]
+        tags: [acceptableStatusCodes]
+        assertions:
+          - expression: __output.acceptable4xxClass.statusCode == 404
+          - expression: __output.acceptable4xxClass.success == true
+            message: "404 should be successful when 4xx is acceptable"
+
+      acceptable-status-codes-fallback:
+        description: Verify an unacceptable status fails the source and falls back
+        extends: [_base]
+        tags: [acceptableStatusCodes]
+        assertions:
+          - expression: '__output.acceptableStrictFallback == "fallback-value"'
+            message: "Unacceptable 404 should fail and fall back to the static value"
 
       custom-response-headers:
         description: Verify custom response headers are returned

--- a/tests/integration/solutions/providers/validation/solution.yaml
+++ b/tests/integration/solutions/providers/validation/solution.yaml
@@ -113,6 +113,31 @@ spec:
               expression: "size(__self) <= 63"
               message: "tmpl: Value '{{.__self}}' exceeds max length"
 
+    # Rule-level when: a validate rule is skipped when its when condition is false
+    conditionalRuleWhen:
+      description: A validate rule with a rule-level when that gates execution
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: prod
+      validate:
+        with:
+          # Runs (when is true) and passes.
+          - provider: validation
+            when:
+              expr: "__self == 'prod'"
+            inputs:
+              match: "^prod$"
+            message: "Production value must be exactly 'prod'"
+          # Skipped (when is false); it would fail if it ever ran.
+          - provider: validation
+            when:
+              expr: "__self == 'dev'"
+            inputs:
+              expression: "false"
+            message: "This rule must never run for non-dev values"
+
   testing:
     config:
       # render-defaults: solution has no workflow.actions section
@@ -171,3 +196,12 @@ spec:
         tags: [dynamic-message]
         assertions:
           - expression: '__output.dynamicTmplMessage == "hello-world"'
+
+      conditional-rule-when:
+        description: Verify a rule-level when=false skips a rule that would otherwise fail
+        extends: [_base]
+        tags: [rule-when]
+        assertions:
+          - expression: '__output.conditionalRuleWhen == "prod"'
+            message: "Resolver should pass because the failing rule is skipped by when"
+


### PR DESCRIPTION
- provider(http): add acceptableStatusCodes input to treat chosen codes (integers, class shorthands like "2xx", or ranges like "200-204") as successful; non-acceptable statuses now fail so onError fallbacks apply, and a new success output reports whether the status was accepted
- resolver: add rule-level when condition to validation rules so a rule is skipped when the expression is false; dependency extraction now accounts for the rule-level when expression
- lint: add parameter-missing-default rule warning when a resolver relies on an unconditional parameter source with no default and no guaranteed fallback, which would fail at runtime when the parameter is absent
- gotmpl: add toHclValue function rendering a valid HCL value expression for the right-hand side of an assignment (object literals and tuples of object literals), complementing toHcl which renders an HCL body
- docs/examples: add tutorials and example solutions covering acceptable status codes, conditional validation rules, and the HCL template helpers