### PR TITLE
feat(test)!: remove render-defaults builtin and merge test files/services

### DIFF
--- a/docs/design/functional-testing.md
+++ b/docs/design/functional-testing.md
@@ -338,7 +338,7 @@ config:
 config:
   skipBuiltins:
     - resolve-defaults
-    - render-defaults
+    - lint
 ~~~
 
 | Field | Type | Default | Description |
@@ -370,8 +370,10 @@ When `testing.config` appears in multiple compose files:
 | `setup` | Appended in compose-file order (first file's steps run first). This is a new merge strategy distinct from the existing reject-duplicates and union patterns |
 | `cleanup` | Appended in compose-file order (first file's steps run first) |
 | `env` | Merged map; last compose file wins on key conflict |
+| `files` | Appended in compose-file order, deduplicated (first-seen wins) |
+| `services` | Appended in compose-file order; duplicate service names across files are **rejected** with an error |
 
-Compose-file order affects `testing.config.setup`, `testing.config.cleanup`, and `testing.config.env` merge ordering but does **not** affect test execution order. Tests from all compose files are merged into a single map and executed alphabetically (see [Test Execution Ordering](#test-execution-ordering)).
+Compose-file order affects `testing.config.setup`, `testing.config.cleanup`, `testing.config.env`, `testing.config.files`, and `testing.config.services` merge ordering but does **not** affect test execution order. Tests from all compose files are merged into a single map and executed alphabetically (see [Test Execution Ordering](#test-execution-ordering)).
 
 `spec.testing.cases` entries are merged by name using the **reject-duplicates** strategy (same as resolvers and actions). If two compose files define a test with the same name, the compose merge fails with an error.
 
@@ -641,7 +643,6 @@ Every solution automatically receives builtin tests unless `testing.config.skipB
 | `builtin:parse` | (internal) | Solution YAML parses without errors |
 | `builtin:lint` | `lint` | No lint errors (warnings allowed) |
 | `builtin:resolve-defaults` | `run resolver` | All resolvers resolve with default values |
-| `builtin:render-defaults` | `render solution` | Render succeeds with default values |
 
 Builtins run before user-defined tests. By default, if a builtin fails, user-defined tests still run (they are independent). Use `--fail-fast` to stop remaining tests for that solution on first failure.
 
@@ -875,7 +876,7 @@ This ensures init scripts cannot modify source files.
 
 Tests execute in a deterministic order:
 
-1. **Builtin tests** run first, in alphabetical order (`builtin:lint`, `builtin:parse`, `builtin:render-defaults`, `builtin:resolve-defaults`)
+1. **Builtin tests** run first, in alphabetical order (`builtin:lint`, `builtin:parse`, `builtin:resolve-defaults`)
 2. **User-defined tests** run next, in alphabetical order by test name
 3. **Template tests** (names starting with `_`) are never executed
 
@@ -1058,13 +1059,12 @@ SOLUTION             TEST                        STATUS   DURATION
 terraform-scaffold   builtin:parse               PASS     1ms
 terraform-scaffold   builtin:lint                PASS     45ms
 terraform-scaffold   builtin:resolve-defaults    PASS     18ms
-terraform-scaffold   builtin:render-defaults     PASS     22ms
 terraform-scaffold   renders-dev-defaults        PASS     12ms
 terraform-scaffold   renders-prod-override       PASS     15ms
 terraform-scaffold   rejects-invalid-env         PASS     8ms
 terraform-scaffold   temporarily-disabled        SKIP     -
 
-7 passed, 0 failed, 0 errors, 1 skipped (121ms)
+6 passed, 0 failed, 0 errors, 1 skipped (121ms)
 ~~~
 
 In verbose mode (`-v`), passing tests show assertion counts:
@@ -1365,7 +1365,7 @@ const (
 ### Additions to Existing Types
 
 - `pkg/solution/spec.go`: Has `Testing *soltesting.TestSuite` field on `Spec`. `HasTests()` and `HasTestConfig()` delegate to `Testing.HasCases()` and `Testing.HasConfig()`
-- `pkg/solution/bundler/compose.go`: `composePart` has `Testing *soltesting.TestSuite` field. Compose merges `spec.testing.cases` (by name, reject duplicates) and `spec.testing.config` (`skipBuiltins`: true-wins for bool / union for lists; `env`: merged map, last-file-wins on conflict; `setup`/`cleanup`: appended in compose-file order)
+- `pkg/solution/bundler/compose.go`: `composePart` has `Testing *soltesting.TestSuite` field. Compose merges `spec.testing.cases` (by name, reject duplicates) and `spec.testing.config` (`skipBuiltins`: true-wins for bool / union for lists; `env`: merged map, last-file-wins on conflict; `setup`/`cleanup`: appended in compose-file order; `files`: appended and deduplicated first-seen-wins; `services`: appended with duplicate names rejected)
 - `pkg/solution/bundler/discover.go`: Add `TestInclude` discovery source; scan `spec.testing.cases[*].files` entries
 
 ---
@@ -1493,7 +1493,7 @@ then outputs skeleton test YAML to stdout. Unlike `-o test` (which captures actu
 `test init` generates a starting point before you run anything.
 
 **Generated test categories:**
-- Smoke tests: `resolve-defaults`, `render-defaults`, `lint`
+- Smoke tests: `resolve-defaults`, `lint`
 - Per-resolver tests: `resolver-<name>` with non-null assertions
 - Validation failure tests: `resolver-<name>-invalid` with `expectFailure: true`
 - Per-action tests: `action-<name>` with provider tags

--- a/docs/tutorials/functional-testing.md
+++ b/docs/tutorials/functional-testing.md
@@ -87,9 +87,8 @@ my-solution    run-basic                 PASS     8ms
 ```
 
 > [!NOTE]
-> The builtin tests (`builtin:parse`, `builtin:lint`, `builtin:resolve-defaults`) run automatically.
-> Solutions without a `workflow` section will also see a `builtin:render-defaults` test that fails
-> since `render solution` requires a workflow. This is expected for resolver-only solutions.
+> The builtin tests (`builtin:parse`, `builtin:lint`, `builtin:resolve-defaults`) run automatically
+> for every solution.
 
 Each test specifies a `command` (the scafctl subcommand to run) and one or more
 `assertions` to validate the output. The runner automatically injects
@@ -792,7 +791,7 @@ config:
 config:
   skipBuiltins:
     - resolve-defaults
-    - render-defaults
+    - lint
 ```
 
 ---
@@ -981,6 +980,8 @@ When `testing.config` appears in multiple compose files:
 | `skipBuiltins` (list) | Unioned (deduplicated) |
 | `setup` / `cleanup` | Appended in compose-file order |
 | `env` | Merged map; last compose file wins on key conflict |
+| `files` | Appended in compose-file order, deduplicated (first-seen wins) |
+| `services` | Appended in compose-file order; duplicate service names are rejected with an error |
 
 ---
 
@@ -1272,14 +1273,13 @@ The sandbox copies files relative to the working directory, so test `files` entr
 
 ## Builtin Tests
 
-By default, four builtin tests run for every solution:
+By default, three builtin tests run for every solution:
 
 | Name | Description |
 |------|-------------|
 | `builtin:parse` | Validates YAML parsing |
 | `builtin:lint` | Runs lint rules (warnings OK) |
 | `builtin:resolve-defaults` | Resolves with default parameters |
-| `builtin:render-defaults` | Renders with default parameters |
 
 Builtins run before user-defined tests. Skip all builtins:
 
@@ -1635,7 +1635,6 @@ The command analyzes your solution and generates:
 | Test Category | What It Creates |
 |---------------|-----------------|
 | **Smoke tests** | `resolve-defaults` — verifies all resolvers resolve with defaults |
-| | `render-defaults` — verifies the solution renders with defaults |
 | | `lint` — verifies the solution has no lint errors |
 | **Per-resolver tests** | `resolver-<name>` — verifies each resolver produces non-null output |
 | **Validation failure tests** | `resolver-<name>-invalid` — verifies resolvers with validation rules reject invalid input (`expectFailure: true`) |
@@ -1695,15 +1694,6 @@ testing:
         tags:
             - smoke
             - lint
-        exitCode: 0
-    render-defaults:
-        description: Verify solution renders with default values
-        command:
-            - render
-            - solution
-        tags:
-            - smoke
-            - render
         exitCode: 0
     resolve-defaults:
         description: Verify all resolvers resolve with default values

--- a/examples/providers/file-conflict-strategies.yaml
+++ b/examples/providers/file-conflict-strategies.yaml
@@ -151,9 +151,6 @@ spec:
               # Never overwrite existing contributing guide
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       basic-run:
         description: Verify solution runs successfully

--- a/examples/solutions/output-dir/solution.yaml
+++ b/examples/solutions/output-dir/solution.yaml
@@ -114,7 +114,7 @@ spec:
   # ===========================================================================
   testing:
     config:
-      skipBuiltins: [render-defaults, resolve-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       resolver-basic:

--- a/examples/solutions/scaffold-demo/README.md
+++ b/examples/solutions/scaffold-demo/README.md
@@ -20,7 +20,6 @@ For this solution, `test init` produces:
 | Test | Description |
 |------|-------------|
 | `lint` | Verify solution has no lint errors |
-| `render-defaults` | Verify solution renders with default values |
 | `resolve-defaults` | Verify all resolvers resolve with default values |
 | `resolver-language` | Verify resolver "language" produces expected output |
 | `resolver-language-invalid` | Verify language validation rejects bad input |

--- a/examples/solutions/tested-solution/README.md
+++ b/examples/solutions/tested-solution/README.md
@@ -15,8 +15,8 @@ Demonstrates functional testing features in scafctl.
 | Multiple templates | `_render-base`, `_resolver-base` |
 | Tags | `tagged-integration`, `render-basic` (smoke), `lint-clean` |
 | Per-test `env` | `env-per-test` |
-| Suite-level `testConfig.env` | `testConfig.env.TEST_MODE` |
-| `testConfig.skipBuiltins` (list) | Skips `resolve-defaults` and `render-defaults` |
+| Suite-level `spec.testing.config.env` | `spec.testing.config.env.TEST_MODE` |
+| `spec.testing.config.skipBuiltins` (list) | Skips `resolve-defaults` and `lint` |
 | Init / Cleanup steps | `init-cleanup` |
 | `expectFailure` | `expect-failure` |
 | Per-test `timeout` | `timeout-test` |

--- a/examples/solutions/tested-solution/solution.yaml
+++ b/examples/solutions/tested-solution/solution.yaml
@@ -64,7 +64,6 @@ spec:
     config:
       skipBuiltins:
         - resolve-defaults
-        - render-defaults
         - lint
       env:
         TEST_MODE: "true"

--- a/pkg/cmd/scafctl/test/functional.go
+++ b/pkg/cmd/scafctl/test/functional.go
@@ -136,7 +136,7 @@ Examples:
 	cCmd.Flags().BoolVar(&opts.UpdateSnapshots, "update-snapshots", false, "Update golden files instead of comparing")
 	cCmd.Flags().BoolVar(&opts.Sequential, "sequential", false, "Run tests sequentially (no concurrency)")
 	cCmd.Flags().IntVarP(&opts.Concurrency, "concurrency", "j", 1, "Maximum number of tests to run in parallel")
-	cCmd.Flags().BoolVar(&opts.SkipBuiltins, "skip-builtins", false, "Skip builtin tests (parse, lint, resolve-defaults, render-defaults)")
+	cCmd.Flags().BoolVar(&opts.SkipBuiltins, "skip-builtins", false, "Skip builtin tests (parse, lint, resolve-defaults)")
 	cCmd.Flags().DurationVar(&opts.TestTimeout, "test-timeout", 0, "Default timeout per test (e.g., 30s, 5m)")
 	cCmd.Flags().DurationVar(&opts.Timeout, "timeout", 0, "Global timeout for all tests (e.g., 10m)")
 	cCmd.Flags().StringArrayVar(&opts.Filter, "filter", nil, "Filter tests by name glob pattern (can be repeated)")

--- a/pkg/concepts/builtin.go
+++ b/pkg/concepts/builtin.go
@@ -201,7 +201,7 @@ Rules:
 - Template cases do not need a command field — they exist only for inheritance.`,
 		Examples: []string{
 			"spec:\n  testing:\n    cases:\n      smoke-test:\n        description: Verify basic rendering\n        command: [render, solution]\n        exitCode: 0\n        files: [templates/]\n        assertions:\n          - expression: \"size(__output) > 0\"\n            message: Output should not be empty",
-			"# Template case (not executed, used for inheritance)\nspec:\n  testing:\n    cases:\n      _files-base:\n        files:\n          - templates/.github/copilot-instructions.md.tpl\n          - templates/.github/instructions/terraform-hcl.instructions.md.tpl\n\n      resolve-defaults:\n        extends: [_files-base]\n        command: [run, resolver]\n        args: [-o, json]\n        exitCode: 0\n\n      render-defaults:\n        extends: [_files-base]\n        command: [render, solution]\n        exitCode: 0",
+			"# Template case (not executed, used for inheritance)\nspec:\n  testing:\n    cases:\n      _files-base:\n        files:\n          - templates/.github/copilot-instructions.md.tpl\n          - templates/.github/instructions/terraform-hcl.instructions.md.tpl\n\n      resolve-defaults:\n        extends: [_files-base]\n        command: [run, resolver]\n        args: [-o, json]\n        exitCode: 0\n\n      render-check:\n        extends: [_files-base]\n        command: [render, solution]\n        args: [-r, appName=demo]\n        exitCode: 0",
 		},
 		SeeAlso: []string{"test-sandbox", "test-assertions", "test-scaffold"},
 	},

--- a/pkg/solution/bundler/compose.go
+++ b/pkg/solution/bundler/compose.go
@@ -137,7 +137,9 @@ func Compose(sol *solution.Solution, bundleRoot string, opts ...ComposeOption) (
 					return nil, err
 				}
 
-				mergeTestConfig(merged, part.Spec.Testing.Config)
+				if err := mergeTestConfig(merged, part.Spec.Testing.Config, relPath); err != nil {
+					return nil, err
+				}
 			}
 
 			mergeIncludes(merged, part.Bundle.Include)
@@ -163,7 +165,7 @@ func mergeResolvers(merged *solution.Solution, resolvers map[string]*resolver.Re
 
 	for name, r := range resolvers {
 		if _, exists := merged.Spec.Resolvers[name]; exists {
-			return fmt.Errorf("duplicate resolver %q: defined in both root solution and composed file %s", name, sourceFile)
+			return fmt.Errorf("duplicate resolver %q: already defined (conflict in composed file %s)", name, sourceFile)
 		}
 		merged.Spec.Resolvers[name] = r
 	}
@@ -188,7 +190,7 @@ func mergeWorkflow(merged *solution.Solution, workflow *action.Workflow, sourceF
 		}
 		for name, a := range workflow.Actions {
 			if _, exists := merged.Spec.Workflow.Actions[name]; exists {
-				return fmt.Errorf("duplicate action %q: defined in both root solution and composed file %s", name, sourceFile)
+				return fmt.Errorf("duplicate action %q: already defined (conflict in composed file %s)", name, sourceFile)
 			}
 			merged.Spec.Workflow.Actions[name] = a
 		}
@@ -201,7 +203,7 @@ func mergeWorkflow(merged *solution.Solution, workflow *action.Workflow, sourceF
 		}
 		for name, a := range workflow.Finally {
 			if _, exists := merged.Spec.Workflow.Finally[name]; exists {
-				return fmt.Errorf("duplicate finally action %q: defined in both root solution and composed file %s", name, sourceFile)
+				return fmt.Errorf("duplicate finally action %q: already defined (conflict in composed file %s)", name, sourceFile)
 			}
 			merged.Spec.Workflow.Finally[name] = a
 		}
@@ -245,7 +247,7 @@ func mergeTests(merged *solution.Solution, tests map[string]*soltesting.TestCase
 
 	for name, tc := range tests {
 		if _, exists := merged.Spec.Testing.Cases[name]; exists {
-			return fmt.Errorf("duplicate test %q: defined in both root solution and composed file %s", name, sourceFile)
+			return fmt.Errorf("duplicate test %q: already defined (conflict in composed file %s)", name, sourceFile)
 		}
 		// Set the Name field from the map key
 		tc.Name = name
@@ -260,9 +262,12 @@ func mergeTests(merged *solution.Solution, tests map[string]*soltesting.TestCase
 //   - Env: merged map, last compose file wins on key conflict.
 //   - Setup: appended in compose-file order.
 //   - Cleanup: appended in compose-file order.
-func mergeTestConfig(merged *solution.Solution, tc *soltesting.TestConfig) {
+//   - Files: appended in compose-file order, deduplicated (first-seen-wins).
+//   - Services: appended in compose-file order; duplicate service names across
+//     files are rejected.
+func mergeTestConfig(merged *solution.Solution, tc *soltesting.TestConfig, sourceFile string) error {
 	if tc == nil {
-		return
+		return nil
 	}
 
 	if merged.Spec.Testing == nil {
@@ -304,6 +309,37 @@ func mergeTestConfig(merged *solution.Solution, tc *soltesting.TestConfig) {
 
 	// Cleanup: appended in compose-file order
 	merged.Spec.Testing.Config.Cleanup = append(merged.Spec.Testing.Config.Cleanup, tc.Cleanup...)
+
+	// Files: appended in compose-file order, deduplicated (first-seen-wins)
+	if len(tc.Files) > 0 {
+		existing := make(map[string]bool, len(merged.Spec.Testing.Config.Files))
+		for _, f := range merged.Spec.Testing.Config.Files {
+			existing[f] = true
+		}
+		for _, f := range tc.Files {
+			if !existing[f] {
+				merged.Spec.Testing.Config.Files = append(merged.Spec.Testing.Config.Files, f)
+				existing[f] = true
+			}
+		}
+	}
+
+	// Services: appended in compose-file order; duplicate names rejected
+	if len(tc.Services) > 0 {
+		existing := make(map[string]bool, len(merged.Spec.Testing.Config.Services))
+		for _, s := range merged.Spec.Testing.Config.Services {
+			existing[s.Name] = true
+		}
+		for _, s := range tc.Services {
+			if existing[s.Name] {
+				return fmt.Errorf("duplicate test service %q: already defined (conflict in composed file %s)", s.Name, sourceFile)
+			}
+			merged.Spec.Testing.Config.Services = append(merged.Spec.Testing.Config.Services, s)
+			existing[s.Name] = true
+		}
+	}
+
+	return nil
 }
 
 // deepCopySolution creates a deep copy of a solution by marshaling to YAML and back.

--- a/pkg/solution/bundler/compose_test.go
+++ b/pkg/solution/bundler/compose_test.go
@@ -539,6 +539,107 @@ spec:
 	assert.Equal(t, "from-b", result.Spec.Testing.Config.Env["SHARED"])
 }
 
+func TestCompose_MergesTestConfig_Files_DedupFirstSeen(t *testing.T) {
+	sol := baseSolution()
+	sol.Compose = []string{"a.yaml", "b.yaml"}
+	readFile := func(path string) ([]byte, error) {
+		switch filepath.ToSlash(path) {
+		case "/tmp/bundle/a.yaml":
+			return []byte(`
+spec:
+  testing:
+    config:
+      files:
+        - shared/a.txt
+`), nil
+		case "/tmp/bundle/b.yaml":
+			return []byte(`
+spec:
+  testing:
+    config:
+      files:
+        - shared/b.txt
+        - shared/a.txt
+`), nil
+		}
+		return nil, fmt.Errorf("file not found: %s", path)
+	}
+	result, err := Compose(sol, "/tmp/bundle", WithReadFileFunc(readFile))
+	require.NoError(t, err)
+	require.NotNil(t, result.Spec.Testing)
+	require.NotNil(t, result.Spec.Testing.Config)
+	assert.Equal(t, []string{"shared/a.txt", "shared/b.txt"}, result.Spec.Testing.Config.Files)
+}
+
+func TestCompose_MergesTestConfig_Services_Appended(t *testing.T) {
+	sol := baseSolution()
+	sol.Compose = []string{"a.yaml", "b.yaml"}
+	readFile := func(path string) ([]byte, error) {
+		switch filepath.ToSlash(path) {
+		case "/tmp/bundle/a.yaml":
+			return []byte(`
+spec:
+  testing:
+    config:
+      services:
+        - name: svc-a
+          type: http
+`), nil
+		case "/tmp/bundle/b.yaml":
+			return []byte(`
+spec:
+  testing:
+    config:
+      services:
+        - name: svc-b
+          type: http
+`), nil
+		}
+		return nil, fmt.Errorf("file not found: %s", path)
+	}
+	result, err := Compose(sol, "/tmp/bundle", WithReadFileFunc(readFile))
+	require.NoError(t, err)
+	require.NotNil(t, result.Spec.Testing)
+	require.NotNil(t, result.Spec.Testing.Config)
+	names := make([]string, len(result.Spec.Testing.Config.Services))
+	for i, s := range result.Spec.Testing.Config.Services {
+		names[i] = s.Name
+	}
+	assert.Equal(t, []string{"svc-a", "svc-b"}, names)
+}
+
+func TestCompose_MergesTestConfig_Services_RejectsDuplicateName(t *testing.T) {
+	sol := baseSolution()
+	sol.Compose = []string{"a.yaml", "b.yaml"}
+	readFile := func(path string) ([]byte, error) {
+		switch filepath.ToSlash(path) {
+		case "/tmp/bundle/a.yaml":
+			return []byte(`
+spec:
+  testing:
+    config:
+      services:
+        - name: svc-shared
+          type: http
+`), nil
+		case "/tmp/bundle/b.yaml":
+			return []byte(`
+spec:
+  testing:
+    config:
+      services:
+        - name: svc-shared
+          type: http
+`), nil
+		}
+		return nil, fmt.Errorf("file not found: %s", path)
+	}
+	_, err := Compose(sol, "/tmp/bundle", WithReadFileFunc(readFile))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate test service")
+	assert.Contains(t, err.Error(), "svc-shared")
+}
+
 func TestCompose_SolutionWithInlineTests_PreservedAfterCompose(t *testing.T) {
 	sol := baseSolution()
 	sol.Compose = []string{"extra.yaml"}

--- a/pkg/solution/soltesting/builtins.go
+++ b/pkg/solution/soltesting/builtins.go
@@ -13,7 +13,6 @@ const (
 	BuiltinParse          = "parse"
 	BuiltinLint           = "lint"
 	BuiltinResolveDefault = "resolve-defaults"
-	BuiltinRenderDefault  = "render-defaults"
 )
 
 // BuiltinTests returns the builtin test cases, filtered by testConfig.skipBuiltins.
@@ -67,7 +66,7 @@ func IsBuiltin(name string) bool {
 	return strings.HasPrefix(name, builtinPrefix)
 }
 
-// allBuiltins returns all four builtin test cases in alphabetical order.
+// allBuiltins returns all builtin test cases in alphabetical order.
 func allBuiltins() []*TestCase {
 	exitCodeZero := 0
 	return []*TestCase{
@@ -86,12 +85,6 @@ func allBuiltins() []*TestCase {
 			// by checking if the solution loaded successfully.
 			// The runner sets pass/error based on the parse result.
 			ExitCode: &exitCodeZero,
-		},
-		{
-			Name:        BuiltinName(BuiltinRenderDefault),
-			Description: "Verify solution renders with default values",
-			Command:     []string{"render", "solution"},
-			ExitCode:    &exitCodeZero,
 		},
 		{
 			Name:        BuiltinName(BuiltinResolveDefault),

--- a/pkg/solution/soltesting/builtins_test.go
+++ b/pkg/solution/soltesting/builtins_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestBuiltinTests_AllReturned(t *testing.T) {
 	builtins := soltesting.BuiltinTests(nil)
-	require.Len(t, builtins, 4)
+	require.Len(t, builtins, 3)
 
 	names := make([]string, len(builtins))
 	for i, b := range builtins {
@@ -24,7 +24,6 @@ func TestBuiltinTests_AllReturned(t *testing.T) {
 	assert.Contains(t, names, "builtin:parse")
 	assert.Contains(t, names, "builtin:lint")
 	assert.Contains(t, names, "builtin:resolve-defaults")
-	assert.Contains(t, names, "builtin:render-defaults")
 }
 
 func TestBuiltinTests_NamesHavePrefix(t *testing.T) {
@@ -50,14 +49,13 @@ func TestBuiltinTests_SkipSpecific(t *testing.T) {
 		},
 	}
 	builtins := soltesting.BuiltinTests(tc)
-	require.Len(t, builtins, 2)
+	require.Len(t, builtins, 1)
 
 	names := make([]string, len(builtins))
 	for i, b := range builtins {
 		names[i] = b.Name
 	}
 	assert.Contains(t, names, "builtin:resolve-defaults")
-	assert.Contains(t, names, "builtin:render-defaults")
 	assert.NotContains(t, names, "builtin:lint")
 	assert.NotContains(t, names, "builtin:parse")
 }
@@ -65,12 +63,12 @@ func TestBuiltinTests_SkipSpecific(t *testing.T) {
 func TestBuiltinTests_DefaultConfig(t *testing.T) {
 	tc := &soltesting.TestConfig{}
 	builtins := soltesting.BuiltinTests(tc)
-	assert.Len(t, builtins, 4)
+	assert.Len(t, builtins, 3)
 }
 
 func TestBuiltinTests_AlphabeticalOrder(t *testing.T) {
 	builtins := soltesting.BuiltinTests(nil)
-	require.Len(t, builtins, 4)
+	require.Len(t, builtins, 3)
 	// Builtins should be in alphabetical order.
 	for i := 1; i < len(builtins); i++ {
 		assert.Less(t, builtins[i-1].Name, builtins[i].Name,
@@ -99,17 +97,6 @@ func TestBuiltinTests_LintHasCommand(t *testing.T) {
 		}
 	}
 	t.Fatal("builtin:lint not found")
-}
-
-func TestBuiltinTests_RenderDefaultsHasCommand(t *testing.T) {
-	builtins := soltesting.BuiltinTests(nil)
-	for _, b := range builtins {
-		if b.Name == "builtin:render-defaults" {
-			assert.Equal(t, []string{"render", "solution"}, b.Command)
-			return
-		}
-	}
-	t.Fatal("builtin:render-defaults not found")
 }
 
 func TestBuiltinTests_ResolveDefaultsHasCommand(t *testing.T) {

--- a/pkg/solution/soltesting/discovery.go
+++ b/pkg/solution/soltesting/discovery.go
@@ -191,8 +191,8 @@ func DiscoverFromFile(filePath string) (*SolutionTests, error) {
 					if composePart.Spec.Testing.Config != nil {
 						if doc.Spec.Testing.Config == nil {
 							doc.Spec.Testing.Config = composePart.Spec.Testing.Config
-						} else {
-							mergeTestConfig(doc.Spec.Testing.Config, composePart.Spec.Testing.Config)
+						} else if err := mergeTestConfig(doc.Spec.Testing.Config, composePart.Spec.Testing.Config, match); err != nil {
+							return nil, err
 						}
 					}
 				}
@@ -225,7 +225,12 @@ func DiscoverFromFile(filePath string) (*SolutionTests, error) {
 }
 
 // mergeTestConfig merges src into dst following compose merge rules.
-func mergeTestConfig(dst, src *TestConfig) {
+//   - SkipBuiltins: true wins; lists are unioned.
+//   - Setup/Cleanup: appended in compose-file order.
+//   - Env: merged (last compose file wins on key conflict).
+//   - Files: appended in compose-file order, deduplicated (first-seen-wins).
+//   - Services: appended in compose-file order; duplicate names are rejected.
+func mergeTestConfig(dst, src *TestConfig, sourceFile string) error {
 	// SkipBuiltins: true wins; lists are unioned
 	if src.SkipBuiltins.All {
 		dst.SkipBuiltins.All = true
@@ -237,6 +242,7 @@ func mergeTestConfig(dst, src *TestConfig) {
 		for _, n := range src.SkipBuiltins.Names {
 			if !seen[n] {
 				dst.SkipBuiltins.Names = append(dst.SkipBuiltins.Names, n)
+				seen[n] = true
 			}
 		}
 	}
@@ -252,6 +258,34 @@ func mergeTestConfig(dst, src *TestConfig) {
 			dst.Env[k] = v
 		}
 	}
+	// Files: appended in compose-file order, deduplicated (first-seen-wins)
+	if len(src.Files) > 0 {
+		seen := make(map[string]bool, len(dst.Files))
+		for _, f := range dst.Files {
+			seen[f] = true
+		}
+		for _, f := range src.Files {
+			if !seen[f] {
+				dst.Files = append(dst.Files, f)
+				seen[f] = true
+			}
+		}
+	}
+	// Services: appended in compose-file order; duplicate names rejected
+	if len(src.Services) > 0 {
+		seen := make(map[string]bool, len(dst.Services))
+		for _, s := range dst.Services {
+			seen[s.Name] = true
+		}
+		for _, s := range src.Services {
+			if seen[s.Name] {
+				return fmt.Errorf("compose file %q: duplicate test service name %q", sourceFile, s.Name)
+			}
+			dst.Services = append(dst.Services, s)
+			seen[s.Name] = true
+		}
+	}
+	return nil
 }
 
 // FilterTests applies the filter options to the discovered tests.

--- a/pkg/solution/soltesting/discovery_test.go
+++ b/pkg/solution/soltesting/discovery_test.go
@@ -440,3 +440,94 @@ spec:
 
 	assert.Equal(t, []string{"data/configs/**", "templates/app/**"}, st.DetectedFiles)
 }
+
+func TestDiscoverFromFile_MergesComposeTestConfigFilesAndServices(t *testing.T) {
+	solutionYAML := `apiVersion: scafctl/v1
+kind: Solution
+metadata:
+  name: compose-config-merge-test
+compose:
+  - extra.yaml
+spec:
+  testing:
+    config:
+      files:
+        - shared/a.txt
+      services:
+        - name: svc-root
+          type: http
+    cases:
+      basic:
+        command: [run, resolver]
+        assertions:
+          - expression: '__exitCode == 0'
+`
+	extraYAML := `apiVersion: scafctl/v1
+kind: Solution
+spec:
+  testing:
+    config:
+      files:
+        - shared/b.txt
+        - shared/a.txt
+      services:
+        - name: svc-extra
+          type: http
+`
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "solution.yaml"), []byte(solutionYAML), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.yaml"), []byte(extraYAML), 0o644))
+
+	st, err := soltesting.DiscoverFromFile(filepath.Join(dir, "solution.yaml"))
+	require.NoError(t, err)
+	require.NotNil(t, st)
+	require.NotNil(t, st.Config)
+
+	// Files appended in compose-file order, deduplicated (first-seen-wins).
+	assert.Equal(t, []string{"shared/a.txt", "shared/b.txt"}, st.Config.Files)
+
+	// Services appended in compose-file order.
+	names := make([]string, len(st.Config.Services))
+	for i, s := range st.Config.Services {
+		names[i] = s.Name
+	}
+	assert.Equal(t, []string{"svc-root", "svc-extra"}, names)
+}
+
+func TestDiscoverFromFile_RejectsDuplicateComposeServiceName(t *testing.T) {
+	solutionYAML := `apiVersion: scafctl/v1
+kind: Solution
+metadata:
+  name: compose-dup-service-test
+compose:
+  - extra.yaml
+spec:
+  testing:
+    config:
+      services:
+        - name: svc-shared
+          type: http
+    cases:
+      basic:
+        command: [run, resolver]
+        assertions:
+          - expression: '__exitCode == 0'
+`
+	extraYAML := `apiVersion: scafctl/v1
+kind: Solution
+spec:
+  testing:
+    config:
+      services:
+        - name: svc-shared
+          type: http
+`
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "solution.yaml"), []byte(solutionYAML), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "extra.yaml"), []byte(extraYAML), 0o644))
+
+	_, err := soltesting.DiscoverFromFile(filepath.Join(dir, "solution.yaml"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate test service name")
+	assert.Contains(t, err.Error(), "svc-shared")
+}

--- a/pkg/solution/soltesting/runner_test.go
+++ b/pkg/solution/soltesting/runner_test.go
@@ -466,7 +466,7 @@ func TestRunnerBuiltinParse(t *testing.T) {
 		{
 			SolutionName: "parse-sol",
 			FilePath:     solutionPath,
-			Config:       &TestConfig{SkipBuiltins: SkipBuiltinsValue{Names: []string{"lint", "resolve-defaults", "render-defaults"}}},
+			Config:       &TestConfig{SkipBuiltins: SkipBuiltinsValue{Names: []string{"lint", "resolve-defaults"}}},
 			Cases:        map[string]*TestCase{},
 		},
 	}

--- a/pkg/solution/soltesting/scaffold.go
+++ b/pkg/solution/soltesting/scaffold.go
@@ -47,7 +47,6 @@ func Scaffold(input *ScaffoldInput) *ScaffoldResult {
 
 	// Always generate builtin-style tests
 	addResolveDefaultsTest(result)
-	addRenderDefaultsTest(result)
 	addLintTest(result)
 
 	// Generate resolver-specific tests
@@ -91,17 +90,6 @@ func addResolveDefaultsTest(result *ScaffoldResult) {
 		Command:     []string{"run", "resolver"},
 		Args:        []string{"-o", "json"},
 		Tags:        []string{"smoke", "resolvers"},
-		ExitCode:    &exitCodeZero,
-	}
-}
-
-// addRenderDefaultsTest adds a test that verifies the solution renders with defaults.
-func addRenderDefaultsTest(result *ScaffoldResult) {
-	exitCodeZero := 0
-	result.Cases["render-defaults"] = &TestCase{
-		Description: "Verify solution renders with default values",
-		Command:     []string{"render", "solution"},
-		Tags:        []string{"smoke", "render"},
 		ExitCode:    &exitCodeZero,
 	}
 }

--- a/pkg/solution/soltesting/scaffold_test.go
+++ b/pkg/solution/soltesting/scaffold_test.go
@@ -18,9 +18,8 @@ func TestScaffold_EmptyInput(t *testing.T) {
 	result := Scaffold(&ScaffoldInput{})
 
 	require.NotNil(t, result)
-	assert.Len(t, result.Cases, 3, "should contain resolve-defaults, render-defaults, and lint")
+	assert.Len(t, result.Cases, 2, "should contain resolve-defaults and lint")
 	assert.Contains(t, result.Cases, "resolve-defaults")
-	assert.Contains(t, result.Cases, "render-defaults")
 	assert.Contains(t, result.Cases, "lint")
 }
 
@@ -61,12 +60,11 @@ func TestScaffold_WithResolvers(t *testing.T) {
 
 	require.NotNil(t, result)
 
-	// 3 base tests + 2 resolver tests + 1 validation failure test = 6
-	assert.Len(t, result.Cases, 6)
+	// 2 base tests + 2 resolver tests + 1 validation failure test = 5
+	assert.Len(t, result.Cases, 5)
 
 	// Base tests
 	assert.Contains(t, result.Cases, "resolve-defaults")
-	assert.Contains(t, result.Cases, "render-defaults")
 	assert.Contains(t, result.Cases, "lint")
 
 	// Resolver tests
@@ -99,8 +97,8 @@ func TestScaffold_WithActions(t *testing.T) {
 
 	require.NotNil(t, result)
 
-	// 3 base tests + 2 action tests = 5
-	assert.Len(t, result.Cases, 5)
+	// 2 base tests + 2 action tests = 4
+	assert.Len(t, result.Cases, 4)
 	assert.Contains(t, result.Cases, "action-build")
 	assert.Contains(t, result.Cases, "action-test")
 

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -5551,6 +5551,167 @@ spec:
 	assert.Contains(t, stdout, "composed-test", "composed test should appear in output")
 }
 
+// TestIntegration_Test_Functional_ComposeFilesMerge verifies that
+// testing.config.files entries from the root solution and a composed file are
+// merged together — both shared files are copied into the test sandbox.
+func TestIntegration_Test_Functional_ComposeFilesMerge(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+	testsDir := filepath.Join(tmpDir, "tests")
+	require.NoError(t, os.MkdirAll(testsDir, 0o755))
+
+	// Both files must exist at the solution root so the sandbox can copy them.
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "a.txt"), []byte("from-root"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "b.txt"), []byte("from-composed"), 0o644))
+
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-compose-files
+  version: 1.0.0
+compose:
+  - tests/*.yaml
+spec:
+  resolvers:
+    fileA:
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: ./a.txt
+    fileB:
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: ./b.txt
+  testing:
+    config:
+      # Root contributes a.txt; the composed file contributes b.txt.
+      files:
+        - a.txt
+    cases:
+      _base:
+        description: Base template
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+`
+	// The composed file adds b.txt to testing.config.files and a test that
+	// asserts both files were copied into the sandbox and read successfully.
+	testFileContent := `spec:
+  testing:
+    config:
+      files:
+        - b.txt
+    cases:
+      reads-both-files:
+        description: Both merged shared files are present in the sandbox
+        extends: [_base]
+        assertions:
+          - expression: '__output.fileA.content == "from-root"'
+            message: root file a.txt should be copied into the sandbox
+          - expression: '__output.fileB.content == "from-composed"'
+            message: composed file b.txt should be merged and copied into the sandbox
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(testsDir, "extra.yaml"), []byte(testFileContent), 0o644))
+
+	stdout, stderr, exitCode := runScafctl(t,
+		"test", "functional",
+		"-f", solutionFile,
+		"--skip-builtins",
+		"--no-color",
+	)
+
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode, "expected exit code 0 when shared files merge across compose files\nstdout: %s\nstderr: %s", stdout, stderr)
+	assert.Contains(t, stdout, "reads-both-files", "composed test should appear in output")
+}
+
+// TestIntegration_Test_Functional_ComposeDuplicateService verifies that a test
+// service defined with the same name in both the root solution and a composed
+// file is rejected with an error.
+func TestIntegration_Test_Functional_ComposeDuplicateService(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+	testsDir := filepath.Join(tmpDir, "tests")
+	require.NoError(t, os.MkdirAll(testsDir, 0o755))
+
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: test-compose-dup-service
+  version: 1.0.0
+compose:
+  - tests/*.yaml
+spec:
+  resolvers:
+    msg:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+  testing:
+    config:
+      services:
+        - name: mock-api
+          type: exec
+          execRules:
+            - command: "echo root"
+              stdout: root
+              exitCode: 0
+    cases:
+      _base:
+        description: Base template
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+`
+	// The composed file declares a service with the same name — must be rejected.
+	testFileContent := `spec:
+  testing:
+    config:
+      services:
+        - name: mock-api
+          type: exec
+          execRules:
+            - command: "echo composed"
+              stdout: composed
+              exitCode: 0
+    cases:
+      composed-test:
+        description: Test from composed file
+        extends: [_base]
+        assertions:
+          - expression: '"msg" in __output'
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(testsDir, "smoke.yaml"), []byte(testFileContent), 0o644))
+
+	stdout, stderr, exitCode := runScafctl(t,
+		"test", "functional",
+		"-f", solutionFile,
+		"--skip-builtins",
+		"--no-color",
+	)
+
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.NotEqual(t, 0, exitCode, "expected non-zero exit code for duplicate test service name")
+	assert.Contains(t, stderr, "duplicate test service", "error should mention the duplicate test service")
+}
+
 func TestIntegration_Test_Functional_AutoDiscovery(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
@@ -5684,7 +5845,6 @@ spec:
 	assert.Equal(t, 0, exitCode, "expected exit code 0")
 	assert.Contains(t, stdout, "cases:")
 	assert.Contains(t, stdout, "resolve-defaults")
-	assert.Contains(t, stdout, "render-defaults")
 	assert.Contains(t, stdout, "lint")
 	assert.Contains(t, stdout, "resolver-repo")
 	assert.Contains(t, stdout, "resolver-version")

--- a/tests/integration/solutions/auto-discovery/solution.yaml
+++ b/tests/integration/solutions/auto-discovery/solution.yaml
@@ -17,9 +17,6 @@ spec:
               value: Discovered!
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       lint-auto-discovery:
         description: Verify lint auto-discovers and succeeds

--- a/tests/integration/solutions/catalog-cwd/solution.yaml
+++ b/tests/integration/solutions/catalog-cwd/solution.yaml
@@ -85,7 +85,7 @@ spec:
 
   testing:
     config:
-      skipBuiltins: [render-defaults, resolve-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       resolvers-work:

--- a/tests/integration/solutions/composed/solution.yaml
+++ b/tests/integration/solutions/composed/solution.yaml
@@ -20,10 +20,6 @@ spec:
               value: composed-test-output
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for rendering tests

--- a/tests/integration/solutions/composition/solution.yaml
+++ b/tests/integration/solutions/composition/solution.yaml
@@ -12,10 +12,6 @@ compose:
 
 spec:
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for composition tests

--- a/tests/integration/solutions/cwd/solution.yaml
+++ b/tests/integration/solutions/cwd/solution.yaml
@@ -34,7 +34,7 @@ spec:
 
   testing:
     config:
-      skipBuiltins: [render-defaults, resolve-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       resolver-basic:

--- a/tests/integration/solutions/dryrun/solution.yaml
+++ b/tests/integration/solutions/dryrun/solution.yaml
@@ -48,9 +48,6 @@ spec:
             - "{{ .greeting }}"
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       dryrun-resolves-values:
         description: Verify dry-run generates WhatIf messages with real resolver data

--- a/tests/integration/solutions/edge-cases/invalid-exclusive/solution.yaml
+++ b/tests/integration/solutions/edge-cases/invalid-exclusive/solution.yaml
@@ -34,8 +34,7 @@ spec:
   testing:
     config:
       # lint: solution has intentionally invalid exclusive declarations (self-ref and missing action refs)
-      # render-defaults: invalid exclusive references cause render to fail
-      skipBuiltins: [lint, render-defaults]
+      skipBuiltins: [lint]
 
     cases:
       lint-rejects-self-reference:

--- a/tests/integration/solutions/edge-cases/invalid-provider/solution.yaml
+++ b/tests/integration/solutions/edge-cases/invalid-provider/solution.yaml
@@ -22,8 +22,7 @@ spec:
     config:
       # lint: solution uses non-existent provider (does-not-exist) that lint correctly rejects
       # resolve-defaults: resolver uses non-existent provider that fails resolution
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [lint, resolve-defaults, render-defaults]
+      skipBuiltins: [lint, resolve-defaults]
 
     cases:
       unknown-provider:

--- a/tests/integration/solutions/edge-cases/timeout-enforcement/solution.yaml
+++ b/tests/integration/solutions/edge-cases/timeout-enforcement/solution.yaml
@@ -24,8 +24,7 @@ spec:
   testing:
     config:
       # resolve-defaults: slowResolver deliberately exceeds its timeout
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       timeout-exceeded:

--- a/tests/integration/solutions/edge-cases/validation-failures/solution.yaml
+++ b/tests/integration/solutions/edge-cases/validation-failures/solution.yaml
@@ -68,8 +68,7 @@ spec:
   testing:
     config:
       # resolve-defaults: resolvers have intentional validation failures by design
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       valid-passes:

--- a/tests/integration/solutions/file-conflict/solution.yaml
+++ b/tests/integration/solutions/file-conflict/solution.yaml
@@ -58,9 +58,6 @@ spec:
           onConflict: append
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       basic-run:
         description: Verify solution workflow actions create files on first run

--- a/tests/integration/solutions/hello-world/solution.yaml
+++ b/tests/integration/solutions/hello-world/solution.yaml
@@ -17,10 +17,6 @@ spec:
               value: Hello, World!
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       render-basic:
         description: Verify solution renders successfully

--- a/tests/integration/solutions/input-flag-validation/solution.yaml
+++ b/tests/integration/solutions/input-flag-validation/solution.yaml
@@ -19,9 +19,6 @@ spec:
               value: validated
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       resolve-with-auto-inject:
         description: Verify resolver works with auto-injected -f flag

--- a/tests/integration/solutions/lint-hyphenated-name/solution.yaml
+++ b/tests/integration/solutions/lint-hyphenated-name/solution.yaml
@@ -29,9 +29,6 @@ spec:
               value: world
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       hyphenated-name-detected:
         description: Lint detects hyphenated resolver name

--- a/tests/integration/solutions/lint-missing-template-dependency/solution.yaml
+++ b/tests/integration/solutions/lint-missing-template-dependency/solution.yaml
@@ -63,7 +63,7 @@ spec:
     config:
       # lint: solution intentionally triggers missing-template-dependency
       # resolve-defaults: render-tree cannot resolve without full deps
-      skipBuiltins: [lint, resolve-defaults, render-defaults]
+      skipBuiltins: [lint, resolve-defaults]
 
     cases:
       missing-deps-detected:

--- a/tests/integration/solutions/lint-resolver-cycle/solution.yaml
+++ b/tests/integration/solutions/lint-resolver-cycle/solution.yaml
@@ -43,7 +43,7 @@ spec:
     config:
       # lint: solution intentionally has a resolver cycle
       # resolve-defaults: resolvers cannot be resolved due to the cycle
-      skipBuiltins: [lint, resolve-defaults, render-defaults]
+      skipBuiltins: [lint, resolve-defaults]
 
     cases:
       cycle-detected:

--- a/tests/integration/solutions/lint-schema/unknown-field/solution.yaml
+++ b/tests/integration/solutions/lint-schema/unknown-field/solution.yaml
@@ -25,8 +25,7 @@ spec:
     config:
       # lint: solution intentionally has unknown top-level field (unknownField) that lint correctly rejects
       # resolve-defaults: resolver uses parameter provider requiring external input
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [lint, resolve-defaults, render-defaults]
+      skipBuiltins: [lint, resolve-defaults]
 
     cases:
       schema-violation-detected:

--- a/tests/integration/solutions/lint-schema/unknown-nested-field/solution.yaml
+++ b/tests/integration/solutions/lint-schema/unknown-nested-field/solution.yaml
@@ -35,8 +35,7 @@ spec:
     config:
       # lint: solution intentionally has unknown nested field (spec.badNestedField) that lint correctly rejects
       # resolve-defaults: resolver uses parameter provider requiring external input
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [lint, resolve-defaults, render-defaults]
+      skipBuiltins: [lint, resolve-defaults]
 
     cases:
       nested-field-detected:

--- a/tests/integration/solutions/lint-suppression/solution.yaml
+++ b/tests/integration/solutions/lint-suppression/solution.yaml
@@ -65,7 +65,7 @@ spec:
     config:
       # lint: solution intentionally triggers transform-shape-mismatch
       # resolve-defaults: http resolver requires network access
-      skipBuiltins: [lint, resolve-defaults, render-defaults]
+      skipBuiltins: [lint, resolve-defaults]
 
     cases:
       flagged-finding-reported:

--- a/tests/integration/solutions/lint-tmpl-underscore/solution.yaml
+++ b/tests/integration/solutions/lint-tmpl-underscore/solution.yaml
@@ -33,7 +33,7 @@ spec:
     config:
       # lint: solution intentionally has tmpl-underscore-prefix lint error
       # resolve-defaults: tmpl value is a literal string (not resolved as template here)
-      skipBuiltins: [lint, resolve-defaults, render-defaults]
+      skipBuiltins: [lint, resolve-defaults]
 
     cases:
       underscore-prefix-detected:

--- a/tests/integration/solutions/message-provider/solution.yaml
+++ b/tests/integration/solutions/message-provider/solution.yaml
@@ -67,9 +67,6 @@ spec:
               label: "step 1"
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       basic-execution:
         description: Verify message provider runs successfully

--- a/tests/integration/solutions/nested-bundle/solution.yaml
+++ b/tests/integration/solutions/nested-bundle/solution.yaml
@@ -29,8 +29,7 @@ spec:
   testing:
     config:
       # resolve-defaults: resolvers read local files that must be staged via files:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/output-dir/solution.yaml
+++ b/tests/integration/solutions/output-dir/solution.yaml
@@ -88,7 +88,7 @@ spec:
 
   testing:
     config:
-      skipBuiltins: [render-defaults, resolve-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       resolver-reads-cwd:

--- a/tests/integration/solutions/plugins/schema-cache/solution.yaml
+++ b/tests/integration/solutions/plugins/schema-cache/solution.yaml
@@ -17,9 +17,6 @@ spec:
               value: schema-cache-test-ok
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       get-provider-cel-schema:
         description: Builtin provider schema is always available

--- a/tests/integration/solutions/plugins/signature-verification/solution.yaml
+++ b/tests/integration/solutions/plugins/signature-verification/solution.yaml
@@ -17,9 +17,6 @@ spec:
               value: Hello from signature test
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       # Verify that the solution runs successfully with default config
       # (signature mode defaults to "off", so no verification occurs).

--- a/tests/integration/solutions/plugins/solution.yaml
+++ b/tests/integration/solutions/plugins/solution.yaml
@@ -17,10 +17,6 @@ spec:
               value: Hello from plugin test
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       plugins-help:
         description: Verify plugins help works

--- a/tests/integration/solutions/providers/cel-regex/solution.yaml
+++ b/tests/integration/solutions/providers/cel-regex/solution.yaml
@@ -123,10 +123,6 @@ spec:
               expression: 'regex.match("^hello", regex.replace(_.dirtyString, "[^a-zA-Z0-9 ]", ""))'
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for regex CEL tests

--- a/tests/integration/solutions/providers/cel/solution.yaml
+++ b/tests/integration/solutions/providers/cel/solution.yaml
@@ -145,10 +145,6 @@ spec:
               expression: '__self.replace(" ", "-")'
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for CEL provider tests

--- a/tests/integration/solutions/providers/debug/solution.yaml
+++ b/tests/integration/solutions/providers/debug/solution.yaml
@@ -90,8 +90,7 @@ spec:
   testing:
     config:
       # resolve-defaults: debugToFile resolver depends on SCAFCTL_SANDBOX_DIR env var
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/directory-security/solution.yaml
+++ b/tests/integration/solutions/providers/directory-security/solution.yaml
@@ -48,8 +48,7 @@ spec:
   testing:
     config:
       # resolve-defaults: resolvers depend on test setup
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/directory/solution.yaml
+++ b/tests/integration/solutions/providers/directory/solution.yaml
@@ -30,8 +30,7 @@ spec:
   testing:
     config:
       # resolve-defaults: resolvers depend on files created by test init steps
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/env-security/solution.yaml
+++ b/tests/integration/solutions/providers/env-security/solution.yaml
@@ -32,8 +32,7 @@ spec:
   testing:
     config:
       # resolve-defaults: resolvers intentionally fail to test security
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
       env:
         SCAFCTL_SEC_TEST_A: "value-a"
         SCAFCTL_SEC_TEST_B: "value-b"

--- a/tests/integration/solutions/providers/env/solution.yaml
+++ b/tests/integration/solutions/providers/env/solution.yaml
@@ -39,8 +39,7 @@ spec:
   testing:
     config:
       # resolve-defaults: testInjected resolver reads SCAFCTL_FUNC_TEST_VAR only set by test harness
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
       env:
         SCAFCTL_FUNC_TEST_VAR: "global-test-value"
         HOME: "/tmp/test-home"

--- a/tests/integration/solutions/providers/exec-mocking/solution.yaml
+++ b/tests/integration/solutions/providers/exec-mocking/solution.yaml
@@ -53,8 +53,7 @@ spec:
   testing:
     config:
       # resolve-defaults: resolvers use exec provider with commands that require mock services
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
       services:
         - name: exec-mock
           type: exec

--- a/tests/integration/solutions/providers/exec/solution.yaml
+++ b/tests/integration/solutions/providers/exec/solution.yaml
@@ -109,8 +109,7 @@ spec:
   testing:
     config:
       # resolve-defaults: resolvers use exec provider requiring shell command execution
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/file-security/solution.yaml
+++ b/tests/integration/solutions/providers/file-security/solution.yaml
@@ -54,9 +54,6 @@ spec:
             rslvr: safeEntries
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for file security tests

--- a/tests/integration/solutions/providers/file/solution.yaml
+++ b/tests/integration/solutions/providers/file/solution.yaml
@@ -47,8 +47,7 @@ spec:
   testing:
     config:
       # resolve-defaults: resolvers read fixture files that only exist via test init steps
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/git-security/solution.yaml
+++ b/tests/integration/solutions/providers/git-security/solution.yaml
@@ -57,8 +57,7 @@ spec:
   testing:
     config:
       # resolve-defaults: resolvers intentionally fail to test security validation
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/git/solution.yaml
+++ b/tests/integration/solutions/providers/git/solution.yaml
@@ -63,8 +63,7 @@ spec:
   testing:
     config:
       # resolve-defaults: resolvers depend on SCAFCTL_SANDBOX_DIR env var and test-created git repo
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/github-v3-operations/solution.yaml
+++ b/tests/integration/solutions/providers/github-v3-operations/solution.yaml
@@ -373,7 +373,7 @@ spec:
 
   testing:
     config:
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
       services:
         - name: mock-github-api
           type: http

--- a/tests/integration/solutions/providers/github/solution.yaml
+++ b/tests/integration/solutions/providers/github/solution.yaml
@@ -131,7 +131,7 @@ spec:
 
   testing:
     config:
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
       services:
         - name: github-mock
           type: http

--- a/tests/integration/solutions/providers/go-template-extensions/solution.yaml
+++ b/tests/integration/solutions/providers/go-template-extensions/solution.yaml
@@ -469,10 +469,6 @@ spec:
                 app={{ $decoded.app }}, version={{ $decoded.version }}
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for go-template extension tests

--- a/tests/integration/solutions/providers/go-template/solution.yaml
+++ b/tests/integration/solutions/providers/go-template/solution.yaml
@@ -232,10 +232,6 @@ spec:
                 items: null
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for go-template provider tests

--- a/tests/integration/solutions/providers/hcl/solution.yaml
+++ b/tests/integration/solutions/providers/hcl/solution.yaml
@@ -218,10 +218,6 @@ spec:
                       ami: ami-12345
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for HCL provider tests

--- a/tests/integration/solutions/providers/http-body-pagination/solution.yaml
+++ b/tests/integration/solutions/providers/http-body-pagination/solution.yaml
@@ -47,7 +47,7 @@ spec:
 
   testing:
     config:
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
       services:
         - name: mock-api
           type: http

--- a/tests/integration/solutions/providers/http-empty-body/solution.yaml
+++ b/tests/integration/solutions/providers/http-empty-body/solution.yaml
@@ -73,8 +73,7 @@ spec:
   testing:
     config:
       # resolve-defaults: resolvers depend on MOCK_BASE_URL env var and mock routes
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
       services:
         - name: mock-api
           type: http

--- a/tests/integration/solutions/providers/http-security/solution.yaml
+++ b/tests/integration/solutions/providers/http-security/solution.yaml
@@ -58,7 +58,7 @@ spec:
 
   testing:
     config:
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
       services:
         - name: mock-api
           type: http

--- a/tests/integration/solutions/providers/http-token-delegation/solution.yaml
+++ b/tests/integration/solutions/providers/http-token-delegation/solution.yaml
@@ -65,7 +65,7 @@ spec:
 
   testing:
     config:
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
       services:
         - name: mock-api
           type: http

--- a/tests/integration/solutions/providers/http/solution.yaml
+++ b/tests/integration/solutions/providers/http/solution.yaml
@@ -147,8 +147,7 @@ spec:
   testing:
     config:
       # resolve-defaults: resolvers depend on MOCK_BASE_URL env var and moc  resolvers
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
       services:
         - name: mock-api
           type: http

--- a/tests/integration/solutions/providers/identity/solution.yaml
+++ b/tests/integration/solutions/providers/identity/solution.yaml
@@ -25,7 +25,7 @@ spec:
 
   testing:
     config:
-      skipBuiltins: [render-defaults, resolve-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/metadata/solution.yaml
+++ b/tests/integration/solutions/providers/metadata/solution.yaml
@@ -16,9 +16,6 @@ spec:
             inputs: {}
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
     cases:
       resolve-runtime-meta:
         description: Verify runtime metadata resolves with expected fields

--- a/tests/integration/solutions/providers/parameter/solution.yaml
+++ b/tests/integration/solutions/providers/parameter/solution.yaml
@@ -99,8 +99,7 @@ spec:
   testing:
     config:
       # resolve-defaults: resolvers use parameter provider requiring external -r flag input
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/per-test-services/solution.yaml
+++ b/tests/integration/solutions/providers/per-test-services/solution.yaml
@@ -38,7 +38,7 @@ spec:
 
   testing:
     config:
-      skipBuiltins: [render-defaults, resolve-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/sleep/solution.yaml
+++ b/tests/integration/solutions/providers/sleep/solution.yaml
@@ -19,10 +19,6 @@ spec:
               duration: "100ms"
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for sleep provider tests

--- a/tests/integration/solutions/providers/solution/solution.yaml
+++ b/tests/integration/solutions/providers/solution/solution.yaml
@@ -65,8 +65,7 @@ spec:
   testing:
     config:
       # resolve-defaults: child solution requires parameter inputs (message, number)
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/providers/static/solution.yaml
+++ b/tests/integration/solutions/providers/static/solution.yaml
@@ -127,10 +127,6 @@ spec:
                 line three
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for static provider tests

--- a/tests/integration/solutions/providers/template-functions/solution.yaml
+++ b/tests/integration/solutions/providers/template-functions/solution.yaml
@@ -106,9 +106,6 @@ spec:
               name: cel-inline-test
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
     cases:
       test-slugify:
         description: Verify slugify produces correct slug

--- a/tests/integration/solutions/providers/validation/solution.yaml
+++ b/tests/integration/solutions/providers/validation/solution.yaml
@@ -139,10 +139,6 @@ spec:
             message: "This rule must never run for non-dev values"
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for validation provider tests

--- a/tests/integration/solutions/rendering/solution.yaml
+++ b/tests/integration/solutions/rendering/solution.yaml
@@ -58,10 +58,6 @@ spec:
               expression: '_.projectName + "-" + _.language + "-" + _.version'
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base for resolver tests

--- a/tests/integration/solutions/resolvers/basedir/solution.yaml
+++ b/tests/integration/solutions/resolvers/basedir/solution.yaml
@@ -28,9 +28,6 @@ spec:
               expression: '_.greeting + " (nested)"'
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       with-basedir:
         description: Verify solution executes correctly when nested via baseDir

--- a/tests/integration/solutions/resolvers/conditional/solution.yaml
+++ b/tests/integration/solutions/resolvers/conditional/solution.yaml
@@ -77,10 +77,6 @@ spec:
               value: "always-here"
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for conditional resolver tests

--- a/tests/integration/solutions/resolvers/dag/solution.yaml
+++ b/tests/integration/solutions/resolvers/dag/solution.yaml
@@ -99,10 +99,6 @@ spec:
               expression: '_.chainC + "D"'
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for DAG tests

--- a/tests/integration/solutions/resolvers/foreach-filter/solution.yaml
+++ b/tests/integration/solutions/resolvers/foreach-filter/solution.yaml
@@ -110,10 +110,6 @@ spec:
               expression: "user"
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
     # =========================================================================
     # Base template

--- a/tests/integration/solutions/resolvers/inputs/solution.yaml
+++ b/tests/integration/solutions/resolvers/inputs/solution.yaml
@@ -42,9 +42,6 @@ spec:
               expression: '"https://" + _.environment + "." + _.region + ".example.com"'
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for input tests

--- a/tests/integration/solutions/resolvers/messages/solution.yaml
+++ b/tests/integration/solutions/resolvers/messages/solution.yaml
@@ -61,8 +61,7 @@ spec:
   testing:
     config:
       # resolve-defaults: invalidPortStatic and invalidPortCel have intentional validation failures
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       valid-resolver-succeeds:

--- a/tests/integration/solutions/resolvers/mocks/solution.yaml
+++ b/tests/integration/solutions/resolvers/mocks/solution.yaml
@@ -36,9 +36,6 @@ spec:
               expression: '_.greeting + " (authenticated)"'
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for mock tests

--- a/tests/integration/solutions/resolvers/param-key-validation/solution.yaml
+++ b/tests/integration/solutions/resolvers/param-key-validation/solution.yaml
@@ -35,7 +35,7 @@ spec:
 
   testing:
     config:
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/resolvers/plan/solution.yaml
+++ b/tests/integration/solutions/resolvers/plan/solution.yaml
@@ -91,9 +91,6 @@ spec:
               value: "base_url-is-standalone"
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for __plan tests

--- a/tests/integration/solutions/resolvers/sensitive/solution.yaml
+++ b/tests/integration/solutions/resolvers/sensitive/solution.yaml
@@ -29,10 +29,6 @@ spec:
               value: "visible-value"
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       sensitive-in-json:
         description: Verify sensitive value is accessible in JSON output

--- a/tests/integration/solutions/resolvers/split-resolver-validation/solution.yaml
+++ b/tests/integration/solutions/resolvers/split-resolver-validation/solution.yaml
@@ -77,8 +77,7 @@ spec:
   testing:
     config:
       # resolve-defaults: userMissingRaw fails validation by design
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
       services:
         - name: mock-api
           type: http

--- a/tests/integration/solutions/resolvers/stdin-params/solution.yaml
+++ b/tests/integration/solutions/resolvers/stdin-params/solution.yaml
@@ -39,7 +39,7 @@ spec:
 
   testing:
     config:
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/resolvers/timeout/solution.yaml
+++ b/tests/integration/solutions/resolvers/timeout/solution.yaml
@@ -35,10 +35,6 @@ spec:
               value: "sleep-completed"
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for timeout tests

--- a/tests/integration/solutions/resolvers/transform-chain/solution.yaml
+++ b/tests/integration/solutions/resolvers/transform-chain/solution.yaml
@@ -101,8 +101,7 @@ spec:
   testing:
     config:
       # resolve-defaults: execTransform resolver uses exec provider requiring shell execution
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [resolve-defaults, render-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:

--- a/tests/integration/solutions/resolvers/type-coercion/solution.yaml
+++ b/tests/integration/solutions/resolvers/type-coercion/solution.yaml
@@ -72,10 +72,6 @@ spec:
               value: "native"
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for type coercion tests

--- a/tests/integration/solutions/resolvers/until/solution.yaml
+++ b/tests/integration/solutions/resolvers/until/solution.yaml
@@ -47,10 +47,6 @@ spec:
               value: "fallback-after-error"
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for until/fallback tests

--- a/tests/integration/solutions/snapshot/solution.yaml
+++ b/tests/integration/solutions/snapshot/solution.yaml
@@ -48,9 +48,6 @@ spec:
               value: "secret-api-key-12345"
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       snapshot-resolvers:
         description: Verify all resolvers resolve for snapshot

--- a/tests/integration/solutions/soldiff/solution.yaml
+++ b/tests/integration/solutions/soldiff/solution.yaml
@@ -53,9 +53,6 @@ spec:
                 }
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       snapshot-creation:
         description: Verify snapshot can be created for diff comparison

--- a/tests/integration/solutions/state/dynamic-enabled/solution.yaml
+++ b/tests/integration/solutions/state/dynamic-enabled/solution.yaml
@@ -46,9 +46,6 @@ spec:
               value: "hello-default"
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       # =====================================================================
       # State disabled: saved parameters NOT loaded

--- a/tests/integration/solutions/state/dynamic-path/solution.yaml
+++ b/tests/integration/solutions/state/dynamic-path/solution.yaml
@@ -45,9 +45,8 @@ spec:
 
   testing:
     config:
-      # render-defaults: solution has no workflow.actions section
       # resolve-defaults: dynamic state path requires __params.project
-      skipBuiltins: [render-defaults, resolve-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       # =====================================================================

--- a/tests/integration/solutions/state/immutable-overwrite/solution.yaml
+++ b/tests/integration/solutions/state/immutable-overwrite/solution.yaml
@@ -36,10 +36,6 @@ spec:
               value: "fixed-value"
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       # =====================================================================
       # First write succeeds (empty state, no conflict)

--- a/tests/integration/solutions/state/immutable/solution.yaml
+++ b/tests/integration/solutions/state/immutable/solution.yaml
@@ -51,9 +51,6 @@ spec:
               value: "default-mutable"
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for immutable state tests

--- a/tests/integration/solutions/state/persistence/solution.yaml
+++ b/tests/integration/solutions/state/persistence/solution.yaml
@@ -44,10 +44,6 @@ spec:
               value: 42
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for state tests

--- a/tests/integration/solutions/state/render-solution/solution.yaml
+++ b/tests/integration/solutions/state/render-solution/solution.yaml
@@ -54,9 +54,6 @@ spec:
             expr: "'echo deploy ' + _.app_version + ' to ' + _.deploy_target"
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       # =====================================================================
       # Render with empty state uses resolver defaults

--- a/tests/integration/solutions/state/render/solution.yaml
+++ b/tests/integration/solutions/state/render/solution.yaml
@@ -43,9 +43,6 @@ spec:
               value: "my-label"
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       # =====================================================================
       # Render with empty state uses fallback

--- a/tests/integration/solutions/state/run-action/solution.yaml
+++ b/tests/integration/solutions/state/run-action/solution.yaml
@@ -70,9 +70,6 @@ spec:
             expr: "'echo deploy v' + _.version + ' to ' + _.environment"
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       # =====================================================================
       # Run specific action with state (first run, no state file)

--- a/tests/integration/solutions/state/run-solution/solution.yaml
+++ b/tests/integration/solutions/state/run-solution/solution.yaml
@@ -53,9 +53,6 @@ spec:
             expr: "'echo deployed to ' + _.deploy_target + ' build=' + _.build_id"
 
   testing:
-    config:
-      skipBuiltins: [render-defaults]
-
     cases:
       # =====================================================================
       # First run: state empty, resolvers use defaults, actions run, state saved

--- a/tests/integration/solutions/state/save-overrides/solution.yaml
+++ b/tests/integration/solutions/state/save-overrides/solution.yaml
@@ -51,10 +51,6 @@ spec:
               value: "my-app"
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for save-overrides tests

--- a/tests/integration/solutions/state/save-verify/solution.yaml
+++ b/tests/integration/solutions/state/save-verify/solution.yaml
@@ -56,10 +56,6 @@ spec:
               value: true
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       _base:
         description: Base template for save verification tests

--- a/tests/integration/solutions/telemetry/solution.yaml
+++ b/tests/integration/solutions/telemetry/solution.yaml
@@ -28,10 +28,6 @@ spec:
               value: integration
 
   testing:
-    config:
-      # render-defaults: solution has no workflow.actions section
-      skipBuiltins: [render-defaults]
-
     cases:
       resolvers-succeed:
         description: Verify all resolvers complete successfully (spans recorded)

--- a/tests/integration/solutions/template-directory/solution.yaml
+++ b/tests/integration/solutions/template-directory/solution.yaml
@@ -63,7 +63,7 @@ spec:
 
   testing:
     config:
-      skipBuiltins: [render-defaults, resolve-defaults]
+      skipBuiltins: [resolve-defaults]
 
     cases:
       _base:


### PR DESCRIPTION
BREAKING CHANGE: the builtin:render-defaults test no longer runs. Only parse, lint, and resolve-defaults run automatically for every solution. Remove 
ender-defaults from any skipBuiltins lists.

- Drop the render-defaults builtin test that failed for resolver-only solutions lacking a workflow.actions section
- Stop scaffolding render-defaults smoke tests via 	est scaffold
- Merge testing.config files (deduplicated, first-seen wins) and services (duplicate service names rejected with an error) across compose files
- Fix SkipBuiltins.Names dedup that missed marking seen names
- Update functional-testing docs/tutorials and example solutions to reflect the three remaining builtins