### PR TITLE
feat(provider)!: bump scafctl-plugin-sdk to v0.11.0 and drop compat shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🚀 Features
 
+- *(auth)* [**breaking**] Drop the legacy OAuth token-metadata compatibility shim when bumping scafctl-plugin-sdk to v0.11.0. Credentials persisted by earlier versions (which carried fields such as `refreshTokenExpiresAt` / `loginFlow`) no longer deserialize, so a one-time re-login is required after upgrading.
 - *(state)* Add `saveOverrides` field to state backend for save-time-only input resolution, enabling patterns like loading from `main` and saving to a resolver-derived feature branch
 - *(lint)* Add `resolver-cycle` rule (error) to detect circular dependencies in the resolver dependency graph
 - *(lint)* Add `missing-template-dependency` rule (warning) to detect render-tree resolvers missing template file dependencies

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/oakwood-commons/httpc v0.1.0
 	github.com/oakwood-commons/kvx v0.12.1-0.20260526145940-98d391c60b9b
 	github.com/oakwood-commons/oauth-helpers v0.2.0
-	github.com/oakwood-commons/scafctl-plugin-sdk v0.10.0
+	github.com/oakwood-commons/scafctl-plugin-sdk v0.11.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pelletier/go-toml/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,8 @@ github.com/oakwood-commons/kvx v0.12.1-0.20260526145940-98d391c60b9b h1:0hECYesH
 github.com/oakwood-commons/kvx v0.12.1-0.20260526145940-98d391c60b9b/go.mod h1:PJktDsEq9PS88UDCkoIT+fgiSXs7dXWcq76Lhk5BmZY=
 github.com/oakwood-commons/oauth-helpers v0.2.0 h1:IIu8AitRWCNp51oRvfBU0D7JGM3Tt3QXUejLwEFZk+Q=
 github.com/oakwood-commons/oauth-helpers v0.2.0/go.mod h1:+VhuszKORoPc9H0HwvS92I/U0828up8XejsUpXS7FvE=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.10.0 h1:km2KASFp7Qh7JAJriLIaW37uD2MNZ7IA/MOSNqVvgeo=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.10.0/go.mod h1:oC2LqrVwXEQBgR2rIp+PbSF0mLfkC1a2G5KJb6CzdgE=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.11.0 h1:IFyFPHbg2sKH24uvJ7xTNKhF7G4aQX86T9AoSdio/ik=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.11.0/go.mod h1:oC2LqrVwXEQBgR2rIp+PbSF0mLfkC1a2G5KJb6CzdgE=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=

--- a/pkg/auth/claims.go
+++ b/pkg/auth/claims.go
@@ -7,3 +7,7 @@ import sdkauth "github.com/oakwood-commons/scafctl-plugin-sdk/auth"
 
 // Claims represents normalized identity claims from any auth handler.
 type Claims = sdkauth.Claims
+
+// HandlerMetadata is the canonical persisted metadata for an auth session,
+// shared by core and all plugin auth handlers.
+type HandlerMetadata = sdkauth.HandlerMetadata

--- a/pkg/auth/claims_test.go
+++ b/pkg/auth/claims_test.go
@@ -6,6 +6,7 @@ package auth
 import (
 	"testing"
 
+	sdkauth "github.com/oakwood-commons/scafctl-plugin-sdk/auth"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -50,4 +51,33 @@ func TestClaims_DisplayIdentity(t *testing.T) {
 			assert.Equal(t, tt.want, tt.claims.DisplayIdentity())
 		})
 	}
+}
+
+func TestHandlerMetadata_IsSDKAlias(t *testing.T) {
+	// Compile-time proof that HandlerMetadata and the SDK type are mutually
+	// assignable without conversion (i.e. a true type alias). Passing a value
+	// of one type where the other is expected only compiles for an alias.
+	wantSDK := func(sdkauth.HandlerMetadata) {}
+	wantCore := func(HandlerMetadata) {}
+	wantSDK(HandlerMetadata{})          // core value satisfies the SDK type
+	wantCore(sdkauth.HandlerMetadata{}) // SDK value satisfies the core type
+
+	// Runtime sanity: fields set through the alias are carried across.
+	meta := HandlerMetadata{SessionID: "session-123", ClientID: "client-abc"}
+	wantSDK(meta)
+	assert.Equal(t, "session-123", meta.SessionID)
+	assert.Equal(t, "client-abc", meta.ClientID)
+}
+
+func TestHandlerMetadata_MetaHelpers(t *testing.T) {
+	// The alias must expose the SDK helper methods (SetMeta/MetaString).
+	meta := &HandlerMetadata{}
+	assert.Equal(t, "", meta.MetaString("missing"))
+
+	meta.SetMeta("server", "https://api.example.com")
+	assert.Equal(t, "https://api.example.com", meta.MetaString("server"))
+
+	// Non-string values resolve to the empty string.
+	meta.SetMeta("count", 42)
+	assert.Equal(t, "", meta.MetaString("count"))
 }

--- a/pkg/auth/oauth2/handler.go
+++ b/pkg/auth/oauth2/handler.go
@@ -443,41 +443,6 @@ type tokenResponse struct {
 	Scope        string `json:"scope"`
 }
 
-type handlerMetadata struct {
-	Claims        *auth.Claims `json:"claims"`
-	ExpiresAt     time.Time    `json:"expiresAt"`
-	Scopes        []string     `json:"scopes"`
-	LastLoginFlow auth.Flow    `json:"lastLoginFlow,omitempty"`
-}
-
-// unmarshalMetadata deserializes metadata JSON, handling field name differences
-// between the generic oauth2 handler and plugin auth handlers.
-// Plugin handlers use "refreshTokenExpiresAt" (vs "expiresAt") and
-// "loginFlow" (vs "lastLoginFlow").
-func unmarshalMetadata(data []byte) (*handlerMetadata, error) {
-	var meta handlerMetadata
-	if err := json.Unmarshal(data, &meta); err != nil {
-		return nil, err
-	}
-
-	// If ExpiresAt is zero, try the plugin handler's field name.
-	if meta.ExpiresAt.IsZero() {
-		var compat struct {
-			RefreshTokenExpiresAt time.Time `json:"refreshTokenExpiresAt"`
-			LoginFlow             auth.Flow `json:"loginFlow"`
-		}
-		if err := json.Unmarshal(data, &compat); err == nil {
-			if !compat.RefreshTokenExpiresAt.IsZero() {
-				meta.ExpiresAt = compat.RefreshTokenExpiresAt
-			}
-			if meta.LastLoginFlow == "" && compat.LoginFlow != "" {
-				meta.LastLoginFlow = compat.LoginFlow
-			}
-		}
-	}
-	return &meta, nil
-}
-
 type exchangeResult struct {
 	Token    string `json:"token"`
 	Username string `json:"username,omitempty"`
@@ -902,7 +867,7 @@ func (h *Handler) storeTokens(ctx context.Context, resp *tokenResponse, claims *
 			return fmt.Errorf("store refresh token: %w", err)
 		}
 	}
-	meta := &handlerMetadata{Claims: claims, ExpiresAt: expiresAt, Scopes: scopes, LastLoginFlow: flow}
+	meta := &auth.HandlerMetadata{Claims: claims, ExpiresAt: expiresAt, Scopes: scopes, LastLoginFlow: flow}
 	metaBytes, err := json.Marshal(meta)
 	if err != nil {
 		return fmt.Errorf("marshal metadata: %w", err)
@@ -960,12 +925,16 @@ func (h *Handler) loadDerivedToken(ctx context.Context) (*auth.Token, error) {
 	return &token, nil
 }
 
-func (h *Handler) loadMetadata(ctx context.Context) (*handlerMetadata, error) {
+func (h *Handler) loadMetadata(ctx context.Context) (*auth.HandlerMetadata, error) {
 	data, err := h.secretStore.Get(ctx, h.profileSecretKey(ctx, secretKeyMetadataSuffix))
 	if err != nil {
 		return nil, err
 	}
-	return unmarshalMetadata(data)
+	var meta auth.HandlerMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return nil, err
+	}
+	return &meta, nil
 }
 
 // ---------- refresh ----------

--- a/pkg/auth/oauth2/handler_test.go
+++ b/pkg/auth/oauth2/handler_test.go
@@ -273,7 +273,7 @@ func TestHandler_Status_Authenticated(t *testing.T) {
 	srv := newTestOAuthServer(t)
 	defer srv.Close()
 	h, store := newTestHandler(t, srv, nil)
-	meta := handlerMetadata{Claims: &auth.Claims{Username: "testuser"}, ExpiresAt: time.Now().Add(1 * time.Hour), Scopes: []string{"read"}}
+	meta := auth.HandlerMetadata{Claims: &auth.Claims{Username: "testuser"}, ExpiresAt: time.Now().Add(1 * time.Hour), Scopes: []string{"read"}}
 	metaBytes, _ := json.Marshal(meta)
 	_ = store.Set(context.Background(), secretKeyPrefix+"test-provider."+secretKeyMetadataSuffix, metaBytes)
 	status, err := h.Status(context.Background())
@@ -286,7 +286,7 @@ func TestHandler_Status_Expired(t *testing.T) {
 	srv := newTestOAuthServer(t)
 	defer srv.Close()
 	h, store := newTestHandler(t, srv, nil)
-	meta := handlerMetadata{Claims: &auth.Claims{Username: "testuser"}, ExpiresAt: time.Now().Add(-1 * time.Hour), Scopes: []string{"read"}}
+	meta := auth.HandlerMetadata{Claims: &auth.Claims{Username: "testuser"}, ExpiresAt: time.Now().Add(-1 * time.Hour), Scopes: []string{"read"}}
 	metaBytes, _ := json.Marshal(meta)
 	_ = store.Set(context.Background(), secretKeyPrefix+"test-provider."+secretKeyMetadataSuffix, metaBytes)
 	status, err := h.Status(context.Background())
@@ -860,7 +860,7 @@ func TestWithSecretKeyPrefix(t *testing.T) {
 
 	// Write metadata under the plugin-style prefix
 	pluginPrefix := "scafctl.auth."
-	meta := handlerMetadata{Claims: &auth.Claims{Username: "testuser"}, ExpiresAt: time.Now().Add(1 * time.Hour), Scopes: []string{"read"}}
+	meta := auth.HandlerMetadata{Claims: &auth.Claims{Username: "testuser"}, ExpiresAt: time.Now().Add(1 * time.Hour), Scopes: []string{"read"}}
 	metaBytes, err := json.Marshal(meta)
 	require.NoError(t, err)
 	require.NoError(t, store.Set(context.Background(), pluginPrefix+"test-provider.metadata", metaBytes))
@@ -880,49 +880,6 @@ func TestWithSecretKeyPrefix(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, status.Authenticated)
 	assert.Equal(t, "testuser", status.Claims.Username)
-}
-
-func TestUnmarshalMetadata_PluginFormat(t *testing.T) {
-	// Plugin handler metadata uses different field names
-	pluginJSON := `{
-		"refreshTokenExpiresAt": "2026-08-13T01:13:46Z",
-		"loginFlow": "interactive",
-		"sessionId": "abc123",
-		"tenantId": "tenant1",
-		"clientId": "client1"
-	}`
-	meta, err := unmarshalMetadata([]byte(pluginJSON))
-	require.NoError(t, err)
-	assert.Equal(t, time.Date(2026, 8, 13, 1, 13, 46, 0, time.UTC), meta.ExpiresAt)
-	assert.Equal(t, auth.FlowInteractive, meta.LastLoginFlow)
-}
-
-func TestUnmarshalMetadata_NativeFormat(t *testing.T) {
-	meta := handlerMetadata{
-		Claims:        &auth.Claims{Username: "testuser"},
-		ExpiresAt:     time.Date(2026, 8, 13, 1, 13, 46, 0, time.UTC),
-		Scopes:        []string{"read"},
-		LastLoginFlow: auth.FlowDeviceCode,
-	}
-	data, err := json.Marshal(meta)
-	require.NoError(t, err)
-
-	result, err := unmarshalMetadata(data)
-	require.NoError(t, err)
-	assert.Equal(t, meta.ExpiresAt, result.ExpiresAt)
-	assert.Equal(t, auth.FlowDeviceCode, result.LastLoginFlow)
-	assert.Equal(t, "testuser", result.Claims.Username)
-}
-
-func TestUnmarshalMetadata_EmptyJSON(t *testing.T) {
-	meta, err := unmarshalMetadata([]byte("{}"))
-	require.NoError(t, err)
-	assert.True(t, meta.ExpiresAt.IsZero())
-}
-
-func TestUnmarshalMetadata_InvalidJSON(t *testing.T) {
-	_, err := unmarshalMetadata([]byte("not json"))
-	assert.Error(t, err)
 }
 
 func TestHandler_Status_Reason_NoSecretStore(t *testing.T) {
@@ -959,7 +916,7 @@ func TestHandler_Status_Reason_Expired(t *testing.T) {
 	srv := newTestOAuthServer(t)
 	defer srv.Close()
 	h, store := newTestHandler(t, srv, nil)
-	meta := handlerMetadata{Claims: &auth.Claims{Username: "testuser"}, ExpiresAt: time.Now().Add(-1 * time.Hour)}
+	meta := auth.HandlerMetadata{Claims: &auth.Claims{Username: "testuser"}, ExpiresAt: time.Now().Add(-1 * time.Hour)}
 	metaBytes, _ := json.Marshal(meta)
 	_ = store.Set(context.Background(), secretKeyPrefix+"test-provider.metadata", metaBytes)
 	status, err := h.Status(context.Background())

--- a/pkg/catalog/fetch_layer.go
+++ b/pkg/catalog/fetch_layer.go
@@ -1,0 +1,67 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/content"
+)
+
+// DefaultMaxLayerSize bounds how large a content layer scafctl will read into
+// memory when fetching a plugin/solution blob. It guards against a hostile or
+// misconfigured registry advertising an enormous blob. Plugin binaries are
+// typically tens of MiB, so 1 GiB is a generous ceiling that still prevents
+// unbounded allocation.
+//
+// Note: oras-go's content.FetchAll / content.ReadAll impose their own 32 MiB
+// cap, which is appropriate for small JSON manifests/configs but far too small
+// for binary layers. fetchLayerContent deliberately bypasses that cap (while
+// preserving size + digest verification) for content layers.
+const DefaultMaxLayerSize int64 = 1 << 30 // 1 GiB
+
+// maxLayerSize is the active upper bound enforced by fetchLayerContent. It
+// defaults to DefaultMaxLayerSize and is a package var (not a const) so tests
+// can lower it to exercise the size-limit path without allocating a real
+// gigabyte-scale buffer. A value <= 0 disables the bound.
+var maxLayerSize = DefaultMaxLayerSize
+
+// fetchLayerContent fetches a content layer (a binary or bundle blob) from the
+// fetcher, verifying it against the descriptor's size and digest.
+//
+// Unlike oras-go's content.FetchAll, it does not impose the 32 MiB ReadAll cap,
+// so large plugin binaries can be fetched. The active bound is maxLayerSize.
+func fetchLayerContent(
+	ctx context.Context,
+	fetcher content.Fetcher,
+	desc ocispec.Descriptor,
+) ([]byte, error) {
+	if desc.Size < 0 {
+		return nil, fmt.Errorf("invalid layer size %d for digest %s", desc.Size, desc.Digest)
+	}
+	if maxLayerSize > 0 && desc.Size > maxLayerSize {
+		return nil, fmt.Errorf("layer size %d exceeds maximum allowed size %d for digest %s", desc.Size, maxLayerSize, desc.Digest)
+	}
+
+	rc, err := fetcher.Fetch(ctx, desc)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	// Stream through a VerifyReader so size and digest are checked as the
+	// content flows, without oras-go's in-memory ReadAll size cap.
+	vr := content.NewVerifyReader(rc, desc)
+	buf := make([]byte, desc.Size)
+	if _, err := io.ReadFull(vr, buf); err != nil {
+		return nil, fmt.Errorf("reading layer content for digest %s: %w", desc.Digest, err)
+	}
+	if err := vr.Verify(); err != nil {
+		return nil, fmt.Errorf("verifying layer content for digest %s: %w", desc.Digest, err)
+	}
+	return buf, nil
+}

--- a/pkg/catalog/fetch_layer_test.go
+++ b/pkg/catalog/fetch_layer_test.go
@@ -1,0 +1,132 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package catalog
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2/content"
+)
+
+// descriptorFor builds an OCI descriptor matching the supplied content.
+func descriptorFor(data []byte) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		MediaType: "application/octet-stream",
+		Digest:    digest.FromBytes(data),
+		Size:      int64(len(data)),
+	}
+}
+
+// fetcherReturning adapts a byte slice into a content.Fetcher that serves it.
+func fetcherReturning(data []byte) content.Fetcher {
+	return content.FetcherFunc(func(_ context.Context, _ ocispec.Descriptor) (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader(string(data))), nil
+	})
+}
+
+func TestFetchLayerContent_Success(t *testing.T) {
+	data := []byte("hello plugin binary content")
+	desc := descriptorFor(data)
+
+	got, err := fetchLayerContent(context.Background(), fetcherReturning(data), desc)
+	require.NoError(t, err)
+	assert.Equal(t, data, got)
+}
+
+func TestFetchLayerContent_BypassesOras32MiBCap(t *testing.T) {
+	// oras-go's content.FetchAll/ReadAll caps reads at 32 MiB. fetchLayerContent
+	// must read larger layers. Use 33 MiB to prove the cap is bypassed.
+	data := make([]byte, 33<<20)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	desc := descriptorFor(data)
+
+	got, err := fetchLayerContent(context.Background(), fetcherReturning(data), desc)
+	require.NoError(t, err)
+	assert.Len(t, got, len(data))
+	assert.Equal(t, data, got)
+}
+
+func TestFetchLayerContent_NegativeSize(t *testing.T) {
+	desc := ocispec.Descriptor{
+		Digest: digest.FromBytes([]byte("x")),
+		Size:   -1,
+	}
+
+	_, err := fetchLayerContent(context.Background(), fetcherReturning([]byte("x")), desc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid layer size")
+}
+
+func TestFetchLayerContent_ExceedsMaxSize(t *testing.T) {
+	// Temporarily lower the active bound so we can exercise the size guard
+	// without allocating a gigabyte-scale buffer.
+	original := maxLayerSize
+	maxLayerSize = 8
+	defer func() { maxLayerSize = original }()
+
+	data := []byte("this content is definitely longer than eight bytes")
+	desc := descriptorFor(data)
+
+	_, err := fetchLayerContent(context.Background(), fetcherReturning(data), desc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum allowed size")
+}
+
+func TestFetchLayerContent_DisabledBoundAllowsAnySize(t *testing.T) {
+	// A non-positive bound disables the size check.
+	original := maxLayerSize
+	maxLayerSize = 0
+	defer func() { maxLayerSize = original }()
+
+	data := []byte("unbounded read is permitted")
+	desc := descriptorFor(data)
+
+	got, err := fetchLayerContent(context.Background(), fetcherReturning(data), desc)
+	require.NoError(t, err)
+	assert.Equal(t, data, got)
+}
+
+func TestFetchLayerContent_FetcherError(t *testing.T) {
+	wantErr := errors.New("registry unreachable")
+	fetcher := content.FetcherFunc(func(_ context.Context, _ ocispec.Descriptor) (io.ReadCloser, error) {
+		return nil, wantErr
+	})
+
+	_, err := fetchLayerContent(context.Background(), fetcher, descriptorFor([]byte("x")))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+}
+
+func TestFetchLayerContent_DigestMismatch(t *testing.T) {
+	data := []byte("the real content served by the registry")
+	// Descriptor advertises a digest for different content of the same length.
+	tampered := []byte("the fake content of an exact equal len.")
+	require.Equal(t, len(data), len(tampered))
+	desc := descriptorFor(tampered)
+
+	_, err := fetchLayerContent(context.Background(), fetcherReturning(data), desc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "verifying layer content")
+}
+
+func TestFetchLayerContent_TruncatedContent(t *testing.T) {
+	full := []byte("the descriptor claims more bytes than the reader provides")
+	desc := descriptorFor(full)
+	// Serve fewer bytes than the descriptor's declared size.
+	short := full[:len(full)-10]
+
+	_, err := fetchLayerContent(context.Background(), fetcherReturning(short), desc)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reading layer content")
+}

--- a/pkg/catalog/index.go
+++ b/pkg/catalog/index.go
@@ -88,7 +88,7 @@ func (c *RemoteCatalog) fetchIndexFromRepo(ctx context.Context, repo *remote.Rep
 	}
 
 	// Fetch the first layer (the JSON index).
-	layerData, err := content.FetchAll(ctx, repo, manifest.Layers[0])
+	layerData, err := fetchLayerContent(ctx, repo, manifest.Layers[0])
 	if err != nil {
 		return nil, fmt.Errorf("fetching catalog index layer: %w", err)
 	}

--- a/pkg/catalog/remote.go
+++ b/pkg/catalog/remote.go
@@ -559,7 +559,7 @@ func (c *RemoteCatalog) fetchInternal(ctx context.Context, ref Reference) ([]byt
 	}
 
 	// Fetch content layer with digest verification
-	contentData, err := content.FetchAll(ctx, repo, manifest.Layers[0])
+	contentData, err := fetchLayerContent(ctx, repo, manifest.Layers[0])
 	if err != nil {
 		return nil, ArtifactInfo{}, fmt.Errorf("failed to fetch content: %w", err)
 	}
@@ -640,7 +640,7 @@ func (c *RemoteCatalog) fetchWithBundleInternal(ctx context.Context, ref Referen
 	}
 
 	// Fetch content layer with digest verification
-	contentData, err := content.FetchAll(ctx, repo, manifest.Layers[0])
+	contentData, err := fetchLayerContent(ctx, repo, manifest.Layers[0])
 	if err != nil {
 		return nil, nil, ArtifactInfo{}, fmt.Errorf("failed to fetch content: %w", err)
 	}
@@ -651,14 +651,14 @@ func (c *RemoteCatalog) fetchWithBundleInternal(ctx context.Context, ref Referen
 		switch manifest.Layers[1].MediaType {
 		case MediaTypeSolutionBundle:
 			// Version 1: single tar layer
-			bundleData, err = content.FetchAll(ctx, repo, manifest.Layers[1])
+			bundleData, err = fetchLayerContent(ctx, repo, manifest.Layers[1])
 			if err != nil {
 				return nil, nil, ArtifactInfo{}, fmt.Errorf("failed to fetch bundle: %w", err)
 			}
 		case MediaTypeSolutionBundleManifest:
 			// Version 2: deduplicated — reassemble into a v1-compatible tar
 			fetchBlob := func(desc ocispec.Descriptor) ([]byte, error) {
-				return content.FetchAll(ctx, repo, desc)
+				return fetchLayerContent(ctx, repo, desc)
 			}
 			bundleData, err = reassembleDedupBundle(manifest, fetchBlob)
 			if err != nil {

--- a/pkg/catalog/remote_multiplatform.go
+++ b/pkg/catalog/remote_multiplatform.go
@@ -104,7 +104,7 @@ func (c *RemoteCatalog) extractLayerContent(
 		return nil, ArtifactInfo{}, fmt.Errorf("manifest has no content layers")
 	}
 
-	contentData, err := content.FetchAll(ctx, repo, manifest.Layers[0])
+	contentData, err := fetchLayerContent(ctx, repo, manifest.Layers[0])
 	if err != nil {
 		return nil, ArtifactInfo{}, fmt.Errorf("failed to fetch content layer: %w", err)
 	}

--- a/pkg/plugin/grpc.go
+++ b/pkg/plugin/grpc.go
@@ -1115,10 +1115,16 @@ func descriptorToProto(desc *provider.Descriptor) *proto.ProviderDescriptor {
 		Deprecated:             desc.IsDeprecated,
 		Beta:                   desc.Beta,
 		HasExtractDependencies: desc.ExtractDependencies != nil,
+		WriteOperations:        desc.WriteOperations,
 	}
 
 	for i, cap := range desc.Capabilities {
 		protoDesc.Capabilities[i] = string(cap)
+	}
+
+	// Convert rich per-operation metadata (write classification, schemas, etc.)
+	for i := range desc.Operations {
+		protoDesc.Operations = append(protoDesc.Operations, operationDescriptorToProto(desc.Operations[i]))
 	}
 
 	// Convert links
@@ -1177,6 +1183,93 @@ func descriptorToProto(desc *provider.Descriptor) *proto.ProviderDescriptor {
 	return protoDesc
 }
 
+// operationDescriptorToProto converts a provider.OperationDescriptor to its proto
+// representation. Operation input/output schemas are serialized as raw JSON bytes,
+// mirroring the lossless schema handling used for the provider descriptor.
+func operationDescriptorToProto(op provider.OperationDescriptor) *proto.OperationDescriptor {
+	protoOp := &proto.OperationDescriptor{
+		Name:               op.Name,
+		DisplayName:        op.DisplayName,
+		Description:        op.Description,
+		IsWrite:            op.IsWrite,
+		Tags:               op.Tags,
+		Deprecated:         op.IsDeprecated,
+		DeprecationMessage: op.DeprecationMessage,
+	}
+
+	if len(op.Capabilities) > 0 {
+		protoOp.Capabilities = make([]string, len(op.Capabilities))
+		for i, c := range op.Capabilities {
+			protoOp.Capabilities[i] = string(c)
+		}
+	}
+
+	if op.InputSchema != nil {
+		if raw, err := json.Marshal(op.InputSchema); err == nil {
+			protoOp.InputSchema = raw
+		}
+	}
+	if op.OutputSchema != nil {
+		if raw, err := json.Marshal(op.OutputSchema); err == nil {
+			protoOp.OutputSchema = raw
+		}
+	}
+
+	for _, ex := range op.Examples {
+		protoOp.Examples = append(protoOp.Examples, &proto.Example{
+			Name:        ex.Name,
+			Description: ex.Description,
+			Yaml:        ex.YAML,
+		})
+	}
+
+	return protoOp
+}
+
+// protoToOperationDescriptor converts a proto.OperationDescriptor back to the
+// provider representation, deserializing schemas from raw JSON bytes.
+func protoToOperationDescriptor(protoOp *proto.OperationDescriptor) provider.OperationDescriptor {
+	op := provider.OperationDescriptor{
+		Name:               protoOp.Name,
+		DisplayName:        protoOp.DisplayName,
+		Description:        protoOp.Description,
+		IsWrite:            protoOp.IsWrite,
+		Tags:               protoOp.Tags,
+		IsDeprecated:       protoOp.Deprecated,
+		DeprecationMessage: protoOp.DeprecationMessage,
+	}
+
+	if len(protoOp.Capabilities) > 0 {
+		op.Capabilities = make([]provider.Capability, len(protoOp.Capabilities))
+		for i, c := range protoOp.Capabilities {
+			op.Capabilities[i] = provider.Capability(c)
+		}
+	}
+
+	if len(protoOp.InputSchema) > 0 {
+		var schema jsonschema.Schema
+		if err := json.Unmarshal(protoOp.InputSchema, &schema); err == nil {
+			op.InputSchema = &schema
+		}
+	}
+	if len(protoOp.OutputSchema) > 0 {
+		var schema jsonschema.Schema
+		if err := json.Unmarshal(protoOp.OutputSchema, &schema); err == nil {
+			op.OutputSchema = &schema
+		}
+	}
+
+	for _, ex := range protoOp.Examples {
+		op.Examples = append(op.Examples, provider.Example{
+			Name:        ex.Name,
+			Description: ex.Description,
+			YAML:        ex.Yaml,
+		})
+	}
+
+	return op
+}
+
 // protoToDescriptor converts proto.ProviderDescriptor to provider.Descriptor
 func protoToDescriptor(protoDesc *proto.ProviderDescriptor) (*provider.Descriptor, error) {
 	var version *semver.Version
@@ -1200,10 +1293,19 @@ func protoToDescriptor(protoDesc *proto.ProviderDescriptor) (*provider.Descripto
 		Icon:            protoDesc.Icon,
 		IsDeprecated:    protoDesc.Deprecated,
 		Beta:            protoDesc.Beta,
+		WriteOperations: protoDesc.WriteOperations,
 	}
 
 	for i, cap := range protoDesc.Capabilities {
 		desc.Capabilities[i] = provider.Capability(cap)
+	}
+
+	// Convert rich per-operation metadata.
+	for _, protoOp := range protoDesc.Operations {
+		if protoOp == nil {
+			continue
+		}
+		desc.Operations = append(desc.Operations, protoToOperationDescriptor(protoOp))
 	}
 
 	// Convert links

--- a/pkg/plugin/grpc_new_test.go
+++ b/pkg/plugin/grpc_new_test.go
@@ -633,6 +633,96 @@ func TestSchemaRoundTrip_Lossless(t *testing.T) {
 	assert.Len(t, statusProp.Enum, 2)
 }
 
+// TestOperationsRoundTrip_Lossless verifies that WriteOperations and the rich
+// Operations metadata survive the descriptorToProto -> protoToDescriptor round
+// trip, and that write classification (the security-relevant part) is preserved
+// for plugin-backed providers -- including when an operation is classified only
+// via Operations[].IsWrite with a nil WriteOperations list.
+func TestOperationsRoundTrip_Lossless(t *testing.T) {
+	t.Run("legacy WriteOperations list", func(t *testing.T) {
+		original := &provider.Descriptor{
+			Name:            "ops-legacy",
+			APIVersion:      "v1",
+			Version:         semver.MustParse("1.0.0"),
+			Capabilities:    []provider.Capability{provider.CapabilityFrom, provider.CapabilityAction},
+			WriteOperations: []string{"create_issue", "delete_issue"},
+		}
+
+		desc, err := protoToDescriptor(descriptorToProto(original))
+		require.NoError(t, err)
+		assert.Equal(t, []string{"create_issue", "delete_issue"}, desc.WriteOperations)
+		assert.True(t, desc.IsWriteOperation("create_issue"))
+		assert.False(t, desc.IsWriteOperation("get_issue"))
+	})
+
+	t.Run("rich Operations metadata with nil WriteOperations", func(t *testing.T) {
+		original := &provider.Descriptor{
+			Name:         "ops-rich",
+			APIVersion:   "v1",
+			Version:      semver.MustParse("1.0.0"),
+			Capabilities: []provider.Capability{provider.CapabilityFrom, provider.CapabilityAction},
+			Operations: []provider.OperationDescriptor{
+				{
+					Name:         "get_issue",
+					DisplayName:  "Get Issue",
+					Description:  "Reads an issue",
+					Capabilities: []provider.Capability{provider.CapabilityFrom},
+					IsWrite:      false,
+					Tags:         []string{"read"},
+					InputSchema: &jsonschema.Schema{
+						Type:       "object",
+						Properties: map[string]*jsonschema.Schema{"id": {Type: "string"}},
+					},
+				},
+				{
+					Name:               "create_issue",
+					DisplayName:        "Create Issue",
+					Description:        "Creates an issue",
+					Capabilities:       []provider.Capability{provider.CapabilityAction},
+					IsWrite:            true,
+					Tags:               []string{"write"},
+					IsDeprecated:       true,
+					DeprecationMessage: "use create_issue_v2",
+					OutputSchema: &jsonschema.Schema{
+						Type:       "object",
+						Properties: map[string]*jsonschema.Schema{"number": {Type: "integer"}},
+					},
+					Examples: []provider.Example{{Name: "basic", Description: "create one", YAML: "kind: from"}},
+				},
+			},
+		}
+
+		protoDesc := descriptorToProto(original)
+		require.Len(t, protoDesc.Operations, 2)
+
+		desc, err := protoToDescriptor(protoDesc)
+		require.NoError(t, err)
+		require.Len(t, desc.Operations, 2)
+
+		// Write classification derived from Operations must survive.
+		assert.Nil(t, desc.WriteOperations)
+		assert.True(t, desc.IsWriteOperation("create_issue"))
+		assert.False(t, desc.IsWriteOperation("get_issue"))
+
+		// Rich metadata fidelity.
+		createOp := desc.Operations[1]
+		assert.Equal(t, "create_issue", createOp.Name)
+		assert.Equal(t, "Create Issue", createOp.DisplayName)
+		assert.True(t, createOp.IsWrite)
+		assert.True(t, createOp.IsDeprecated)
+		assert.Equal(t, "use create_issue_v2", createOp.DeprecationMessage)
+		assert.Equal(t, []provider.Capability{provider.CapabilityAction}, createOp.Capabilities)
+		require.NotNil(t, createOp.OutputSchema)
+		assert.Contains(t, createOp.OutputSchema.Properties, "number")
+		require.Len(t, createOp.Examples, 1)
+		assert.Equal(t, "basic", createOp.Examples[0].Name)
+
+		readOp := desc.Operations[0]
+		require.NotNil(t, readOp.InputSchema)
+		assert.Contains(t, readOp.InputSchema.Properties, "id")
+	})
+}
+
 // TestSchemaRoundTrip_StructuredFallback verifies that the structured
 // Parameter fields work correctly when raw JSON is not available (e.g.,
 // talking to an older plugin).

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -32,16 +32,12 @@ const (
 
 	// CapabilityState signals that a provider can act as a state persistence backend.
 	// Providers with this capability handle load/save/delete operations for solution state.
-	// This capability is defined in scafctl (not the SDK) because state is an application-level
-	// concern that external plugin providers can also implement.
-	CapabilityState Capability = "state"
+	CapabilityState = sdkprovider.CapabilityState
 
 	// CapabilityKubeconfig signals that a provider can perform kubeconfig and cluster
 	// operations (write/remove kubeconfig entries, detect auth type, check reachability,
 	// whoami). Providers with this capability dispatch on an "operation" input field.
-	// This capability is defined in scafctl (not the SDK) because kubeconfig wiring is an
-	// application-level concern that external plugin providers can also implement.
-	CapabilityKubeconfig Capability = "kubeconfig"
+	CapabilityKubeconfig = sdkprovider.CapabilityKubeconfig
 )
 
 // Contact represents maintainer contact information.
@@ -53,79 +49,25 @@ type Link = sdkprovider.Link
 // Example represents a usage example for a provider.
 type Example = sdkprovider.Example
 
+// OperationDescriptor is re-exported from the SDK so host code can describe and
+// round-trip per-operation metadata (including write classification).
+type OperationDescriptor = sdkprovider.OperationDescriptor
+
 // ValidateDescriptor validates that a Descriptor meets all requirements.
-// It extends the SDK validation with scafctl-specific capabilities (e.g., CapabilityState).
+// It delegates directly to the SDK validator, which understands all capabilities
+// including scafctl-host capabilities (CapabilityState, CapabilityKubeconfig).
+// A shallow copy is passed so the caller's top-level fields are never reassigned;
+// note this does not deep-copy nested maps/slices (e.g. OutputSchemas), which
+// remain shared. The SDK validator is read-only and does not mutate them.
 func ValidateDescriptor(desc *Descriptor) error {
-	// Temporarily strip scafctl-specific capabilities before calling the SDK validator,
-	// then validate them locally. This avoids "unknown capability" errors from the SDK.
-	var localCaps []Capability
-	var sdkCaps []Capability
-	for _, cap := range desc.Capabilities {
-		if isScafctlCapability(cap) {
-			localCaps = append(localCaps, cap)
-		} else {
-			sdkCaps = append(sdkCaps, cap)
-		}
+	if desc == nil {
+		return fmt.Errorf("descriptor is nil")
 	}
-
-	// Validate SDK-known capabilities via the SDK validator using a shallow
-	// copy so we never mutate the caller's descriptor (avoids data races if
-	// registration ever runs concurrently).
-	if len(sdkCaps) > 0 {
-		sdkDesc := *desc
-		sdkDesc.Capabilities = sdkCaps
-		if err := sdkprovider.ValidateDescriptor(&sdkDesc); err != nil {
-			return err
-		}
-	} else if desc.OutputSchemas == nil {
-		// Even without SDK capabilities, enforce the same baseline descriptor
-		// requirements that the SDK validator normally checks.
-		return fmt.Errorf("descriptor must define OutputSchemas")
-	}
-
-	// Validate scafctl-specific capabilities locally
-	for _, cap := range localCaps {
-		schema, exists := desc.OutputSchemas[cap]
-		if !exists {
-			return fmt.Errorf("missing output schema for capability %q", cap)
-		}
-		requiredFields := scafctlCapabilityRequiredFields(cap)
-		for fieldName, expectedType := range requiredFields {
-			if schema == nil || schema.Properties == nil {
-				return fmt.Errorf("capability %q requires output field %q", cap, fieldName)
-			}
-			prop, found := schema.Properties[fieldName]
-			if !found || prop == nil {
-				return fmt.Errorf("capability %q requires output field %q", cap, fieldName)
-			}
-			if prop.Type != expectedType {
-				return fmt.Errorf("capability %q field %q must be type %q, got %q", cap, fieldName, expectedType, prop.Type)
-			}
-		}
-	}
-
-	return nil
+	sdkDesc := *desc
+	return sdkprovider.ValidateDescriptor(&sdkDesc)
 }
 
-// isScafctlCapability reports whether the capability is a scafctl-defined capability
-// (not known to the SDK) that requires local validation.
-func isScafctlCapability(c Capability) bool {
-	return c == CapabilityState || c == CapabilityKubeconfig
-}
-
-// scafctlCapabilityRequiredFields returns the required output fields for a
-// scafctl-defined capability. Every scafctl capability must report a boolean
-// "success" field so callers can detect operation outcome uniformly.
-func scafctlCapabilityRequiredFields(_ Capability) map[string]string {
-	return map[string]string{
-		"success": "boolean",
-	}
-}
-
-// IsCapabilityValid checks if the capability is valid, including scafctl-specific capabilities.
+// IsCapabilityValid reports whether the capability is recognized by the SDK.
 func IsCapabilityValid(c Capability) bool {
-	if isScafctlCapability(c) {
-		return true
-	}
 	return c.IsValid()
 }

--- a/pkg/provider/registry_test.go
+++ b/pkg/provider/registry_test.go
@@ -697,6 +697,12 @@ func TestValidateDescriptor(t *testing.T) {
 	}
 }
 
+func TestValidateDescriptor_Nil(t *testing.T) {
+	err := ValidateDescriptor(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "descriptor is nil")
+}
+
 func TestRegistry_MarkKnown(t *testing.T) {
 	t.Run("marks new name as known", func(t *testing.T) {
 		r := NewRegistry()

--- a/pkg/tokenprovider/build.go
+++ b/pkg/tokenprovider/build.go
@@ -4,6 +4,7 @@
 package tokenprovider
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
@@ -39,6 +40,20 @@ func Build(mode runmode.Mode, authReg *auth.Registry, identityReg *Registry) (*R
 				return nil, fmt.Errorf("registering CLI adapter %q: %w", h.Name(), err)
 			}
 		}
+		// Lazily resolve sources that are not eagerly registered. Official auth
+		// handlers are not built into the core binary; they live in the official
+		// registry and are downloaded on demand. The auth registry's own
+		// fallback resolver fetches and registers them, so consult it here before
+		// failing. Without this, a post-login registry bridge fails with
+		// "source not found" whenever the plugin was not cached at startup
+		// (e.g. headless CI).
+		reg.SetFallback(func(ctx context.Context, name string) (TokenProvider, error) {
+			h, err := authReg.GetContext(ctx, name)
+			if err != nil {
+				return nil, err
+			}
+			return NewAuthHandlerAdapter(h), nil
+		})
 	}
 
 	return reg, nil

--- a/pkg/tokenprovider/build_test.go
+++ b/pkg/tokenprovider/build_test.go
@@ -139,6 +139,37 @@ func TestBuild_CLIMode_NilAuthRegistry(t *testing.T) {
 	assert.Equal(t, 0, reg.Len())
 }
 
+func TestBuild_CLIMode_LazyFallbackResolvesOfficialHandler(t *testing.T) {
+	// Simulate an official handler that is not eagerly registered at startup
+	// (not cached) but is resolvable via the auth registry's fallback (the
+	// official-registry download path).
+	authReg := auth.NewRegistry(auth.WithFallbackResolver(
+		func(_ context.Context, name string) (auth.Handler, error) {
+			if name == "github" {
+				return &mockHandler{name: "github", displayName: "GitHub"}, nil
+			}
+			return nil, errors.New("not an official handler")
+		},
+	))
+
+	reg, err := Build(runmode.CLI, authReg, nil)
+	require.NoError(t, err)
+
+	// github is absent from the eager snapshot...
+	_, ok := reg.Get("github")
+	assert.False(t, ok)
+
+	// ...but GetContext resolves it lazily via the auth registry fallback.
+	src, err := reg.GetContext(context.Background(), "github")
+	require.NoError(t, err)
+	assert.Equal(t, "github", src.Name())
+
+	// Unknown handlers still surface a not-found error.
+	_, err = reg.GetContext(context.Background(), "nonexistent")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSourceNotFound)
+}
+
 func TestBuild_APIMode(t *testing.T) {
 	identityReg := NewRegistry()
 	require.NoError(t, identityReg.Register(&mockTokenProvider{name: "entra"}))

--- a/pkg/tokenprovider/registry.go
+++ b/pkg/tokenprovider/registry.go
@@ -4,21 +4,40 @@
 package tokenprovider
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sort"
 	"sync"
 )
 
-// Registry is a thread-safe map of named TokenProviders, built once at startup.
+// FallbackResolver lazily resolves a TokenProvider by name when it is not
+// already registered. It is consulted by GetContext on a cache miss, allowing
+// official plugin-backed sources to be fetched and registered on demand instead
+// of failing immediately. Returning a nil provider with a nil error is treated
+// as "not found".
+type FallbackResolver func(ctx context.Context, name string) (TokenProvider, error)
+
+// Registry is a thread-safe map of named TokenProviders. Eagerly-registered
+// sources are populated at startup; an optional FallbackResolver resolves
+// additional sources lazily on first use.
 type Registry struct {
-	mu      sync.RWMutex
-	sources map[string]TokenProvider
+	mu       sync.RWMutex
+	sources  map[string]TokenProvider
+	fallback FallbackResolver
 }
 
 // NewRegistry creates an empty token provider registry.
 func NewRegistry() *Registry {
 	return &Registry{sources: make(map[string]TokenProvider)}
+}
+
+// SetFallback configures the lazy fallback resolver consulted by GetContext
+// when a source is not already registered. Passing nil clears it.
+func (r *Registry) SetFallback(fn FallbackResolver) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.fallback = fn
 }
 
 // Register adds a TokenProvider to the registry. Returns an error if the source
@@ -45,12 +64,58 @@ func (r *Registry) Register(source TokenProvider) error {
 }
 
 // Get returns the TokenProvider registered under name and true,
-// or nil and false if no source is registered.
+// or nil and false if no source is registered. Get never consults the
+// fallback resolver; use GetContext for lazy resolution.
 func (r *Registry) Get(name string) (TokenProvider, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	s, ok := r.sources[name]
 	return s, ok
+}
+
+// GetContext returns the TokenProvider registered under name. On a cache miss
+// it consults the fallback resolver (if configured), which may lazily resolve
+// and download an official plugin-backed source. A successfully resolved source
+// is cached for subsequent lookups. Returns an error wrapping ErrSourceNotFound
+// when the source is neither registered nor resolvable.
+func (r *Registry) GetContext(ctx context.Context, name string) (TokenProvider, error) {
+	r.mu.RLock()
+	s, ok := r.sources[name]
+	fallback := r.fallback
+	r.mu.RUnlock()
+	if ok {
+		return s, nil
+	}
+	if fallback == nil {
+		return nil, fmt.Errorf("%w: %s", ErrSourceNotFound, name)
+	}
+
+	resolved, err := fallback(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s: %w", ErrSourceNotFound, name, err)
+	}
+	if resolved == nil {
+		return nil, fmt.Errorf("%w: %s", ErrSourceNotFound, name)
+	}
+
+	// Enforce the same name invariant as Register before caching: the resolved
+	// provider must report a name matching the requested name. This prevents a
+	// buggy fallback from caching a provider with an empty or mismatched Name(),
+	// which would leave the registry internally inconsistent.
+	if resolvedName := resolved.Name(); resolvedName != name {
+		return nil, fmt.Errorf("%w: %s: fallback resolved provider with mismatched name %q", ErrSourceNotFound, name, resolvedName)
+	}
+
+	// Cache for subsequent lookups, tolerating a concurrent resolution that
+	// may have registered the same name first.
+	r.mu.Lock()
+	if existing, exists := r.sources[name]; exists {
+		resolved = existing
+	} else {
+		r.sources[name] = resolved
+	}
+	r.mu.Unlock()
+	return resolved, nil
 }
 
 // MustGet returns the TokenProvider or panics if not found.

--- a/pkg/tokenprovider/registry_test.go
+++ b/pkg/tokenprovider/registry_test.go
@@ -142,6 +142,104 @@ func TestRegistry_Len(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// GetContext / Fallback Tests
+// ---------------------------------------------------------------------------
+
+func TestRegistry_GetContext_Registered(t *testing.T) {
+	reg := NewRegistry()
+	require.NoError(t, reg.Register(newMockSource("github")))
+
+	src, err := reg.GetContext(context.Background(), "github")
+	require.NoError(t, err)
+	assert.Equal(t, "github", src.Name())
+}
+
+func TestRegistry_GetContext_NoFallback(t *testing.T) {
+	reg := NewRegistry()
+
+	_, err := reg.GetContext(context.Background(), "github")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSourceNotFound)
+}
+
+func TestRegistry_GetContext_FallbackResolves(t *testing.T) {
+	reg := NewRegistry()
+	var calls int
+	reg.SetFallback(func(_ context.Context, name string) (TokenProvider, error) {
+		calls++
+		return newMockSource(name), nil
+	})
+
+	// First lookup triggers the fallback.
+	src, err := reg.GetContext(context.Background(), "github")
+	require.NoError(t, err)
+	assert.Equal(t, "github", src.Name())
+	assert.Equal(t, 1, calls)
+
+	// Resolved source is cached: the fallback is not consulted again.
+	src, err = reg.GetContext(context.Background(), "github")
+	require.NoError(t, err)
+	assert.Equal(t, "github", src.Name())
+	assert.Equal(t, 1, calls)
+}
+
+func TestRegistry_GetContext_FallbackError(t *testing.T) {
+	reg := NewRegistry()
+	reg.SetFallback(func(_ context.Context, _ string) (TokenProvider, error) {
+		return nil, errors.New("download failed")
+	})
+
+	_, err := reg.GetContext(context.Background(), "github")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSourceNotFound)
+	assert.Contains(t, err.Error(), "download failed")
+}
+
+func TestRegistry_GetContext_FallbackNotFound(t *testing.T) {
+	reg := NewRegistry()
+	reg.SetFallback(func(_ context.Context, _ string) (TokenProvider, error) {
+		return nil, nil
+	})
+
+	_, err := reg.GetContext(context.Background(), "github")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSourceNotFound)
+}
+
+func TestRegistry_GetContext_FallbackMismatchedName(t *testing.T) {
+	reg := NewRegistry()
+	var calls int
+	reg.SetFallback(func(_ context.Context, _ string) (TokenProvider, error) {
+		calls++
+		// Buggy fallback returns a provider whose Name() does not match.
+		return newMockSource("wrong"), nil
+	})
+
+	_, err := reg.GetContext(context.Background(), "github")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSourceNotFound)
+	assert.Contains(t, err.Error(), "mismatched name")
+
+	// The inconsistent provider must not be cached: a second lookup consults
+	// the fallback again rather than returning a stale, wrong entry.
+	_, err = reg.GetContext(context.Background(), "github")
+	require.Error(t, err)
+	assert.Equal(t, 2, calls)
+}
+
+func TestRegistry_GetContext_FallbackEmptyName(t *testing.T) {
+	reg := NewRegistry()
+	reg.SetFallback(func(_ context.Context, _ string) (TokenProvider, error) {
+		return newMockSource(""), nil
+	})
+
+	_, err := reg.GetContext(context.Background(), "github")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSourceNotFound)
+	assert.Contains(t, err.Error(), "mismatched name")
+}
+
+// ---------------------------------------------------------------------------
 // Context Tests
 // ---------------------------------------------------------------------------
 
@@ -201,4 +299,18 @@ func TestGetToken_SourceError(t *testing.T) {
 	_, err := GetToken(ctx, "entra", RequestOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "token expired")
+}
+
+func TestGetToken_LazyFallbackResolution(t *testing.T) {
+	// A source absent from the registry snapshot is resolved on demand via the
+	// fallback (mirroring an official handler downloaded after startup).
+	reg := NewRegistry()
+	reg.SetFallback(func(_ context.Context, name string) (TokenProvider, error) {
+		return newMockSource(name), nil
+	})
+	ctx := WithRegistry(context.Background(), reg)
+
+	token, err := GetToken(ctx, "github", RequestOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "tok-github", token.AccessToken)
 }

--- a/pkg/tokenprovider/tokenprovider.go
+++ b/pkg/tokenprovider/tokenprovider.go
@@ -11,7 +11,6 @@ package tokenprovider
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -67,15 +66,17 @@ func ExtractPassthroughTokenFromContext(ctx context.Context, provider string) (T
 
 // GetToken is the primary convenience function for consumers. It extracts
 // the registry from context, looks up the named source, and retrieves a token.
+// The lookup consults the registry's fallback resolver, so official handlers
+// that are not yet downloaded are fetched on demand before failing.
 func GetToken(ctx context.Context, provider string, opts RequestOptions) (Token, error) {
 	reg := RegistryFromContext(ctx)
 	if reg == nil {
 		return Token{}, ErrNoRegistry
 	}
 
-	source, ok := reg.Get(provider)
-	if !ok {
-		return Token{}, fmt.Errorf("%w: %s", ErrSourceNotFound, provider)
+	source, err := reg.GetContext(ctx, provider)
+	if err != nil {
+		return Token{}, err
 	}
 
 	return source.GetToken(ctx, opts)


### PR DESCRIPTION
Adopt SDK v0.11.0, which natively understands the scafctl-host
capabilities (state, kubeconfig) and exposes a canonical
auth.HandlerMetadata. Removes the host-side compatibility layers that
existed only to bridge the previous SDK version.

- provider: simplify ValidateDescriptor to delegate directly to the SDK
  validator; drop the strip-then-validate workaround and the local
  isScafctlCapability/scafctlCapabilityRequiredFields helpers
- provider: CapabilityState and CapabilityKubeconfig now alias the SDK
  constants; add a nil-descriptor guard and test
- auth: add HandlerMetadata type alias for the SDK type; remove the
  private handlerMetadata struct and unmarshalMetadata field-name shim
  from the oauth2 handler
- tokenprovider: lazily consult the official auth registry when a token
  source is not eagerly registered. The CLI builds its token-source
  registry once at startup from cached handlers; official handlers that
  were not cached (e.g. headless CI) were absent, so the post-login
  registry bridge failed with "source not found". GetContext now falls
  back to the auth registry's official-plugin download path before
  failing. The fallback-resolved provider's name is validated against the
  requested name before caching, matching Register's invariants
- provider/plugin: thread WriteOperations and the new v0.11 Operations
  metadata through the gRPC descriptor mapping. The host previously
  dropped both fields for plugin-backed providers, so write operations
  were never classified and could not be rejected in read-only resolver
  contexts. Completes the v0.11 uptake: the SDK proto already carried the
  fields; scafctl just never consumed them
- deps: bump github.com/oakwood-commons/scafctl-plugin-sdk to v0.11.0

Bundled plugin-install fix (surfaced while validating the SDK uptake
against the official kubeconfig plugin):

- catalog: fix installation of official plugins whose content layer
  exceeds 32 MiB (e.g. kubeconfig 0.1.1, ~35 MiB binary). oras
  content.ReadAll caps in-memory reads at 32 MiB and rejected the layer
  with "invalid descriptor size", which a downstream fallback then masked
  as "manifest has no content layers". Content layers are now fetched via
  a streaming VerifyReader (size + digest verified) bounded by a
  configurable guard instead of the hard 32 MiB cap

Closes #549
Closes #551
Closes #558

BREAKING CHANGE: auth.HandlerMetadata is now a type alias for
scafctl-plugin-sdk/auth.HandlerMetadata, and provider CapabilityState
and CapabilityKubeconfig alias the SDK constants. Persisted oauth2
session metadata is now read using the SDK's canonical field names
(expiresAt, lastLoginFlow); metadata written by pre-v0.11 plugin
handlers using the old field names (refreshTokenExpiresAt, loginFlow)
will no longer populate those fields and may force re-authentication.
