### PR TITLE
feat(auth): add kube login and logout commands with default-handler resolution

### DIFF
--- a/docs/design/kubeconfig-provider-implementation-plan.md
+++ b/docs/design/kubeconfig-provider-implementation-plan.md
@@ -151,7 +151,7 @@ signature. The manager marshals typed structs to maps (JSON round-trip, like
 
 | operation          | Inputs (key fields)                                                                                                   | Output (Data fields)                          |
 |--------------------|---------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
-| `kubeconfig_write` | `server`, `audience`, `cluster_name`, `context_name`, `user_name`, `kubeconfig_path`, `exec_command`, `exec_args`, `insecure_skip_tls`, `set_current_context` | `success`, `context_name`, `kubeconfig_path`  |
+| `kubeconfig_write` | `server`, `audience`, `cluster_name`, `context_name`, `user_name`, `kubeconfig_path`, `exec_command`, `exec_args`, `ca_data`, `interactive_mode`, `install_hint`, `provide_cluster_info`, `insecure_skip_tls`, `set_current_context` | `success`, `context_name`, `kubeconfig_path`  |
 | `kubeconfig_remove`| `cluster_name`, `context_name`, `user_name`, `kubeconfig_path`                                                        | `success`, `removed`                          |
 | `current_server`   | `kubeconfig_path`, `context_name`                                                                                    | `server`                                      |
 | `detect_auth_type` | `server`, `insecure_skip_tls`                                                                                        | `auth_type` (auto/oauth/oidc), `oidc_issuer`, `oauth_endpoint` |
@@ -172,6 +172,15 @@ Contract notes:
   never caches it.
 - `kubeconfig_path` empty means "resolve `KUBECONFIG` env or `~/.kube/config`"
   inside the plugin via `clientcmd` loading rules.
+- `ca_data` is a PEM-encoded cluster CA bundle. When set, the written cluster
+  entry pins the API server to this CA instead of falling back to
+  `insecure_skip_tls`.
+- `interactive_mode`, `install_hint`, and `provide_cluster_info` map to the
+  kubeconfig exec block (`client.authentication.k8s.io`): `interactive_mode`
+  (`Never`/`IfAvailable`/`Always`) controls whether kubectl may run the exec
+  credential plugin interactively, `install_hint` is the message kubectl shows
+  when the exec command is missing from `PATH`, and `provide_cluster_info` asks
+  kubectl to pass cluster details to the plugin via `KUBERNETES_EXEC_INFO`.
 
 ## 5. Module / repo layout
 

--- a/docs/design/kubernetes-auth.md
+++ b/docs/design/kubernetes-auth.md
@@ -20,7 +20,7 @@ The design is layered by dependency weight so each phase ships independently:
 | 1b | `ClusterResolver` interface + `RootOptions` hook | core (`pkg/kube`) | Shipped |
 | 2a | Kubeconfig provider capability contract + host-side manager | core (`pkg/kubeconfig`, `CapabilityKubeconfig`) | Shipped |
 | 2b | Kubeconfig provider plugin implementation (`client-go`/`clientcmd`) | plugin | Planned |
-| 3 | Thin `login` / `kube` command | core | Planned |
+| 3 | Thin `kube login` / `kube logout` commands | core (`pkg/kube/login`, `pkg/cmd/scafctl/kube`) | Shipped |
 | 4 | OpenShift OAuth auth-handler plugin | plugin | Planned |
 
 Phases 1-3 add no OpenShift- or vendor-specific code and already deliver
@@ -62,6 +62,8 @@ type ClusterInfo struct {
     ConsoleURL      string
     AuthType        AuthType
     OIDCAudience    string
+    DefaultHandler  string
+    CAData          string
     InsecureSkipTLS bool
 }
 
@@ -80,11 +82,27 @@ type ClusterResolver interface {
 | `ConsoleURL` | Optional web console URL (informational). |
 | `AuthType` | Authentication method; empty means auto-detect. |
 | `OIDCAudience` | Client ID / audience the minted token must target for OIDC clusters. |
+| `DefaultHandler` | Auth handler used when the caller omits `--handler`. Lets users run `kube login <cluster>` without naming a handler. Optional. |
+| `CAData` | PEM-encoded cluster CA bundle. When set, login pins the API server to this CA instead of falling back to `InsecureSkipTLS`. |
 | `InsecureSkipTLS` | Disables API server TLS verification (development only). |
 
 `ClusterInfo.Validate()` rejects an empty `Name` (`ErrEmptyClusterName`) or an
 unrecognized `AuthType` (`ErrInvalidAuthType`). `APIServerURL` is intentionally
 optional because login can resolve it via `--server` or auto-detection.
+
+### Handler Resolution
+
+The auth handler is chosen after the cluster is resolved, using the precedence
+`--handler` flag -> resolved `ClusterInfo.DefaultHandler` -> error
+(`ErrNoHandler`). The CLI passes `auth.GetHandler` to the login orchestration as
+a `Deps.HandlerLookup` hook so the domain layer owns the precedence and the
+command stays thin. This lets an embedder's cluster registry supply the default
+handler so users can run `kube login <cluster>` with no flags.
+
+`kube login --verify` requires a successful post-login `whoami`; when the
+kubeconfig provider is unavailable (static-fallback path) verification cannot run
+and `--verify` fails by design. Without `--verify`, `whoami` remains best-effort
+and only populates the reported identity.
 
 ### Embedder Hook
 
@@ -129,12 +147,17 @@ with no resolver involved.
   context with an `ExecConfig` credential plugin; implements `DetectAuthType`,
   `CheckAPIServerReachable` (`/healthz`), and `Whoami` (SelfSubjectReview).
   Vendor-neutral; reused by both OIDC and OpenShift paths.
-- **Phase 3 -- Kube wiring on `auth login` / `auth logout`.** Orchestration
-  only: run the handler login to mint a token, then delegate the kubeconfig
-  write to the Phase 2b provider over the existing provider RPC. Surfaced as
-  `auth login <handler> --cluster <name>` (and matching `auth logout`) rather
-  than a new top-level command. Consumes `kube.ClusterResolver` to resolve a
-  cluster name into `--server` and `--audience`. `client-go` never enters core.
+- **Phase 3 -- `kube login` / `kube logout` commands (Shipped).**
+  Orchestration only, in `pkg/kube/login` (domain) with thin CLI wiring in
+  `pkg/cmd/scafctl/kube`: run the handler login to mint a token, then delegate
+  the kubeconfig write to the Phase 2b provider over the existing provider RPC.
+  Surfaced under a dedicated `kube` command group as `kube login [cluster]
+  [--handler <name>]` and `kube logout [cluster]`. Consumes
+  `kube.ClusterResolver` to resolve a cluster name into `--server`,
+  `--audience`, and a default handler (so `--handler` is optional when the
+  resolver supplies `ClusterInfo.DefaultHandler`). When the kubeconfig provider
+  plugin cannot be fetched, it degrades gracefully to writing a minimal static
+  exec-credential kubeconfig directly. `client-go` never enters core.
 - **Phase 4 -- OpenShift OAuth handler plugin.** The one genuinely
   OpenShift-specific credential source: localhost-callback implicit-grant flow,
   plus `ListProjects` / MOTD behind graceful degradation.
@@ -148,6 +171,18 @@ with no resolver involved.
 - **`kube` package naming.** Every `ClusterInfo` field is Kubernetes-API-server
   specific, so the package is named for the `kube` domain rather than a generic
   `cluster` name.
+- **CLI-only surface (no API / MCP exposure).** `kube login` and `kube logout`
+  are intentionally not exposed through the HTTP API server or the MCP tool set.
+  Both run interactive credential flows (browser redirect / device code) and
+  mutate machine-local state -- the user's kubeconfig and the credential cache.
+  Driving them from a remote API server or an MCP host would run the auth flow
+  and write kubeconfig on the wrong machine. This mirrors the existing auth
+  surface: the MCP `auth_*` tools are read-only inspection (`auth_status`,
+  `list_auth_handlers`, `auth_list_tokens`, `auth_purge_expired`) with no
+  `login` tool, and the API server exposes only solution/catalog/schema
+  endpoints. Coverage therefore lives in CLI integration tests
+  (`tests/integration/cli_test.go`) and package unit tests, with no
+  `api_test.go` or `pkg/mcp/tools_*.go` counterparts by design.
 
 ## Resolved Open Questions
 
@@ -156,11 +191,22 @@ Phases 2-4.
 
 ### Q1 -- Command Placement
 
-Fold kube login into the existing auth group as
-`auth login <handler> --cluster <name>` (plus matching `auth logout`), rather
-than adding a top-level `login` command. The handler is the credential source
-(unchanged); `--cluster <name>` triggers the kube wiring. Without `--cluster`,
-`auth login` behaves exactly as before.
+Surface kube login under a dedicated `kube` command group as `kube login
+[cluster] --handler <name>` (plus matching `kube logout [cluster]`), rather than
+nesting it under the auth group or placing it at the top level. The handler is
+the credential source (selected with `--handler`); a positional cluster name (or
+`--server`) triggers the kube wiring and kubeconfig write. Grouping cluster
+operations under `kube` keeps the "log into a cluster" workflow discoverable,
+names the feature for the Kubernetes domain it serves, and leaves room for
+sibling commands (`kube list`, `kube current`, `kube whoami`) without colliding
+with the identity-oriented `auth login`.
+
+> Note: earlier drafts proposed folding this into `auth login <handler>
+> --cluster <name>`, then dedicated top-level `login` / `logout` commands. The
+> shipped design uses a `kube` command group instead: `kube` is the honest name
+> (every `ClusterInfo` field is Kubernetes-specific), it mirrors the `pkg/kube`
+> package boundary, and it avoids two competing "login" verbs at different
+> levels (`login` vs `auth login`).
 
 ### Q2 -- Handler Granularity
 

--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -2136,6 +2136,111 @@ For a complete, copy-pasteable walkthrough see the
 
 [k8s-exec]: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins
 
+### One-Step Cluster Login (`kube login` / `kube logout`)
+
+The `--exec-credential` wiring above is manual: you edit kubeconfig yourself. The
+`kube login` and `kube logout` commands automate that setup. `kube login` runs
+your auth handler, then writes the cluster, user (with the `exec` block), and
+context entries for you. `kube logout` reverses it and clears the cached
+credentials.
+
+Two inputs play distinct roles. The handler is the **credential source** (which
+identity provider authenticates you, for example `entra`). The cluster argument
+(resolved through your cluster resolver) or `--server` selects the **cluster**
+you connect to and supplies its API server and OIDC audience. The handler says
+_who you are_, the cluster says _where you connect_.
+
+When your cluster resolver records a default handler for a cluster, you can omit
+`--handler` entirely and just name the cluster; pass `--handler` only to override
+that default or when targeting a bare `--server` with no resolver.
+
+Target a cluster known to your cluster resolver, or point
+at an API server directly:
+
+{{< tabs "auth-tutorial-kube-login" >}}
+{{% tab "Bash" %}}
+```bash
+# Resolver-backed: cluster name resolves to API server, audience, and handler
+scafctl kube login prod
+
+# Override the resolver's default handler
+scafctl kube login prod --handler entra
+
+# Explicit API server, no resolver required (handler must be named)
+scafctl kube login --handler entra \
+  --server https://api.example.com:6443 \
+  --cluster-name prod --context prod --user prod --current
+
+# Reuse the identity automatically on every kubectl/oc call
+kubectl --context prod get pods
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Resolver-backed: cluster name resolves to API server, audience, and handler
+scafctl kube login prod
+
+# Override the resolver's default handler
+scafctl kube login prod --handler entra
+
+# Explicit API server, no resolver required (handler must be named)
+scafctl kube login --handler entra `
+  --server https://api.example.com:6443 `
+  --cluster-name prod --context prod --user prod --current
+
+# Reuse the identity automatically on every kubectl/oc call
+kubectl --context prod get pods
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Common `kube login` flags:
+
+| Flag | Purpose |
+|------|---------|
+| `--handler` | Auth handler to authenticate with. Optional when the resolver supplies a default for the cluster. |
+| `--server` | API server URL when no resolver is configured. |
+| `--audience` | OIDC audience the minted token must target. |
+| `--profile` | Auth profile baked into the exec args (for example `work`). |
+| `--current` | Set the new context as the current context. |
+| `--verify` | Confirm the authenticated identity via a post-login whoami (requires the kubeconfig provider). |
+| `--kubeconfig` | Target kubeconfig file (defaults to `KUBECONFIG` or `~/.kube/config`). |
+
+When the kubeconfig provider plugin is unavailable, `kube login` falls back to
+writing a minimal static kubeconfig directly, so the workflow still works
+offline.
+
+`kube logout` removes the managed kubeconfig entry. When you pass `--handler`, it
+revokes that handler's cached credentials (unless `--keep-credentials` is set).
+Without `--handler` it revokes the cluster's resolver-supplied default handler on
+a best-effort basis -- if no default handler can be resolved, it removes only the
+kubeconfig entry. Use `--keep-credentials` to skip credential revocation entirely:
+
+{{< tabs "auth-tutorial-kube-logout" >}}
+{{% tab "Bash" %}}
+```bash
+# Remove the kubeconfig entry and revoke cached credentials
+scafctl kube logout prod --handler entra
+
+# Remove only the kubeconfig entry, keep credentials for other clusters
+scafctl kube logout prod --keep-credentials
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Remove the kubeconfig entry and revoke cached credentials
+scafctl kube logout prod --handler entra
+
+# Remove only the kubeconfig entry, keep credentials for other clusters
+scafctl kube logout prod --keep-credentials
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Both commands support structured output (`-o json`, `-o yaml`) for automation.
+For a complete walkthrough see the
+[Kubernetes login / logout example](../../examples/auth/kube-login.md).
+
 ### Decoding the JWT (Header + Payload)
 
 Use `--decode` to inspect the full JWT structure -- both the **header** and the **payload** -- without needing an external decoder tool. Signature validation is intentionally skipped; this is for debugging only:

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -223,6 +223,15 @@ scafctl auto-detects `KUBERNETES_EXEC_INFO` and emits the envelope even without
 the flag. See [kubectl-exec-credential.md](kubectl-exec-credential.md) for the
 full kubeconfig wiring.
 
+To automate the kubeconfig setup, use `scafctl kube login`, which runs the handler
+login and writes the cluster/user/context entries for you:
+
+```bash
+scafctl kube login prod --handler oidc --current
+```
+
+See [kube-login.md](kube-login.md) for the full login/logout workflow.
+
 > Note: `auth token` prints the **raw token by default**; `--raw` remains an
 > explicit alias. Use `-o json`/`-o yaml` for the structured metadata object.
 
@@ -281,5 +290,6 @@ scafctl auth handlers remove entra
 
 - [Auth Tutorial](../../docs/tutorials/auth-tutorial.md) -- full walkthrough
 - [kubectl Exec Credential](kubectl-exec-credential.md) -- use scafctl as a Kubernetes credential plugin
+- [Kubernetes login / logout](kube-login.md) -- automate kubeconfig setup with `scafctl kube login`
 - [HTTP Provider with Entra](../providers/http-entra.yaml) -- example HTTP call with Entra auth
 - [GitHub API Provider](../providers/github-api.yaml) -- example GitHub API call

--- a/examples/auth/kube-login.md
+++ b/examples/auth/kube-login.md
@@ -1,0 +1,107 @@
+# scafctl kube login / kube logout for Kubernetes and OpenShift
+
+`scafctl kube login` automates the [client-go credential plugin][k8s-exec] setup
+described in [kubectl-exec-credential.md](kubectl-exec-credential.md). Instead of
+hand-editing kubeconfig, it runs your auth handler's login and writes the cluster,
+user (with an `exec` block), and context entries for you. `scafctl kube logout`
+reverses it: it removes the kubeconfig entry and, unless `--keep-credentials` is
+set, revokes the handler's cached credentials. With `--handler` it revokes that
+handler; without it, the cluster's resolver-supplied default handler is revoked
+on a best-effort basis (any resolution failure is ignored and only the
+kubeconfig entry is removed).
+
+## How It Works
+
+`scafctl kube login` performs three steps:
+
+1. Resolves the cluster's API server, auth method, and default auth handler (via
+   the configured cluster resolver, explicit flags, or auto-detection).
+2. Runs the resolved auth handler's interactive login.
+3. Writes a kubeconfig user entry whose `exec` block invokes this binary as a
+   credential plugin. Every later `kubectl` / `oc` call mints a fresh token on
+   demand -- no static cluster token is stored.
+
+When the kubeconfig provider plugin is unavailable, `scafctl kube login` falls
+back to writing a minimal static kubeconfig directly, so the workflow still works
+offline.
+
+## Log In
+
+Target a cluster known to your cluster resolver. When the resolver records a
+default handler for the cluster, you do not need `--handler`:
+
+```bash
+scafctl kube login prod
+```
+
+Pass `--handler` to override the resolver's default:
+
+```bash
+scafctl kube login prod --handler oidc
+```
+
+Or point at an API server directly, without a resolver (name the handler since
+there is no resolver default):
+
+```bash
+scafctl kube login --handler oidc \
+  --server https://api.example.com:6443 \
+  --cluster-name prod --context prod --user prod \
+  --current
+```
+
+Common flags:
+
+- `--handler`: the auth handler to authenticate with. Optional when the resolver
+  supplies a default for the cluster.
+- `--server`: API server URL when no resolver is configured.
+- `--audience`: OIDC audience the minted token must target.
+- `--profile`: auth profile baked into the exec args (for example `work`).
+- `--current`: set the new context as the current context.
+- `--verify`: confirm the authenticated identity via a post-login whoami
+  (requires the kubeconfig provider).
+- `--kubeconfig`: target kubeconfig file (defaults to `KUBECONFIG` or
+  `~/.kube/config`).
+
+## Use It
+
+After login, `kubectl` reuses the scafctl-managed identity automatically:
+
+```bash
+kubectl --context prod get pods
+```
+
+## Log Out
+
+Remove the kubeconfig entry and revoke the handler's cached credentials:
+
+```bash
+scafctl kube logout prod --handler oidc
+```
+
+Keep the cached credentials (for example to stay logged in for other clusters)
+while removing only the kubeconfig entry:
+
+```bash
+scafctl kube logout prod --keep-credentials
+```
+
+## Scripting
+
+Both commands support structured output for automation:
+
+```bash
+scafctl kube login prod --handler oidc -o json
+scafctl kube logout prod -o json
+```
+
+## Limitations
+
+For OpenShift-style OAuth (implicit-grant) clusters, the kubeconfig `exec` block
+mints credentials from the handler's cached token. If that token expires and the
+handler stored no refresh token, the credential plugin returns
+not-authenticated rather than starting a fresh interactive login -- kubectl calls
+then fail until you run `scafctl kube login` again. OIDC and other handlers that
+refresh silently are unaffected.
+
+[k8s-exec]: https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins

--- a/pkg/cmd/scafctl/kube/kube.go
+++ b/pkg/cmd/scafctl/kube/kube.go
@@ -1,0 +1,43 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/cobra"
+)
+
+// CommandKube creates the 'kube' command group for Kubernetes / OpenShift
+// cluster operations.
+func CommandKube(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "kube",
+		Aliases: []string{"k8s"},
+		Short:   "Manage Kubernetes / OpenShift cluster access",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Manage authenticated access to Kubernetes and OpenShift clusters.
+
+			These commands authenticate with a scafctl auth handler and wire kubectl /
+			oc to a cluster by writing a kubeconfig exec-credential entry. Subsequent
+			kubectl / oc calls mint fresh tokens on demand without re-running login.
+
+			Use 'scafctl kube login <cluster> --handler <name>' to authenticate and
+			write a kubeconfig entry.
+			Use 'scafctl kube logout <cluster>' to remove the entry and optionally
+			revoke the handler's cached credentials.
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		SilenceUsage: true,
+	}
+
+	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
+	cmd.AddCommand(CommandLogin(cliParams, ioStreams, cmdPath))
+	cmd.AddCommand(CommandLogout(cliParams, ioStreams, cmdPath))
+
+	return cmd
+}

--- a/pkg/cmd/scafctl/kube/kube_test.go
+++ b/pkg/cmd/scafctl/kube/kube_test.go
@@ -1,0 +1,43 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+)
+
+func TestCommandKube(t *testing.T) {
+	t.Parallel()
+
+	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
+	cmd := CommandKube(embedderParams(), ioStreams, "mycli")
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "kube", cmd.Name())
+	assert.Contains(t, cmd.Aliases, "k8s")
+
+	sub := make(map[string]bool)
+	for _, c := range cmd.Commands() {
+		sub[c.Name()] = true
+	}
+	assert.True(t, sub["login"], "kube must expose the login subcommand")
+	assert.True(t, sub["logout"], "kube must expose the logout subcommand")
+}
+
+func TestCommandKube_LongHelpUsesBinaryName(t *testing.T) {
+	t.Parallel()
+
+	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
+	cmd := CommandKube(embedderParams(), ioStreams, "mycli")
+
+	// The heredoc references "scafctl"; it must be rewritten to the embedder's
+	// binary name so help text is never hardcoded.
+	assert.Contains(t, cmd.Long, "mycli kube login")
+	assert.NotContains(t, cmd.Long, "scafctl kube login")
+}

--- a/pkg/cmd/scafctl/kube/login.go
+++ b/pkg/cmd/scafctl/kube/login.go
@@ -1,0 +1,179 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package kube provides the 'kube' command group and its 'login' / 'logout'
+// subcommands that authenticate to a Kubernetes / OpenShift cluster and write a
+// kubeconfig exec-credential entry. The commands are thin wiring around the
+// pkg/kube/login domain package.
+package kube
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	kubeapi "github.com/oakwood-commons/scafctl/pkg/kube"
+	kubelogin "github.com/oakwood-commons/scafctl/pkg/kube/login"
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	skvx "github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// CommandLogin creates the top-level 'login' command.
+func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	var (
+		handlerName    string
+		server         string
+		audience       string
+		clusterName    string
+		contextName    string
+		userName       string
+		kubeconfigPath string
+		profile        string
+		setCurrent     bool
+		insecure       bool
+		verify         bool
+		timeout        time.Duration
+		outputFlags    flags.KvxOutputFlags
+	)
+	outputFlags.AppName = cliParams.BinaryName
+
+	cmd := &cobra.Command{
+		Use:   "login [cluster]",
+		Short: "Authenticate to a Kubernetes or OpenShift cluster",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Authenticate to a Kubernetes or OpenShift cluster and write a kubeconfig
+			entry that mints credentials on demand.
+
+			The command runs an auth handler's interactive login, then writes a
+			kubeconfig user entry whose exec block invokes this binary as a client-go
+			credential plugin. Subsequent kubectl/oc calls obtain fresh tokens without
+			re-running login.
+
+			The cluster argument is resolved through the configured cluster resolver,
+			which also supplies the default auth handler. Pass --handler to override it,
+			or --server to target a cluster directly without a resolver.
+
+			Examples:
+			  # Login to a resolver-known cluster (handler comes from the resolver)
+			  scafctl kube login prod
+
+			  # Override the handler the resolver would choose
+			  scafctl kube login prod --handler oidc
+
+			  # Login directly to an API server (no resolver; handler required)
+			  scafctl kube login --handler oidc --server https://api.example.com:6443
+
+			  # Login, make the new context current, and verify the identity
+			  scafctl kube login prod --current --verify
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		SilenceUsage: true,
+		Args:         cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			w := writer.FromContext(ctx)
+			if w == nil {
+				return fmt.Errorf("writer not initialized in context")
+			}
+
+			var cluster string
+			if len(args) == 1 {
+				cluster = args[0]
+			}
+
+			deps := kubelogin.Deps{
+				Kubeconfig: kubeconfig.NewManager(cliParams.BinaryName),
+				Resolver:   kubeapi.ResolverFromContext(ctx),
+				BinaryName: cliParams.BinaryName,
+				HandlerLookup: func(ctx context.Context, name string) (kubelogin.Authenticator, error) {
+					return auth.GetHandler(ctx, name)
+				},
+			}
+			req := kubelogin.Request{
+				Cluster:           cluster,
+				Handler:           handlerName,
+				Server:            server,
+				Audience:          audience,
+				ClusterName:       clusterName,
+				ContextName:       contextName,
+				UserName:          userName,
+				KubeconfigPath:    kubeconfigPath,
+				Profile:           profile,
+				SetCurrentContext: setCurrent,
+				InsecureSkipTLS:   insecure,
+				Verify:            verify,
+				Timeout:           timeout,
+			}
+
+			res, err := kubelogin.Login(ctx, deps, req)
+			if err != nil {
+				w.Errorf("%v", err)
+				if errors.Is(err, kubelogin.ErrNoHandler) || errors.Is(err, kubelogin.ErrNoServer) {
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
+				if errors.Is(err, kubelogin.ErrVerificationFailed) && res != nil {
+					w.Warningf("kubeconfig entry %q was written; only identity verification failed", res.ContextName)
+				}
+				return exitcode.WithCode(err, exitcode.GeneralError)
+			}
+
+			return renderLoginResult(ioStreams, &outputFlags, w, res)
+		},
+	}
+
+	cmd.Flags().StringVar(&handlerName, "handler", "", "Auth handler to authenticate with (defaults to the cluster's configured handler)")
+	cmd.Flags().StringVar(&server, "server", "", "API server URL (overrides the resolved cluster)")
+	cmd.Flags().StringVar(&audience, "audience", "", "OIDC audience the minted token must target")
+	cmd.Flags().StringVar(&clusterName, "cluster-name", "", "kubeconfig cluster entry name (defaults to the cluster)")
+	cmd.Flags().StringVar(&contextName, "context", "", "kubeconfig context name (defaults to the cluster name)")
+	cmd.Flags().StringVar(&userName, "user", "", "kubeconfig user entry name (defaults to the cluster name)")
+	cmd.Flags().StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the kubeconfig file (defaults to KUBECONFIG or ~/.kube/config)")
+	cmd.Flags().StringVar(&profile, "profile", "", "Auth profile baked into the exec credential args")
+	cmd.Flags().BoolVar(&setCurrent, "current", false, "Set the new context as the current context")
+	cmd.Flags().BoolVar(&insecure, "insecure-skip-tls-verify", false, "Disable API server TLS verification (development only)")
+	cmd.Flags().BoolVar(&verify, "verify", false, "Verify the authenticated identity via a post-login whoami (requires the kubeconfig provider)")
+	cmd.Flags().DurationVar(&timeout, "timeout", 0, "Login timeout (e.g. 5m); zero uses the handler default")
+	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
+
+	return cmd
+}
+
+// renderLoginResult writes the login result as structured output or a human
+// summary.
+func renderLoginResult(ioStreams *terminal.IOStreams, outputFlags *flags.KvxOutputFlags, w *writer.Writer, res *kubelogin.Result) error {
+	row := map[string]any{
+		"context":    res.ContextName,
+		"server":     res.Server,
+		"kubeconfig": res.KubeconfigPath,
+		"authType":   string(res.AuthType),
+		"handler":    res.Handler,
+		"user":       res.Username,
+		"fallback":   res.UsedFallback,
+	}
+	opts := flags.ToKvxOutputOptions(outputFlags,
+		skvx.WithIOStreams(ioStreams),
+		skvx.WithOutputColumnOrder([]string{"context", "server", "kubeconfig", "authType", "handler", "user", "fallback"}),
+	)
+	if skvx.IsStructuredFormat(opts.Format) {
+		return opts.Write([]map[string]any{row})
+	}
+
+	w.Successf("Logged in to %q", res.ContextName)
+	w.Infof("Kubeconfig: %s", res.KubeconfigPath)
+	if res.Username != "" {
+		w.Infof("User: %s", res.Username)
+	}
+	if res.UsedFallback {
+		w.Warningf("kubeconfig provider unavailable; wrote a static kubeconfig entry")
+	}
+	return nil
+}

--- a/pkg/cmd/scafctl/kube/login_test.go
+++ b/pkg/cmd/scafctl/kube/login_test.go
@@ -1,0 +1,186 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	kubeapi "github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+)
+
+func newTestContext(t *testing.T) (context.Context, *bytes.Buffer) {
+	t.Helper()
+	var buf bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(context.Background(), w)
+	ctx = logger.WithLogger(ctx, logger.GetNoopLogger())
+	return ctx, &buf
+}
+
+// mockHandlerName is the handler name registered by withMockHandler.
+const mockHandlerName = "oidc"
+
+// withMockHandler registers a mock auth handler in the context's auth registry.
+func withMockHandler(t *testing.T, ctx context.Context) (context.Context, *auth.MockHandler) {
+	t.Helper()
+	mock := auth.NewMockHandler(mockHandlerName)
+	mock.LoginResult = &auth.Result{}
+	reg := auth.NewRegistry()
+	require.NoError(t, reg.Register(mock))
+	return auth.WithRegistry(ctx, reg), mock
+}
+
+// embedderParams returns CLI params with a non-default binary name to exercise
+// the embedder contract.
+func embedderParams() *settings.Run {
+	p := settings.NewCliParams()
+	p.BinaryName = "mycli"
+	return p
+}
+
+func runCmd(t *testing.T, cmd *cobra.Command, ctx context.Context, args ...string) error {
+	t.Helper()
+	cmd.SetContext(ctx)
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+func TestCommandLogin_MissingHandler(t *testing.T) {
+	t.Parallel()
+	ctx, _ := newTestContext(t)
+
+	// No --handler, no resolver default: login cannot pick a handler.
+	cmd := CommandLogin(embedderParams(), terminal.NewIOStreams(nil, nil, nil, false), "mycli")
+	err := runCmd(t, cmd, ctx, "prod", "--server", "https://api.example.com:6443")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "auth handler is required")
+	assert.Equal(t, exitcode.InvalidInput, exitcode.GetCode(err))
+}
+
+func TestCommandLogin_MissingServer(t *testing.T) {
+	t.Parallel()
+	ctx, _ := newTestContext(t)
+	ctx, _ = withMockHandler(t, ctx)
+
+	// No --server and no resolver default: login cannot determine the server.
+	cmd := CommandLogin(embedderParams(), terminal.NewIOStreams(nil, nil, nil, false), "mycli")
+	err := runCmd(t, cmd, ctx, "prod", "--handler", "oidc")
+	require.Error(t, err)
+	assert.Equal(t, exitcode.InvalidInput, exitcode.GetCode(err))
+}
+
+func TestCommandLogin_UnknownHandler(t *testing.T) {
+	t.Parallel()
+	ctx, _ := newTestContext(t)
+	ctx = auth.WithRegistry(ctx, auth.NewRegistry())
+
+	cmd := CommandLogin(embedderParams(), terminal.NewIOStreams(nil, nil, nil, false), "mycli")
+	err := runCmd(t, cmd, ctx, "prod", "--handler", "nope", "--server", "https://api.example.com:6443")
+	require.Error(t, err)
+}
+
+func TestCommandLogin_FallbackWritesKubeconfig(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx, mock := withMockHandler(t, ctx)
+	mock.GetTokenResult = &auth.Token{AccessToken: "tok"}
+
+	path := filepath.Join(t.TempDir(), "config")
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(embedderParams(), ioStreams, "mycli")
+	err := runCmd(t, cmd, ctx, "prod",
+		"--handler", "oidc",
+		"--server", "https://api.example.com:6443",
+		"--kubeconfig", path,
+		"--current",
+	)
+	require.NoError(t, err)
+	assert.FileExists(t, path)
+	assert.Len(t, mock.LoginCalls, 1)
+	assert.Contains(t, buf.String(), "Logged in")
+}
+
+func TestCommandLogin_JSONOutput(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx, _ = withMockHandler(t, ctx)
+
+	path := filepath.Join(t.TempDir(), "config")
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(embedderParams(), ioStreams, "mycli")
+	err := runCmd(t, cmd, ctx, "prod",
+		"--handler", "oidc",
+		"--server", "https://api.example.com:6443",
+		"--kubeconfig", path,
+		"--output", "json",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "\"context\"")
+	assert.Contains(t, buf.String(), "prod")
+}
+
+func TestCommandLogin_HandlerFromResolverDefault(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx, mock := withMockHandler(t, ctx)
+	mock.GetTokenResult = &auth.Token{AccessToken: "tok"}
+
+	// The resolver supplies both the API server and the default handler, so the
+	// user can omit --server and --handler entirely.
+	resolver := &kubeapi.MockResolver{ResolveResult: &kubeapi.ClusterInfo{
+		Name:           "prod",
+		APIServerURL:   "https://api.example.com:6443",
+		DefaultHandler: mockHandlerName,
+	}}
+	ctx = kubeapi.WithResolver(ctx, resolver)
+
+	path := filepath.Join(t.TempDir(), "config")
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(embedderParams(), ioStreams, "mycli")
+	err := runCmd(t, cmd, ctx, "prod", "--kubeconfig", path)
+	require.NoError(t, err)
+	assert.FileExists(t, path)
+	assert.Len(t, mock.LoginCalls, 1)
+	assert.Contains(t, buf.String(), "Logged in")
+}
+
+func TestCommandLogin_VerifyFailsWithoutProvider(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx, mock := withMockHandler(t, ctx)
+	mock.GetTokenResult = &auth.Token{AccessToken: "tok"}
+
+	path := filepath.Join(t.TempDir(), "config")
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	// In the static-fallback path the kubeconfig provider (and thus whoami) is
+	// unavailable, so --verify must fail even though the entry is written.
+	cmd := CommandLogin(embedderParams(), ioStreams, "mycli")
+	err := runCmd(t, cmd, ctx, "prod",
+		"--handler", "oidc",
+		"--server", "https://api.example.com:6443",
+		"--kubeconfig", path,
+		"--verify",
+	)
+	require.Error(t, err)
+	assert.FileExists(t, path, "kubeconfig entry is written even when verification fails")
+	assert.Contains(t, buf.String(), "was written", "user is told the entry was written despite the verify failure")
+}

--- a/pkg/cmd/scafctl/kube/logout.go
+++ b/pkg/cmd/scafctl/kube/logout.go
@@ -1,0 +1,159 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	kubeapi "github.com/oakwood-commons/scafctl/pkg/kube"
+	kubelogin "github.com/oakwood-commons/scafctl/pkg/kube/login"
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	skvx "github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// CommandLogout creates the top-level 'logout' command.
+func CommandLogout(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	var (
+		handlerName     string
+		clusterName     string
+		contextName     string
+		userName        string
+		kubeconfigPath  string
+		keepCredentials bool
+		outputFlags     flags.KvxOutputFlags
+	)
+	outputFlags.AppName = cliParams.BinaryName
+
+	cmd := &cobra.Command{
+		Use:   "logout [cluster]",
+		Short: "Remove a cluster's kubeconfig entry and clear credentials",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Remove a cluster's kubeconfig entry and clear the cached credentials.
+
+			When --handler is provided, that handler's cached tokens are revoked
+			unless --keep-credentials is set. Without --handler, the cluster's
+			default handler (supplied by the resolver) is revoked instead, so
+			logout clears the same credentials that login obtained. Use
+			--keep-credentials to remove only the kubeconfig entry (for example to
+			log out of the cluster while staying authenticated for other clusters).
+
+			Examples:
+			  # Log out of a cluster and revoke its credentials
+			  scafctl kube logout prod
+
+			  # Revoke a specific handler's credentials
+			  scafctl kube logout prod --handler oidc
+
+			  # Remove the kubeconfig entry but keep cached credentials
+			  scafctl kube logout prod --keep-credentials
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		SilenceUsage: true,
+		Args:         cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			w := writer.FromContext(ctx)
+			if w == nil {
+				return fmt.Errorf("writer not initialized in context")
+			}
+
+			var cluster string
+			if len(args) == 1 {
+				cluster = args[0]
+			}
+
+			deps := kubelogin.Deps{
+				Kubeconfig: kubeconfig.NewManager(cliParams.BinaryName),
+				Resolver:   kubeapi.ResolverFromContext(ctx),
+				BinaryName: cliParams.BinaryName,
+				HandlerLookup: func(ctx context.Context, name string) (kubelogin.Authenticator, error) {
+					return auth.GetHandler(ctx, name)
+				},
+			}
+			if handlerName != "" {
+				handler, err := auth.GetHandler(ctx, handlerName)
+				if err != nil {
+					w.Errorf("%v", err)
+					return exitcode.WithCode(fmt.Errorf("resolve auth handler %q: %w", handlerName, err), exitcode.InvalidInput)
+				}
+				deps.Handler = handler
+			}
+
+			res, err := kubelogin.Logout(ctx, deps, kubelogin.LogoutRequest{
+				Cluster:         cluster,
+				ClusterName:     clusterName,
+				ContextName:     contextName,
+				UserName:        userName,
+				KubeconfigPath:  kubeconfigPath,
+				KeepCredentials: keepCredentials,
+			})
+			if err != nil {
+				w.Errorf("%v", err)
+				if errors.Is(err, kubelogin.ErrNoCluster) {
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
+				return exitcode.WithCode(err, exitcode.GeneralError)
+			}
+
+			// Report the entry that was actually targeted: a --cluster-name (or
+			// --context) invocation has no positional cluster argument, so fall
+			// back to those so the output is never blank.
+			effectiveCluster := cluster
+			if effectiveCluster == "" {
+				effectiveCluster = clusterName
+			}
+			if effectiveCluster == "" {
+				effectiveCluster = contextName
+			}
+			return renderLogoutResult(ioStreams, &outputFlags, w, effectiveCluster, res)
+		},
+	}
+
+	cmd.Flags().StringVar(&handlerName, "handler", "", "Auth handler whose credentials to revoke (defaults to the cluster's configured handler)")
+	cmd.Flags().StringVar(&clusterName, "cluster-name", "", "kubeconfig cluster entry name (defaults to the cluster)")
+	cmd.Flags().StringVar(&contextName, "context", "", "kubeconfig context name (defaults to the cluster name)")
+	cmd.Flags().StringVar(&userName, "user", "", "kubeconfig user entry name (defaults to the cluster name)")
+	cmd.Flags().StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the kubeconfig file (defaults to KUBECONFIG or ~/.kube/config)")
+	cmd.Flags().BoolVar(&keepCredentials, "keep-credentials", false, "Leave the handler's cached credentials in place")
+	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
+
+	return cmd
+}
+
+// renderLogoutResult writes the logout result as structured output or a human
+// summary.
+func renderLogoutResult(ioStreams *terminal.IOStreams, outputFlags *flags.KvxOutputFlags, w *writer.Writer, cluster string, res *kubelogin.LogoutResult) error {
+	row := map[string]any{
+		"cluster":  cluster,
+		"removed":  res.Removed,
+		"fallback": res.UsedFallback,
+	}
+	opts := flags.ToKvxOutputOptions(outputFlags,
+		skvx.WithIOStreams(ioStreams),
+		skvx.WithOutputColumnOrder([]string{"cluster", "removed", "fallback"}),
+	)
+	if skvx.IsStructuredFormat(opts.Format) {
+		return opts.Write([]map[string]any{row})
+	}
+
+	if res.Removed {
+		w.Success("Removed kubeconfig entry")
+	} else {
+		w.Infof("No matching kubeconfig entry found")
+	}
+	if res.UsedFallback {
+		w.Warningf("kubeconfig provider unavailable; edited the kubeconfig directly")
+	}
+	return nil
+}

--- a/pkg/cmd/scafctl/kube/logout_test.go
+++ b/pkg/cmd/scafctl/kube/logout_test.go
@@ -1,0 +1,126 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	kubeapi "github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+)
+
+func TestCommandLogout_NoCluster(t *testing.T) {
+	t.Parallel()
+	ctx, _ := newTestContext(t)
+
+	cmd := CommandLogout(embedderParams(), terminal.NewIOStreams(nil, nil, nil, false), "mycli")
+	err := runCmd(t, cmd, ctx)
+	require.Error(t, err)
+	assert.Equal(t, exitcode.InvalidInput, exitcode.GetCode(err))
+}
+
+func TestCommandLogout_RemovesEntryAndRevokes(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx, mock := withMockHandler(t, ctx)
+
+	// Seed a kubeconfig entry by logging in first (fallback path).
+	path := filepath.Join(t.TempDir(), "config")
+	loginCmd := CommandLogin(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, loginCmd, ctx, "prod",
+		"--handler", "oidc",
+		"--server", "https://api.example.com:6443",
+		"--kubeconfig", path,
+	))
+
+	buf.Reset()
+	logoutCmd := CommandLogout(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, logoutCmd, ctx, "prod",
+		"--handler", "oidc",
+		"--kubeconfig", path,
+	))
+	assert.Equal(t, 1, mock.LogoutCalls)
+	assert.Contains(t, buf.String(), "Removed kubeconfig entry")
+}
+
+func TestCommandLogout_KeepCredentials(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx, mock := withMockHandler(t, ctx)
+
+	path := filepath.Join(t.TempDir(), "config")
+	loginCmd := CommandLogin(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, loginCmd, ctx, "prod",
+		"--handler", "oidc",
+		"--server", "https://api.example.com:6443",
+		"--kubeconfig", path,
+	))
+
+	logoutCmd := CommandLogout(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, logoutCmd, ctx, "prod",
+		"--kubeconfig", path,
+		"--keep-credentials",
+	))
+	assert.Equal(t, 0, mock.LogoutCalls, "keep-credentials must skip handler logout")
+}
+
+func TestCommandLogout_RevokesResolverDefaultHandler(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx, mock := withMockHandler(t, ctx)
+
+	// The resolver names the default handler, so "logout prod" with no --handler
+	// revokes the same handler that login used.
+	resolver := &kubeapi.MockResolver{ResolveResult: &kubeapi.ClusterInfo{
+		Name:           "prod",
+		APIServerURL:   "https://api.example.com:6443",
+		DefaultHandler: mockHandlerName,
+	}}
+	ctx = kubeapi.WithResolver(ctx, resolver)
+
+	path := filepath.Join(t.TempDir(), "config")
+	loginCmd := CommandLogin(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, loginCmd, ctx, "prod", "--kubeconfig", path))
+
+	buf.Reset()
+	logoutCmd := CommandLogout(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, logoutCmd, ctx, "prod", "--kubeconfig", path))
+	assert.Equal(t, 1, mock.LogoutCalls, "resolver default handler must be revoked without --handler")
+}
+
+func TestCommandLogout_OutputUsesEffectiveClusterFromFlag(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx, _ = withMockHandler(t, ctx)
+
+	// Seed an entry, then log out via --cluster-name with no positional cluster
+	// argument: the structured output must still report the targeted entry.
+	path := filepath.Join(t.TempDir(), "config")
+	loginCmd := CommandLogin(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, loginCmd, ctx, "prod",
+		"--handler", "oidc",
+		"--server", "https://api.example.com:6443",
+		"--kubeconfig", path,
+	))
+
+	buf.Reset()
+	logoutCmd := CommandLogout(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, logoutCmd, ctx,
+		"--cluster-name", "prod",
+		"--handler", "oidc",
+		"--kubeconfig", path,
+		"-o", "json",
+	))
+
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &rows))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "prod", rows[0]["cluster"], "cluster field must fall back to --cluster-name")
+}

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/explain"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get"
 	inspectcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/inspect"
+	kubecmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/kube"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/lint"
 	mcpcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/mcp"
 	newcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/new"
@@ -877,6 +878,7 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 	cCmd.AddCommand(withGroup(groupConfig, secretscmd.CommandSecrets(cliParams, ioStreams, binaryName)))
 	cCmd.AddCommand(withGroup(groupConfig, statecmd.CommandState(cliParams, ioStreams, binaryName)))
 	cCmd.AddCommand(withGroup(groupConfig, authcmd.CommandAuth(cliParams, ioStreams, binaryName)))
+	cCmd.AddCommand(withGroup(groupConfig, kubecmd.CommandKube(cliParams, ioStreams, binaryName)))
 	cCmd.AddCommand(withGroup(groupConfig, cachecmd.CommandCache(cliParams, ioStreams, binaryName)))
 	cCmd.AddCommand(withGroup(groupConfig, credhelpercmd.CommandCredentialHelper(cliParams, ioStreams, binaryName)))
 

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -76,6 +76,17 @@ type ClusterInfo struct {
 	// for OIDC clusters. Ignored for non-OIDC clusters.
 	OIDCAudience string `json:"oidcAudience,omitempty" yaml:"oidcAudience,omitempty" doc:"Client ID/audience the minted token must target for OIDC clusters" maxLength:"512" example:"my-cluster-client-id"`
 
+	// DefaultHandler is the auth handler used to authenticate to this cluster
+	// when the caller does not pass an explicit --handler. Optional; empty means
+	// the caller must supply a handler. Embedders set it from their cluster
+	// registry so users can run "login <cluster>" without naming a handler.
+	DefaultHandler string `json:"defaultHandler,omitempty" yaml:"defaultHandler,omitempty" doc:"Auth handler used when no explicit handler is supplied" maxLength:"253" example:"entra"`
+
+	// CAData is the PEM-encoded cluster certificate authority bundle. When set,
+	// login pins the API server to this CA instead of falling back to
+	// InsecureSkipTLS. Embedders supply it from their cluster registry.
+	CAData string `json:"caData,omitempty" yaml:"caData,omitempty" doc:"PEM-encoded cluster CA bundle; preferred over insecureSkipTLS" maxLength:"1048576"`
+
 	// InsecureSkipTLS disables API server TLS verification. Use only for
 	// development clusters with self-signed certificates.
 	InsecureSkipTLS bool `json:"insecureSkipTLS,omitempty" yaml:"insecureSkipTLS,omitempty" doc:"Disable API server TLS verification (development only)"`

--- a/pkg/kube/kube_test.go
+++ b/pkg/kube/kube_test.go
@@ -51,6 +51,7 @@ func TestClusterInfo_Validate(t *testing.T) {
 				ConsoleURL:      "https://console.example.com",
 				AuthType:        AuthTypeOIDC,
 				OIDCAudience:    "client-id",
+				DefaultHandler:  "entra",
 				InsecureSkipTLS: true,
 			},
 		},

--- a/pkg/kube/login/execargs.go
+++ b/pkg/kube/login/execargs.go
@@ -1,0 +1,48 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+)
+
+// buildExecArgs returns the static arguments baked into the kubeconfig exec
+// block. The runtime command becomes:
+//
+//	<binary> auth token <handler> --exec-credential [--scope <audience>] [--profile <profile>]
+//
+// The cluster audience is passed as a scope only for handlers that accept
+// per-request scopes; other handlers fix their scopes at login time.
+func buildExecArgs(h Authenticator, info kube.ClusterInfo, profile string) []string {
+	args := []string{execAuthCmd, execTokenCmd, h.Name(), execCredentialFlag}
+	if info.OIDCAudience != "" && auth.HasCapability(h.Capabilities(), auth.CapScopesOnTokenRequest) {
+		args = append(args, execScopeFlag, info.OIDCAudience)
+	}
+	if profile != "" {
+		args = append(args, execProfileFlag, profile)
+	}
+	return args
+}
+
+// interactiveModeFor chooses the kubeconfig exec interactiveMode. OAuth
+// implicit-grant handlers return no refresh token, so the user must re-login on
+// expiry: allow an interactive prompt when a terminal is attached. Refresh-
+// capable handlers (OIDC, and the auto default) refresh silently, so never
+// prompt from inside a kubectl subprocess.
+func interactiveModeFor(authType kube.AuthType) string {
+	if authType == kube.AuthTypeOAuth {
+		return kubeconfig.InteractiveModeIfAvailable
+	}
+	return kubeconfig.InteractiveModeNever
+}
+
+// buildInstallHint returns the message kubectl shows when the host binary is
+// missing from PATH. It is embedder-aware via the binary name.
+func buildInstallHint(binaryName string) string {
+	return fmt.Sprintf("%s not found in PATH; install it and run %q to refresh credentials", binaryName, binaryName+" kube login")
+}

--- a/pkg/kube/login/execargs_test.go
+++ b/pkg/kube/login/execargs_test.go
@@ -1,0 +1,74 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+)
+
+func TestBuildExecArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		caps    []auth.Capability
+		info    kube.ClusterInfo
+		profile string
+		want    []string
+	}{
+		{
+			name: "minimal",
+			info: kube.ClusterInfo{},
+			want: []string{"auth", "token", "h", "--exec-credential"},
+		},
+		{
+			name: "scope when capable with audience",
+			caps: []auth.Capability{auth.CapScopesOnTokenRequest},
+			info: kube.ClusterInfo{OIDCAudience: "aud"},
+			want: []string{"auth", "token", "h", "--exec-credential", "--scope", "aud"},
+		},
+		{
+			name: "no scope when not capable",
+			info: kube.ClusterInfo{OIDCAudience: "aud"},
+			want: []string{"auth", "token", "h", "--exec-credential"},
+		},
+		{
+			name:    "profile appended",
+			info:    kube.ClusterInfo{},
+			profile: "work",
+			want:    []string{"auth", "token", "h", "--exec-credential", "--profile", "work"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			h := &stubAuth{name: "h", caps: tt.caps}
+			got := buildExecArgs(h, tt.info, tt.profile)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestInteractiveModeFor(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, kubeconfig.InteractiveModeIfAvailable, interactiveModeFor(kube.AuthTypeOAuth))
+	assert.Equal(t, kubeconfig.InteractiveModeNever, interactiveModeFor(kube.AuthTypeOIDC))
+	assert.Equal(t, kubeconfig.InteractiveModeNever, interactiveModeFor(kube.AuthTypeAuto))
+}
+
+func TestBuildInstallHint(t *testing.T) {
+	t.Parallel()
+
+	hint := buildInstallHint("mycli")
+	assert.Contains(t, hint, "mycli")
+	assert.True(t, strings.Contains(hint, "mycli kube login"), "hint should reference the kube login command")
+}

--- a/pkg/kube/login/fallback.go
+++ b/pkg/kube/login/fallback.go
@@ -1,0 +1,296 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth/execcredential"
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+)
+
+// Permissions for the kubeconfig file and its parent directory.
+const (
+	kubeconfigFileMode = 0o600
+	kubeconfigDirMode  = 0o700
+)
+
+// Top-level kubeconfig keys manipulated by the static writer.
+const (
+	keyAPIVersion     = "apiVersion"
+	keyKind           = "kind"
+	keyClusters       = "clusters"
+	keyUsers          = "users"
+	keyContexts       = "contexts"
+	keyCurrentContext = "current-context"
+)
+
+// writeStaticKubeconfig writes a minimal exec-credential kubeconfig without the
+// provider plugin. It is the fallback path taken when the kubeconfig provider is
+// unavailable. It preserves all existing data in the target file by round-
+// tripping through a generic map (comments and key ordering are not preserved).
+func writeStaticKubeconfig(in kubeconfig.WriteInput) (kubeconfig.WriteResult, error) {
+	path, err := resolveKubeconfigPath(in.KubeconfigPath)
+	if err != nil {
+		return kubeconfig.WriteResult{}, err
+	}
+	clusterName := in.ClusterName
+	contextName := firstNonEmpty(in.ContextName, clusterName)
+	userName := firstNonEmpty(in.UserName, clusterName)
+
+	cfg, err := loadKubeconfig(path)
+	if err != nil {
+		return kubeconfig.WriteResult{}, err
+	}
+	cfg[keyAPIVersion] = "v1"
+	cfg[keyKind] = "Config"
+
+	cfg[keyClusters] = upsertNamed(toAnySlice(cfg[keyClusters]), clusterName, "cluster", clusterValue(in))
+	cfg[keyUsers] = upsertNamed(toAnySlice(cfg[keyUsers]), userName, "user", userValue(in))
+	cfg[keyContexts] = upsertNamed(toAnySlice(cfg[keyContexts]), contextName, "context", map[string]any{
+		"cluster": clusterName,
+		"user":    userName,
+	})
+	if in.SetCurrentContext {
+		cfg[keyCurrentContext] = contextName
+	}
+
+	if err := writeKubeconfigFile(path, cfg); err != nil {
+		return kubeconfig.WriteResult{}, err
+	}
+	return kubeconfig.WriteResult{
+		Success:        true,
+		ContextName:    contextName,
+		KubeconfigPath: path,
+	}, nil
+}
+
+// removeStaticKubeconfig removes the named cluster/user/context entries from the
+// kubeconfig file without the provider plugin. It returns whether any entry was
+// removed.
+func removeStaticKubeconfig(in kubeconfig.RemoveInput) (bool, error) {
+	path, err := resolveKubeconfigPath(in.KubeconfigPath)
+	if err != nil {
+		return false, err
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path is a user-controlled kubeconfig location
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read kubeconfig %q: %w", path, err)
+	}
+	var cfg map[string]any
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return false, fmt.Errorf("parse kubeconfig %q: %w", path, err)
+	}
+	if cfg == nil {
+		return false, nil
+	}
+
+	clusterName := in.ClusterName
+	contextName := firstNonEmpty(in.ContextName, clusterName)
+	userName := firstNonEmpty(in.UserName, clusterName)
+
+	clusters, rc := removeNamed(toAnySlice(cfg[keyClusters]), clusterName)
+	users, ru := removeNamed(toAnySlice(cfg[keyUsers]), userName)
+	contexts, rx := removeNamed(toAnySlice(cfg[keyContexts]), contextName)
+	if !rc && !ru && !rx {
+		return false, nil
+	}
+	cfg[keyClusters] = clusters
+	cfg[keyUsers] = users
+	cfg[keyContexts] = contexts
+	if cc, _ := cfg[keyCurrentContext].(string); cc == contextName {
+		delete(cfg, keyCurrentContext)
+	}
+
+	if err := writeKubeconfigFile(path, cfg); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// clusterValue builds the kubeconfig cluster entry. CA data is preferred over
+// skipping TLS verification.
+func clusterValue(in kubeconfig.WriteInput) map[string]any {
+	cluster := map[string]any{"server": in.Server}
+	switch {
+	case in.CAData != "":
+		cluster["certificate-authority-data"] = base64.StdEncoding.EncodeToString([]byte(in.CAData))
+	case in.InsecureSkipTLS:
+		cluster["insecure-skip-tls-verify"] = true
+	}
+	return cluster
+}
+
+// userValue builds the kubeconfig user entry with a client-go exec credential
+// plugin block.
+func userValue(in kubeconfig.WriteInput) map[string]any {
+	exec := map[string]any{
+		"apiVersion":         execcredential.DefaultAPIVersion,
+		"command":            in.ExecCommand,
+		"args":               in.ExecArgs,
+		"provideClusterInfo": in.ProvideClusterInfo,
+	}
+	if in.InteractiveMode != "" {
+		exec["interactiveMode"] = in.InteractiveMode
+	}
+	if in.InstallHint != "" {
+		exec["installHint"] = in.InstallHint
+	}
+	return map[string]any{"exec": exec}
+}
+
+// loadKubeconfig reads and parses an existing kubeconfig, returning an empty map
+// when the file does not exist.
+func loadKubeconfig(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path is a user-controlled kubeconfig location
+	switch {
+	case err == nil:
+		var cfg map[string]any
+		if uerr := yaml.Unmarshal(data, &cfg); uerr != nil {
+			return nil, fmt.Errorf("parse existing kubeconfig %q: %w", path, uerr)
+		}
+		if cfg == nil {
+			cfg = map[string]any{}
+		}
+		return cfg, nil
+	case errors.Is(err, fs.ErrNotExist):
+		return map[string]any{}, nil
+	default:
+		return nil, fmt.Errorf("read kubeconfig %q: %w", path, err)
+	}
+}
+
+// writeKubeconfigFile marshals and writes the kubeconfig with restrictive
+// permissions, creating the parent directory when needed. The write is atomic
+// (temp file + fsync + rename) so an interrupt or a concurrent login cannot
+// leave a truncated or corrupted kubeconfig.
+func writeKubeconfigFile(path string, cfg map[string]any) error {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal kubeconfig: %w", err)
+	}
+	dir := filepath.Dir(path)
+	if dir == "" {
+		dir = "."
+	}
+	if err := os.MkdirAll(dir, kubeconfigDirMode); err != nil {
+		return fmt.Errorf("create kubeconfig directory %q: %w", dir, err)
+	}
+
+	tmp, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create temp kubeconfig in %q: %w", dir, err)
+	}
+	tmpName := tmp.Name()
+	removeTmp := true
+	defer func() {
+		if removeTmp {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if err := tmp.Chmod(kubeconfigFileMode); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("chmod temp kubeconfig %q: %w", tmpName, err)
+	}
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("write temp kubeconfig %q: %w", tmpName, err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("sync temp kubeconfig %q: %w", tmpName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close temp kubeconfig %q: %w", tmpName, err)
+	}
+
+	renameErr := os.Rename(tmpName, path) //nolint:gosec // path is a user-controlled kubeconfig location
+	if renameErr != nil {
+		// Windows does not reliably support renaming over an existing file.
+		// Retry after removing the destination when it already exists.
+		if _, statErr := os.Stat(path); statErr == nil {
+			if removeErr := os.Remove(path); removeErr == nil {
+				renameErr = os.Rename(tmpName, path) //nolint:gosec // same rationale as above
+			}
+		}
+		if renameErr != nil {
+			return fmt.Errorf("write kubeconfig %q: %w", path, renameErr)
+		}
+	}
+	removeTmp = false
+	return nil
+}
+
+// resolveKubeconfigPath resolves the kubeconfig path: the explicit path, else
+// the first entry of KUBECONFIG, else ~/.kube/config.
+func resolveKubeconfigPath(explicit string) (string, error) {
+	if explicit != "" {
+		return explicit, nil
+	}
+	if env := os.Getenv("KUBECONFIG"); env != "" {
+		for _, p := range filepath.SplitList(env) {
+			if p != "" {
+				return p, nil
+			}
+		}
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory for kubeconfig: %w", err)
+	}
+	return filepath.Join(home, ".kube", "config"), nil
+}
+
+// upsertNamed replaces the entry named name in a kubeconfig list (clusters,
+// users, or contexts) or appends it. key is the inner field name ("cluster",
+// "user", or "context").
+func upsertNamed(list []any, name, key string, value map[string]any) []any {
+	entry := map[string]any{"name": name, key: value}
+	for i, item := range list {
+		if m, ok := item.(map[string]any); ok {
+			if n, _ := m["name"].(string); n == name {
+				list[i] = entry
+				return list
+			}
+		}
+	}
+	return append(list, entry)
+}
+
+// removeNamed drops the entry named name from a kubeconfig list, reporting
+// whether a match was removed.
+func removeNamed(list []any, name string) ([]any, bool) {
+	out := make([]any, 0, len(list))
+	removed := false
+	for _, item := range list {
+		if m, ok := item.(map[string]any); ok {
+			if n, _ := m["name"].(string); n == name {
+				removed = true
+				continue
+			}
+		}
+		out = append(out, item)
+	}
+	return out, removed
+}
+
+// toAnySlice coerces a kubeconfig list field to []any, returning nil for absent
+// or malformed values.
+func toAnySlice(v any) []any {
+	if s, ok := v.([]any); ok {
+		return s
+	}
+	return nil
+}

--- a/pkg/kube/login/fallback_test.go
+++ b/pkg/kube/login/fallback_test.go
@@ -1,0 +1,295 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth/execcredential"
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+)
+
+func readKubeconfig(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	var cfg map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	return cfg
+}
+
+func namedEntry(t *testing.T, cfg map[string]any, key, name string) map[string]any {
+	t.Helper()
+	list, ok := cfg[key].([]any)
+	require.True(t, ok, "expected list for %q", key)
+	for _, item := range list {
+		m, ok := item.(map[string]any)
+		require.True(t, ok)
+		if n, _ := m["name"].(string); n == name {
+			return m
+		}
+	}
+	t.Fatalf("entry %q not found in %q", name, key)
+	return nil
+}
+
+func TestWriteStaticKubeconfig_NewFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "config")
+	in := kubeconfig.WriteInput{
+		Server:            "https://api.example.com:6443",
+		ClusterName:       "prod",
+		ContextName:       "prod-ctx",
+		UserName:          "prod-user",
+		KubeconfigPath:    path,
+		ExecCommand:       "mycli",
+		ExecArgs:          []string{"auth", "token", "oidc", "--exec-credential"},
+		InteractiveMode:   kubeconfig.InteractiveModeNever,
+		InstallHint:       "install mycli",
+		InsecureSkipTLS:   true,
+		SetCurrentContext: true,
+	}
+
+	res, err := writeStaticKubeconfig(in)
+	require.NoError(t, err)
+	assert.True(t, res.Success)
+	assert.Equal(t, "prod-ctx", res.ContextName)
+	assert.Equal(t, path, res.KubeconfigPath)
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(kubeconfigFileMode), info.Mode().Perm())
+
+	cfg := readKubeconfig(t, path)
+	assert.Equal(t, "v1", cfg["apiVersion"])
+	assert.Equal(t, "Config", cfg["kind"])
+	assert.Equal(t, "prod-ctx", cfg["current-context"])
+
+	cluster := namedEntry(t, cfg, "clusters", "prod")["cluster"].(map[string]any)
+	assert.Equal(t, "https://api.example.com:6443", cluster["server"])
+	assert.Equal(t, true, cluster["insecure-skip-tls-verify"])
+
+	user := namedEntry(t, cfg, "users", "prod-user")["user"].(map[string]any)
+	exec := user["exec"].(map[string]any)
+	assert.Equal(t, execcredential.DefaultAPIVersion, exec["apiVersion"])
+	assert.Equal(t, "mycli", exec["command"])
+	assert.Equal(t, "Never", exec["interactiveMode"])
+	assert.Equal(t, "install mycli", exec["installHint"])
+	assert.Equal(t, false, exec["provideClusterInfo"])
+
+	ctx := namedEntry(t, cfg, "contexts", "prod-ctx")["context"].(map[string]any)
+	assert.Equal(t, "prod", ctx["cluster"])
+	assert.Equal(t, "prod-user", ctx["user"])
+}
+
+func TestWriteStaticKubeconfig_CADataPreferred(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	in := kubeconfig.WriteInput{
+		Server:          "https://api.example.com:6443",
+		ClusterName:     "prod",
+		KubeconfigPath:  path,
+		ExecCommand:     "mycli",
+		CAData:          "PEM-DATA",
+		InsecureSkipTLS: true,
+	}
+	_, err := writeStaticKubeconfig(in)
+	require.NoError(t, err)
+
+	cfg := readKubeconfig(t, path)
+	cluster := namedEntry(t, cfg, "clusters", "prod")["cluster"].(map[string]any)
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("PEM-DATA")), cluster["certificate-authority-data"])
+	_, hasInsecure := cluster["insecure-skip-tls-verify"]
+	assert.False(t, hasInsecure, "CA data must take precedence over insecure-skip-tls-verify")
+}
+
+func TestWriteStaticKubeconfig_PreservesExistingEntries(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	existing := map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Config",
+		"clusters": []any{
+			map[string]any{"name": "other", "cluster": map[string]any{"server": "https://other:6443"}},
+		},
+		"custom-extension": "keep-me",
+	}
+	data, err := yaml.Marshal(existing)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, kubeconfigFileMode))
+
+	in := kubeconfig.WriteInput{
+		Server:         "https://api.example.com:6443",
+		ClusterName:    "prod",
+		KubeconfigPath: path,
+		ExecCommand:    "mycli",
+	}
+	_, err = writeStaticKubeconfig(in)
+	require.NoError(t, err)
+
+	cfg := readKubeconfig(t, path)
+	assert.Equal(t, "keep-me", cfg["custom-extension"], "unknown top-level keys must be preserved")
+	// Both the pre-existing and new cluster entries are present.
+	clusters := cfg["clusters"].([]any)
+	assert.Len(t, clusters, 2)
+}
+
+func TestWriteStaticKubeconfig_UpsertReplaces(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	in := kubeconfig.WriteInput{
+		Server:         "https://api.example.com:6443",
+		ClusterName:    "prod",
+		KubeconfigPath: path,
+		ExecCommand:    "mycli",
+	}
+	_, err := writeStaticKubeconfig(in)
+	require.NoError(t, err)
+
+	in.Server = "https://api.updated.com:6443"
+	_, err = writeStaticKubeconfig(in)
+	require.NoError(t, err)
+
+	cfg := readKubeconfig(t, path)
+	clusters := cfg["clusters"].([]any)
+	require.Len(t, clusters, 1, "upsert must replace, not duplicate")
+	cluster := namedEntry(t, cfg, "clusters", "prod")["cluster"].(map[string]any)
+	assert.Equal(t, "https://api.updated.com:6443", cluster["server"])
+}
+
+func TestRemoveStaticKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	in := kubeconfig.WriteInput{
+		Server:            "https://api.example.com:6443",
+		ClusterName:       "prod",
+		KubeconfigPath:    path,
+		ExecCommand:       "mycli",
+		SetCurrentContext: true,
+	}
+	_, err := writeStaticKubeconfig(in)
+	require.NoError(t, err)
+
+	removed, err := removeStaticKubeconfig(kubeconfig.RemoveInput{
+		ClusterName:    "prod",
+		KubeconfigPath: path,
+	})
+	require.NoError(t, err)
+	assert.True(t, removed)
+
+	cfg := readKubeconfig(t, path)
+	assert.Empty(t, cfg["clusters"])
+	assert.Empty(t, cfg["users"])
+	assert.Empty(t, cfg["contexts"])
+	_, hasCurrent := cfg["current-context"]
+	assert.False(t, hasCurrent, "current-context referencing the removed context must be cleared")
+}
+
+func TestRemoveStaticKubeconfig_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	removed, err := removeStaticKubeconfig(kubeconfig.RemoveInput{
+		ClusterName:    "prod",
+		KubeconfigPath: filepath.Join(t.TempDir(), "does-not-exist"),
+	})
+	require.NoError(t, err)
+	assert.False(t, removed)
+}
+
+func TestRemoveStaticKubeconfig_NoMatch(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	_, err := writeStaticKubeconfig(kubeconfig.WriteInput{
+		Server:         "https://api.example.com:6443",
+		ClusterName:    "prod",
+		KubeconfigPath: path,
+		ExecCommand:    "mycli",
+	})
+	require.NoError(t, err)
+
+	removed, err := removeStaticKubeconfig(kubeconfig.RemoveInput{
+		ClusterName:    "nonexistent",
+		KubeconfigPath: path,
+	})
+	require.NoError(t, err)
+	assert.False(t, removed)
+}
+
+func TestWriteStaticKubeconfig_AtomicNoTempLeftover(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	in := kubeconfig.WriteInput{
+		Server:         "https://api.example.com:6443",
+		ClusterName:    "prod",
+		KubeconfigPath: path,
+		ExecCommand:    "mycli",
+	}
+	_, err := writeStaticKubeconfig(in)
+	require.NoError(t, err)
+	// Overwrite an existing file to exercise the rename-over path.
+	in.Server = "https://api.updated.com:6443"
+	_, err = writeStaticKubeconfig(in)
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "only the final kubeconfig should remain")
+	assert.Equal(t, "config", entries[0].Name())
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(kubeconfigFileMode), info.Mode().Perm())
+}
+
+func TestResolveKubeconfigPath(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveKubeconfigPath("/explicit/path")
+	require.NoError(t, err)
+	assert.Equal(t, "/explicit/path", got)
+}
+
+func TestResolveKubeconfigPath_KubeconfigEnv(t *testing.T) {
+	// Cannot run in parallel: mutates the KUBECONFIG environment variable.
+	first := filepath.Join("/tmp", "first")
+	second := filepath.Join("/tmp", "second")
+	t.Setenv("KUBECONFIG", string(os.PathListSeparator)+first+string(os.PathListSeparator)+second)
+
+	got, err := resolveKubeconfigPath("")
+	require.NoError(t, err)
+	assert.Equal(t, first, got, "first non-empty KUBECONFIG entry wins")
+}
+
+func TestResolveKubeconfigPath_HomeFallback(t *testing.T) {
+	// Cannot run in parallel: mutates the KUBECONFIG environment variable.
+	t.Setenv("KUBECONFIG", "")
+
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	got, err := resolveKubeconfigPath("")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".kube", "config"), got)
+}

--- a/pkg/kube/login/login.go
+++ b/pkg/kube/login/login.go
@@ -1,0 +1,346 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package login orchestrates Kubernetes / OpenShift login: it resolves a
+// cluster's connection details, runs an auth handler's interactive login, and
+// writes a kubeconfig exec-credential entry that invokes the host binary as a
+// client-go credential plugin on every subsequent kubectl/oc call.
+//
+// The package is dependency-light: it carries no client-go. The heavy
+// kubeconfig machinery lives behind the kubeconfig provider plugin (driven via
+// the KubeconfigWriter interface, satisfied by *kubeconfig.Manager). When that
+// provider is unavailable, login falls back to writing a minimal static
+// kubeconfig with a hand-rolled YAML writer (see fallback.go).
+package login
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+)
+
+// Exec-credential argument fragments baked into the kubeconfig exec block. The
+// runtime command is "<binary> auth token <handler> --exec-credential [...]".
+const (
+	execAuthCmd  = "auth"
+	execTokenCmd = "token"
+	// execCredentialFlag is a CLI flag name passed to the exec plugin, not a secret.
+	execCredentialFlag = "--exec-credential" //nolint:gosec // G101: flag name, not a credential
+	execScopeFlag      = "--scope"
+	execProfileFlag    = "--profile"
+)
+
+// Sentinel errors returned by the orchestration.
+var (
+	// ErrNoHandler indicates no auth handler could be determined from an
+	// explicit handler, the request handler name, or the resolved cluster's
+	// DefaultHandler.
+	ErrNoHandler = errors.New("login: auth handler is required; pass a handler or configure the cluster's default handler")
+
+	// ErrNoServer indicates no cluster API server could be resolved from a
+	// cluster resolver or an explicit --server flag.
+	ErrNoServer = errors.New("login: no cluster server resolved; provide --server or configure a cluster resolver")
+
+	// ErrNoCluster indicates a logout request did not identify a cluster.
+	ErrNoCluster = errors.New("login: cluster name is required")
+
+	// ErrNoKubeconfigWriter indicates the request did not supply a kubeconfig
+	// writer dependency.
+	ErrNoKubeconfigWriter = errors.New("login: kubeconfig writer is required")
+
+	// ErrVerificationFailed indicates a --verify login could not confirm the
+	// authenticated identity via a post-login whoami. The kubeconfig entry is
+	// still written; only the verification step failed.
+	ErrVerificationFailed = errors.New("login: post-login identity verification failed")
+)
+
+// Authenticator is the subset of auth.Handler the login orchestration needs.
+// *auth.Handler implementations satisfy it; tests supply a stub.
+type Authenticator interface {
+	Name() string
+	DisplayName() string
+	Login(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error)
+	GetToken(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error)
+	Logout(ctx context.Context) error
+	Capabilities() []auth.Capability
+}
+
+// KubeconfigWriter is the subset of *kubeconfig.Manager the orchestration
+// needs. Implementations return kubeconfig.ErrProviderUnavailable to signal that
+// the caller should fall back to a static kubeconfig write.
+type KubeconfigWriter interface {
+	WriteKubeconfig(ctx context.Context, in kubeconfig.WriteInput) (kubeconfig.WriteResult, error)
+	RemoveEntry(ctx context.Context, in kubeconfig.RemoveInput) (kubeconfig.RemoveResult, error)
+	DetectAuthType(ctx context.Context, in kubeconfig.DetectInput) (kubeconfig.DetectResult, error)
+	Whoami(ctx context.Context, in kubeconfig.WhoamiInput) (kubeconfig.WhoamiResult, error)
+}
+
+// Deps carries the collaborators the orchestration depends on. Resolver is
+// optional: when nil, cluster details come from explicit flags and
+// auto-detection.
+type Deps struct {
+	// Handler authenticates the user and supplies tokens. When nil, the handler
+	// is resolved via HandlerLookup using the request handler name or the
+	// resolved cluster's DefaultHandler.
+	Handler Authenticator
+
+	// HandlerLookup resolves an auth handler by name. It is consulted only when
+	// Handler is nil, so the handler can be chosen from the resolved cluster's
+	// DefaultHandler. The CLI passes a thin wrapper around auth.GetHandler.
+	HandlerLookup func(ctx context.Context, name string) (Authenticator, error)
+
+	// Kubeconfig drives kubeconfig reads/writes via the provider.
+	Kubeconfig KubeconfigWriter
+
+	// Resolver resolves cluster names to connection details. Optional.
+	Resolver kube.ClusterResolver
+
+	// BinaryName is the host binary baked into the kubeconfig exec command.
+	// Empty falls back to settings.CliBinaryName.
+	BinaryName string
+}
+
+// Request configures a login.
+type Request struct {
+	// Cluster is the logical cluster name resolved via the cluster resolver.
+	Cluster string
+
+	// Handler is the auth handler name. When empty, the handler is taken from
+	// the resolved cluster's DefaultHandler. The resolved handler is supplied
+	// via Deps.Handler or Deps.HandlerLookup.
+	Handler string
+
+	// Server overrides the resolved API server URL.
+	Server string
+
+	// Audience overrides the resolved OIDC audience.
+	Audience string
+
+	// ClusterName, ContextName, and UserName name the kubeconfig entries. Empty
+	// values default to the cluster name.
+	ClusterName string
+	ContextName string
+	UserName    string
+
+	// KubeconfigPath is the kubeconfig file to write. Empty resolves KUBECONFIG
+	// or ~/.kube/config.
+	KubeconfigPath string
+
+	// Profile is the auth profile baked into the exec args. Empty omits it.
+	Profile string
+
+	// SetCurrentContext marks the written context as current-context.
+	SetCurrentContext bool
+
+	// InsecureSkipTLS disables API server TLS verification (development only).
+	InsecureSkipTLS bool
+
+	// Verify requires a successful post-login whoami; when set and the whoami
+	// does not succeed, Login returns ErrVerificationFailed. Verification needs
+	// the kubeconfig provider and is unavailable in the static-fallback path.
+	Verify bool
+
+	// Timeout bounds the interactive login. Zero uses the handler default.
+	Timeout time.Duration
+}
+
+// Result reports the outcome of a login.
+type Result struct {
+	// Handler is the auth handler that authenticated the user.
+	Handler string
+
+	// ContextName is the kubeconfig context that was written.
+	ContextName string
+
+	// KubeconfigPath is the kubeconfig file that was written.
+	KubeconfigPath string
+
+	// Server is the cluster API server URL.
+	Server string
+
+	// AuthType is the resolved (or detected) authentication method.
+	AuthType kube.AuthType
+
+	// Username and Groups come from a best-effort whoami; empty when whoami did
+	// not run or did not succeed.
+	Username string
+	Groups   []string
+
+	// ExpiresAt is the login token's expiry, when known.
+	ExpiresAt time.Time
+
+	// UsedFallback reports that the static kubeconfig writer was used because
+	// the kubeconfig provider was unavailable.
+	UsedFallback bool
+}
+
+// Login resolves the cluster, runs the handler login, and writes a kubeconfig
+// exec-credential entry (falling back to a static write when the provider is
+// unavailable). A best-effort whoami populates the subject identity. When
+// req.Verify is set, a whoami that does not succeed makes Login return
+// ErrVerificationFailed (the kubeconfig entry is still written).
+func Login(ctx context.Context, deps Deps, req Request) (*Result, error) {
+	if deps.Handler == nil && deps.HandlerLookup == nil {
+		return nil, ErrNoHandler
+	}
+	if deps.Kubeconfig == nil {
+		return nil, ErrNoKubeconfigWriter
+	}
+	binaryName := deps.BinaryName
+	if binaryName == "" {
+		binaryName = settings.CliBinaryName
+	}
+
+	// Apply the requested profile to the context so the initial handler login
+	// and the post-login whoami store/read credentials under the same profile
+	// that the written kubeconfig exec block passes via --profile. Without this
+	// the login would write tokens to the active profile while kubectl later
+	// looks them up under req.Profile and fails to mint credentials.
+	if req.Profile != "" {
+		ctx = auth.WithProfile(ctx, req.Profile)
+	}
+
+	info, err := resolveCluster(ctx, deps, req)
+	if err != nil {
+		return nil, err
+	}
+
+	handler, err := resolveHandler(ctx, deps, req, info)
+	if err != nil {
+		return nil, err
+	}
+
+	loginOpts := auth.LoginOptions{Timeout: req.Timeout}
+	if info.OIDCAudience != "" && auth.HasCapability(handler.Capabilities(), auth.CapScopesOnLogin) {
+		loginOpts.Scopes = []string{info.OIDCAudience}
+	}
+	if _, err := handler.Login(ctx, loginOpts); err != nil {
+		return nil, fmt.Errorf("login with handler %q: %w", handler.Name(), err)
+	}
+
+	// Name the kubeconfig entries. Unlike resolveCluster (which derives the
+	// logical identity used to look the cluster up, so req.Cluster wins), the
+	// explicit --cluster-name flag takes precedence here because its sole
+	// purpose is to override the written kubeconfig entry name.
+	clusterName := firstNonEmpty(req.ClusterName, req.Cluster, info.Name)
+	contextName := firstNonEmpty(req.ContextName, clusterName)
+	userName := firstNonEmpty(req.UserName, clusterName)
+
+	writeIn := kubeconfig.WriteInput{
+		Server:             info.APIServerURL,
+		Audience:           info.OIDCAudience,
+		ClusterName:        clusterName,
+		ContextName:        contextName,
+		UserName:           userName,
+		KubeconfigPath:     req.KubeconfigPath,
+		ExecCommand:        binaryName,
+		ExecArgs:           buildExecArgs(handler, info, req.Profile),
+		InteractiveMode:    interactiveModeFor(info.AuthType),
+		InstallHint:        buildInstallHint(binaryName),
+		ProvideClusterInfo: false,
+		CAData:             info.CAData,
+		InsecureSkipTLS:    info.InsecureSkipTLS,
+		SetCurrentContext:  req.SetCurrentContext,
+	}
+
+	result := &Result{
+		Handler:  handler.Name(),
+		Server:   info.APIServerURL,
+		AuthType: info.AuthType,
+	}
+
+	writeRes, err := deps.Kubeconfig.WriteKubeconfig(ctx, writeIn)
+	switch {
+	case err == nil:
+		result.ContextName = writeRes.ContextName
+		result.KubeconfigPath = writeRes.KubeconfigPath
+	case errors.Is(err, kubeconfig.ErrProviderUnavailable):
+		fbRes, fbErr := writeStaticKubeconfig(writeIn)
+		if fbErr != nil {
+			return nil, fmt.Errorf("kubeconfig provider unavailable and static fallback failed: %w", fbErr)
+		}
+		result.ContextName = fbRes.ContextName
+		result.KubeconfigPath = fbRes.KubeconfigPath
+		result.UsedFallback = true
+	default:
+		return nil, fmt.Errorf("write kubeconfig: %w", err)
+	}
+
+	verified := populateIdentity(ctx, deps, handler, info, result)
+	if req.Verify && !verified {
+		return result, ErrVerificationFailed
+	}
+	return result, nil
+}
+
+// resolveHandler returns the authenticator to use. An explicit Deps.Handler wins;
+// otherwise the handler name comes from the request (explicit --handler) or the
+// resolved cluster's DefaultHandler, and is looked up via Deps.HandlerLookup.
+func resolveHandler(ctx context.Context, deps Deps, req Request, info kube.ClusterInfo) (Authenticator, error) {
+	if deps.Handler != nil {
+		return deps.Handler, nil
+	}
+	name := firstNonEmpty(req.Handler, info.DefaultHandler)
+	if name == "" {
+		return nil, ErrNoHandler
+	}
+	if deps.HandlerLookup == nil {
+		return nil, ErrNoHandler
+	}
+	handler, err := deps.HandlerLookup(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("resolve auth handler %q: %w", name, err)
+	}
+	return handler, nil
+}
+
+// populateIdentity runs a best-effort whoami so the result reports the subject.
+// It reports whether the whoami succeeded. Every failure here is non-fatal to
+// the kubeconfig write (it is already done); the caller decides whether an
+// unsuccessful whoami matters (see req.Verify).
+func populateIdentity(ctx context.Context, deps Deps, handler Authenticator, info kube.ClusterInfo, result *Result) bool {
+	token, err := handler.GetToken(ctx, tokenOptionsFor(handler, info))
+	if err != nil || token == nil {
+		return false
+	}
+	result.ExpiresAt = token.ExpiresAt
+	who, err := deps.Kubeconfig.Whoami(ctx, kubeconfig.WhoamiInput{
+		Server:          info.APIServerURL,
+		Token:           token.AccessToken,
+		Audience:        info.OIDCAudience,
+		CAData:          info.CAData,
+		InsecureSkipTLS: info.InsecureSkipTLS,
+	})
+	if err != nil || !who.Success {
+		return false
+	}
+	result.Username = who.Username
+	result.Groups = who.Groups
+	return true
+}
+
+// tokenOptionsFor builds the token request, passing the cluster audience as a
+// scope only for handlers that accept per-request scopes.
+func tokenOptionsFor(h Authenticator, info kube.ClusterInfo) auth.TokenOptions {
+	opts := auth.TokenOptions{}
+	if info.OIDCAudience != "" && auth.HasCapability(h.Capabilities(), auth.CapScopesOnTokenRequest) {
+		opts.Scope = info.OIDCAudience
+	}
+	return opts
+}
+
+// firstNonEmpty returns the first non-empty string, or "" when all are empty.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/pkg/kube/login/login_test.go
+++ b/pkg/kube/login/login_test.go
@@ -1,0 +1,490 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+)
+
+// stubAuth is a test Authenticator that records inputs and returns configured
+// outputs.
+type stubAuth struct {
+	name         string
+	caps         []auth.Capability
+	loginErr     error
+	loginOpts    auth.LoginOptions
+	loginProfile string
+	token        *auth.Token
+	tokenErr     error
+	tokenOpts    auth.TokenOptions
+	tokenProfile string
+	logoutErr    error
+	logoutCalls  int
+}
+
+func (s *stubAuth) Name() string        { return s.name }
+func (s *stubAuth) DisplayName() string { return s.name }
+
+func (s *stubAuth) Login(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
+	s.loginOpts = opts
+	s.loginProfile = auth.ProfileFromContext(ctx)
+	if s.loginErr != nil {
+		return nil, s.loginErr
+	}
+	return &auth.Result{}, nil
+}
+
+func (s *stubAuth) GetToken(ctx context.Context, opts auth.TokenOptions) (*auth.Token, error) {
+	s.tokenOpts = opts
+	s.tokenProfile = auth.ProfileFromContext(ctx)
+	return s.token, s.tokenErr
+}
+
+func (s *stubAuth) Logout(_ context.Context) error {
+	s.logoutCalls++
+	return s.logoutErr
+}
+
+func (s *stubAuth) Capabilities() []auth.Capability { return s.caps }
+
+// stubKube is a test KubeconfigWriter that records inputs and returns configured
+// outputs.
+type stubKube struct {
+	writeIn   kubeconfig.WriteInput
+	writeRes  kubeconfig.WriteResult
+	writeErr  error
+	removeIn  kubeconfig.RemoveInput
+	removeRes kubeconfig.RemoveResult
+	removeErr error
+	detectIn  kubeconfig.DetectInput
+	detectRes kubeconfig.DetectResult
+	detectErr error
+	whoamiIn  kubeconfig.WhoamiInput
+	whoamiRes kubeconfig.WhoamiResult
+	whoamiErr error
+}
+
+func (s *stubKube) WriteKubeconfig(_ context.Context, in kubeconfig.WriteInput) (kubeconfig.WriteResult, error) {
+	s.writeIn = in
+	return s.writeRes, s.writeErr
+}
+
+func (s *stubKube) RemoveEntry(_ context.Context, in kubeconfig.RemoveInput) (kubeconfig.RemoveResult, error) {
+	s.removeIn = in
+	return s.removeRes, s.removeErr
+}
+
+func (s *stubKube) DetectAuthType(_ context.Context, in kubeconfig.DetectInput) (kubeconfig.DetectResult, error) {
+	s.detectIn = in
+	return s.detectRes, s.detectErr
+}
+
+func (s *stubKube) Whoami(_ context.Context, in kubeconfig.WhoamiInput) (kubeconfig.WhoamiResult, error) {
+	s.whoamiIn = in
+	return s.whoamiRes, s.whoamiErr
+}
+
+func TestLogin_NoHandler(t *testing.T) {
+	t.Parallel()
+
+	_, err := Login(context.Background(), Deps{}, Request{})
+	assert.ErrorIs(t, err, ErrNoHandler)
+}
+
+func TestLogin_NoServer(t *testing.T) {
+	t.Parallel()
+
+	deps := Deps{
+		Handler:    &stubAuth{name: "oidc"},
+		Kubeconfig: &stubKube{},
+	}
+	_, err := Login(context.Background(), deps, Request{Cluster: "prod"})
+	assert.ErrorIs(t, err, ErrNoServer)
+}
+
+func TestLogin_NoKubeconfigWriter(t *testing.T) {
+	t.Parallel()
+
+	// A handler is available but no kubeconfig writer: Login must report the
+	// missing dependency instead of panicking on a nil writer.
+	deps := Deps{Handler: &stubAuth{name: "oidc"}}
+	_, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+	})
+	assert.ErrorIs(t, err, ErrNoKubeconfigWriter)
+}
+
+func TestLogin_ProfileAppliedToContext(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{
+		name:  "oidc",
+		token: &auth.Token{AccessToken: "tok"},
+	}
+	kc := &stubKube{
+		writeRes:  kubeconfig.WriteResult{Success: true, ContextName: "prod"},
+		whoamiRes: kubeconfig.WhoamiResult{Success: true, Username: "alice"},
+	}
+	deps := Deps{Handler: handler, Kubeconfig: kc}
+
+	_, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+		Profile:     "work",
+	})
+	require.NoError(t, err)
+	// The requested profile must reach both the initial login and the token
+	// request so credentials are stored and read under the same profile that
+	// the kubeconfig exec block passes via --profile.
+	assert.Equal(t, "work", handler.loginProfile)
+	assert.Equal(t, "work", handler.tokenProfile)
+}
+
+func TestLogin_ResolverError(t *testing.T) {
+	t.Parallel()
+
+	resolveErr := errors.New("boom")
+	deps := Deps{
+		Handler:    &stubAuth{name: "oidc"},
+		Kubeconfig: &stubKube{},
+		Resolver:   &kube.MockResolver{ResolveErr: resolveErr},
+	}
+	_, err := Login(context.Background(), deps, Request{Cluster: "prod"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, resolveErr)
+}
+
+func TestLogin_LoginError(t *testing.T) {
+	t.Parallel()
+
+	loginErr := errors.New("auth failed")
+	deps := Deps{
+		Handler:    &stubAuth{name: "oidc", loginErr: loginErr},
+		Kubeconfig: &stubKube{},
+	}
+	_, err := Login(context.Background(), deps, Request{Server: "https://api.example.com:6443", ClusterName: "prod"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, loginErr)
+}
+
+func TestLogin_ProviderSuccess(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{
+		name:  "oidc",
+		caps:  []auth.Capability{auth.CapScopesOnTokenRequest},
+		token: &auth.Token{AccessToken: "tok", ExpiresAt: time.Date(2026, 6, 24, 15, 4, 5, 0, time.UTC)},
+	}
+	kc := &stubKube{
+		writeRes:  kubeconfig.WriteResult{Success: true, ContextName: "prod", KubeconfigPath: "/tmp/cfg"},
+		whoamiRes: kubeconfig.WhoamiResult{Success: true, Username: "alice", Groups: []string{"dev"}},
+	}
+	deps := Deps{Handler: handler, Kubeconfig: kc, BinaryName: "mycli"}
+
+	res, err := Login(context.Background(), deps, Request{
+		Cluster:           "prod",
+		Server:            "https://api.example.com:6443",
+		Audience:          "my-client-id",
+		Profile:           "work",
+		SetCurrentContext: true,
+	})
+	require.NoError(t, err)
+
+	assert.False(t, res.UsedFallback)
+	assert.Equal(t, "prod", res.ContextName)
+	assert.Equal(t, "/tmp/cfg", res.KubeconfigPath)
+	assert.Equal(t, "https://api.example.com:6443", res.Server)
+	assert.Equal(t, "alice", res.Username)
+	assert.Equal(t, []string{"dev"}, res.Groups)
+	assert.Equal(t, handler.token.ExpiresAt, res.ExpiresAt)
+
+	// Embedder binary name is baked into the exec command.
+	assert.Equal(t, "mycli", kc.writeIn.ExecCommand)
+	assert.Equal(t, []string{"auth", "token", "oidc", "--exec-credential", "--scope", "my-client-id", "--profile", "work"}, kc.writeIn.ExecArgs)
+	assert.True(t, kc.writeIn.SetCurrentContext)
+	// Scope-on-token handler passes the audience as the token request scope.
+	assert.Equal(t, "my-client-id", handler.tokenOpts.Scope)
+	assert.Equal(t, "tok", kc.whoamiIn.Token)
+}
+
+func TestLogin_DefaultBinaryName(t *testing.T) {
+	t.Parallel()
+
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true, ContextName: "prod"}}
+	deps := Deps{Handler: &stubAuth{name: "oidc"}, Kubeconfig: kc}
+
+	_, err := Login(context.Background(), deps, Request{Server: "https://api.example.com:6443", ClusterName: "prod"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, kc.writeIn.ExecCommand, "default binary name must be applied")
+}
+
+func TestLogin_ScopesOnLogin(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{name: "oidc", caps: []auth.Capability{auth.CapScopesOnLogin}}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+	deps := Deps{Handler: handler, Kubeconfig: kc}
+
+	_, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+		Audience:    "aud-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"aud-1"}, handler.loginOpts.Scopes)
+	// Without CapScopesOnTokenRequest, the audience is not a token scope nor an exec --scope arg.
+	assert.Empty(t, handler.tokenOpts.Scope)
+	assert.NotContains(t, kc.writeIn.ExecArgs, "--scope")
+}
+
+func TestLogin_WriteError(t *testing.T) {
+	t.Parallel()
+
+	writeErr := errors.New("disk full")
+	deps := Deps{
+		Handler:    &stubAuth{name: "oidc"},
+		Kubeconfig: &stubKube{writeErr: writeErr},
+	}
+	_, err := Login(context.Background(), deps, Request{Server: "https://api.example.com:6443", ClusterName: "prod"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, writeErr)
+}
+
+func TestLogin_FallbackOnProviderUnavailable(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config")
+	kc := &stubKube{
+		writeErr: fmt.Errorf("%w: not registered", kubeconfig.ErrProviderUnavailable),
+	}
+	deps := Deps{Handler: &stubAuth{name: "oidc"}, Kubeconfig: kc, BinaryName: "mycli"}
+
+	res, err := Login(context.Background(), deps, Request{
+		Server:            "https://api.example.com:6443",
+		ClusterName:       "prod",
+		KubeconfigPath:    cfgPath,
+		SetCurrentContext: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, res.UsedFallback)
+	assert.Equal(t, "prod", res.ContextName)
+	assert.Equal(t, cfgPath, res.KubeconfigPath)
+	assert.FileExists(t, cfgPath)
+}
+
+func TestLogin_WhoamiFailureNonFatal(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{
+		name:  "oidc",
+		token: &auth.Token{AccessToken: "tok"},
+	}
+	kc := &stubKube{
+		writeRes:  kubeconfig.WriteResult{Success: true, ContextName: "prod"},
+		whoamiErr: errors.New("whoami down"),
+	}
+	deps := Deps{Handler: handler, Kubeconfig: kc}
+
+	res, err := Login(context.Background(), deps, Request{Server: "https://api.example.com:6443", ClusterName: "prod"})
+	require.NoError(t, err)
+	assert.Empty(t, res.Username)
+}
+
+func TestLogin_ResolverCADataReachesWriteInput(t *testing.T) {
+	t.Parallel()
+
+	const caBundle = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"
+	resolver := &kube.MockResolver{ResolveResult: &kube.ClusterInfo{
+		Name:         "prod",
+		APIServerURL: "https://api.example.com:6443",
+		CAData:       caBundle,
+	}}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true, ContextName: "prod"}}
+	deps := Deps{Handler: &stubAuth{name: "oidc"}, Kubeconfig: kc, Resolver: resolver}
+
+	_, err := Login(context.Background(), deps, Request{Cluster: "prod"})
+	require.NoError(t, err)
+	assert.Equal(t, caBundle, kc.writeIn.CAData, "resolver-supplied CA bundle must reach the kubeconfig write")
+}
+
+func TestLogin_VerifyUsesCADataForWhoami(t *testing.T) {
+	t.Parallel()
+
+	const caBundle = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"
+	resolver := &kube.MockResolver{ResolveResult: &kube.ClusterInfo{
+		Name:         "prod",
+		APIServerURL: "https://api.example.com:6443",
+		CAData:       caBundle,
+	}}
+	handler := &stubAuth{name: "oidc", token: &auth.Token{AccessToken: "tok"}}
+	kc := &stubKube{
+		writeRes:  kubeconfig.WriteResult{Success: true, ContextName: "prod"},
+		whoamiRes: kubeconfig.WhoamiResult{Success: true, Username: "alice"},
+	}
+	deps := Deps{Handler: handler, Kubeconfig: kc, Resolver: resolver}
+
+	res, err := Login(context.Background(), deps, Request{Cluster: "prod", Verify: true})
+	require.NoError(t, err)
+	assert.Equal(t, "alice", res.Username)
+	// The CA bundle must be passed to the verification whoami so --verify does
+	// not fail TLS against private-CA clusters that work via the kubeconfig.
+	assert.Equal(t, caBundle, kc.whoamiIn.CAData)
+}
+
+func TestLogin_NoHandlerAndNoLookup(t *testing.T) {
+	t.Parallel()
+
+	// Neither an explicit handler nor a lookup hook: cannot authenticate.
+	_, err := Login(context.Background(), Deps{Kubeconfig: &stubKube{}}, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+	})
+	assert.ErrorIs(t, err, ErrNoHandler)
+}
+
+func TestLogin_HandlerFromResolverDefault(t *testing.T) {
+	t.Parallel()
+
+	// No explicit --handler; the handler name comes from the cluster's
+	// DefaultHandler and is resolved via HandlerLookup.
+	handler := &stubAuth{name: "entra"}
+	var lookupName string
+	resolver := &kube.MockResolver{ResolveResult: &kube.ClusterInfo{
+		Name:           "prod",
+		APIServerURL:   "https://api.example.com:6443",
+		DefaultHandler: "entra",
+	}}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true, ContextName: "prod"}}
+	deps := Deps{
+		Kubeconfig: kc,
+		Resolver:   resolver,
+		HandlerLookup: func(_ context.Context, name string) (Authenticator, error) {
+			lookupName = name
+			return handler, nil
+		},
+	}
+
+	res, err := Login(context.Background(), deps, Request{Cluster: "prod"})
+	require.NoError(t, err)
+	assert.Equal(t, "entra", lookupName, "resolver DefaultHandler must drive the lookup")
+	assert.Equal(t, "entra", res.Handler)
+}
+
+func TestLogin_RequestHandlerOverridesDefault(t *testing.T) {
+	t.Parallel()
+
+	// An explicit request handler wins over the cluster's DefaultHandler.
+	var lookupName string
+	resolver := &kube.MockResolver{ResolveResult: &kube.ClusterInfo{
+		Name:           "prod",
+		APIServerURL:   "https://api.example.com:6443",
+		DefaultHandler: "entra",
+	}}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true, ContextName: "prod"}}
+	deps := Deps{
+		Kubeconfig: kc,
+		Resolver:   resolver,
+		HandlerLookup: func(_ context.Context, name string) (Authenticator, error) {
+			lookupName = name
+			return &stubAuth{name: name}, nil
+		},
+	}
+
+	_, err := Login(context.Background(), deps, Request{Cluster: "prod", Handler: "github"})
+	require.NoError(t, err)
+	assert.Equal(t, "github", lookupName, "explicit request handler must override the default")
+}
+
+func TestLogin_HandlerLookupError(t *testing.T) {
+	t.Parallel()
+
+	lookupErr := errors.New("unknown handler")
+	deps := Deps{
+		Kubeconfig: &stubKube{},
+		HandlerLookup: func(_ context.Context, _ string) (Authenticator, error) {
+			return nil, lookupErr
+		},
+	}
+
+	_, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+		Handler:     "nope",
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, lookupErr)
+}
+
+func TestLogin_LookupModeNoHandlerName(t *testing.T) {
+	t.Parallel()
+
+	// HandlerLookup is configured but no handler name is available (no flag and
+	// the resolved cluster has no DefaultHandler): expect ErrNoHandler.
+	deps := Deps{
+		Kubeconfig: &stubKube{},
+		HandlerLookup: func(_ context.Context, _ string) (Authenticator, error) {
+			return &stubAuth{name: "x"}, nil
+		},
+	}
+	_, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+	})
+	assert.ErrorIs(t, err, ErrNoHandler)
+}
+
+func TestLogin_VerifySuccess(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{name: "oidc", token: &auth.Token{AccessToken: "tok"}}
+	kc := &stubKube{
+		writeRes:  kubeconfig.WriteResult{Success: true, ContextName: "prod"},
+		whoamiRes: kubeconfig.WhoamiResult{Success: true, Username: "alice"},
+	}
+	deps := Deps{Handler: handler, Kubeconfig: kc}
+
+	res, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+		Verify:      true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "alice", res.Username)
+}
+
+func TestLogin_VerifyFailure(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{name: "oidc", token: &auth.Token{AccessToken: "tok"}}
+	kc := &stubKube{
+		writeRes:  kubeconfig.WriteResult{Success: true, ContextName: "prod"},
+		whoamiRes: kubeconfig.WhoamiResult{Success: false},
+	}
+	deps := Deps{Handler: handler, Kubeconfig: kc}
+
+	res, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+		Verify:      true,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrVerificationFailed)
+	// The kubeconfig entry is still written even though verification failed.
+	require.NotNil(t, res)
+	assert.Equal(t, "prod", res.ContextName)
+}

--- a/pkg/kube/login/logout.go
+++ b/pkg/kube/login/logout.go
@@ -1,0 +1,108 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+)
+
+// LogoutRequest configures a logout.
+type LogoutRequest struct {
+	// Cluster is the logical cluster name; it defaults the entry names.
+	Cluster string
+
+	// ClusterName, ContextName, and UserName name the kubeconfig entries to
+	// remove. Empty values default to the cluster name.
+	ClusterName string
+	ContextName string
+	UserName    string
+
+	// KubeconfigPath is the kubeconfig file to edit. Empty resolves KUBECONFIG
+	// or ~/.kube/config.
+	KubeconfigPath string
+
+	// KeepCredentials skips the handler logout, leaving cached tokens in place.
+	KeepCredentials bool
+}
+
+// LogoutResult reports the outcome of a logout.
+type LogoutResult struct {
+	// Removed reports whether a matching kubeconfig entry was removed.
+	Removed bool
+
+	// UsedFallback reports that the static kubeconfig writer was used because
+	// the kubeconfig provider was unavailable.
+	UsedFallback bool
+}
+
+// Logout removes the managed kubeconfig entry and, unless KeepCredentials is
+// set, clears the handler's cached credentials. It falls back to a static
+// kubeconfig edit when the provider is unavailable.
+func Logout(ctx context.Context, deps Deps, req LogoutRequest) (*LogoutResult, error) {
+	clusterName := firstNonEmpty(req.ClusterName, req.Cluster)
+	if clusterName == "" {
+		return nil, ErrNoCluster
+	}
+	if deps.Kubeconfig == nil {
+		return nil, ErrNoKubeconfigWriter
+	}
+	removeIn := kubeconfig.RemoveInput{
+		ClusterName:    clusterName,
+		ContextName:    firstNonEmpty(req.ContextName, clusterName),
+		UserName:       firstNonEmpty(req.UserName, clusterName),
+		KubeconfigPath: req.KubeconfigPath,
+	}
+
+	result := &LogoutResult{}
+	res, err := deps.Kubeconfig.RemoveEntry(ctx, removeIn)
+	switch {
+	case err == nil:
+		result.Removed = res.Removed
+	case errors.Is(err, kubeconfig.ErrProviderUnavailable):
+		removed, fbErr := removeStaticKubeconfig(removeIn)
+		if fbErr != nil {
+			return nil, fmt.Errorf("kubeconfig provider unavailable and static fallback failed: %w", fbErr)
+		}
+		result.Removed = removed
+		result.UsedFallback = true
+	default:
+		return nil, fmt.Errorf("remove kubeconfig entry: %w", err)
+	}
+
+	if !req.KeepCredentials {
+		if handler := logoutHandler(ctx, deps, req); handler != nil {
+			if err := handler.Logout(ctx); err != nil {
+				return result, fmt.Errorf("logout handler %q: %w", handler.Name(), err)
+			}
+		}
+	}
+	return result, nil
+}
+
+// logoutHandler returns the handler whose cached credentials should be revoked.
+// An explicit Deps.Handler wins; otherwise the resolved cluster's DefaultHandler
+// is looked up best-effort so "logout <cluster>" revokes the same handler that
+// "login <cluster>" used. Returns nil when no handler can be determined; the
+// caller treats credential revocation as optional.
+func logoutHandler(ctx context.Context, deps Deps, req LogoutRequest) Authenticator {
+	if deps.Handler != nil {
+		return deps.Handler
+	}
+	if deps.Resolver == nil || deps.HandlerLookup == nil || req.Cluster == "" {
+		return nil
+	}
+	resolved, err := deps.Resolver.Resolve(ctx, req.Cluster)
+	if err != nil || resolved == nil || resolved.DefaultHandler == "" {
+		return nil
+	}
+	handler, err := deps.HandlerLookup(ctx, resolved.DefaultHandler)
+	if err != nil {
+		return nil
+	}
+	return handler
+}

--- a/pkg/kube/login/logout_test.go
+++ b/pkg/kube/login/logout_test.go
@@ -1,0 +1,213 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+)
+
+func TestLogout_NoCluster(t *testing.T) {
+	t.Parallel()
+
+	_, err := Logout(context.Background(), Deps{Kubeconfig: &stubKube{}}, LogoutRequest{})
+	assert.ErrorIs(t, err, ErrNoCluster)
+}
+
+func TestLogout_NoKubeconfigWriter(t *testing.T) {
+	t.Parallel()
+
+	_, err := Logout(context.Background(), Deps{}, LogoutRequest{Cluster: "prod"})
+	assert.ErrorIs(t, err, ErrNoKubeconfigWriter)
+}
+
+func TestLogout_ProviderSuccess(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{name: "oidc"}
+	kc := &stubKube{removeRes: kubeconfig.RemoveResult{Success: true, Removed: true}}
+	deps := Deps{Handler: handler, Kubeconfig: kc}
+
+	res, err := Logout(context.Background(), deps, LogoutRequest{Cluster: "prod"})
+	require.NoError(t, err)
+	assert.True(t, res.Removed)
+	assert.False(t, res.UsedFallback)
+	assert.Equal(t, 1, handler.logoutCalls)
+	assert.Equal(t, "prod", kc.removeIn.ClusterName)
+	assert.Equal(t, "prod", kc.removeIn.ContextName)
+	assert.Equal(t, "prod", kc.removeIn.UserName)
+}
+
+func TestLogout_KeepCredentials(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{name: "oidc"}
+	kc := &stubKube{removeRes: kubeconfig.RemoveResult{Removed: true}}
+	deps := Deps{Handler: handler, Kubeconfig: kc}
+
+	_, err := Logout(context.Background(), deps, LogoutRequest{Cluster: "prod", KeepCredentials: true})
+	require.NoError(t, err)
+	assert.Equal(t, 0, handler.logoutCalls, "KeepCredentials must skip handler logout")
+}
+
+func TestLogout_HandlerLogoutError(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{name: "oidc", logoutErr: errors.New("revoke failed")}
+	kc := &stubKube{removeRes: kubeconfig.RemoveResult{Removed: true}}
+	deps := Deps{Handler: handler, Kubeconfig: kc}
+
+	res, err := Logout(context.Background(), deps, LogoutRequest{Cluster: "prod"})
+	require.Error(t, err)
+	assert.True(t, res.Removed, "kubeconfig removal already happened")
+}
+
+func TestLogout_RemoveError(t *testing.T) {
+	t.Parallel()
+
+	removeErr := errors.New("io error")
+	deps := Deps{Kubeconfig: &stubKube{removeErr: removeErr}}
+
+	_, err := Logout(context.Background(), deps, LogoutRequest{Cluster: "prod"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, removeErr)
+}
+
+func TestLogout_FallbackOnProviderUnavailable(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	_, err := writeStaticKubeconfig(kubeconfig.WriteInput{
+		Server:         "https://api.example.com:6443",
+		ClusterName:    "prod",
+		KubeconfigPath: path,
+		ExecCommand:    "mycli",
+	})
+	require.NoError(t, err)
+
+	kc := &stubKube{removeErr: fmt.Errorf("%w: nope", kubeconfig.ErrProviderUnavailable)}
+	deps := Deps{Handler: &stubAuth{name: "oidc"}, Kubeconfig: kc}
+
+	res, err := Logout(context.Background(), deps, LogoutRequest{Cluster: "prod", KubeconfigPath: path})
+	require.NoError(t, err)
+	assert.True(t, res.UsedFallback)
+	assert.True(t, res.Removed)
+}
+
+func TestLogout_RevokesResolverDefaultHandler(t *testing.T) {
+	t.Parallel()
+
+	// No explicit Deps.Handler: logout resolves the cluster's DefaultHandler and
+	// revokes the same handler that login would have used.
+	handler := &stubAuth{name: "entra"}
+	var lookupName string
+	kc := &stubKube{removeRes: kubeconfig.RemoveResult{Removed: true}}
+	deps := Deps{
+		Kubeconfig: kc,
+		Resolver:   &kube.MockResolver{ResolveResult: &kube.ClusterInfo{Name: "prod", DefaultHandler: "entra"}},
+		HandlerLookup: func(_ context.Context, name string) (Authenticator, error) {
+			lookupName = name
+			return handler, nil
+		},
+	}
+
+	res, err := Logout(context.Background(), deps, LogoutRequest{Cluster: "prod"})
+	require.NoError(t, err)
+	assert.True(t, res.Removed)
+	assert.Equal(t, "entra", lookupName, "resolver DefaultHandler must drive the revoke")
+	assert.Equal(t, 1, handler.logoutCalls)
+}
+
+func TestLogout_DefaultHandlerKeepCredentials(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{name: "entra"}
+	kc := &stubKube{removeRes: kubeconfig.RemoveResult{Removed: true}}
+	deps := Deps{
+		Kubeconfig: kc,
+		Resolver:   &kube.MockResolver{ResolveResult: &kube.ClusterInfo{Name: "prod", DefaultHandler: "entra"}},
+		HandlerLookup: func(_ context.Context, name string) (Authenticator, error) {
+			return handler, nil
+		},
+	}
+
+	_, err := Logout(context.Background(), deps, LogoutRequest{Cluster: "prod", KeepCredentials: true})
+	require.NoError(t, err)
+	assert.Equal(t, 0, handler.logoutCalls, "KeepCredentials must skip the default-handler revoke")
+}
+
+func TestLogout_NoDefaultHandlerSkipsRevoke(t *testing.T) {
+	t.Parallel()
+
+	// Resolver supplies no DefaultHandler and no explicit handler is given: the
+	// kubeconfig entry is still removed and credential revocation is skipped.
+	lookupCalled := false
+	kc := &stubKube{removeRes: kubeconfig.RemoveResult{Removed: true}}
+	deps := Deps{
+		Kubeconfig: kc,
+		Resolver:   &kube.MockResolver{ResolveResult: &kube.ClusterInfo{Name: "prod"}},
+		HandlerLookup: func(_ context.Context, _ string) (Authenticator, error) {
+			lookupCalled = true
+			return &stubAuth{name: "x"}, nil
+		},
+	}
+
+	res, err := Logout(context.Background(), deps, LogoutRequest{Cluster: "prod"})
+	require.NoError(t, err)
+	assert.True(t, res.Removed)
+	assert.False(t, lookupCalled, "no DefaultHandler means no handler lookup")
+}
+
+func TestLogout_DefaultHandlerLookupErrorIsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	// A failed handler lookup must not fail logout: the kubeconfig entry removal
+	// is the primary action.
+	kc := &stubKube{removeRes: kubeconfig.RemoveResult{Removed: true}}
+	deps := Deps{
+		Kubeconfig: kc,
+		Resolver:   &kube.MockResolver{ResolveResult: &kube.ClusterInfo{Name: "prod", DefaultHandler: "entra"}},
+		HandlerLookup: func(_ context.Context, _ string) (Authenticator, error) {
+			return nil, errors.New("handler not registered")
+		},
+	}
+
+	res, err := Logout(context.Background(), deps, LogoutRequest{Cluster: "prod"})
+	require.NoError(t, err)
+	assert.True(t, res.Removed)
+}
+
+func TestLogout_ExplicitHandlerWinsOverDefault(t *testing.T) {
+	t.Parallel()
+
+	// An explicit Deps.Handler is revoked directly; the resolver is not consulted
+	// for the default handler.
+	explicit := &stubAuth{name: "github"}
+	lookupCalled := false
+	kc := &stubKube{removeRes: kubeconfig.RemoveResult{Removed: true}}
+	deps := Deps{
+		Handler:    explicit,
+		Kubeconfig: kc,
+		Resolver:   &kube.MockResolver{ResolveResult: &kube.ClusterInfo{Name: "prod", DefaultHandler: "entra"}},
+		HandlerLookup: func(_ context.Context, _ string) (Authenticator, error) {
+			lookupCalled = true
+			return &stubAuth{name: "entra"}, nil
+		},
+	}
+
+	_, err := Logout(context.Background(), deps, LogoutRequest{Cluster: "prod"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, explicit.logoutCalls)
+	assert.False(t, lookupCalled, "explicit handler must bypass the resolver default")
+}

--- a/pkg/kube/login/resolve.go
+++ b/pkg/kube/login/resolve.go
@@ -1,0 +1,90 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+)
+
+// resolveCluster assembles the cluster connection details from (in priority
+// order) explicit request flags, the configured cluster resolver, and
+// best-effort auto-detection of the authentication method. Explicit flags
+// always override resolved values.
+func resolveCluster(ctx context.Context, deps Deps, req Request) (kube.ClusterInfo, error) {
+	var info kube.ClusterInfo
+
+	if req.Cluster != "" && deps.Resolver != nil {
+		resolved, err := deps.Resolver.Resolve(ctx, req.Cluster)
+		if err != nil {
+			return kube.ClusterInfo{}, fmt.Errorf("resolve cluster %q: %w", req.Cluster, err)
+		}
+		if resolved != nil {
+			info = *resolved
+		}
+	}
+	if info.Name == "" {
+		info.Name = firstNonEmpty(req.Cluster, req.ClusterName)
+	}
+
+	if req.Server != "" {
+		info.APIServerURL = req.Server
+	}
+	if req.Audience != "" {
+		info.OIDCAudience = req.Audience
+	}
+	if req.InsecureSkipTLS {
+		info.InsecureSkipTLS = true
+		// The kubeconfig writer prefers CAData over InsecureSkipTLS, so a
+		// resolver-supplied CA bundle would silently defeat the explicit
+		// insecure flag. Clear it so --insecure-skip-tls-verify takes effect.
+		info.CAData = ""
+	}
+
+	if info.APIServerURL == "" {
+		return kube.ClusterInfo{}, ErrNoServer
+	}
+
+	// Fall back to a name derived from the server host for the direct
+	// --server flow (no cluster argument and no --cluster-name), which the CLI
+	// advertises. Validate() rejects an empty name, so this keeps that flow
+	// working instead of forcing users to add --cluster-name.
+	if info.Name == "" {
+		info.Name = clusterNameFromServer(info.APIServerURL)
+	}
+
+	// Auto-detect the auth method when it is unset. Detection failure (including
+	// an unavailable provider) is non-fatal: the auth type stays auto and the
+	// handler decides the flow.
+	if info.AuthType == kube.AuthTypeAuto && deps.Kubeconfig != nil {
+		det, err := deps.Kubeconfig.DetectAuthType(ctx, kubeconfig.DetectInput{
+			Server:          info.APIServerURL,
+			InsecureSkipTLS: info.InsecureSkipTLS,
+		})
+		if err == nil && det.Success && det.AuthType.Valid() {
+			info.AuthType = det.AuthType
+		}
+	}
+
+	if err := info.Validate(); err != nil {
+		return kube.ClusterInfo{}, err
+	}
+	return info, nil
+}
+
+// clusterNameFromServer derives a kubeconfig entry name from an API server URL,
+// used for the direct --server flow when no cluster name is supplied. It returns
+// the host (without port), falling back to the trimmed raw server string so the
+// result is never empty for a non-empty server.
+func clusterNameFromServer(server string) string {
+	if u, err := url.Parse(server); err == nil && u.Hostname() != "" {
+		return u.Hostname()
+	}
+	return strings.TrimSpace(server)
+}

--- a/pkg/kube/login/resolve_test.go
+++ b/pkg/kube/login/resolve_test.go
@@ -1,0 +1,147 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+)
+
+func TestResolveCluster_ExplicitFlagsOverrideResolver(t *testing.T) {
+	t.Parallel()
+
+	resolver := &kube.MockResolver{
+		ResolveResult: &kube.ClusterInfo{
+			Name:         "prod",
+			APIServerURL: "https://resolved:6443",
+			OIDCAudience: "resolved-aud",
+			AuthType:     kube.AuthTypeOIDC,
+		},
+	}
+	deps := Deps{Resolver: resolver, Kubeconfig: &stubKube{}}
+
+	info, err := resolveCluster(context.Background(), deps, Request{
+		Cluster:         "prod",
+		Server:          "https://override:6443",
+		Audience:        "override-aud",
+		InsecureSkipTLS: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://override:6443", info.APIServerURL)
+	assert.Equal(t, "override-aud", info.OIDCAudience)
+	assert.True(t, info.InsecureSkipTLS)
+	assert.Equal(t, []string{"prod"}, resolver.ResolveCalls)
+}
+
+func TestResolveCluster_NoResolverUsesFlags(t *testing.T) {
+	t.Parallel()
+
+	info, err := resolveCluster(context.Background(), Deps{Kubeconfig: &stubKube{}}, Request{
+		ClusterName: "ignored",
+		Cluster:     "prod",
+		Server:      "https://api.example.com:6443",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "prod", info.Name)
+	assert.Equal(t, "https://api.example.com:6443", info.APIServerURL)
+}
+
+func TestResolveCluster_MissingServer(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveCluster(context.Background(), Deps{}, Request{Cluster: "prod"})
+	assert.ErrorIs(t, err, ErrNoServer)
+}
+
+func TestResolveCluster_AutoDetect(t *testing.T) {
+	t.Parallel()
+
+	kc := &stubKube{detectRes: kubeconfig.DetectResult{Success: true, AuthType: kube.AuthTypeOIDC}}
+	deps := Deps{Kubeconfig: kc}
+
+	info, err := resolveCluster(context.Background(), deps, Request{
+		ClusterName: "prod",
+		Server:      "https://api.example.com:6443",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, kube.AuthTypeOIDC, info.AuthType)
+	assert.Equal(t, "https://api.example.com:6443", kc.detectIn.Server)
+}
+
+func TestResolveCluster_AutoDetectFailureNonFatal(t *testing.T) {
+	t.Parallel()
+
+	kc := &stubKube{detectErr: errors.New("probe failed")}
+	deps := Deps{Kubeconfig: kc}
+
+	info, err := resolveCluster(context.Background(), deps, Request{
+		ClusterName: "prod",
+		Server:      "https://api.example.com:6443",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, kube.AuthTypeAuto, info.AuthType)
+}
+
+func TestResolveCluster_ResolverNilResult(t *testing.T) {
+	t.Parallel()
+
+	resolver := &kube.MockResolver{ResolveResult: nil}
+	deps := Deps{Resolver: resolver}
+
+	_, err := resolveCluster(context.Background(), deps, Request{Cluster: "prod"})
+	// No server resolved and none supplied.
+	assert.ErrorIs(t, err, ErrNoServer)
+}
+
+func TestResolveCluster_NameDerivedFromServerHost(t *testing.T) {
+	t.Parallel()
+
+	// Direct --server flow with no cluster argument and no --cluster-name:
+	// the name must be derived from the host so Validate() passes.
+	info, err := resolveCluster(context.Background(), Deps{}, Request{
+		Server: "https://api.example.com:6443",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "api.example.com", info.Name)
+}
+
+func TestResolveCluster_NameFallsBackToRawServer(t *testing.T) {
+	t.Parallel()
+
+	// A bare host (not a parseable URL with a host component) falls back to the
+	// trimmed raw server string so the name is never empty.
+	info, err := resolveCluster(context.Background(), Deps{}, Request{
+		Server: "api.example.com:6443",
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, info.Name)
+}
+
+func TestResolveCluster_InsecureSkipTLSClearsResolverCAData(t *testing.T) {
+	t.Parallel()
+
+	resolver := &kube.MockResolver{ResolveResult: &kube.ClusterInfo{
+		Name:         "prod",
+		APIServerURL: "https://api.example.com:6443",
+		CAData:       "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----",
+	}}
+	deps := Deps{Resolver: resolver, Kubeconfig: &stubKube{}}
+
+	info, err := resolveCluster(context.Background(), deps, Request{
+		Cluster:         "prod",
+		InsecureSkipTLS: true,
+	})
+	require.NoError(t, err)
+	// The writer prefers CAData over InsecureSkipTLS; it must be cleared so the
+	// explicit insecure flag is honored.
+	assert.True(t, info.InsecureSkipTLS)
+	assert.Empty(t, info.CAData)
+}

--- a/pkg/kubeconfig/types.go
+++ b/pkg/kubeconfig/types.go
@@ -49,6 +49,24 @@ const (
 // inputOperation is the input field that selects the operation to perform.
 const inputOperation = "operation"
 
+// InteractiveMode values control whether kubectl may run the exec credential
+// plugin interactively. They mirror client-go's
+// ExecConfig.InteractiveMode (client.authentication.k8s.io). Handlers that can
+// refresh silently use Never; handlers that require a re-login on expiry (for
+// example implicit-grant OAuth) use IfAvailable so kubectl only prompts when a
+// terminal is attached.
+const (
+	// InteractiveModeNever never runs the plugin interactively.
+	InteractiveModeNever = "Never"
+
+	// InteractiveModeIfAvailable runs the plugin interactively only when stdin
+	// is a terminal.
+	InteractiveModeIfAvailable = "IfAvailable"
+
+	// InteractiveModeAlways always runs the plugin interactively.
+	InteractiveModeAlways = "Always"
+)
+
 // Sentinel errors returned by the manager.
 var (
 	// ErrProviderUnavailable indicates the kubeconfig provider could not be
@@ -93,6 +111,25 @@ type WriteInput struct {
 	// ExecArgs are the static arguments for the kubeconfig exec block.
 	ExecArgs []string `json:"exec_args,omitempty" yaml:"exec_args,omitempty" doc:"Static arguments for the kubeconfig exec block" maxItems:"100"`
 
+	// CAData is the PEM-encoded cluster certificate authority bundle. When set,
+	// it is preferred over InsecureSkipTLS so the API server's certificate is
+	// verified.
+	CAData string `json:"ca_data,omitempty" yaml:"ca_data,omitempty" doc:"PEM-encoded cluster CA bundle; preferred over insecure_skip_tls" maxLength:"1048576"`
+
+	// InteractiveMode controls whether kubectl may run the exec credential
+	// plugin interactively (Never, IfAvailable, or Always). Empty defaults to
+	// IfAvailable inside the provider.
+	InteractiveMode string `json:"interactive_mode,omitempty" yaml:"interactive_mode,omitempty" doc:"Exec plugin interactive mode (Never, IfAvailable, Always)" enum:"Never,IfAvailable,Always" example:"IfAvailable"`
+
+	// InstallHint is the message kubectl shows when the exec command is missing
+	// from PATH. Empty omits the hint.
+	InstallHint string `json:"install_hint,omitempty" yaml:"install_hint,omitempty" doc:"Message kubectl shows when the exec command is missing from PATH" maxLength:"4096"`
+
+	// ProvideClusterInfo asks kubectl to pass cluster details to the plugin via
+	// KUBERNETES_EXEC_INFO. It is false when the server is baked into the exec
+	// args.
+	ProvideClusterInfo bool `json:"provide_cluster_info,omitempty" yaml:"provide_cluster_info,omitempty" doc:"Pass cluster details to the plugin via KUBERNETES_EXEC_INFO"`
+
 	// InsecureSkipTLS disables API server TLS verification (development only).
 	InsecureSkipTLS bool `json:"insecure_skip_tls,omitempty" yaml:"insecure_skip_tls,omitempty" doc:"Disable API server TLS verification (development only)"`
 
@@ -102,16 +139,20 @@ type WriteInput struct {
 
 func (in WriteInput) toInputs() map[string]any {
 	return map[string]any{
-		"server":              in.Server,
-		"audience":            in.Audience,
-		"cluster_name":        in.ClusterName,
-		"context_name":        in.ContextName,
-		"user_name":           in.UserName,
-		"kubeconfig_path":     in.KubeconfigPath,
-		"exec_command":        in.ExecCommand,
-		"exec_args":           in.ExecArgs,
-		"insecure_skip_tls":   in.InsecureSkipTLS,
-		"set_current_context": in.SetCurrentContext,
+		"server":               in.Server,
+		"audience":             in.Audience,
+		"cluster_name":         in.ClusterName,
+		"context_name":         in.ContextName,
+		"user_name":            in.UserName,
+		"kubeconfig_path":      in.KubeconfigPath,
+		"exec_command":         in.ExecCommand,
+		"exec_args":            in.ExecArgs,
+		"ca_data":              in.CAData,
+		"interactive_mode":     in.InteractiveMode,
+		"install_hint":         in.InstallHint,
+		"provide_cluster_info": in.ProvideClusterInfo,
+		"insecure_skip_tls":    in.InsecureSkipTLS,
+		"set_current_context":  in.SetCurrentContext,
 	}
 }
 
@@ -256,6 +297,11 @@ type WhoamiInput struct {
 	// Audience is the OIDC audience the token targets.
 	Audience string `json:"audience,omitempty" yaml:"audience,omitempty" doc:"OIDC audience the token targets" maxLength:"512"`
 
+	// CAData is the PEM-encoded cluster certificate authority bundle. When set,
+	// it is preferred over InsecureSkipTLS so the SelfSubjectReview call verifies
+	// the API server's certificate against a private CA.
+	CAData string `json:"ca_data,omitempty" yaml:"ca_data,omitempty" doc:"PEM-encoded cluster CA bundle; preferred over insecure_skip_tls" maxLength:"1048576"`
+
 	// InsecureSkipTLS disables TLS verification (development only).
 	InsecureSkipTLS bool `json:"insecure_skip_tls,omitempty" yaml:"insecure_skip_tls,omitempty" doc:"Disable TLS verification (development only)"`
 }
@@ -265,6 +311,7 @@ func (in WhoamiInput) toInputs() map[string]any {
 		"server":            in.Server,
 		"token":             in.Token,
 		"audience":          in.Audience,
+		"ca_data":           in.CAData,
 		"insecure_skip_tls": in.InsecureSkipTLS,
 	}
 }

--- a/pkg/kubeconfig/types_test.go
+++ b/pkg/kubeconfig/types_test.go
@@ -16,24 +16,49 @@ import (
 func TestWriteInput_ToInputs(t *testing.T) {
 	t.Parallel()
 	in := WriteInput{
-		Server:            "https://api.example.com:6443",
-		Audience:          "aud",
-		ClusterName:       "prod",
-		ContextName:       "ctx",
-		UserName:          "user",
-		KubeconfigPath:    "/tmp/kubeconfig",
-		ExecCommand:       "scafctl",
-		ExecArgs:          []string{"auth", "token"},
-		InsecureSkipTLS:   true,
-		SetCurrentContext: true,
+		Server:             "https://api.example.com:6443",
+		Audience:           "aud",
+		ClusterName:        "prod",
+		ContextName:        "ctx",
+		UserName:           "user",
+		KubeconfigPath:     "/tmp/kubeconfig",
+		ExecCommand:        "scafctl",
+		ExecArgs:           []string{"auth", "token"},
+		CAData:             "-----BEGIN CERTIFICATE-----",
+		InteractiveMode:    InteractiveModeIfAvailable,
+		InstallHint:        "install scafctl",
+		ProvideClusterInfo: true,
+		InsecureSkipTLS:    true,
+		SetCurrentContext:  true,
 	}
 	got := in.toInputs()
 	assert.Equal(t, "https://api.example.com:6443", got["server"])
 	assert.Equal(t, "prod", got["cluster_name"])
 	assert.Equal(t, "scafctl", got["exec_command"])
 	assert.Equal(t, []string{"auth", "token"}, got["exec_args"])
+	assert.Equal(t, "-----BEGIN CERTIFICATE-----", got["ca_data"])
+	assert.Equal(t, InteractiveModeIfAvailable, got["interactive_mode"])
+	assert.Equal(t, "install scafctl", got["install_hint"])
+	assert.Equal(t, true, got["provide_cluster_info"])
 	assert.Equal(t, true, got["insecure_skip_tls"])
 	assert.Equal(t, true, got["set_current_context"])
+}
+
+func TestWhoamiInput_ToInputs(t *testing.T) {
+	t.Parallel()
+	in := WhoamiInput{
+		Server:          "https://api.example.com:6443",
+		Token:           "tok",
+		Audience:        "aud",
+		CAData:          "-----BEGIN CERTIFICATE-----",
+		InsecureSkipTLS: true,
+	}
+	got := in.toInputs()
+	assert.Equal(t, "https://api.example.com:6443", got["server"])
+	assert.Equal(t, "tok", got["token"])
+	assert.Equal(t, "aud", got["audience"])
+	assert.Equal(t, "-----BEGIN CERTIFICATE-----", got["ca_data"])
+	assert.Equal(t, true, got["insecure_skip_tls"])
 }
 
 func TestDecodeOutput_MapPath(t *testing.T) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2109,6 +2109,44 @@ func TestIntegration_AuthLoginGCPInvalidFlow(t *testing.T) {
 	)
 }
 
+func TestIntegration_LoginHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "kube", "login", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "--handler")
+	assert.Contains(t, stdout, "--server")
+	assert.Contains(t, stdout, "--verify")
+	assert.Contains(t, stdout, "kubeconfig")
+}
+
+func TestIntegration_LoginMissingHandler(t *testing.T) {
+	t.Parallel()
+	// No --handler and no cluster resolver configured, so no default handler is
+	// available: login fails asking for a handler.
+	_, stderr, exitCode := runScafctl(t, "kube", "login", "prod", "--server", "https://api.example.com:6443")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "auth handler is required")
+}
+
+func TestIntegration_LogoutHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "kube", "logout", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "--keep-credentials")
+	assert.Contains(t, stdout, "kubeconfig")
+}
+
+func TestIntegration_LogoutNoCluster(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t, "kube", "logout")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "cluster name is required")
+}
+
 func TestIntegration_AuthStatusGCP(t *testing.T) {
 	t.Parallel()
 	_, stderr, exitCode := runScafctl(t, "auth", "status", "gcp")


### PR DESCRIPTION
Introduce first-class Kubernetes authentication via kube login and kube logout, wiring an exec-credential bridge into kubeconfig so kubectl can mint tokens through scafctl auth handlers.

- Add kube command group (alias `k8s`) with `login` and `logout` subcommands as thin CLI wiring over the new pkg/kube/login domain package
- Resolve the auth handler from the cluster's DefaultHandler when no --handler is supplied, so `login <cluster>` and `logout <cluster>` work without naming a handler
- Add headless ergonomics: --verify identity check, interactive-mode selection (Never/IfAvailable/Always), install hints, and CA pinning via ClusterInfo.CAData (preferred over insecureSkipTLS)
- Provide a client-go-free static kubeconfig writer fallback used when the kubeconfig provider plugin is unavailable
- Extend ClusterInfo with DefaultHandler and CAData, and WriteInput with CAData, InteractiveMode, InstallHint, and ProvideClusterInfo
- Keep the feature CLI-only by design (no API/MCP exposure) and respect the embedder binary name throughout help and install hints
- Document handler resolution and the CLI-only surface in the design doc, tutorial, and examples

Closes #559
Relates to #536