### PR TITLE
feat(auth): add ClusterResolver embedder hook for Kubernetes auth

### DIFF
--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -46,6 +46,7 @@ Architecture and design documentation for scafctl.
 - [Entra Auth Implementation](entra-auth-implementation.md) — Microsoft Entra ID authentication
 - [GCP Auth Handler](gcp-auth-handler.md) — Google Cloud Platform authentication
 - [GitHub Auth Handler](github-auth-handler.md) — GitHub authentication
+- [Kubernetes / OpenShift Auth](kubernetes-auth.md) — Exec-credential bridge and cluster-resolver hook
 - [State](state.md) — State management design
 
 ## Contributing

--- a/docs/design/kubernetes-auth.md
+++ b/docs/design/kubernetes-auth.md
@@ -1,0 +1,140 @@
+---
+title: "Kubernetes / OpenShift Authentication"
+---
+
+# Kubernetes / OpenShift Authentication
+
+## Overview
+
+This document describes scafctl's first-class Kubernetes / OpenShift
+authentication design (issue #536). The goal is to let any scafctl auth handler
+serve tokens to `kubectl` / `oc` (and any kubeconfig-aware tool) while keeping
+the **core dependency-light** -- no `client-go` in core. Heavier machinery lives
+in plugins.
+
+The design is layered by dependency weight so each phase ships independently:
+
+| Phase | Scope | Location | Status |
+|-------|-------|----------|--------|
+| 1a | Handler-agnostic exec-credential output on `auth token` | core (`pkg/auth/execcredential`) | Shipped |
+| 1b | `ClusterResolver` interface + `RootOptions` hook | core (`pkg/kube`) | Shipped |
+| 2 | Kubeconfig provider plugin (`client-go`/`clientcmd`) | plugin | Planned |
+| 3 | Thin `login` / `kube` command | core | Planned |
+| 4 | OpenShift OAuth auth-handler plugin | plugin | Planned |
+
+Phases 1-3 add no OpenShift- or vendor-specific code and already deliver
+credential-helper support for any OIDC cluster.
+
+## Phase 1a: Exec-Credential Output (Shipped)
+
+`auth token <handler> --exec-credential` emits a
+`client.authentication.k8s.io/v1` `ExecCredential` (`status.token`,
+`status.expirationTimestamp`) built from the token already returned by
+`GetToken`. The payload is a hand-rolled struct -- no `client-go` import. Output
+is auto-enabled when kubectl sets `KUBERNETES_EXEC_INFO`, so the kubeconfig exec
+command needs no special flag.
+
+See the [auth tutorial](../tutorials/auth-tutorial.md) for the kubeconfig wiring.
+
+## Phase 1b: ClusterResolver (Shipped)
+
+The `pkg/kube` package defines a dependency-free extension point that maps a
+cluster name to its connection details. scafctl ships **no** cluster data --
+embedders with a cluster registry provide the implementation.
+
+### The Interface
+
+~~~go
+package kube
+
+type AuthType string
+
+const (
+    AuthTypeAuto  AuthType = ""      // auto-detect
+    AuthTypeOAuth AuthType = "oauth" // OpenShift bundled OAuth server
+    AuthTypeOIDC  AuthType = "oidc"  // external OIDC identity provider
+)
+
+type ClusterInfo struct {
+    Name            string
+    APIServerURL    string
+    ConsoleURL      string
+    AuthType        AuthType
+    OIDCAudience    string
+    InsecureSkipTLS bool
+}
+
+type ClusterResolver interface {
+    Resolve(ctx context.Context, name string) (*ClusterInfo, error)
+    List(ctx context.Context) ([]ClusterInfo, error) // powers completion
+}
+~~~
+
+### ClusterInfo Fields
+
+| Field | Purpose |
+|-------|---------|
+| `Name` | Cluster's logical name used for lookup and completion. |
+| `APIServerURL` | API server endpoint. May be empty for `--server` or auto-detection. |
+| `ConsoleURL` | Optional web console URL (informational). |
+| `AuthType` | Authentication method; empty means auto-detect. |
+| `OIDCAudience` | Client ID / audience the minted token must target for OIDC clusters. |
+| `InsecureSkipTLS` | Disables API server TLS verification (development only). |
+
+`ClusterInfo.Validate()` rejects an empty `Name` (`ErrEmptyClusterName`) or an
+unrecognized `AuthType` (`ErrInvalidAuthType`). `APIServerURL` is intentionally
+optional because login can resolve it via `--server` or auto-detection.
+
+### Embedder Hook
+
+Embedders supply a resolver through `RootOptions.ClusterResolver`. When set, it
+is attached to the command context and retrievable with
+`kube.ResolverFromContext(ctx)`:
+
+~~~go
+opts := &scafctl.RootOptions{
+    BinaryName:      "mycli",
+    ClusterResolver: myClusterRegistry, // implements kube.ClusterResolver
+}
+cmd, cleanup := scafctl.Root(opts)
+defer cleanup()
+~~~
+
+When unset, `kube.ResolverFromContext` returns `nil` and cluster-aware commands
+fall back to an explicit `--server` and auto-detection. Setting a resolver lights
+up positional cluster names, shell completion (via `List`), and OIDC audience
+resolution.
+
+### Runtime Model
+
+Cluster details are resolved **once at login** and baked into the kubeconfig
+exec args, never resolved on every `kubectl` call. Resolving on each call would
+run the embedder's lookup inside a non-interactive subprocess (latency plus a
+hard runtime dependency). The runtime helper then mints a token for fixed args
+with no resolver involved.
+
+## Phases 2-4 (Planned)
+
+- **Phase 2 -- Kubeconfig provider plugin.** Carries `client-go`/`clientcmd`.
+  Merges/writes the kubeconfig cluster, user, and context with an `ExecConfig`
+  credential plugin; provides `DetectAuthType`, `CheckAPIServerReachable`
+  (`/healthz`), and `Whoami` (SelfSubjectReview). Vendor-neutral; reused by both
+  OIDC and OpenShift paths.
+- **Phase 3 -- Thin `login` / `kube` command.** Orchestration only: run
+  `handler.Login` to mint a token, then delegate the kubeconfig write to the
+  Phase 2 provider over the existing provider RPC. Consumes
+  `kube.ClusterResolver` to resolve a positional cluster name into `--server`
+  and `--audience`. `client-go` never enters core.
+- **Phase 4 -- OpenShift OAuth handler plugin.** The one genuinely
+  OpenShift-specific credential source: localhost-callback implicit-grant flow,
+  plus `ListProjects` / MOTD behind graceful degradation.
+
+## Design Decisions
+
+- **No `client-go` in core.** It lives only in the Phase 2 kubeconfig provider
+  plugin (and an optional shared library), never in `pkg/kube`.
+- **No cluster data in core.** Cluster resolution is an embedder concern behind
+  `ClusterResolver`.
+- **`kube` package naming.** Every `ClusterInfo` field is Kubernetes-API-server
+  specific, so the package is named for the `kube` domain rather than a generic
+  `cluster` name.

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -45,6 +45,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/credentialhelper"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	"github.com/oakwood-commons/scafctl/pkg/kube"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/metrics"
 	"github.com/oakwood-commons/scafctl/pkg/paths"
@@ -195,6 +196,15 @@ type RootOptions struct {
 	// (config.Plugins.Signatures). Embedders can supply a policy directly
 	// to enforce stricter verification without relying on user config.
 	PluginSignaturePolicy *plugin.SignaturePolicy
+
+	// ClusterResolver resolves Kubernetes/OpenShift cluster names to
+	// connection details. When non-nil it is attached to the command context
+	// so cluster-aware commands can map a positional cluster name to its API
+	// server URL, auth type, and OIDC audience. When nil, those commands fall
+	// back to explicit --server flags and auto-detection. scafctl ships no
+	// cluster data; embedders with a cluster registry provide the
+	// implementation.
+	ClusterResolver kube.ClusterResolver
 }
 
 // NewRootOptions returns a RootOptions with production defaults
@@ -548,6 +558,12 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 			}
 
 			ctx = auth.WithRegistry(ctx, authRegistry)
+
+			// Attach the embedder-provided cluster resolver, if any, so
+			// cluster-aware commands can resolve names to connection details.
+			if opts.ClusterResolver != nil {
+				ctx = kube.WithResolver(ctx, opts.ClusterResolver)
+			}
 
 			// ── Resolve global auth profile ──
 			// Precedence: --auth-profile flag > env var > (per-handler config is resolved later)

--- a/pkg/cmd/scafctl/root_test.go
+++ b/pkg/cmd/scafctl/root_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/kube"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -310,4 +311,65 @@ func TestRoot_WithBuiltinAuthHandlers_Execution(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "builtin handler 'internal-idp' should appear in auth handlers output")
+}
+
+func TestRoot_WithClusterResolver(t *testing.T) {
+	t.Parallel()
+	resolver := &kube.MockResolver{}
+	cmd, cleanup := Root(&RootOptions{
+		BinaryName:      "mycli",
+		ClusterResolver: resolver,
+	})
+	defer cleanup()
+	require.NotNil(t, cmd)
+
+	// Verify the command tree was constructed with the option accepted.
+	assert.Equal(t, "mycli", cmd.Use)
+}
+
+func TestRoot_WithClusterResolver_Execution(t *testing.T) {
+	t.Parallel()
+	resolver := &kube.MockResolver{}
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	var captured kube.ClusterResolver
+	cmd, cleanup := Root(&RootOptions{
+		IOStreams:       ioStreams,
+		BinaryName:      "mycli",
+		ClusterResolver: resolver,
+		PreRunHook: func(c *cobra.Command, _ []string) error {
+			captured = kube.ResolverFromContext(c.Context())
+			return nil
+		},
+	})
+	defer cleanup()
+	cmd.SetArgs([]string{"auth", "handlers", "-o", "json"})
+	require.NoError(t, cmd.Execute())
+
+	// The embedder-provided resolver must be attached to the command context.
+	assert.Same(t, resolver, captured)
+}
+
+func TestRoot_WithoutClusterResolver_Execution(t *testing.T) {
+	t.Parallel()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	capturedSet := false
+	var captured kube.ClusterResolver
+	cmd, cleanup := Root(&RootOptions{
+		IOStreams:  ioStreams,
+		BinaryName: "mycli",
+		PreRunHook: func(c *cobra.Command, _ []string) error {
+			captured = kube.ResolverFromContext(c.Context())
+			capturedSet = true
+			return nil
+		},
+	})
+	defer cleanup()
+	cmd.SetArgs([]string{"auth", "handlers", "-o", "json"})
+	require.NoError(t, cmd.Execute())
+
+	// With no resolver configured, the context must not carry one.
+	assert.True(t, capturedSet, "PreRunHook should have run")
+	assert.Nil(t, captured)
 }

--- a/pkg/kube/context.go
+++ b/pkg/kube/context.go
@@ -1,0 +1,23 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import "context"
+
+type contextKey string
+
+const resolverKey contextKey = "kube.resolver"
+
+// WithResolver returns a new context with the cluster resolver attached.
+func WithResolver(ctx context.Context, resolver ClusterResolver) context.Context {
+	return context.WithValue(ctx, resolverKey, resolver)
+}
+
+// ResolverFromContext retrieves the cluster resolver from the context. It
+// returns nil when no resolver is configured, in which case callers fall back
+// to explicit --server flags and auto-detection.
+func ResolverFromContext(ctx context.Context) ClusterResolver {
+	resolver, _ := ctx.Value(resolverKey).(ClusterResolver)
+	return resolver
+}

--- a/pkg/kube/context_test.go
+++ b/pkg/kube/context_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolverFromContext_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	resolver := &MockResolver{}
+	ctx := WithResolver(context.Background(), resolver)
+
+	got := ResolverFromContext(ctx)
+	assert.Same(t, resolver, got)
+}
+
+func TestResolverFromContext_Absent(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, ResolverFromContext(context.Background()))
+}

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -1,0 +1,108 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package kube provides dependency-free primitives for resolving Kubernetes /
+// OpenShift cluster connection details by name. It carries no client-go
+// dependency: it only defines the ClusterInfo shape, the ClusterResolver
+// extension point, and context plumbing so embedders can supply a cluster
+// registry. The heavier kubeconfig machinery (client-go/clientcmd) lives in a
+// separate provider plugin.
+package kube
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Sentinel errors returned by ClusterInfo.Validate so callers can match with
+// errors.Is rather than string comparison.
+var (
+	// ErrEmptyClusterName indicates a ClusterInfo with no Name.
+	ErrEmptyClusterName = errors.New("cluster name must not be empty")
+
+	// ErrInvalidAuthType indicates a ClusterInfo with an unrecognized AuthType.
+	ErrInvalidAuthType = errors.New("invalid auth type")
+)
+
+// AuthType identifies how a client authenticates to a cluster's API server.
+// The empty value means "auto-detect" so embedders can leave it unset.
+type AuthType string
+
+const (
+	// AuthTypeAuto leaves the authentication method to runtime auto-detection.
+	AuthTypeAuto AuthType = ""
+
+	// AuthTypeOAuth selects an OAuth login flow (e.g. the OpenShift bundled
+	// OAuth server's implicit grant).
+	AuthTypeOAuth AuthType = "oauth"
+
+	// AuthTypeOIDC selects an external OIDC identity provider flow.
+	AuthTypeOIDC AuthType = "oidc"
+)
+
+// Valid reports whether the AuthType is one of the recognized values.
+func (a AuthType) Valid() bool {
+	switch a {
+	case AuthTypeAuto, AuthTypeOAuth, AuthTypeOIDC:
+		return true
+	default:
+		return false
+	}
+}
+
+// ClusterInfo describes the connection and authentication details for a single
+// Kubernetes / OpenShift cluster. It is pure data with no client-go types so it
+// can live in core. Tags are provided so embedders can unmarshal a cluster
+// registry from YAML/JSON config.
+type ClusterInfo struct {
+	// Name is the cluster's logical name used for lookup and completion.
+	Name string `json:"name" yaml:"name" doc:"Cluster logical name used for lookup and completion" maxLength:"253" example:"prod"`
+
+	// APIServerURL is the cluster's API server endpoint (https://...). It may
+	// be empty when the caller supplies an explicit --server or relies on
+	// auto-detection.
+	APIServerURL string `json:"apiServerURL,omitempty" yaml:"apiServerURL,omitempty" doc:"Cluster API server endpoint; may be empty for --server or auto-detection" maxLength:"2048" example:"https://api.example.com:6443"`
+
+	// ConsoleURL is the optional web console URL (informational).
+	ConsoleURL string `json:"consoleURL,omitempty" yaml:"consoleURL,omitempty" doc:"Optional web console URL (informational)" maxLength:"2048" example:"https://console.example.com"`
+
+	// AuthType selects the authentication method. The zero value
+	// (AuthTypeAuto) means auto-detect.
+	AuthType AuthType `json:"authType,omitempty" yaml:"authType,omitempty" doc:"Authentication method; empty means auto-detect" example:"oidc"`
+
+	// OIDCAudience is the client ID / audience the minted token must target
+	// for OIDC clusters. Ignored for non-OIDC clusters.
+	OIDCAudience string `json:"oidcAudience,omitempty" yaml:"oidcAudience,omitempty" doc:"Client ID/audience the minted token must target for OIDC clusters" maxLength:"512" example:"my-cluster-client-id"`
+
+	// InsecureSkipTLS disables API server TLS verification. Use only for
+	// development clusters with self-signed certificates.
+	InsecureSkipTLS bool `json:"insecureSkipTLS,omitempty" yaml:"insecureSkipTLS,omitempty" doc:"Disable API server TLS verification (development only)"`
+}
+
+// Validate checks the ClusterInfo for required fields and a recognized
+// AuthType. APIServerURL is intentionally optional because login can resolve it
+// via an explicit --server flag or auto-detection.
+func (c ClusterInfo) Validate() error {
+	if strings.TrimSpace(c.Name) == "" {
+		return ErrEmptyClusterName
+	}
+	if !c.AuthType.Valid() {
+		return fmt.Errorf("%w: %q", ErrInvalidAuthType, c.AuthType)
+	}
+	return nil
+}
+
+// ClusterResolver resolves cluster names to connection details. Embedders with a
+// cluster registry provide the implementation; scafctl ships no cluster data.
+// When no resolver is configured, commands fall back to explicit --server flags
+// and auto-detection.
+type ClusterResolver interface {
+	// Resolve returns the ClusterInfo for the named cluster.
+	Resolve(ctx context.Context, name string) (*ClusterInfo, error)
+
+	// List returns all known clusters. It powers shell completion of cluster
+	// names.
+	List(ctx context.Context) ([]ClusterInfo, error)
+}

--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -1,0 +1,85 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthType_Valid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		authType AuthType
+		want     bool
+	}{
+		{name: "auto/empty", authType: AuthTypeAuto, want: true},
+		{name: "oauth", authType: AuthTypeOAuth, want: true},
+		{name: "oidc", authType: AuthTypeOIDC, want: true},
+		{name: "unknown", authType: AuthType("saml"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, tt.authType.Valid())
+		})
+	}
+}
+
+func TestClusterInfo_Validate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		info    ClusterInfo
+		wantErr error
+	}{
+		{
+			name: "valid minimal",
+			info: ClusterInfo{Name: "prod"},
+		},
+		{
+			name: "valid full",
+			info: ClusterInfo{
+				Name:            "prod",
+				APIServerURL:    "https://api.example.com:6443",
+				ConsoleURL:      "https://console.example.com",
+				AuthType:        AuthTypeOIDC,
+				OIDCAudience:    "client-id",
+				InsecureSkipTLS: true,
+			},
+		},
+		{
+			name:    "empty name",
+			info:    ClusterInfo{Name: ""},
+			wantErr: ErrEmptyClusterName,
+		},
+		{
+			name:    "whitespace name",
+			info:    ClusterInfo{Name: "   "},
+			wantErr: ErrEmptyClusterName,
+		},
+		{
+			name:    "invalid auth type",
+			info:    ClusterInfo{Name: "prod", AuthType: AuthType("saml")},
+			wantErr: ErrInvalidAuthType,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.info.Validate()
+			if tt.wantErr == nil {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}

--- a/pkg/kube/mock.go
+++ b/pkg/kube/mock.go
@@ -1,0 +1,58 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"context"
+	"sync"
+)
+
+// MockResolver implements ClusterResolver for testing. Configure the result
+// values or override the *Func fields for custom behavior.
+type MockResolver struct {
+	mu sync.Mutex
+
+	ResolveResult *ClusterInfo
+	ResolveErr    error
+	ListResult    []ClusterInfo
+	ListErr       error
+
+	// ResolveFunc, when set, takes precedence over ResolveResult/ResolveErr.
+	ResolveFunc func(ctx context.Context, name string) (*ClusterInfo, error)
+	// ListFunc, when set, takes precedence over ListResult/ListErr.
+	ListFunc func(ctx context.Context) ([]ClusterInfo, error)
+
+	// ResolveCalls records the names passed to Resolve, in order.
+	ResolveCalls []string
+	// ListCalls counts the number of List invocations.
+	ListCalls int
+}
+
+// Resolve returns the configured cluster info or invokes ResolveFunc.
+func (m *MockResolver) Resolve(ctx context.Context, name string) (*ClusterInfo, error) {
+	m.mu.Lock()
+	m.ResolveCalls = append(m.ResolveCalls, name)
+	fn := m.ResolveFunc
+	result := m.ResolveResult
+	err := m.ResolveErr
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, name)
+	}
+	return result, err
+}
+
+// List returns the configured clusters or invokes ListFunc.
+func (m *MockResolver) List(ctx context.Context) ([]ClusterInfo, error) {
+	m.mu.Lock()
+	m.ListCalls++
+	fn := m.ListFunc
+	result := m.ListResult
+	err := m.ListErr
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(ctx)
+	}
+	return result, err
+}

--- a/pkg/kube/mock_test.go
+++ b/pkg/kube/mock_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Ensure MockResolver satisfies the interface.
+var _ ClusterResolver = (*MockResolver)(nil)
+
+func TestMockResolver_Results(t *testing.T) {
+	t.Parallel()
+
+	want := &ClusterInfo{Name: "prod", APIServerURL: "https://api.example.com"}
+	m := &MockResolver{
+		ResolveResult: want,
+		ListResult:    []ClusterInfo{*want},
+	}
+
+	got, err := m.Resolve(context.Background(), "prod")
+	require.NoError(t, err)
+	assert.Same(t, want, got)
+
+	list, err := m.List(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, list, 1)
+
+	assert.Equal(t, []string{"prod"}, m.ResolveCalls)
+	assert.Equal(t, 1, m.ListCalls)
+}
+
+func TestMockResolver_Errors(t *testing.T) {
+	t.Parallel()
+
+	resolveErr := errors.New("resolve boom")
+	listErr := errors.New("list boom")
+	m := &MockResolver{ResolveErr: resolveErr, ListErr: listErr}
+
+	_, err := m.Resolve(context.Background(), "x")
+	assert.ErrorIs(t, err, resolveErr)
+
+	_, err = m.List(context.Background())
+	assert.ErrorIs(t, err, listErr)
+}
+
+func TestMockResolver_Funcs(t *testing.T) {
+	t.Parallel()
+
+	m := &MockResolver{
+		ResolveFunc: func(_ context.Context, name string) (*ClusterInfo, error) {
+			return &ClusterInfo{Name: name}, nil
+		},
+		ListFunc: func(_ context.Context) ([]ClusterInfo, error) {
+			return []ClusterInfo{{Name: "a"}, {Name: "b"}}, nil
+		},
+	}
+
+	got, err := m.Resolve(context.Background(), "dynamic")
+	require.NoError(t, err)
+	assert.Equal(t, "dynamic", got.Name)
+
+	list, err := m.List(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, list, 2)
+}


### PR DESCRIPTION
Introduce the dependency-free pkg/kube package (Phase 1b of #536) that lets embedders resolve Kubernetes/OpenShift cluster connection details by name without pulling client-go into core.

- Add pkg/kube with ClusterInfo, AuthType, and the ClusterResolver interface, plus context plumbing (WithResolver/ResolverFromContext) and a MockResolver test helper
- Validate ClusterInfo via sentinel errors (ErrEmptyClusterName, ErrInvalidAuthType) and tag fields for schema/example generation
- Wire RootOptions.ClusterResolver into the command context so embedders can opt in; nil leaves cluster-aware behavior off
- Document the layered Kubernetes/OpenShift auth design in docs/design/kubernetes-auth.md and link it from the design index

Relates to #536