### PR TITLE
feat(provider): add kubeconfig capability and host-side manager

### DIFF
--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -47,6 +47,7 @@ Architecture and design documentation for scafctl.
 - [GCP Auth Handler](gcp-auth-handler.md) — Google Cloud Platform authentication
 - [GitHub Auth Handler](github-auth-handler.md) — GitHub authentication
 - [Kubernetes / OpenShift Auth](kubernetes-auth.md) — Exec-credential bridge and cluster-resolver hook
+- [Kubeconfig Provider Implementation Plan](kubeconfig-provider-implementation-plan.md) — Phase 2 plan for the kubeconfig provider plugin
 - [State](state.md) — State management design
 
 ## Contributing

--- a/docs/design/kubeconfig-provider-implementation-plan.md
+++ b/docs/design/kubeconfig-provider-implementation-plan.md
@@ -1,0 +1,364 @@
+---
+title: "Kubeconfig Provider Implementation Plan (Phase 2)"
+---
+
+# Kubeconfig Provider Implementation Plan (Phase 2)
+
+## 1. Summary
+
+Phase 2 of issue #536 builds the **kubeconfig provider** -- a go-plugin gRPC
+binary, carried in its own module, that owns all `client-go`/`clientcmd` work so
+core never imports the heavy Kubernetes client packages. It is auto-fetched on
+demand and performs the Kubernetes-side mechanics (merge/write a kubeconfig
+exec-credential entry, remove it, read the current server, detect oauth-vs-oidc,
+check reachability, and run a SelfSubjectReview whoami). A new in-core host-side
+manager package (`pkg/kubeconfig`) drives it, mirroring `pkg/state`. The provider
+is stateless -- it never stores or caches tokens (Q4) and receives a token only
+for `whoami`. The Phase 3 `auth login <handler> --cluster` command and the Phase
+4 OpenShift handler consume this provider; both are out of scope here.
+
+The work is split into Phase 2a (in-core contract + manager + mock, no
+client-go) and Phase 2b (the external plugin module with client-go).
+
+## 2. Architecture Decisions
+
+### Layers affected
+
+- **provider** -- new scafctl-defined capability `CapabilityKubeconfig`.
+- **new package `pkg/kubeconfig`** -- host-side manager (direct analogue of
+  `pkg/state/manager.go`).
+- **provider/official** -- register `kubeconfig` for auto-fetch.
+- **external module** (separate repo) -- the plugin carrying client-go.
+
+No CLI/MCP/API changes in Phase 2 (those land in Phase 3).
+
+### Mirror the state backend
+
+The state backend is the exact precedent for invoking a provider directly from a
+domain package outside a solution DAG:
+
+- `pkg/state/manager.go` resolves a provider via `registry.Get`, checks it has
+  `CapabilityState`, calls `provider.Execute` with an `operation` input
+  (`state_load`/`state_save`/`state_delete`), and extracts `Output.Data`.
+- The provider dispatches on the `operation` field
+  (`pkg/provider/builtin/httpprovider/http_state.go`).
+
+The kubeconfig provider reuses this shape with operation dispatch on an
+`operation` input field, and a host-side manager that resolves, checks the
+capability, executes, and unmarshals typed output.
+
+~~~text
+auth login <handler> --cluster X        (Phase 3, core, no client-go)
+        |
+        v
+pkg/kubeconfig.Manager                   (Phase 2a, core -- mirrors pkg/state.Manager)
+        | ensure provider registered (fetch-then-register; see section 3)
+        | registry.Get("kubeconfig"); check CapabilityKubeconfig
+        | Execute(operation=kubeconfig_write, inputs=...)
+        v
+kubeconfig provider plugin               (Phase 2b, external module, carries client-go)
+        | clientcmd merge/write, rest /healthz, SelfSubjectReview
+        v
+~/.kube/config  +  detection/whoami results
+~~~
+
+### Capability: `CapabilityKubeconfig`, not `CapabilityAction` (recommended)
+
+Recommendation: a dedicated `CapabilityKubeconfig`, defined in `pkg/provider`
+(not the SDK), exactly like `CapabilityState`.
+
+Rationale:
+
+- **Clean discovery + validation.** `ValidateDescriptor` already special-cases
+  scafctl-defined capabilities (it strips them before the SDK validator and
+  validates required output fields locally). A dedicated capability lets the
+  manager assert the right provider type via `registry.ListByCapability` /
+  capability check, exactly as state does. Reusing `CapabilityAction` would make
+  any action provider falsely appear as a kubeconfig backend.
+- **Mirrors an established, merged pattern** (`CapabilityState`), so reviewers and
+  embedders already understand it; external plugins can implement it too.
+- **Cost is small.** It is one constant plus a required-output-fields entry in
+  `ValidateDescriptor`, copying the `stateCapabilityRequiredFields` approach.
+
+Trade-off: `CapabilityAction` would avoid touching `ValidateDescriptor`, but at
+the cost of weaker typing and discovery. The state precedent settles this in
+favor of a dedicated capability.
+
+## 3. The host invocation path and the registry/auto-fetch resolution
+
+### Finding (the flagged risk, resolved)
+
+The state manager assumes the provider is **already** in the registry because
+state runs *inside* a solution execution, where the plugin pool has already run
+`Ensure`/`Adopt` to populate the registry. A command-initiated
+`auth login --cluster` call has **no solution and no pool pass**, so nothing
+pre-populates the registry. Therefore the kubeconfig manager needs a thin
+**fetch-then-register** step -- it cannot assume a populated registry.
+
+That step already exists as a reusable precedent: `autoResolveProviderByName`
+in `pkg/cmd/scafctl/run/common.go`, used by `run provider <name>` (also a
+command-initiated, non-solution call). It does exactly:
+
+1. `official.RegistryFromContext(ctx)` -> look up the official entry by name.
+2. `prepare.BuildPluginFetcher(ctx)` -> build a `plugin.Fetcher`.
+3. `fetcher.FetchPlugins(ctx, []solution.PluginDependency{dep}, nil)` where
+   `dep = entry.ToPluginDependency()`.
+4. `plugin.RegisterFetchedPlugins(ctx, reg, results, pluginCfg, clientOpts...)`
+   -> wraps each provider and `registry.Register`s it; returns `[]*plugin.Client`.
+
+Crucially, `RegisterFetchedPlugins` returns the spawned `*plugin.Client`s, and
+**the caller owns their lifecycle and must `Kill()` them** when done. State never
+deals with this because the pool owns plugin lifecycle there.
+
+### Resolution
+
+`pkg/kubeconfig.Manager` performs its own fetch-then-register, modeled on
+`autoResolveProviderByName`, and returns a cleanup func that kills the clients.
+Concretely the manager's `ensure` step:
+
+1. If `registry.Get("kubeconfig")` already returns a provider (e.g. a solution
+   run pre-loaded it, or a test injected a mock), use it as-is.
+2. Else look up `kubeconfig` in `official.RegistryFromContext(ctx)`, build the
+   fetcher via `prepare.BuildPluginFetcher(ctx)`, `FetchPlugins`, then
+   `RegisterFetchedPlugins` into a manager-owned `provider.Registry`. Stash the
+   returned clients so `Manager.Close()` kills them.
+
+### Graceful fallback (Q3)
+
+Any failure in ensure/fetch/execute returns a sentinel
+(`ErrProviderUnavailable`) so the Phase 3 command can fall back to writing a
+kubeconfig that shells out to `<host-binary> auth token <handler>
+--exec-credential` directly. The manager exposes this as a typed error; the
+fallback policy itself lives in Phase 3, not in the manager.
+
+### Lifecycle note
+
+Because the manager spawns plugin clients for a one-shot command, it must:
+
+- spawn lazily (only when an operation is actually invoked),
+- reuse a single client across all operations in one command invocation, and
+- `Kill()` on `Close()` (deferred by the Phase 3 command).
+
+This is the one material difference from `pkg/state` and is called out as a sub-
+decision in section 12.
+
+## 4. The capability and operation contract
+
+All operations dispatch on the `operation` input field. Inputs/outputs are flat
+`map[string]any` to match the SDK `ExecuteProvider(name, input) -> Output{Data}`
+signature. The manager marshals typed structs to maps (JSON round-trip, like
+`state.structToMap`) and unmarshals `Output.Data` back into typed results.
+
+| operation          | Inputs (key fields)                                                                                                   | Output (Data fields)                          |
+|--------------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
+| `kubeconfig_write` | `server`, `audience`, `cluster_name`, `context_name`, `user_name`, `kubeconfig_path`, `exec_command`, `exec_args`, `insecure_skip_tls`, `set_current_context` | `success`, `context_name`, `kubeconfig_path`  |
+| `kubeconfig_remove`| `cluster_name`, `context_name`, `user_name`, `kubeconfig_path`                                                        | `success`, `removed`                          |
+| `current_server`   | `kubeconfig_path`, `context_name`                                                                                    | `server`                                      |
+| `detect_auth_type` | `server`, `insecure_skip_tls`                                                                                        | `auth_type` (auto/oauth/oidc), `oidc_issuer`, `oauth_endpoint` |
+| `reachable`        | `server`, `insecure_skip_tls`                                                                                        | `reachable` (bool), `status` (int)            |
+| `whoami`           | `server`, `token`, `audience`, `insecure_skip_tls`                                                                   | `username`, `groups` (list), `uid`            |
+
+Required output field across all operations: `success` (boolean) -- this is the
+field `ValidateDescriptor` enforces for `CapabilityKubeconfig`, copying the
+state pattern.
+
+Contract notes:
+
+- `exec_command` / `exec_args` are supplied by the host so the **host binary
+  name** (embedder contract) is baked into the kubeconfig exec block; the
+  provider never hardcodes `scafctl`. At login time the host bakes the resolved
+  `--server`/`--audience` into static exec args.
+- The provider is **stateless** -- it receives a `token` only for `whoami` and
+  never caches it.
+- `kubeconfig_path` empty means "resolve `KUBECONFIG` env or `~/.kube/config`"
+  inside the plugin via `clientcmd` loading rules.
+
+## 5. Module / repo layout
+
+### Host side (this repo)
+
+- `pkg/provider` -- add `CapabilityKubeconfig` + `kubeconfigCapabilityRequiredFields`
+  + `ValidateDescriptor`/`IsCapabilityValid` coverage (mirror `CapabilityState`).
+- `pkg/kubeconfig/` (new) -- the manager, typed input/output structs, sentinels,
+  and a `mock.go` provider for tests. Mirrors `pkg/state` file layout.
+- `pkg/provider/official/official.go` -- add
+  `{Name: "kubeconfig", CatalogRef: "kubeconfig", DefaultVersion: "latest",
+  Description: "..."}` to `defaultProviders`. This makes it auto-fetchable via
+  the existing `Fetcher` pipeline (`ToPluginDependency`).
+
+### Plugin side (separate module / repo)
+
+- New module mirroring the existing official providers
+  (`git`, `exec`, ...), published to
+  `ghcr.io/oakwood-commons/providers/kubeconfig`.
+- Depends on `scafctl-plugin-sdk` v0.10.0 + `k8s.io/client-go`
+  (`tools/clientcmd`, `rest`, `transport`) + `k8s.io/apimachinery`.
+- Implements the SDK `Plugin` interface (`GetProviders`,
+  `GetProviderDescriptor`, `ExecuteProvider`, `ExecuteProviderStream`,
+  `DescribeWhatIf`, `ConfigureProvider`, `ExtractDependencies`, `StopProvider`);
+  `main()` calls `sdkplugin.Serve(&KubeconfigPlugin{})`, modeled on
+  `examples/plugins/echo/main.go`.
+- `ExecuteProvider` switches on `input["operation"]` and routes to per-operation
+  handlers.
+
+### client-go boundary (verified)
+
+Core already has `k8s.io/apimachinery` as a direct dep and `k8s.io/client-go`
+only as indirect. Keeping the plugin in a separate module ensures the heavy
+client-go packages (`clientcmd`/`rest`/`transport`) never enter core's direct
+import graph. The shared typed structs live in `pkg/kubeconfig`
+(apimachinery-free), and the plugin imports or mirrors them.
+
+## 6. Interface Design
+
+Define these contracts first (signatures illustrative; finalize during 2a):
+
+~~~go
+// pkg/provider/provider.go
+const CapabilityKubeconfig Capability = "kubeconfig"
+
+// pkg/kubeconfig/manager.go
+type Manager struct {
+    registry   *provider.Registry
+    clients    []*plugin.Client // owned; killed on Close
+    binaryName string
+    // ... fetcher/official wiring resolved lazily from ctx
+}
+
+func NewManager(binaryName string, opts ...Option) *Manager
+
+// ensure resolves "kubeconfig" from the registry, fetching+registering it on
+// demand when absent (mirrors autoResolveProviderByName). Wraps fetch/execute
+// failures as ErrProviderUnavailable for the Phase 3 fallback.
+func (m *Manager) ensure(ctx context.Context) (provider.Provider, error)
+
+func (m *Manager) WriteKubeconfig(ctx context.Context, in WriteInput) (WriteResult, error)
+func (m *Manager) RemoveEntry(ctx context.Context, in RemoveInput) (RemoveResult, error)
+func (m *Manager) CurrentServer(ctx context.Context, in CurrentServerInput) (string, error)
+func (m *Manager) DetectAuthType(ctx context.Context, in DetectInput) (DetectResult, error)
+func (m *Manager) Reachable(ctx context.Context, in ReachableInput) (ReachableResult, error)
+func (m *Manager) Whoami(ctx context.Context, in WhoamiInput) (WhoamiResult, error)
+
+func (m *Manager) Close() error // kills spawned plugin clients
+
+// Sentinels
+var (
+    ErrProviderUnavailable = errors.New("kubeconfig: provider unavailable")
+    ErrInvalidOperation    = errors.New("kubeconfig: invalid operation output")
+)
+~~~
+
+Typed input/output structs (Huma validation tags, mirroring `kube.ClusterInfo`)
+reuse `kube.AuthType` for `DetectResult.AuthType`. Each struct has a
+`toInputs() map[string]any` and there is an `extract*` helper per result type
+(direct `*Result` pointer first, then map fallback after JSON round-trip --
+copying `state.extractStateData`).
+
+## 7. Error Handling
+
+- New sentinels: `ErrProviderUnavailable` (fetch/register/spawn failed -> Phase 3
+  falls back to a static exec-credential kubeconfig) and `ErrInvalidOperation`
+  (malformed `Output.Data`).
+- Wrap with `fmt.Errorf("kubeconfig: <context>: %w", err)` throughout.
+- Plugin side wraps clientcmd/rest errors and returns
+  `Output{Data: {"success": false, ...}}` with a descriptive error so the host
+  can surface a clear message.
+
+## 8. Task Breakdown
+
+### Phase 2a -- In-core contract + manager (this repo)
+
+| # | Task | Files | Complexity | Depends on |
+|---|------|-------|-----------|------------|
+| 1 | Add `CapabilityKubeconfig` + required-output-fields + validation/IsCapabilityValid coverage | `pkg/provider/provider.go`, `pkg/provider/provider_test.go` | S | -- |
+| 2 | Typed input/output structs (+ Huma tags), `toInputs`/`extract*` helpers, sentinels | `pkg/kubeconfig/types.go` | M | 1 |
+| 3 | `Manager` with `ensure` (registry.Get -> fetch-then-register fallback), per-op methods, `Close()` | `pkg/kubeconfig/manager.go` | L | 1, 2 |
+| 4 | `mock.go` provider implementing `CapabilityKubeconfig` + operation dispatch | `pkg/kubeconfig/mock.go` | M | 1, 2 |
+| 5 | Table-driven manager tests against mock; embedder binary-name test; capability validation tests; benchmarks | `pkg/kubeconfig/*_test.go` | M | 3, 4 |
+| 6 | Register `kubeconfig` in official providers; confirm fetcher cooldown/fallback path | `pkg/provider/official/official.go`, `official_test.go` | S | -- |
+
+### Phase 2b -- External kubeconfig provider plugin (separate repo)
+
+| # | Task | Complexity | Depends on |
+|---|------|-----------|------------|
+| 7 | New module: SDK `Plugin` impl, `kubeconfig` provider, `CapabilityKubeconfig`, descriptor + output schemas, `operation` dispatch, `main()`=`Serve` | M | 2 |
+| 8 | `clientcmd` merge/write + remove + current-server (exec-credential user block) | L | 7 |
+| 9 | `rest`-based `/healthz` reachability + `SelfSubjectReview` whoami | M | 7 |
+| 10 | `detect_auth_type` (probe `.well-known/oauth-authorization-server` + OIDC discovery) -> oauth/oidc | M | 7 |
+| 11 | Cluster-name sanitization helper in a small companion library (reused by Phase 4 OpenShift handler) | S | 8 |
+| 12 | Plugin unit tests (temp `KUBECONFIG` + `httptest`), `mock.go`, benchmarks | M | 8, 9, 10 |
+| 13 | CI/release: build, cosign-sign, publish to `ghcr.io/oakwood-commons/providers/kubeconfig` | M | 7-12 |
+
+The bulk of host work (2a) lands and is fully testable against the mock before
+the plugin exists.
+
+## 9. Testing Strategy
+
+- **In-core (2a):** table-driven `Manager` tests against `mock.go` (no client-go
+  in core test deps); capability-validation tests for `ValidateDescriptor`;
+  an embedder test asserting a non-default binary name (e.g. `"mycli"`) flows
+  into `exec_command`; `extract*` round-trip tests (pointer + map paths);
+  benchmarks for the hot `toInputs`/`extract` path. Target 70%+ patch coverage.
+- **Plugin (2b):** `clientcmd` write/remove/current-server against a temp
+  `KUBECONFIG` file; `httptest` servers for `reachable` (`/healthz`),
+  `detect_auth_type` (well-known endpoints), and `whoami` (`SelfSubjectReview`);
+  `mock.go` for the ops interface; per-provider benchmarks (provider
+  conventions). Negative cases: unreachable server, malformed kubeconfig,
+  ambiguous detection.
+- **Integration:** deferred to Phase 3, where the CLI command wires the manager
+  end-to-end against a fake API server (CLI-scope test under
+  `tests/integration/`).
+- **E2E:** run `task test:e2e` once after 2a, redirect to a file, grep results.
+
+## 10. Embedder / binary-name handling
+
+- `pkg/kubeconfig.Manager` is constructed with the host binary name
+  (`settings.Run.BinaryName`, falling back to `settings.CliBinaryName`) and
+  passes it as `exec_command` so embedders (e.g. `cldctl`) get correct kubeconfig
+  exec args. No hardcoded `scafctl`.
+- The fetch-then-register path uses the manager's configured binary name
+  (`m.binaryName`) for the `plugin.ProviderConfig.BinaryName`, keeping plugin
+  cache paths/config consistent with the `exec_command` baked into the
+  kubeconfig and self-contained for embedders calling the package directly.
+- A manager test must assert the baked `exec_command`/`exec_args` for a non-
+  default binary name.
+
+## 11. Documentation & Examples
+
+- Update `docs/design/kubernetes-auth.md` to mark Phase 2 design-complete and
+  link this plan.
+- Add an `examples/` kubeconfig snippet only once Phase 3 wires the command
+  (the provider is not directly user-invokable in a solution).
+- MCP: no new tool in Phase 2 (no user-facing command yet).
+- Markdown: ASCII-only, tilde fences for blocks containing backticks, no emojis,
+  `--` not em dashes.
+
+## 12. Risks & Sub-decisions
+
+- **Plugin lifecycle for one-shot commands (the main difference from state).**
+  The manager spawns plugin clients and must `Kill()` them on `Close()`; the
+  Phase 3 command `defer`s it. Reuse one client across all ops in a single
+  invocation. Resolved approach: model on `autoResolveProviderByName` +
+  manager-owned `Close()`.
+- **Auto-fetch outside a solution -- RESOLVED.** No pool pass populates the
+  registry for a command-initiated call; the manager does its own fetch-then-
+  register via `official.RegistryFromContext` + `prepare.BuildPluginFetcher` +
+  `FetchPlugins` + `plugin.RegisterFetchedPlugins`. Failure -> `ErrProviderUnavailable`
+  -> Phase 3 static exec-credential fallback.
+- **`CapabilityKubeconfig` vs `CapabilityAction` -- RESOLVED** in favor of a
+  dedicated capability (clean validation/discovery, mirrors state).
+- **Detection reliability.** `detect_auth_type` is best-effort; an embedder-set
+  `ClusterInfo.AuthType` always wins over probing.
+- **Companion library boundary.** Keep sanitization/detection helpers in a small
+  library within the plugin module so the Phase 4 OpenShift handler can import
+  them; finalize the boundary in task 11.
+- **Security.** TLS verification on by default; `insecure_skip_tls` is opt-in and
+  documented as development-only. The provider never logs the `whoami` token.
+
+## 13. Out of Scope (later phases)
+
+- Phase 3: `auth login <handler> --cluster` / `auth logout --cluster` wiring +
+  fallback policy.
+- Phase 4: OpenShift OAuth handler plugin.
+- Token caching: reuses the existing keyring `TokenCache` (Q4); the provider
+  never touches it.

--- a/docs/design/kubernetes-auth.md
+++ b/docs/design/kubernetes-auth.md
@@ -18,7 +18,8 @@ The design is layered by dependency weight so each phase ships independently:
 |-------|-------|----------|--------|
 | 1a | Handler-agnostic exec-credential output on `auth token` | core (`pkg/auth/execcredential`) | Shipped |
 | 1b | `ClusterResolver` interface + `RootOptions` hook | core (`pkg/kube`) | Shipped |
-| 2 | Kubeconfig provider plugin (`client-go`/`clientcmd`) | plugin | Planned |
+| 2a | Kubeconfig provider capability contract + host-side manager | core (`pkg/kubeconfig`, `CapabilityKubeconfig`) | Shipped |
+| 2b | Kubeconfig provider plugin implementation (`client-go`/`clientcmd`) | plugin | Planned |
 | 3 | Thin `login` / `kube` command | core | Planned |
 | 4 | OpenShift OAuth auth-handler plugin | plugin | Planned |
 
@@ -113,28 +114,79 @@ run the embedder's lookup inside a non-interactive subprocess (latency plus a
 hard runtime dependency). The runtime helper then mints a token for fixed args
 with no resolver involved.
 
-## Phases 2-4 (Planned)
+## Phases 2-4
 
-- **Phase 2 -- Kubeconfig provider plugin.** Carries `client-go`/`clientcmd`.
-  Merges/writes the kubeconfig cluster, user, and context with an `ExecConfig`
-  credential plugin; provides `DetectAuthType`, `CheckAPIServerReachable`
-  (`/healthz`), and `Whoami` (SelfSubjectReview). Vendor-neutral; reused by both
-  OIDC and OpenShift paths.
-- **Phase 3 -- Thin `login` / `kube` command.** Orchestration only: run
-  `handler.Login` to mint a token, then delegate the kubeconfig write to the
-  Phase 2 provider over the existing provider RPC. Consumes
-  `kube.ClusterResolver` to resolve a positional cluster name into `--server`
-  and `--audience`. `client-go` never enters core.
+- **Phase 2a -- Kubeconfig provider capability contract (Shipped).** The
+  in-core `CapabilityKubeconfig` provider capability plus the host-side driver
+  in `pkg/kubeconfig` (typed inputs/outputs, `Manager`, mock, official-provider
+  registration). Defines the six operations dispatched on the `operation`
+  input -- `kubeconfig_write`, `kubeconfig_remove`, `current_server`,
+  `detect_auth_type`, `reachable`, `whoami` -- each returning `success: boolean`.
+  No `client-go` enters core; the manager resolves and drives the external
+  plugin over the existing provider RPC.
+- **Phase 2b -- Kubeconfig provider plugin implementation (Planned).** Carries
+  `client-go`/`clientcmd`. Merges/writes the kubeconfig cluster, user, and
+  context with an `ExecConfig` credential plugin; implements `DetectAuthType`,
+  `CheckAPIServerReachable` (`/healthz`), and `Whoami` (SelfSubjectReview).
+  Vendor-neutral; reused by both OIDC and OpenShift paths.
+- **Phase 3 -- Kube wiring on `auth login` / `auth logout`.** Orchestration
+  only: run the handler login to mint a token, then delegate the kubeconfig
+  write to the Phase 2b provider over the existing provider RPC. Surfaced as
+  `auth login <handler> --cluster <name>` (and matching `auth logout`) rather
+  than a new top-level command. Consumes `kube.ClusterResolver` to resolve a
+  cluster name into `--server` and `--audience`. `client-go` never enters core.
 - **Phase 4 -- OpenShift OAuth handler plugin.** The one genuinely
   OpenShift-specific credential source: localhost-callback implicit-grant flow,
   plus `ListProjects` / MOTD behind graceful degradation.
 
 ## Design Decisions
 
-- **No `client-go` in core.** It lives only in the Phase 2 kubeconfig provider
+- **No `client-go` in core.** It lives only in the Phase 2b kubeconfig provider
   plugin (and an optional shared library), never in `pkg/kube`.
 - **No cluster data in core.** Cluster resolution is an embedder concern behind
   `ClusterResolver`.
 - **`kube` package naming.** Every `ClusterInfo` field is Kubernetes-API-server
   specific, so the package is named for the `kube` domain rather than a generic
   `cluster` name.
+
+## Resolved Open Questions
+
+The four open questions from issue #536 are resolved as follows. These shape
+Phases 2-4.
+
+### Q1 -- Command Placement
+
+Fold kube login into the existing auth group as
+`auth login <handler> --cluster <name>` (plus matching `auth logout`), rather
+than adding a top-level `login` command. The handler is the credential source
+(unchanged); `--cluster <name>` triggers the kube wiring. Without `--cluster`,
+`auth login` behaves exactly as before.
+
+### Q2 -- Handler Granularity
+
+Keep single-purpose handlers; do not build a branching meta-handler. Reuse the
+existing handlers (`gcp`, `entra`, `github`, and a future generic `oidc`
+handler) for OIDC clusters, and add exactly one `openshift` OAuth handler as a
+Phase 4 plugin for the bundled-OAuth case. Selection happens at the command
+level via `ClusterInfo.AuthType` plus the provider's `DetectAuthType`, not
+inside a handler.
+
+### Q3 -- Thin Command vs Embedder-Provided
+
+The kube wiring lives in core (so every embedder gets it) and delegates all
+`client-go` work to the Phase 2b kubeconfig provider over gRPC. The provider is
+auto-fetched on demand via the existing plugin `Fetcher`; if it cannot be
+fetched, core degrades gracefully to `auth token <handler> --exec-credential`
+for manual kubeconfig wiring (which already works without any plugin). The
+provider RPC surface is roughly `WriteKubeconfig`, `RemoveManagedEntries`,
+`GetCurrentContextServer`, `DetectAuthType`, `CheckAPIServerReachable`, and
+`Whoami`.
+
+### Q4 -- Token Cache
+
+Reuse the existing auth keyring `TokenCache`; do not add a kube-specific cache.
+The exec-credential path already reads from it, so a second cache would create
+two sources of truth. The Phase 2b provider stays stateless and never handles
+tokens. The resolved OIDC audience is folded into the cache-key scope dimension
+so audience-specific tokens are distinct entries. Kube logout clears the keyring
+(existing path) and additionally removes the managed kubeconfig entry.

--- a/docs/design/plugins.md
+++ b/docs/design/plugins.md
@@ -337,13 +337,13 @@ settings:
 
 ### Official Provider Auto-Resolution
 
-scafctl maintains a hardcoded registry of 10 official providers distributed as
+scafctl maintains a hardcoded registry of official providers distributed as
 external plugins. When a solution references one of these providers and it is
 not already registered (via `bundle.plugins` or a local plugin), scafctl
 transparently fetches the provider from the official catalog at runtime.
 
 **Official providers**: `directory`, `env`, `exec`, `git`, `github`, `hcl`,
-`identity`, `metadata`, `secret`, `sleep`
+`identity`, `kubeconfig`, `metadata`, `secret`, `sleep`
 
 **Resolution flow**:
 

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -179,7 +179,7 @@ type RootOptions struct {
 
 	// OfficialProviders overrides the default official provider registry used
 	// for auto-resolution. When nil and DisableOfficialProviders is false,
-	// the default registry (all 10 extracted first-party providers) is used.
+	// the default registry (all first-party providers) is used.
 	// Embedders can supply a custom registry via official.NewRegistryFrom to
 	// extend or replace the default set.
 	OfficialProviders *official.Registry

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -107,7 +107,7 @@ type Settings struct {
 	DisableOfficialCatalog bool `json:"disableOfficialCatalog,omitempty" yaml:"disableOfficialCatalog,omitempty" mapstructure:"disableOfficialCatalog" doc:"Disable the built-in official catalog"`
 
 	// DisableOfficialProviders prevents auto-resolution of official first-party
-	// providers (the 10 extracted providers published to ghcr.io/oakwood-commons).
+	// providers (published to ghcr.io/oakwood-commons).
 	// When true, providers must be either built-in or explicitly declared in
 	// bundle.plugins. Embedders can set this when their CLI should not
 	// auto-fetch providers from the scafctl community catalog.

--- a/pkg/kubeconfig/manager.go
+++ b/pkg/kubeconfig/manager.go
@@ -1,0 +1,251 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kubeconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
+)
+
+// Manager drives the kubeconfig provider from the host side. It mirrors
+// pkg/state.Manager but, because it is invoked by a command outside a solution
+// DAG, it resolves the provider itself: it first checks the registry and, on a
+// miss, fetches and registers the official kubeconfig provider on demand. The
+// manager owns any plugin clients it spawns and kills them on Close.
+//
+// The manager is not safe for concurrent use; a single command invocation drives
+// it sequentially and calls Close (typically deferred) when done.
+type Manager struct {
+	registry   *provider.Registry
+	clients    []*plugin.Client // spawned by ensure; killed on Close
+	registered []string         // provider names registered by ensure; unregistered on Close
+	binaryName string
+	resolved   provider.Provider // cached after the first successful ensure
+}
+
+// Option configures a Manager.
+type Option func(*Manager)
+
+// WithRegistry injects a provider registry. Tests use this to register a mock
+// kubeconfig provider so ensure resolves it without fetching. When omitted, the
+// manager creates its own registry and fetches the provider on demand.
+func WithRegistry(reg *provider.Registry) Option {
+	return func(m *Manager) {
+		m.registry = reg
+	}
+}
+
+// NewManager creates a kubeconfig manager. binaryName is baked into the
+// kubeconfig exec block (as exec_command) for write operations so embedders get
+// correct exec args; an empty binaryName falls back to settings.CliBinaryName.
+func NewManager(binaryName string, opts ...Option) *Manager {
+	if binaryName == "" {
+		binaryName = settings.CliBinaryName
+	}
+	m := &Manager{binaryName: binaryName}
+	for _, opt := range opts {
+		opt(m)
+	}
+	if m.registry == nil {
+		m.registry = provider.NewRegistry()
+	}
+	return m
+}
+
+// ensure resolves the kubeconfig provider, fetching and registering it on
+// demand when absent. All failures are wrapped as ErrProviderUnavailable so the
+// Phase 3 command can fall back to a static exec-credential kubeconfig.
+func (m *Manager) ensure(ctx context.Context) (provider.Provider, error) {
+	if m.resolved != nil {
+		return m.resolved, nil
+	}
+
+	// Already registered (e.g. a solution run pre-loaded it or a test injected a
+	// mock).
+	if prov, ok := m.registry.Get(ProviderName); ok {
+		if err := assertKubeconfigCapability(prov); err != nil {
+			return nil, err
+		}
+		m.resolved = prov
+		return prov, nil
+	}
+
+	// Fetch-then-register, modeled on autoResolveProviderByName.
+	officialReg := official.RegistryFromContext(ctx)
+	if officialReg == nil {
+		return nil, fmt.Errorf("%w: official registry not available in context", ErrProviderUnavailable)
+	}
+
+	entry, ok := officialReg.Get(ProviderName)
+	if !ok {
+		return nil, fmt.Errorf("%w: %q is not an official provider", ErrProviderUnavailable, ProviderName)
+	}
+
+	fetcher, err := prepare.BuildPluginFetcher(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("%w: build plugin fetcher: %w", ErrProviderUnavailable, err)
+	}
+
+	dep := entry.ToPluginDependency()
+	results, err := fetcher.FetchPlugins(ctx, []solution.PluginDependency{dep}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: fetch provider %q: %w", ErrProviderUnavailable, ProviderName, err)
+	}
+
+	pluginCfg := &plugin.ProviderConfig{
+		BinaryName: m.binaryName,
+	}
+	clientOpts := plugin.AuthClientOptsFromContext(ctx)
+	before := nameSet(m.registry.List())
+	clients, err := plugin.RegisterFetchedPlugins(ctx, m.registry, results, pluginCfg, clientOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("%w: register provider %q: %w", ErrProviderUnavailable, ProviderName, err)
+	}
+	m.clients = append(m.clients, clients...)
+	for _, name := range m.registry.List() {
+		if !before[name] {
+			m.registered = append(m.registered, name)
+		}
+	}
+
+	prov, ok := m.registry.Get(ProviderName)
+	if !ok {
+		return nil, fmt.Errorf("%w: provider %q not registered after fetch", ErrProviderUnavailable, ProviderName)
+	}
+	if err := assertKubeconfigCapability(prov); err != nil {
+		return nil, err
+	}
+	m.resolved = prov
+	return prov, nil
+}
+
+// WriteKubeconfig merges and writes a kubeconfig exec-credential entry. When
+// ExecCommand is empty it defaults to the manager's binary name so embedders get
+// correct kubeconfig exec args.
+func (m *Manager) WriteKubeconfig(ctx context.Context, in WriteInput) (WriteResult, error) {
+	if in.ExecCommand == "" {
+		in.ExecCommand = m.binaryName
+	}
+	result, err := m.execute(ctx, OperationWrite, in.toInputs())
+	if err != nil {
+		return WriteResult{}, err
+	}
+	return decodeOutput[WriteResult](result)
+}
+
+// RemoveEntry removes a kubeconfig cluster/context/user entry.
+func (m *Manager) RemoveEntry(ctx context.Context, in RemoveInput) (RemoveResult, error) {
+	result, err := m.execute(ctx, OperationRemove, in.toInputs())
+	if err != nil {
+		return RemoveResult{}, err
+	}
+	return decodeOutput[RemoveResult](result)
+}
+
+// CurrentServer reads the current server URL from a kubeconfig. It returns an
+// empty string when the provider reports the lookup did not succeed (for
+// example, no current-context or a missing kubeconfig).
+func (m *Manager) CurrentServer(ctx context.Context, in CurrentServerInput) (string, error) {
+	result, err := m.execute(ctx, OperationCurrentServer, in.toInputs())
+	if err != nil {
+		return "", err
+	}
+	out, err := decodeOutput[currentServerResult](result)
+	if err != nil {
+		return "", err
+	}
+	if !out.Success {
+		return "", nil
+	}
+	return out.Server, nil
+}
+
+// DetectAuthType probes a server to detect the authentication method.
+func (m *Manager) DetectAuthType(ctx context.Context, in DetectInput) (DetectResult, error) {
+	result, err := m.execute(ctx, OperationDetectAuthType, in.toInputs())
+	if err != nil {
+		return DetectResult{}, err
+	}
+	return decodeOutput[DetectResult](result)
+}
+
+// Reachable checks whether an API server is reachable.
+func (m *Manager) Reachable(ctx context.Context, in ReachableInput) (ReachableResult, error) {
+	result, err := m.execute(ctx, OperationReachable, in.toInputs())
+	if err != nil {
+		return ReachableResult{}, err
+	}
+	return decodeOutput[ReachableResult](result)
+}
+
+// Whoami runs a SelfSubjectReview to identify the token's subject.
+func (m *Manager) Whoami(ctx context.Context, in WhoamiInput) (WhoamiResult, error) {
+	result, err := m.execute(ctx, OperationWhoami, in.toInputs())
+	if err != nil {
+		return WhoamiResult{}, err
+	}
+	return decodeOutput[WhoamiResult](result)
+}
+
+// Close unregisters any providers the manager registered and kills any plugin
+// clients it spawned. Unregistering happens first so a caller-owned registry
+// (injected via WithRegistry) that outlives the manager is not left holding dead
+// wrappers that point at killed clients. It is safe to call multiple times and
+// on a manager that never spawned a client.
+func (m *Manager) Close() error {
+	for _, name := range m.registered {
+		m.registry.Unregister(name)
+	}
+	m.registered = nil
+	for _, c := range m.clients {
+		if c != nil {
+			c.Kill()
+		}
+	}
+	m.clients = nil
+	return nil
+}
+
+// nameSet builds a lookup set from a slice of provider names.
+func nameSet(names []string) map[string]bool {
+	set := make(map[string]bool, len(names))
+	for _, n := range names {
+		set[n] = true
+	}
+	return set
+}
+
+// execute resolves the provider, sets the operation discriminator, and runs the
+// provider with the kubeconfig execution mode.
+func (m *Manager) execute(ctx context.Context, op string, inputs map[string]any) (*provider.ExecutionResult, error) {
+	prov, err := m.ensure(ctx)
+	if err != nil {
+		return nil, err
+	}
+	inputs[inputOperation] = op
+	execCtx := provider.WithExecutionMode(ctx, provider.CapabilityKubeconfig)
+	result, err := provider.Execute(execCtx, prov, inputs)
+	if err != nil {
+		return nil, fmt.Errorf("kubeconfig: execute %s: %w", op, err)
+	}
+	return result, nil
+}
+
+// assertKubeconfigCapability verifies the resolved provider advertises
+// CapabilityKubeconfig.
+func assertKubeconfigCapability(prov provider.Provider) error {
+	for _, cap := range prov.Descriptor().Capabilities {
+		if cap == provider.CapabilityKubeconfig {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w: provider %q lacks CapabilityKubeconfig", ErrProviderUnavailable, ProviderName)
+}

--- a/pkg/kubeconfig/manager_test.go
+++ b/pkg/kubeconfig/manager_test.go
@@ -1,0 +1,312 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kubeconfig
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/official"
+	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
+)
+
+// stubProvider is a minimal provider whose capabilities are configurable, used
+// to exercise the capability-assertion path.
+type stubProvider struct {
+	caps []provider.Capability
+}
+
+func (s *stubProvider) Descriptor() *provider.Descriptor {
+	return &provider.Descriptor{
+		Name:         ProviderName,
+		APIVersion:   "v1",
+		Version:      semver.MustParse("1.0.0"),
+		Description:  "stub",
+		Capabilities: s.caps,
+		OutputSchemas: map[provider.Capability]*jsonschema.Schema{
+			provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+				"value": schemahelper.StringProp("value"),
+			}),
+		},
+	}
+}
+
+func (s *stubProvider) Execute(_ context.Context, _ any) (*provider.Output, error) {
+	return &provider.Output{Data: map[string]any{"success": true}}, nil
+}
+
+func registryWith(t *testing.T, p provider.Provider) *provider.Registry {
+	t.Helper()
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(p))
+	return reg
+}
+
+func TestManager_WriteKubeconfig(t *testing.T) {
+	t.Parallel()
+	mock := NewMockProvider()
+	m := NewManager("scafctl", WithRegistry(registryWith(t, mock)))
+
+	res, err := m.WriteKubeconfig(context.Background(), WriteInput{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+		ContextName: "prod-ctx",
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Success)
+	assert.Equal(t, "prod-ctx", res.ContextName)
+
+	call, ok := mock.LastCall()
+	require.True(t, ok)
+	assert.Equal(t, OperationWrite, call.Operation)
+	assert.Equal(t, "scafctl", call.Inputs["exec_command"])
+}
+
+func TestManager_WriteKubeconfig_BakesEmbedderBinaryName(t *testing.T) {
+	t.Parallel()
+	mock := NewMockProvider()
+	m := NewManager("mycli", WithRegistry(registryWith(t, mock)))
+
+	_, err := m.WriteKubeconfig(context.Background(), WriteInput{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+	})
+	require.NoError(t, err)
+
+	call, ok := mock.LastCall()
+	require.True(t, ok)
+	assert.Equal(t, "mycli", call.Inputs["exec_command"],
+		"embedder binary name must be baked into exec_command")
+}
+
+func TestManager_WriteKubeconfig_ExplicitExecCommandWins(t *testing.T) {
+	t.Parallel()
+	mock := NewMockProvider()
+	m := NewManager("mycli", WithRegistry(registryWith(t, mock)))
+
+	_, err := m.WriteKubeconfig(context.Background(), WriteInput{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+		ExecCommand: "explicit",
+	})
+	require.NoError(t, err)
+
+	call, _ := mock.LastCall()
+	assert.Equal(t, "explicit", call.Inputs["exec_command"])
+}
+
+func TestManager_RemoveEntry(t *testing.T) {
+	t.Parallel()
+	mock := &MockProvider{Remove: &RemoveResult{Removed: true}}
+	m := NewManager("scafctl", WithRegistry(registryWith(t, mock)))
+
+	res, err := m.RemoveEntry(context.Background(), RemoveInput{ClusterName: "prod"})
+	require.NoError(t, err)
+	assert.True(t, res.Success)
+	assert.True(t, res.Removed)
+	call, _ := mock.LastCall()
+	assert.Equal(t, OperationRemove, call.Operation)
+}
+
+func TestManager_CurrentServer(t *testing.T) {
+	t.Parallel()
+	mock := &MockProvider{Server: "https://api.example.com:6443"}
+	m := NewManager("scafctl", WithRegistry(registryWith(t, mock)))
+
+	server, err := m.CurrentServer(context.Background(), CurrentServerInput{ContextName: "prod"})
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.example.com:6443", server)
+	call, _ := mock.LastCall()
+	assert.Equal(t, OperationCurrentServer, call.Operation)
+}
+
+func TestManager_CurrentServer_NotSuccessReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	mock := &MockProvider{
+		ExecuteFunc: func(_ context.Context, _ string, _ map[string]any) (*provider.Output, error) {
+			return &provider.Output{Data: map[string]any{
+				"success": false,
+				"server":  "https://stale.example.com:6443",
+			}}, nil
+		},
+	}
+	m := NewManager("scafctl", WithRegistry(registryWith(t, mock)))
+
+	server, err := m.CurrentServer(context.Background(), CurrentServerInput{})
+	require.NoError(t, err)
+	assert.Empty(t, server, "a non-success lookup must not leak a stale server URL")
+}
+
+func TestManager_DetectAuthType(t *testing.T) {
+	t.Parallel()
+	mock := &MockProvider{Detect: &DetectResult{AuthType: kube.AuthTypeOIDC, OIDCIssuer: "https://issuer"}}
+	m := NewManager("scafctl", WithRegistry(registryWith(t, mock)))
+
+	res, err := m.DetectAuthType(context.Background(), DetectInput{Server: "https://api.example.com:6443"})
+	require.NoError(t, err)
+	assert.Equal(t, kube.AuthTypeOIDC, res.AuthType)
+	assert.Equal(t, "https://issuer", res.OIDCIssuer)
+}
+
+func TestManager_Reachable(t *testing.T) {
+	t.Parallel()
+	mock := &MockProvider{Reachable: &ReachableResult{Reachable: false, Status: 503}}
+	m := NewManager("scafctl", WithRegistry(registryWith(t, mock)))
+
+	res, err := m.Reachable(context.Background(), ReachableInput{Server: "https://api.example.com:6443"})
+	require.NoError(t, err)
+	assert.False(t, res.Reachable)
+	assert.Equal(t, 503, res.Status)
+}
+
+func TestManager_Whoami(t *testing.T) {
+	t.Parallel()
+	mock := &MockProvider{Whoami: &WhoamiResult{Username: "alice", Groups: []string{"dev"}, UID: "u1"}}
+	m := NewManager("scafctl", WithRegistry(registryWith(t, mock)))
+
+	res, err := m.Whoami(context.Background(), WhoamiInput{
+		Server: "https://api.example.com:6443",
+		Token:  "secret-token",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "alice", res.Username)
+	assert.Equal(t, []string{"dev"}, res.Groups)
+	assert.Equal(t, "u1", res.UID)
+
+	call, _ := mock.LastCall()
+	assert.Equal(t, "secret-token", call.Inputs["token"])
+}
+
+func TestManager_Ensure_ProviderUnavailableWithoutOfficialRegistry(t *testing.T) {
+	t.Parallel()
+	m := NewManager("scafctl") // empty internal registry, no official registry in ctx
+
+	_, err := m.Reachable(context.Background(), ReachableInput{Server: "https://api.example.com:6443"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProviderUnavailable)
+}
+
+func TestManager_Ensure_NotAnOfficialProvider(t *testing.T) {
+	t.Parallel()
+	m := NewManager("scafctl") // empty internal registry forces the fetch path
+
+	// Official registry present in context but without a kubeconfig entry.
+	officialReg := official.NewRegistryFrom([]official.Provider{
+		{Name: "env", CatalogRef: "env", DefaultVersion: "latest"},
+	})
+	ctx := official.WithRegistry(context.Background(), officialReg)
+
+	_, err := m.Reachable(ctx, ReachableInput{Server: "https://api.example.com:6443"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProviderUnavailable)
+	assert.Contains(t, err.Error(), "not an official provider")
+}
+
+func TestManager_Ensure_ProviderLacksCapability(t *testing.T) {
+	t.Parallel()
+	stub := &stubProvider{caps: []provider.Capability{provider.CapabilityFrom}}
+	m := NewManager("scafctl", WithRegistry(registryWith(t, stub)))
+
+	_, err := m.Reachable(context.Background(), ReachableInput{Server: "https://api.example.com:6443"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrProviderUnavailable)
+}
+
+func TestManager_Ensure_CachesResolvedProvider(t *testing.T) {
+	t.Parallel()
+	mock := NewMockProvider()
+	m := NewManager("scafctl", WithRegistry(registryWith(t, mock)))
+
+	_, err := m.Reachable(context.Background(), ReachableInput{Server: "https://a"})
+	require.NoError(t, err)
+	require.NotNil(t, m.resolved)
+
+	_, err = m.Reachable(context.Background(), ReachableInput{Server: "https://b"})
+	require.NoError(t, err)
+	assert.Len(t, mock.Calls, 2)
+}
+
+func TestManager_ExecuteError(t *testing.T) {
+	t.Parallel()
+	mock := &MockProvider{Err: errors.New("boom")}
+	m := NewManager("scafctl", WithRegistry(registryWith(t, mock)))
+
+	_, err := m.Reachable(context.Background(), ReachableInput{Server: "https://a"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestManager_Close_NoClients(t *testing.T) {
+	t.Parallel()
+	m := NewManager("scafctl", WithRegistry(provider.NewRegistry()))
+	assert.NoError(t, m.Close())
+	// Idempotent.
+	assert.NoError(t, m.Close())
+}
+
+func TestManager_Close_UnregistersRegisteredProviders(t *testing.T) {
+	t.Parallel()
+	// A caller-owned registry that outlives the manager must not be left holding
+	// providers this manager registered during ensure.
+	reg := registryWith(t, NewMockProvider())
+	m := NewManager("scafctl", WithRegistry(reg))
+	m.registered = []string{ProviderName}
+
+	require.NoError(t, m.Close())
+
+	_, ok := reg.Get(ProviderName)
+	assert.False(t, ok, "Close must unregister providers it registered")
+	assert.Nil(t, m.registered)
+
+	// Idempotent: a second Close does not panic and the provider stays gone.
+	require.NoError(t, m.Close())
+	_, ok = reg.Get(ProviderName)
+	assert.False(t, ok)
+}
+
+func TestManager_WriteKubeconfig_DefaultsContextToClusterName(t *testing.T) {
+	t.Parallel()
+	mock := NewMockProvider()
+	m := NewManager("scafctl", WithRegistry(registryWith(t, mock)))
+
+	res, err := m.WriteKubeconfig(context.Background(), WriteInput{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+	})
+	require.NoError(t, err)
+	assert.True(t, res.Success)
+	assert.Equal(t, "prod", res.ContextName,
+		"empty context name must default to the cluster name")
+}
+
+func TestNewManager_DefaultBinaryName(t *testing.T) {
+	t.Parallel()
+	m := NewManager("")
+	assert.Equal(t, "scafctl", m.binaryName)
+	assert.NotNil(t, m.registry)
+}
+
+func BenchmarkManager_Reachable(b *testing.B) {
+	mock := NewMockProvider()
+	reg := provider.NewRegistry()
+	_ = reg.Register(mock)
+	m := NewManager("scafctl", WithRegistry(reg))
+	ctx := context.Background()
+	in := ReachableInput{Server: "https://api.example.com:6443"}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := m.Reachable(ctx, in); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/kubeconfig/mock.go
+++ b/pkg/kubeconfig/mock.go
@@ -1,0 +1,161 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kubeconfig
+
+import (
+	"context"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/google/jsonschema-go/jsonschema"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
+)
+
+// MockCall records a single ExecuteProvider invocation for assertions.
+type MockCall struct {
+	// Operation is the value of the "operation" input field.
+	Operation string
+
+	// Inputs is the full input map passed to the provider.
+	Inputs map[string]any
+}
+
+// MockProvider is an in-process provider implementing CapabilityKubeconfig with
+// operation dispatch. Tests register it in a provider.Registry (via
+// WithRegistry) so the manager resolves it without fetching a plugin. It records
+// every call and returns configurable canned outputs.
+//
+// Outputs default to a JSON-serializable map (mirroring the real plugin gRPC
+// round-trip) so the manager's map-fallback decode path is exercised. Set
+// ExecuteFunc to fully override behavior, or Err to fail every operation.
+type MockProvider struct {
+	// ExecuteFunc, when set, fully overrides dispatch. op is the operation field.
+	ExecuteFunc func(ctx context.Context, op string, inputs map[string]any) (*provider.Output, error)
+
+	// Err, when set (and ExecuteFunc is nil), is returned for every operation.
+	Err error
+
+	// Canned outputs returned by the default dispatch. Nil fields fall back to
+	// echoing relevant input values with success=true.
+	Write     *WriteResult
+	Remove    *RemoveResult
+	Server    string
+	Detect    *DetectResult
+	Reachable *ReachableResult
+	Whoami    *WhoamiResult
+
+	// Calls records every invocation in order.
+	Calls []MockCall
+}
+
+// NewMockProvider returns a MockProvider with default success behavior.
+func NewMockProvider() *MockProvider {
+	return &MockProvider{}
+}
+
+// Descriptor implements provider.Provider.
+func (m *MockProvider) Descriptor() *provider.Descriptor {
+	return &provider.Descriptor{
+		Name:        ProviderName,
+		DisplayName: "Mock Kubeconfig",
+		Description: "Mock kubeconfig provider for testing",
+		APIVersion:  "v1",
+		Version:     semver.MustParse("1.0.0"),
+		Capabilities: []provider.Capability{
+			provider.CapabilityKubeconfig,
+		},
+		OutputSchemas: map[provider.Capability]*jsonschema.Schema{
+			provider.CapabilityKubeconfig: schemahelper.ObjectSchema([]string{"success"}, map[string]*jsonschema.Schema{
+				"success": schemahelper.BoolProp("Whether the operation succeeded"),
+			}),
+		},
+	}
+}
+
+// Execute implements provider.Provider. It records the call and dispatches on
+// the "operation" input field.
+func (m *MockProvider) Execute(ctx context.Context, input any) (*provider.Output, error) {
+	inputs, _ := input.(map[string]any)
+	op, _ := inputs[inputOperation].(string)
+	m.Calls = append(m.Calls, MockCall{Operation: op, Inputs: inputs})
+
+	if m.ExecuteFunc != nil {
+		return m.ExecuteFunc(ctx, op, inputs)
+	}
+	if m.Err != nil {
+		return nil, m.Err
+	}
+
+	switch op {
+	case OperationWrite:
+		ctxName, _ := inputs["context_name"].(string)
+		path, _ := inputs["kubeconfig_path"].(string)
+		if ctxName == "" {
+			// Mirror the real provider: an empty context name defaults to the
+			// cluster name.
+			ctxName, _ = inputs["cluster_name"].(string)
+		}
+		if m.Write != nil {
+			ctxName = m.Write.ContextName
+			path = m.Write.KubeconfigPath
+		}
+		return mapOutput(map[string]any{
+			"success":         true,
+			"context_name":    ctxName,
+			"kubeconfig_path": path,
+		}), nil
+	case OperationRemove:
+		removed := true
+		if m.Remove != nil {
+			removed = m.Remove.Removed
+		}
+		return mapOutput(map[string]any{
+			"success": true,
+			"removed": removed,
+		}), nil
+	case OperationCurrentServer:
+		return mapOutput(map[string]any{
+			"success": true,
+			"server":  m.Server,
+		}), nil
+	case OperationDetectAuthType:
+		out := map[string]any{"success": true}
+		if m.Detect != nil {
+			out["auth_type"] = string(m.Detect.AuthType)
+			out["oidc_issuer"] = m.Detect.OIDCIssuer
+			out["oauth_endpoint"] = m.Detect.OAuthEndpoint
+		}
+		return mapOutput(out), nil
+	case OperationReachable:
+		out := map[string]any{"success": true, "reachable": true, "status": 200}
+		if m.Reachable != nil {
+			out["reachable"] = m.Reachable.Reachable
+			out["status"] = m.Reachable.Status
+		}
+		return mapOutput(out), nil
+	case OperationWhoami:
+		out := map[string]any{"success": true}
+		if m.Whoami != nil {
+			out["username"] = m.Whoami.Username
+			out["groups"] = m.Whoami.Groups
+			out["uid"] = m.Whoami.UID
+		}
+		return mapOutput(out), nil
+	default:
+		return mapOutput(map[string]any{"success": false}), nil
+	}
+}
+
+// LastCall returns the most recent recorded call, or false when none exist.
+func (m *MockProvider) LastCall() (MockCall, bool) {
+	if len(m.Calls) == 0 {
+		return MockCall{}, false
+	}
+	return m.Calls[len(m.Calls)-1], true
+}
+
+func mapOutput(data map[string]any) *provider.Output {
+	return &provider.Output{Data: data}
+}

--- a/pkg/kubeconfig/types.go
+++ b/pkg/kubeconfig/types.go
@@ -1,0 +1,319 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package kubeconfig provides the host-side manager that drives the external
+// kubeconfig provider plugin. The provider carries all client-go/clientcmd work
+// so core never imports the heavy Kubernetes client packages. The manager
+// mirrors pkg/state: it resolves a provider with CapabilityKubeconfig from the
+// registry (fetching+registering it on demand), dispatches operations via an
+// "operation" input field, and unmarshals typed results from the provider
+// output.
+//
+// The provider is stateless: it receives a token only for the whoami operation
+// and never caches it.
+package kubeconfig
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+)
+
+// ProviderName is the registry name of the kubeconfig provider.
+const ProviderName = "kubeconfig"
+
+// Operation identifiers dispatched on the provider "operation" input field.
+const (
+	// OperationWrite merges and writes a kubeconfig exec auth entry.
+	OperationWrite = "kubeconfig_write"
+
+	// OperationRemove removes a kubeconfig cluster/context/user entry.
+	OperationRemove = "kubeconfig_remove"
+
+	// OperationCurrentServer reads the current server URL from a kubeconfig.
+	OperationCurrentServer = "current_server"
+
+	// OperationDetectAuthType probes a server to detect oauth vs oidc.
+	OperationDetectAuthType = "detect_auth_type"
+
+	// OperationReachable checks whether an API server is reachable.
+	OperationReachable = "reachable"
+
+	// OperationWhoami runs a SelfSubjectReview to identify the token's subject.
+	OperationWhoami = "whoami"
+)
+
+// inputOperation is the input field that selects the operation to perform.
+const inputOperation = "operation"
+
+// Sentinel errors returned by the manager.
+var (
+	// ErrProviderUnavailable indicates the kubeconfig provider could not be
+	// resolved, fetched, registered, or spawned. The Phase 3 command falls back
+	// to writing a static exec-credential kubeconfig when it sees this error.
+	ErrProviderUnavailable = errors.New("kubeconfig: provider unavailable")
+
+	// ErrInvalidOperation indicates the provider returned malformed output that
+	// could not be decoded into the expected result type.
+	ErrInvalidOperation = errors.New("kubeconfig: invalid operation output")
+)
+
+// WriteInput describes a kubeconfig_write operation. The host supplies
+// ExecCommand/ExecArgs so the embedder binary name is baked into the kubeconfig
+// exec block; the provider never hardcodes a binary name.
+type WriteInput struct {
+	// Server is the cluster API server URL.
+	Server string `json:"server" yaml:"server" doc:"Cluster API server URL" maxLength:"2048" example:"https://api.example.com:6443"`
+
+	// Audience is the OIDC audience/client ID the minted token must target.
+	Audience string `json:"audience,omitempty" yaml:"audience,omitempty" doc:"OIDC audience/client ID for the minted token" maxLength:"512"`
+
+	// ClusterName is the kubeconfig cluster entry name.
+	ClusterName string `json:"cluster_name" yaml:"cluster_name" doc:"Kubeconfig cluster entry name" maxLength:"253" example:"prod"`
+
+	// ContextName is the kubeconfig context entry name. Empty defaults to the
+	// cluster name inside the provider.
+	ContextName string `json:"context_name,omitempty" yaml:"context_name,omitempty" doc:"Kubeconfig context entry name" maxLength:"253"`
+
+	// UserName is the kubeconfig user entry name. Empty defaults to the cluster
+	// name inside the provider.
+	UserName string `json:"user_name,omitempty" yaml:"user_name,omitempty" doc:"Kubeconfig user entry name" maxLength:"253"`
+
+	// KubeconfigPath is the kubeconfig file path. Empty resolves the KUBECONFIG
+	// env var or ~/.kube/config inside the provider.
+	KubeconfigPath string `json:"kubeconfig_path,omitempty" yaml:"kubeconfig_path,omitempty" doc:"Kubeconfig file path; empty resolves KUBECONFIG or ~/.kube/config" maxLength:"4096"`
+
+	// ExecCommand is the command placed in the kubeconfig exec block (the host
+	// binary name).
+	ExecCommand string `json:"exec_command" yaml:"exec_command" doc:"Command for the kubeconfig exec block (host binary name)" maxLength:"4096" example:"scafctl"`
+
+	// ExecArgs are the static arguments for the kubeconfig exec block.
+	ExecArgs []string `json:"exec_args,omitempty" yaml:"exec_args,omitempty" doc:"Static arguments for the kubeconfig exec block" maxItems:"100"`
+
+	// InsecureSkipTLS disables API server TLS verification (development only).
+	InsecureSkipTLS bool `json:"insecure_skip_tls,omitempty" yaml:"insecure_skip_tls,omitempty" doc:"Disable API server TLS verification (development only)"`
+
+	// SetCurrentContext sets the written context as the current-context.
+	SetCurrentContext bool `json:"set_current_context,omitempty" yaml:"set_current_context,omitempty" doc:"Set the written context as current-context"`
+}
+
+func (in WriteInput) toInputs() map[string]any {
+	return map[string]any{
+		"server":              in.Server,
+		"audience":            in.Audience,
+		"cluster_name":        in.ClusterName,
+		"context_name":        in.ContextName,
+		"user_name":           in.UserName,
+		"kubeconfig_path":     in.KubeconfigPath,
+		"exec_command":        in.ExecCommand,
+		"exec_args":           in.ExecArgs,
+		"insecure_skip_tls":   in.InsecureSkipTLS,
+		"set_current_context": in.SetCurrentContext,
+	}
+}
+
+// WriteResult is the kubeconfig_write output.
+type WriteResult struct {
+	// Success reports whether the operation succeeded.
+	Success bool `json:"success" yaml:"success" doc:"Whether the operation succeeded"`
+
+	// ContextName is the name of the written (or merged) context.
+	ContextName string `json:"context_name" yaml:"context_name" doc:"Name of the written context"`
+
+	// KubeconfigPath is the resolved kubeconfig file path that was written.
+	KubeconfigPath string `json:"kubeconfig_path" yaml:"kubeconfig_path" doc:"Resolved kubeconfig file path that was written"`
+}
+
+// RemoveInput describes a kubeconfig_remove operation.
+type RemoveInput struct {
+	// ClusterName is the kubeconfig cluster entry name to remove.
+	ClusterName string `json:"cluster_name" yaml:"cluster_name" doc:"Kubeconfig cluster entry name to remove" maxLength:"253"`
+
+	// ContextName is the kubeconfig context entry name to remove.
+	ContextName string `json:"context_name,omitempty" yaml:"context_name,omitempty" doc:"Kubeconfig context entry name to remove" maxLength:"253"`
+
+	// UserName is the kubeconfig user entry name to remove.
+	UserName string `json:"user_name,omitempty" yaml:"user_name,omitempty" doc:"Kubeconfig user entry name to remove" maxLength:"253"`
+
+	// KubeconfigPath is the kubeconfig file path. Empty resolves the KUBECONFIG
+	// env var or ~/.kube/config inside the provider.
+	KubeconfigPath string `json:"kubeconfig_path,omitempty" yaml:"kubeconfig_path,omitempty" doc:"Kubeconfig file path; empty resolves KUBECONFIG or ~/.kube/config" maxLength:"4096"`
+}
+
+func (in RemoveInput) toInputs() map[string]any {
+	return map[string]any{
+		"cluster_name":    in.ClusterName,
+		"context_name":    in.ContextName,
+		"user_name":       in.UserName,
+		"kubeconfig_path": in.KubeconfigPath,
+	}
+}
+
+// RemoveResult is the kubeconfig_remove output.
+type RemoveResult struct {
+	// Success reports whether the operation succeeded.
+	Success bool `json:"success" yaml:"success" doc:"Whether the operation succeeded"`
+
+	// Removed reports whether a matching entry existed and was removed.
+	Removed bool `json:"removed" yaml:"removed" doc:"Whether a matching entry was removed"`
+}
+
+// CurrentServerInput describes a current_server operation.
+type CurrentServerInput struct {
+	// KubeconfigPath is the kubeconfig file path. Empty resolves the KUBECONFIG
+	// env var or ~/.kube/config inside the provider.
+	KubeconfigPath string `json:"kubeconfig_path,omitempty" yaml:"kubeconfig_path,omitempty" doc:"Kubeconfig file path; empty resolves KUBECONFIG or ~/.kube/config" maxLength:"4096"`
+
+	// ContextName is the context to read. Empty uses the current-context.
+	ContextName string `json:"context_name,omitempty" yaml:"context_name,omitempty" doc:"Context to read; empty uses the current-context" maxLength:"253"`
+}
+
+func (in CurrentServerInput) toInputs() map[string]any {
+	return map[string]any{
+		"kubeconfig_path": in.KubeconfigPath,
+		"context_name":    in.ContextName,
+	}
+}
+
+// currentServerResult is the current_server output.
+type currentServerResult struct {
+	Success bool   `json:"success" yaml:"success"`
+	Server  string `json:"server" yaml:"server"`
+}
+
+// DetectInput describes a detect_auth_type operation.
+type DetectInput struct {
+	// Server is the cluster API server URL to probe.
+	Server string `json:"server" yaml:"server" doc:"Cluster API server URL to probe" maxLength:"2048" example:"https://api.example.com:6443"`
+
+	// InsecureSkipTLS disables TLS verification while probing (development only).
+	InsecureSkipTLS bool `json:"insecure_skip_tls,omitempty" yaml:"insecure_skip_tls,omitempty" doc:"Disable TLS verification while probing (development only)"`
+}
+
+func (in DetectInput) toInputs() map[string]any {
+	return map[string]any{
+		"server":            in.Server,
+		"insecure_skip_tls": in.InsecureSkipTLS,
+	}
+}
+
+// DetectResult is the detect_auth_type output.
+type DetectResult struct {
+	// Success reports whether the probe completed.
+	Success bool `json:"success" yaml:"success" doc:"Whether the probe completed"`
+
+	// AuthType is the detected authentication method (auto/oauth/oidc).
+	AuthType kube.AuthType `json:"auth_type" yaml:"auth_type" doc:"Detected authentication method (auto/oauth/oidc)" example:"oidc"`
+
+	// OIDCIssuer is the discovered OIDC issuer URL, when AuthType is oidc.
+	OIDCIssuer string `json:"oidc_issuer,omitempty" yaml:"oidc_issuer,omitempty" doc:"Discovered OIDC issuer URL"`
+
+	// OAuthEndpoint is the discovered OAuth authorization endpoint, when
+	// AuthType is oauth.
+	OAuthEndpoint string `json:"oauth_endpoint,omitempty" yaml:"oauth_endpoint,omitempty" doc:"Discovered OAuth authorization endpoint"`
+}
+
+// ReachableInput describes a reachable operation.
+type ReachableInput struct {
+	// Server is the cluster API server URL to check.
+	Server string `json:"server" yaml:"server" doc:"Cluster API server URL to check" maxLength:"2048" example:"https://api.example.com:6443"`
+
+	// InsecureSkipTLS disables TLS verification while checking (development only).
+	InsecureSkipTLS bool `json:"insecure_skip_tls,omitempty" yaml:"insecure_skip_tls,omitempty" doc:"Disable TLS verification while checking (development only)"`
+}
+
+func (in ReachableInput) toInputs() map[string]any {
+	return map[string]any{
+		"server":            in.Server,
+		"insecure_skip_tls": in.InsecureSkipTLS,
+	}
+}
+
+// ReachableResult is the reachable output.
+type ReachableResult struct {
+	// Success reports whether the check completed.
+	Success bool `json:"success" yaml:"success" doc:"Whether the check completed"`
+
+	// Reachable reports whether the API server responded.
+	Reachable bool `json:"reachable" yaml:"reachable" doc:"Whether the API server responded"`
+
+	// Status is the HTTP status code returned by the health probe.
+	Status int `json:"status" yaml:"status" doc:"HTTP status code returned by the health probe" maximum:"599" example:"200"`
+}
+
+// WhoamiInput describes a whoami operation. The token is supplied only for this
+// operation and is never cached by the provider.
+type WhoamiInput struct {
+	// Server is the cluster API server URL.
+	Server string `json:"server" yaml:"server" doc:"Cluster API server URL" maxLength:"2048" example:"https://api.example.com:6443"`
+
+	// Token is the bearer token used for the SelfSubjectReview call.
+	Token string `json:"token" yaml:"token" doc:"Bearer token for the SelfSubjectReview call" maxLength:"8192"`
+
+	// Audience is the OIDC audience the token targets.
+	Audience string `json:"audience,omitempty" yaml:"audience,omitempty" doc:"OIDC audience the token targets" maxLength:"512"`
+
+	// InsecureSkipTLS disables TLS verification (development only).
+	InsecureSkipTLS bool `json:"insecure_skip_tls,omitempty" yaml:"insecure_skip_tls,omitempty" doc:"Disable TLS verification (development only)"`
+}
+
+func (in WhoamiInput) toInputs() map[string]any {
+	return map[string]any{
+		"server":            in.Server,
+		"token":             in.Token,
+		"audience":          in.Audience,
+		"insecure_skip_tls": in.InsecureSkipTLS,
+	}
+}
+
+// WhoamiResult is the whoami output.
+type WhoamiResult struct {
+	// Success reports whether the review completed.
+	Success bool `json:"success" yaml:"success" doc:"Whether the review completed"`
+
+	// Username is the authenticated subject's username.
+	Username string `json:"username" yaml:"username" doc:"Authenticated subject's username"`
+
+	// Groups are the subject's group memberships.
+	Groups []string `json:"groups,omitempty" yaml:"groups,omitempty" doc:"Subject's group memberships" maxItems:"1000"`
+
+	// UID is the subject's unique identifier.
+	UID string `json:"uid,omitempty" yaml:"uid,omitempty" doc:"Subject's unique identifier"`
+}
+
+// decodeOutput decodes a provider execution result into the typed result T.
+// It accepts a direct typed value (returned by in-process providers and mocks)
+// and falls back to a JSON round-trip of the output data (returned after a
+// plugin gRPC round-trip serializes the data to a map). Malformed output is
+// reported as ErrInvalidOperation.
+func decodeOutput[T any](result *provider.ExecutionResult) (T, error) {
+	var out T
+	if result == nil {
+		return out, fmt.Errorf("%w: nil execution result", ErrInvalidOperation)
+	}
+	if result.Output.Data == nil {
+		return out, fmt.Errorf("%w: nil output data", ErrInvalidOperation)
+	}
+
+	switch typed := result.Output.Data.(type) {
+	case *T:
+		if typed == nil {
+			return out, fmt.Errorf("%w: nil typed output", ErrInvalidOperation)
+		}
+		return *typed, nil
+	case T:
+		return typed, nil
+	}
+
+	b, err := json.Marshal(result.Output.Data)
+	if err != nil {
+		return out, fmt.Errorf("%w: marshal output: %w", ErrInvalidOperation, err)
+	}
+	if err := json.Unmarshal(b, &out); err != nil {
+		return out, fmt.Errorf("%w: unmarshal output: %w", ErrInvalidOperation, err)
+	}
+	return out, nil
+}

--- a/pkg/kubeconfig/types_test.go
+++ b/pkg/kubeconfig/types_test.go
@@ -1,0 +1,146 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kubeconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+)
+
+func TestWriteInput_ToInputs(t *testing.T) {
+	t.Parallel()
+	in := WriteInput{
+		Server:            "https://api.example.com:6443",
+		Audience:          "aud",
+		ClusterName:       "prod",
+		ContextName:       "ctx",
+		UserName:          "user",
+		KubeconfigPath:    "/tmp/kubeconfig",
+		ExecCommand:       "scafctl",
+		ExecArgs:          []string{"auth", "token"},
+		InsecureSkipTLS:   true,
+		SetCurrentContext: true,
+	}
+	got := in.toInputs()
+	assert.Equal(t, "https://api.example.com:6443", got["server"])
+	assert.Equal(t, "prod", got["cluster_name"])
+	assert.Equal(t, "scafctl", got["exec_command"])
+	assert.Equal(t, []string{"auth", "token"}, got["exec_args"])
+	assert.Equal(t, true, got["insecure_skip_tls"])
+	assert.Equal(t, true, got["set_current_context"])
+}
+
+func TestDecodeOutput_MapPath(t *testing.T) {
+	t.Parallel()
+	result := &provider.ExecutionResult{
+		Output: provider.Output{Data: map[string]any{
+			"success":         true,
+			"context_name":    "prod-ctx",
+			"kubeconfig_path": "/tmp/kubeconfig",
+		}},
+	}
+	got, err := decodeOutput[WriteResult](result)
+	require.NoError(t, err)
+	assert.True(t, got.Success)
+	assert.Equal(t, "prod-ctx", got.ContextName)
+	assert.Equal(t, "/tmp/kubeconfig", got.KubeconfigPath)
+}
+
+func TestDecodeOutput_PointerPath(t *testing.T) {
+	t.Parallel()
+	want := &WriteResult{Success: true, ContextName: "prod-ctx"}
+	result := &provider.ExecutionResult{Output: provider.Output{Data: want}}
+	got, err := decodeOutput[WriteResult](result)
+	require.NoError(t, err)
+	assert.Equal(t, *want, got)
+}
+
+func TestDecodeOutput_ValuePath(t *testing.T) {
+	t.Parallel()
+	want := WriteResult{Success: true, ContextName: "prod-ctx"}
+	result := &provider.ExecutionResult{Output: provider.Output{Data: want}}
+	got, err := decodeOutput[WriteResult](result)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestDecodeOutput_NilTypedPointer(t *testing.T) {
+	t.Parallel()
+	var nilPtr *WriteResult
+	result := &provider.ExecutionResult{Output: provider.Output{Data: nilPtr}}
+	_, err := decodeOutput[WriteResult](result)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidOperation)
+}
+
+func TestDecodeOutput_NilResult(t *testing.T) {
+	t.Parallel()
+	_, err := decodeOutput[WriteResult](nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidOperation)
+}
+
+func TestDecodeOutput_NilData(t *testing.T) {
+	t.Parallel()
+	result := &provider.ExecutionResult{Output: provider.Output{Data: nil}}
+	_, err := decodeOutput[WriteResult](result)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidOperation)
+}
+
+func TestDecodeOutput_Unmarshalable(t *testing.T) {
+	t.Parallel()
+	// A channel cannot be marshaled to JSON, forcing the marshal error path.
+	result := &provider.ExecutionResult{Output: provider.Output{Data: make(chan int)}}
+	_, err := decodeOutput[WriteResult](result)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidOperation)
+}
+
+func TestDecodeOutput_DetectResultAuthType(t *testing.T) {
+	t.Parallel()
+	result := &provider.ExecutionResult{
+		Output: provider.Output{Data: map[string]any{
+			"success":   true,
+			"auth_type": "oidc",
+		}},
+	}
+	got, err := decodeOutput[DetectResult](result)
+	require.NoError(t, err)
+	assert.Equal(t, kube.AuthTypeOIDC, got.AuthType)
+}
+
+func BenchmarkWriteInput_ToInputs(b *testing.B) {
+	in := WriteInput{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+		ExecCommand: "scafctl",
+		ExecArgs:    []string{"auth", "token"},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = in.toInputs()
+	}
+}
+
+func BenchmarkDecodeOutput_MapPath(b *testing.B) {
+	result := &provider.ExecutionResult{
+		Output: provider.Output{Data: map[string]any{
+			"success":         true,
+			"context_name":    "prod-ctx",
+			"kubeconfig_path": "/tmp/kubeconfig",
+		}},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := decodeOutput[WriteResult](result); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/mcp/tools_plugin_test.go
+++ b/pkg/mcp/tools_plugin_test.go
@@ -116,8 +116,8 @@ func TestHandleListOfficialProviders(t *testing.T) {
 		var items []officialProviderItem
 		require.NoError(t, json.Unmarshal([]byte(text), &items))
 
-		// Should contain the 10 default official providers
-		assert.Len(t, items, 10)
+		// Should contain all the default official providers
+		assert.Len(t, items, len(official.DefaultProviders()))
 
 		// Verify they are sorted alphabetically
 		names := make([]string, len(items))

--- a/pkg/provider/official/listing_test.go
+++ b/pkg/provider/official/listing_test.go
@@ -44,7 +44,7 @@ func TestListItems_DefaultRegistry(t *testing.T) {
 	ctx := WithRegistry(context.Background(), reg)
 
 	items := ListItems(ctx)
-	assert.Len(t, items, 10)
+	assert.Len(t, items, len(DefaultProviders()))
 
 	for _, item := range items {
 		assert.Equal(t, "official", item.Source)

--- a/pkg/provider/official/official.go
+++ b/pkg/provider/official/official.go
@@ -53,8 +53,8 @@ type Provider struct {
 	Description string `json:"description,omitempty" yaml:"description,omitempty" doc:"Human-readable summary of the provider"`
 }
 
-// defaultProviders is the canonical list of all 10 extracted first-party
-// providers. Sorted alphabetically by name.
+// defaultProviders is the canonical list of all first-party providers that the
+// runtime can auto-fetch. Sorted alphabetically by name.
 //
 // DefaultVersion is "latest" so the catalog resolver picks the newest
 // available version. This avoids hard-coding a concrete semver that must
@@ -71,6 +71,7 @@ var defaultProviders = []Provider{
 	{Name: "github", CatalogRef: "github", DefaultVersion: "latest", Description: "Interact with the GitHub API (repos, issues, PRs, releases, and more)"},
 	{Name: "hcl", CatalogRef: "hcl", DefaultVersion: "latest", Description: "Parse and evaluate HCL/Terraform configuration files"},
 	{Name: "identity", CatalogRef: "identity", DefaultVersion: "latest", Description: "Retrieve authenticated identity claims and token metadata"},
+	{Name: "kubeconfig", CatalogRef: "kubeconfig", DefaultVersion: "latest", Description: "Write and manage kubeconfig exec-credential entries and probe cluster auth"},
 	{Name: "metadata", CatalogRef: "metadata", DefaultVersion: "latest", Description: "Access runtime metadata such as OS, architecture, and build info"},
 	{Name: "secret", CatalogRef: "secret", DefaultVersion: "latest", Description: "Store and retrieve encrypted secrets using the local credential store"},
 	{Name: "sleep", CatalogRef: "sleep", DefaultVersion: "latest", Description: "Pause execution for a specified duration"},
@@ -82,7 +83,7 @@ type Registry struct {
 }
 
 // NewRegistry returns the default official provider registry containing
-// all 10 extracted first-party providers.
+// all first-party providers available for auto-fetch.
 func NewRegistry() *Registry {
 	return NewRegistryFrom(defaultProviders)
 }
@@ -107,7 +108,7 @@ func NewRegistryFrom(providers []Provider) *Registry {
 	return &Registry{providers: m}
 }
 
-// DefaultProviders returns a copy of the 10 official provider entries.
+// DefaultProviders returns a copy of the official provider entries.
 // Embedders can append their own entries and pass the result to
 // NewRegistryFrom to extend rather than replace the defaults.
 func DefaultProviders() []Provider {

--- a/pkg/provider/official/official_test.go
+++ b/pkg/provider/official/official_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewRegistry_Contains10Providers(t *testing.T) {
+func TestNewRegistry_ContainsAllProviders(t *testing.T) {
 	r := NewRegistry()
-	assert.Equal(t, 10, r.Len())
+	assert.Equal(t, len(DefaultProviders()), r.Len())
 }
 
 func TestNewRegistry_AllNamesPresent(t *testing.T) {
@@ -21,7 +21,7 @@ func TestNewRegistry_AllNamesPresent(t *testing.T) {
 
 	expected := []string{
 		"directory", "env", "exec", "git", "github", "hcl",
-		"identity", "metadata", "secret", "sleep",
+		"identity", "kubeconfig", "metadata", "secret", "sleep",
 	}
 	assert.Equal(t, expected, r.Names())
 }
@@ -130,7 +130,7 @@ func TestDefaultProviders_ReturnsCopy(t *testing.T) {
 }
 
 func TestDefaultProviders_Count(t *testing.T) {
-	assert.Equal(t, 10, len(DefaultProviders()))
+	assert.Equal(t, NewRegistry().Len(), len(DefaultProviders()))
 }
 
 func TestDefaultProviders_ExtendPattern(t *testing.T) {
@@ -139,7 +139,7 @@ func TestDefaultProviders_ExtendPattern(t *testing.T) {
 	)
 
 	r := NewRegistryFrom(extended)
-	assert.Equal(t, 11, r.Len())
+	assert.Equal(t, len(extended), r.Len())
 	assert.True(t, r.Has("exec"))
 	assert.True(t, r.Has("aws"))
 }
@@ -198,7 +198,7 @@ func TestRegistry_Len(t *testing.T) {
 		providers []Provider
 		want      int
 	}{
-		{name: "default", providers: DefaultProviders(), want: 10},
+		{name: "default", providers: DefaultProviders(), want: len(DefaultProviders())},
 		{name: "empty", providers: nil, want: 0},
 		{name: "custom", providers: []Provider{{Name: "a"}, {Name: "b"}}, want: 2},
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -35,6 +35,13 @@ const (
 	// This capability is defined in scafctl (not the SDK) because state is an application-level
 	// concern that external plugin providers can also implement.
 	CapabilityState Capability = "state"
+
+	// CapabilityKubeconfig signals that a provider can perform kubeconfig and cluster
+	// operations (write/remove kubeconfig entries, detect auth type, check reachability,
+	// whoami). Providers with this capability dispatch on an "operation" input field.
+	// This capability is defined in scafctl (not the SDK) because kubeconfig wiring is an
+	// application-level concern that external plugin providers can also implement.
+	CapabilityKubeconfig Capability = "kubeconfig"
 )
 
 // Contact represents maintainer contact information.
@@ -54,7 +61,7 @@ func ValidateDescriptor(desc *Descriptor) error {
 	var localCaps []Capability
 	var sdkCaps []Capability
 	for _, cap := range desc.Capabilities {
-		if cap == CapabilityState {
+		if isScafctlCapability(cap) {
 			localCaps = append(localCaps, cap)
 		} else {
 			sdkCaps = append(sdkCaps, cap)
@@ -82,7 +89,7 @@ func ValidateDescriptor(desc *Descriptor) error {
 		if !exists {
 			return fmt.Errorf("missing output schema for capability %q", cap)
 		}
-		requiredFields := stateCapabilityRequiredFields()
+		requiredFields := scafctlCapabilityRequiredFields(cap)
 		for fieldName, expectedType := range requiredFields {
 			if schema == nil || schema.Properties == nil {
 				return fmt.Errorf("capability %q requires output field %q", cap, fieldName)
@@ -100,8 +107,16 @@ func ValidateDescriptor(desc *Descriptor) error {
 	return nil
 }
 
-// stateCapabilityRequiredFields returns the required output fields for CapabilityState.
-func stateCapabilityRequiredFields() map[string]string {
+// isScafctlCapability reports whether the capability is a scafctl-defined capability
+// (not known to the SDK) that requires local validation.
+func isScafctlCapability(c Capability) bool {
+	return c == CapabilityState || c == CapabilityKubeconfig
+}
+
+// scafctlCapabilityRequiredFields returns the required output fields for a
+// scafctl-defined capability. Every scafctl capability must report a boolean
+// "success" field so callers can detect operation outcome uniformly.
+func scafctlCapabilityRequiredFields(_ Capability) map[string]string {
 	return map[string]string{
 		"success": "boolean",
 	}
@@ -109,7 +124,7 @@ func stateCapabilityRequiredFields() map[string]string {
 
 // IsCapabilityValid checks if the capability is valid, including scafctl-specific capabilities.
 func IsCapabilityValid(c Capability) bool {
-	if c == CapabilityState {
+	if isScafctlCapability(c) {
 		return true
 	}
 	return c.IsValid()

--- a/pkg/provider/registry_test.go
+++ b/pkg/provider/registry_test.go
@@ -918,6 +918,105 @@ func TestValidateDescriptor_CapabilityState(t *testing.T) {
 	}
 }
 
+func TestValidateDescriptor_CapabilityKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		desc    *Descriptor
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name: "valid kubeconfig capability",
+			desc: &Descriptor{
+				Name:         "kubeconfig",
+				APIVersion:   "v1",
+				Version:      semver.MustParse("1.0.0"),
+				Description:  "Kubeconfig provider",
+				Capabilities: []Capability{CapabilityKubeconfig},
+				Schema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"operation": {Type: "string"},
+					},
+				},
+				OutputSchemas: map[Capability]*jsonschema.Schema{
+					CapabilityKubeconfig: {
+						Type: "object",
+						Properties: map[string]*jsonschema.Schema{
+							"success": {Type: "boolean"},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "missing output schema for kubeconfig",
+			desc: &Descriptor{
+				Name:         "kubeconfig",
+				APIVersion:   "v1",
+				Version:      semver.MustParse("1.0.0"),
+				Description:  "Kubeconfig provider",
+				Capabilities: []Capability{CapabilityKubeconfig},
+				Schema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"operation": {Type: "string"},
+					},
+				},
+				OutputSchemas: map[Capability]*jsonschema.Schema{},
+			},
+			wantErr: true,
+			errMsg:  "missing output schema",
+		},
+		{
+			name: "kubeconfig output schema missing success field",
+			desc: &Descriptor{
+				Name:         "kubeconfig",
+				APIVersion:   "v1",
+				Version:      semver.MustParse("1.0.0"),
+				Description:  "Kubeconfig provider",
+				Capabilities: []Capability{CapabilityKubeconfig},
+				Schema: &jsonschema.Schema{
+					Type: "object",
+					Properties: map[string]*jsonschema.Schema{
+						"operation": {Type: "string"},
+					},
+				},
+				OutputSchemas: map[Capability]*jsonschema.Schema{
+					CapabilityKubeconfig: {
+						Type:       "object",
+						Properties: map[string]*jsonschema.Schema{},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "requires output field",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateDescriptor(tt.desc)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIsCapabilityValid_Kubeconfig(t *testing.T) {
+	t.Parallel()
+	assert.True(t, IsCapabilityValid(CapabilityKubeconfig))
+	assert.True(t, IsCapabilityValid(CapabilityState))
+}
+
 func TestValidateDescriptor_DoesNotMutateCapabilities(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Introduce in-core scaffolding for first-class Kubernetes/OpenShift auth (Phase 2a). Adds a kubeconfig provider capability and a host-side driver that lets handlers write and manage kubeconfig exec-credential entries and probe cluster auth, without pulling client-go into core.

- Add CapabilityKubeconfig provider capability requiring a boolean "success" output field; generalize validation via isScafctlCapability and scafctlCapabilityRequiredFields
- Add pkg/kubeconfig package: typed six-operation contract (kubeconfig_write, kubeconfig_remove, current_server, detect_auth_type, reachable, whoami), a host-side Manager, and a mock provider
- Register kubeconfig as an official auto-fetch provider
- Make official provider count references count-agnostic in docs and code
- Update design docs (kubernetes-auth Phase 2a/2b split, plugins list) and add the kubeconfig provider implementation plan
- Add unit tests and benchmarks for the capability and manager

Relates to #536