### PR TITLE
feat(spec)!: add continueOnError, parameter aliases, and lint rules

### DIFF
--- a/.github/instructions/go-conventions.instructions.md
+++ b/.github/instructions/go-conventions.instructions.md
@@ -21,6 +21,59 @@ Always add JSON/YAML tags. Use [Huma validation tags](https://huma.rocks/feature
 | `expr` | `Expression` | `pkg/celexp` |
 | `tmpl` | `GoTemplatingContent` | `pkg/gotmpl` |
 
+## Deprecating a Field
+
+scafctl has a reusable, struct-tag-driven deprecation mechanism. Deprecating a
+spec field requires no per-field lint code -- you tag the old field, keep it
+working, and add the replacement. The worked example is the resolver/action
+`onError` enum being superseded by `continueOnError`.
+
+Follow these steps:
+
+1. Tag the OLD field as deprecated and name its replacement:
+
+~~~go
+OnError ErrorBehavior `json:"onError,omitempty" yaml:"onError,omitempty" deprecated:"true" deprecatedReplacement:"continueOnError" doc:"DEPRECATED: use continueOnError instead. ..."`
+~~~
+
+   - `deprecated:"true"` -- required; marks the field deprecated.
+   - `deprecatedReplacement:"<newYamlKey>"` -- the replacement's YAML key; drives
+     lint messaging and the schema `[DEPRECATED] (use <replacement>)` marker.
+   - `deprecatedMessage:"<extra guidance>"` -- optional free-form note appended to
+     the lint warning.
+
+2. Keep the old field fully functional (parse + translate) for at least one major
+   version. Never delete a field in the same release you deprecate it. Provide a
+   translation path (e.g. `onError: continue` -> `continueOnError: true`,
+   `onError: fail` -> `continueOnError: false`) and document the mapping in the
+   new field's `doc` tag.
+
+3. Add the NEW field. If it is a `*Condition`, do NOT add an `example` tag (Huma
+   validates examples against the object schema and a scalar like `true` will
+   panic schema generation).
+
+4. The plumbing is automatic:
+   - `pkg/schema/introspect.go` reads the tags into `FieldInfo`.
+   - `pkg/schema/format.go` renders `[DEPRECATED] (use <replacement>)`.
+   - Huma emits `deprecated: true` in the JSON schema from the `deprecated` tag.
+   - The generic `deprecated-field` lint rule (`pkg/lint/deprecated.go`) emits a
+     WARNING when the old field is set. Add a traversal call there for the new
+     struct location if it is not already walked (resolvers, workflow actions,
+     and forEach are covered).
+
+5. If the old and new fields are mutually exclusive, the `deprecated-field-conflict`
+   rule emits an ERROR when both are set on the same object (runtime: the new
+   field wins). This is the default behavior of `emitDeprecated`.
+
+6. Escalate by SEMVER, not wall-clock time: warn now -> error in the next major ->
+   remove in the major after that. CI can opt into strict mode by treating lint
+   warnings as failures.
+
+7. Migrate first-party docs and examples to the new field, but keep ONE example of
+   the deprecated field to demonstrate the warning, and keep a test asserting the
+   old field still works and warns. Cross-reference the `deprecated-field` rule's
+   explain text so `explain_lint_rule` and these instructions tell the same story.
+
 ## Error Handling
 
 Always wrap errors with context:

--- a/.github/skills/solution-spec/SKILL.md
+++ b/.github/skills/solution-spec/SKILL.md
@@ -170,7 +170,7 @@ spec:
           destination: {expr: "_.output_path"}
         dependsOn: []
         when: "_.enabled"         # CEL condition
-        onError: fail             # fail | continue
+        continueOnError: false    # bool or CEL (truthy continues, falsy fails); replaces deprecated onError
         timeout: 30s
         exclusive: [other-write]  # Mutual exclusion
         retry:

--- a/docs/tutorials/actions-tutorial.md
+++ b/docs/tutorials/actions-tutorial.md
@@ -227,7 +227,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: environment
           - provider: static
@@ -368,7 +368,7 @@ spec:
           in:
             expr: "_.targets"
           concurrency: 2
-          onError: continue
+          continueOnError: true
         inputs:
           command:
             expr: "'echo Deploying ' + _.version + ' to ' + __item"
@@ -414,13 +414,21 @@ The `deploy` action expands into three iterations -- one per target. With `concu
 | `item` | Alias for `__item` (e.g., `item: server` lets you use `server` instead) |
 | `index` | Alias for `__index` |
 | `concurrency` | Max parallel iterations (default: unlimited) |
-| `onError` | `fail` (default) or `continue` — controls behavior when an iteration fails |
+| `continueOnError` | bool or CEL condition — truthy continues when an iteration fails, falsy fails (replaces deprecated `onError`) |
 
 ---
 
 ## Error Handling
 
-By default, if an action fails the entire workflow stops. Use `onError: continue` to allow the workflow to proceed past failures.
+By default, if an action fails the entire workflow stops. Use
+`continueOnError: true` to allow the workflow to proceed past failures. The
+field also accepts a CEL condition (evaluated with the error bound as
+`__error`) to recover only for specific errors.
+
+> The legacy `onError` enum (`continue`/`fail`) is **deprecated** but still
+> works. Migrate `onError: continue` to `continueOnError: true` and
+> `onError: fail` to `continueOnError: false`. When both are set,
+> `continueOnError` wins and the linter reports an error.
 
 Create a file called `error-handling-demo.yaml`:
 
@@ -439,7 +447,7 @@ spec:
       optional-cleanup:
         description: Optional cleanup that might fail
         provider: exec
-        onError: continue
+        continueOnError: true
         inputs:
           command: "echo 'Attempting optional cleanup...' && exit 1"
 
@@ -476,9 +484,9 @@ Running required setup...
 Doing main work...
 ```
 
-The `optional-cleanup` action fails (`exit 1`), but because `onError: continue` is set, the workflow continues. The `main-work` action still runs.
+The `optional-cleanup` action fails (`exit 1`), but because `continueOnError: true` is set, the workflow continues. The `main-work` action still runs.
 
-Without `onError: continue`, the workflow would stop at `optional-cleanup` and `main-work` would be skipped.
+Without `continueOnError: true`, the workflow would stop at `optional-cleanup` and `main-work` would be skipped.
 
 ---
 
@@ -1279,17 +1287,17 @@ actions:
     timeout: 1h
 ```
 
-### 4. Use OnError Wisely
+### 4. Use ContinueOnError Wisely
 
 ```yaml
 actions:
   # Critical operations should fail fast
   database-migration:
-    onError: fail
-  
+    continueOnError: false
+
   # Optional operations can continue
   send-notification:
-    onError: continue
+    continueOnError: true
 ```
 
 ### 5. Leverage ForEach for Parallelism

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -221,6 +221,121 @@ scafctl lint explain missing-description -o json
 {{% /tab %}}
 {{< /tabs >}}
 
+### Example: Catching `.orValue()` on a Concrete Value
+
+Some rules catch subtle bugs that pass a plain syntax check but fail at runtime.
+The `orvalue-on-non-optional` rule (severity: error) flags `.orValue(...)` calls on
+a provably non-optional receiver, such as a plain identifier or a field-access chain:
+
+```yaml
+# Triggers orvalue-on-non-optional: __self is concrete, not optional.
+transform:
+  with:
+    - provider: cel
+      inputs:
+        expression: '__self.orValue([])'
+```
+
+`orValue()` only has an overload on CEL optional types, so calling it on a concrete
+value has no matching overload and fails at runtime even though the expression parses.
+This commonly happens when an optional marker (`.?`) is dropped during editing. Fix it
+by making the receiver optional, or by removing `.orValue(...)` and supplying the
+fallback another way:
+
+```yaml
+# Fixed: optional access makes orValue() apply.
+transform:
+  with:
+    - provider: cel
+      inputs:
+        expression: '_.?items.orValue([])'
+```
+
+Explain the rule for full guidance:
+
+{{< tabs "linting-tutorial-cmd-orvalue" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl lint explain orvalue-on-non-optional
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint explain orvalue-on-non-optional
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+### Example: Catching Deprecated Fields
+
+The linter also flags fields that have been superseded by a newer field. The
+`deprecated-field` rule (severity: warning) reports each deprecated field still
+in use and names its replacement, while `deprecated-field-conflict` (severity:
+error) fires when both the deprecated field and its replacement are set on the
+same object.
+
+For example, the `onError` enum on resolver sources, transforms, and actions is
+deprecated in favor of `continueOnError`:
+
+```yaml
+# Triggers deprecated-field: onError is deprecated, use continueOnError.
+resolve:
+  with:
+    - provider: http
+      onError: continue
+      inputs:
+        url: https://config.example.com/settings
+    - provider: static
+      inputs:
+        value: { debug: false }
+```
+
+Migrate `onError: continue` to `continueOnError: true` and `onError: fail` to
+`continueOnError: false`:
+
+```yaml
+# Fixed: continueOnError replaces the deprecated onError enum.
+resolve:
+  with:
+    - provider: http
+      continueOnError: true
+      inputs:
+        url: https://config.example.com/settings
+    - provider: static
+      inputs:
+        value: { debug: false }
+```
+
+Setting both at once triggers the `deprecated-field-conflict` error. At runtime
+`continueOnError` wins and the deprecated `onError` is silently ignored, so the
+linter forces you to remove one:
+
+```yaml
+# Triggers deprecated-field-conflict: remove onError, keep continueOnError.
+- provider: http
+  onError: continue
+  continueOnError: true
+  inputs:
+    url: https://config.example.com/settings
+```
+
+Explain either rule for full guidance:
+
+{{< tabs "linting-tutorial-cmd-deprecated" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl lint explain deprecated-field
+scafctl lint explain deprecated-field-conflict
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint explain deprecated-field
+scafctl lint explain deprecated-field-conflict
+```
+{{% /tab %}}
+{{< /tabs >}}
+
 ## 4. Linting in CI/CD
 
 ### GitHub Actions Example

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -2115,7 +2115,12 @@ Access CLI parameters passed via `-r` flags.
 
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
-| `key` | string | ✅ | Parameter name |
+| `key` | string | ❌ | Parameter name (exact match). Provide either `key` or `keys`; `key` takes precedence over `keys` when both are set. |
+| `keys` | array of string | ❌ | Ordered list of parameter names (aliases) for a single logical parameter. The first name provided via CLI wins. Evaluated after `key`. |
+| `default` | any | ❌ | Value returned when the parameter is not provided. |
+| `type` | string | ❌ | Set to `string` to return the value verbatim and suppress type inference. |
+
+At least one of `key` or `keys` must be provided.
 
 ### Output
 
@@ -2137,6 +2142,17 @@ resolve:
     - provider: static
       inputs:
         value: "dev"  # Default if not provided
+```
+
+```yaml
+# Accept the same parameter under any of several flag names (aliases).
+# Whichever of -r environment / -r e / -r env was provided wins.
+resolve:
+  with:
+    - provider: parameter
+      inputs:
+        keys: [environment, e, env]
+        default: dev
 ```
 
 Usage:

--- a/docs/tutorials/resolver-tutorial.md
+++ b/docs/tutorials/resolver-tutorial.md
@@ -113,7 +113,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: user_name
           - provider: static
@@ -281,7 +281,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: env
           - provider: static
@@ -293,7 +293,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: port
           - provider: static
@@ -384,7 +384,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: input
           - provider: static
@@ -517,7 +517,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: port
           - provider: static
@@ -593,7 +593,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: email
           - provider: static
@@ -685,7 +685,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: appName
           - provider: static
@@ -711,7 +711,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: env
           - provider: static
@@ -749,7 +749,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: env
           - provider: static
@@ -938,9 +938,56 @@ Output:
 }
 ```
 
-**onError Options** (resolve phase):
-- `continue` (default): Try the next source in the list. The resolve phase acts as an implicit fallback chain.
-- `fail`: Stop execution immediately and return the error without trying remaining sources.
+**Controlling fallback with `continueOnError`** (resolve phase):
+
+The resolve phase falls through to the next source by default. Use
+`continueOnError` to control this explicitly. It accepts a boolean or a CEL
+condition (truthy recovers, falsy fails):
+
+- `continueOnError: true` (resolve default): Try the next source in the list.
+  The resolve phase acts as an implicit fallback chain.
+- `continueOnError: false`: Stop execution immediately and return the error
+  without trying remaining sources.
+
+> The legacy `onError` enum (`continue`/`fail`) is **deprecated** but still
+> works. Migrate `onError: continue` to `continueOnError: true` and
+> `onError: fail` to `continueOnError: false`. When both are set,
+> `continueOnError` wins and the linter reports an error.
+
+### Conditional Recovery with `continueOnError`
+
+A boolean `continueOnError` is unconditional: it either always recovers or
+always fails. Pass a CEL condition instead to recover only for *specific*
+errors and fail for everything else. The condition is evaluated when the source
+(or transform step) fails, with the error text bound as `__error`:
+
+- If the condition is truthy, the error is recovered (resolve: try the next
+  source; transform: skip the step and keep the current value).
+- If the condition is falsy, the resolver fails.
+
+```yaml
+spec:
+  resolvers:
+    config:
+      type: any
+      resolve:
+        with:
+          # Recover only on transient timeouts; fail fast on anything else
+          # (auth errors, bad config, etc.) instead of silently falling back.
+          - provider: http
+            inputs:
+              url: https://config.example.com/settings
+              timeout: 5s
+            continueOnError: __error.contains("timeout")
+          - provider: static
+            inputs:
+              value:
+                debug: false
+```
+
+Inside `continueOnError` the error text is available as the top-level variable
+`__error` (the same way `__self` is exposed in transform/validate conditions).
+The condition must evaluate to a boolean.
 
 ### Custom Error Messages
 
@@ -1090,7 +1137,7 @@ spec:
 
 With `acceptableStatusCodes` set, a `404` yields `success: true` and the body is
 still returned (and parsed when `autoParseJson` is enabled). Any status outside
-the set -- such as `500` -- fails the source, which lets an `onError: continue`
+the set -- such as `500` -- fails the source, which lets a `continueOnError: true`
 policy fall back to the next source:
 
 ```yaml
@@ -1102,7 +1149,7 @@ spec:
         with:
           # Fails on any status other than 2xx or 404, falling through below.
           - provider: http
-            onError: continue
+            continueOnError: true
             inputs:
               url: https://api.example.com/config
               method: GET
@@ -1188,7 +1235,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: env
           - provider: static
@@ -1295,7 +1342,7 @@ spec:
       resolve:
         with:
           - provider: http
-            onError: continue
+            continueOnError: true
             inputs:
               url: https://features.example.com/api/flags
           - provider: static
@@ -1364,7 +1411,7 @@ spec:
       resolve:
         with:
           # In practice, use env or file providers here
-          # with onError: continue to fall through
+          # with continueOnError: true to fall through
           - provider: static
             inputs:
               value: "default-dev-password"

--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -1182,7 +1182,7 @@ Output:
 
 The parameter provider supports an optional `default` input that provides a
 fallback value when the parameter is not passed via `-r` flags. This is simpler
-than using a multi-step fallback chain with `onError: continue` and a `static`
+than using a multi-step fallback chain with `continueOnError: true` and a `static`
 provider.
 
 Create a file called `param-default-demo.yaml`:

--- a/examples/actions/README.md
+++ b/examples/actions/README.md
@@ -12,7 +12,7 @@ This directory contains example action configurations demonstrating the Actions 
 | [action-alias.yaml](action-alias.yaml) | Action aliases for shorter expression references |
 | [foreach-deploy.yaml](foreach-deploy.yaml) | ForEach expansion for deploying to multiple targets |
 | [exclusive-actions.yaml](exclusive-actions.yaml) | Mutual exclusion for actions that share a resource |
-| [error-handling.yaml](error-handling.yaml) | Error handling with onError: continue |
+| [error-handling.yaml](error-handling.yaml) | Error handling with continueOnError: true |
 | [retry-backoff.yaml](retry-backoff.yaml) | Retry with exponential backoff |
 | [conditional-retry.yaml](conditional-retry.yaml) | Conditional retry with retryIf expressions |
 | [conditional-execution.yaml](conditional-execution.yaml) | When conditions for conditional execution |
@@ -122,7 +122,7 @@ workflow:
   actions:
     optional-step:
       provider: exec
-      onError: continue
+      continueOnError: true
       inputs:
         command: "optional-command.sh"
 ```

--- a/examples/actions/complex-workflow.yaml
+++ b/examples/actions/complex-workflow.yaml
@@ -132,7 +132,7 @@ spec:
           - init
         timeout: 5m
         # Linting issues shouldn't block deployment
-        onError: continue
+        continueOnError: true
         inputs:
           command: "echo 'Running linters...'"
 
@@ -199,7 +199,7 @@ spec:
           in:
             expr: "_.targets"
           concurrency: 2
-          onError: continue
+          continueOnError: true
         timeout: 10m
         retry:
           maxAttempts: 3

--- a/examples/actions/error-handling.yaml
+++ b/examples/actions/error-handling.yaml
@@ -9,7 +9,7 @@ metadata:
   tags:
     - action-example
     - workflow
-  description: Error handling with onError continue
+  description: Error handling with continueOnError
 
 spec:
   resolvers:
@@ -36,7 +36,7 @@ spec:
         displayName: Optional Cleanup
         provider: exec
         # Continue workflow even if this fails
-        onError: continue
+        continueOnError: true
         inputs:
           # This command will fail (exit code 1)
           command: "echo 'Attempting optional cleanup...' && exit 1"
@@ -50,7 +50,7 @@ spec:
         inputs:
           command: "echo 'Running required setup...'"
 
-      # Demonstrate forEach with onError: continue
+      # Demonstrate forEach with continueOnError
       health-checks:
         description: Run health checks
         displayName: Health Checks
@@ -61,7 +61,7 @@ spec:
           in:
             expr: "_.checks"
           # Continue checking other services if one fails
-          onError: continue
+          continueOnError: true
         inputs:
           name:
             expr: "__item.name"

--- a/examples/actions/foreach-deploy.yaml
+++ b/examples/actions/foreach-deploy.yaml
@@ -62,7 +62,7 @@ spec:
           # Optional: limit concurrent deployments
           concurrency: 2
           # Optional: continue deploying to remaining targets if one fails
-          onError: continue
+          continueOnError: true
         inputs:
           target:
             # __item is the current array element

--- a/examples/providers/http-acceptable-status.yaml
+++ b/examples/providers/http-acceptable-status.yaml
@@ -15,8 +15,8 @@ metadata:
     Treat selected non-2xx statuses as successful with acceptableStatusCodes.
     Each output carries a 'success' flag (true for any 2xx by default). Entries
     may be exact integers (404), class shorthands ("4xx"), or inclusive ranges
-    ("400-404"). Any status outside the set fails the source, which an
-    onError: continue policy can turn into a fallback.
+    ("400-404"). Any status outside the set fails the source, which a
+    continueOnError: true policy can turn into a fallback.
 
 spec:
   resolvers:
@@ -56,14 +56,14 @@ spec:
               acceptableStatusCodes: ["2xx", "4xx"]
 
     # Strict set + fallback: a 500 is not acceptable, so the source fails and
-    # onError: continue falls through to the static value.
+    # continueOnError: true falls through to the static value.
     strictWithFallback:
       description: An unacceptable 500 fails the source and falls back to a static value
       type: any
       resolve:
         with:
           - provider: http
-            onError: continue
+            continueOnError: true
             inputs:
               url: https://httpbin.org/status/500
               method: GET

--- a/examples/resolver-stress-demo.yaml
+++ b/examples/resolver-stress-demo.yaml
@@ -18,12 +18,12 @@
 # | Resolve        | when (phase-level)           | team_email                                   |
 # | Resolve        | until (stop condition)       | team_email                                   |
 # | Resolve        | source-level when            | team_email                                   |
-# | Resolve        | source-level onError         | team_email                                   |
+# | Resolve        | source-level continueOnError | team_email                                   |
 # | Resolve        | multiple sources (fallback)  | team_email                                   |
 # |----------------|------------------------------|----------------------------------------------|
 # | Transform      | when (phase-level)           | log_level                                    |
 # | Transform      | step-level when              | log_level                                    |
-# | Transform      | step-level onError           | log_level                                    |
+# | Transform      | step-level continueOnError   | log_level                                    |
 # | Transform      | __self reference             | cost_center                                  |
 # | Transform      | forEach item/index aliases   | dns_records                                  |
 # | Transform      | forEach concurrency          | service_endpoints                            |
@@ -169,7 +169,7 @@ spec:
             inputs:
               value: platform-engineering
 
-    # 7b. Optional team email (demonstrates resolve.when, until, multiple sources, source-level when/onError)
+    # 7b. Optional team email (demonstrates resolve.when, until, multiple sources, source-level when/continueOnError)
     team_email:
       description: Team contact email with fallback chain
       displayName: Team Email
@@ -186,12 +186,12 @@ spec:
               expr: "has(_.team_id)"  # Only try if team_id exists
             inputs:
               value: null  # Simulates parameter not provided
-            onError: continue  # Continue to next source on failure
+            continueOnError: true  # Continue to next source on failure
           # Source 2: Try environment variable
           - provider: static
             inputs:
               value: null  # Simulates env var not set
-            onError: continue
+            continueOnError: true
           # Source 3: Compute from team_id (final fallback)
           - provider: cel
             inputs:
@@ -247,7 +247,7 @@ spec:
               expression: "__self >= 1 && __self <= 100"
               message: "Replica count must be between 1 and 100"
 
-    # 11. Log level (demonstrates transform.when, step-level when, onError)
+    # 11. Log level (demonstrates transform.when, step-level when, continueOnError)
     log_level:
       description: Default logging level
       type: string
@@ -271,7 +271,7 @@ spec:
               expr: "_.environment == 'production'"
             inputs:
               expression: "'prod-' + __self"
-            onError: continue  # Continue even if this step fails
+            continueOnError: true  # Continue even if this step fails
       validate:
         with:
           - provider: validation
@@ -1152,11 +1152,11 @@ spec:
                     'resolve_when_phase_condition',
                     'resolve_until_stop_condition',
                     'source_level_when',
-                    'source_level_onError_continue',
+                    'source_level_continueOnError',
                     'multiple_source_fallback_chain',
                     'transform_when_phase_condition',
                     'transform_step_when',
-                    'transform_step_onError',
+                    'transform_step_continueOnError',
                     'validation_match_and_notMatch',
                     'multiple_validations_per_resolver',
                     'dynamic_message_tmpl',

--- a/examples/resolvers/README.md
+++ b/examples/resolvers/README.md
@@ -83,5 +83,5 @@ Use these examples as templates for your own solutions. Key things to remember:
 1. **Start simple** -- begin with static values and add complexity
 2. **Use types** -- explicitly declare types for better error messages
 3. **Validate inputs** -- add validation rules for critical values
-4. **Handle errors** -- use `onError: continue` for fallbacks
+4. **Handle errors** -- use `continueOnError: true` for fallbacks
 5. **Mark sensitive data** -- use `sensitive: true` to redact secrets in table output (JSON/YAML reveal values for machine consumption; use `--show-sensitive` to reveal in all formats)

--- a/examples/resolvers/dependencies.yaml
+++ b/examples/resolvers/dependencies.yaml
@@ -24,7 +24,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: env
           - provider: static
@@ -37,7 +37,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: region
           - provider: static

--- a/examples/resolvers/env-config.yaml
+++ b/examples/resolvers/env-config.yaml
@@ -23,7 +23,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: env
           - provider: static

--- a/examples/resolvers/error-recovery.yaml
+++ b/examples/resolvers/error-recovery.yaml
@@ -1,0 +1,57 @@
+# Run: scafctl run resolver -f examples/resolvers/error-recovery.yaml -o json
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: conditional-error-recovery
+  displayName: Conditional Error Recovery
+  category: resolvers
+  tags:
+    - resolver-example
+    - error-handling
+  description: |
+    Demonstrates continueOnError, a CEL condition evaluated when a source or
+    transform step fails. The failing error text is bound to the top-level
+    __error variable. When the condition is truthy, the error is recovered
+    (the source is skipped / the current value is kept); otherwise the
+    resolver fails. continueOnError replaces the deprecated onError field
+    and takes precedence when both are set.
+
+spec:
+  resolvers:
+    # Source-level recovery: a missing optional config file is an expected,
+    # recoverable condition, so we fall through to the static default. Any
+    # other read failure (e.g. permissions) would NOT match and would fail
+    # the resolver instead of silently falling back.
+    optionalConfig:
+      description: Optional config file with a safe default
+      type: string
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: ./this-config-does-not-exist.txt
+            continueOnError: '__error.contains("file does not exist")'
+          - provider: static
+            inputs:
+              value: "default-config"
+
+    # Transform-level recovery: keep the upstream value when an enrichment
+    # step fails for a known, tolerable reason. Transforms default to
+    # failing, so without continueOnError this failure would abort.
+    enriched:
+      description: Value with best-effort enrichment
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "base-value"
+      transform:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: ./optional-enrichment-data.txt
+            continueOnError: '__error.contains("file does not exist")'

--- a/examples/resolvers/feature-flags.yaml
+++ b/examples/resolvers/feature-flags.yaml
@@ -24,7 +24,7 @@ spec:
           # Try remote feature flag service first
           # (This will fail in the example, demonstrating fallback)
           - provider: http
-            onError: continue
+            continueOnError: true
             inputs:
               url: https://features.example.com/api/v1/flags
               method: GET

--- a/examples/resolvers/parameters.yaml
+++ b/examples/resolvers/parameters.yaml
@@ -56,7 +56,7 @@ spec:
               default: false
 
     # String parameter using fallback chain (alternative pattern)
-    # Use onError: continue + static provider when you need a dynamic
+    # Use continueOnError: true + static provider when you need a dynamic
     # fallback (e.g. a ValueRef or expression) instead of a literal default.
     region:
       description: Deployment region from CLI or fallback chain
@@ -64,13 +64,31 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: region
           - provider: static
             inputs:
               value: "us-east-1"
-    
+
+    # Parameter with alias keys (first-match-wins)
+    # "keys" accepts the same logical parameter under several flag names.
+    # Names are tried in declared order, so when more than one alias is
+    # passed the earliest one in the list wins.
+    #   scafctl run resolver -f parameters.yaml -r environment=prod
+    #   scafctl run resolver -f parameters.yaml -r e=staging
+    #   scafctl run resolver -f parameters.yaml -r env=qa
+    environment:
+      description: Target environment (accepts environment, e, or env)
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              keys: [environment, e, env]
+              default: dev
+
+
     # Computed greeting using parameters
     greeting:
       description: Final greeting message

--- a/examples/resolvers/secrets.yaml
+++ b/examples/resolvers/secrets.yaml
@@ -38,7 +38,7 @@ spec:
       resolve:
         with:
           - provider: secret
-            onError: continue
+            continueOnError: true
             inputs:
               operation: get
               name: optional-setting
@@ -88,7 +88,7 @@ spec:
       resolve:
         with:
           - provider: secret
-            onError: continue
+            continueOnError: true
             inputs:
               operation: get
               name: db-host
@@ -114,7 +114,7 @@ spec:
       resolve:
         with:
           - provider: env
-            onError: continue
+            continueOnError: true
             inputs:
               name: APP_ENV
           - provider: static

--- a/examples/resolvers/validation-conditional-rule.yaml
+++ b/examples/resolvers/validation-conditional-rule.yaml
@@ -29,7 +29,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: env
           - provider: static
@@ -42,7 +42,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: appName
           - provider: static

--- a/examples/resolvers/validation-dynamic-messages.yaml
+++ b/examples/resolvers/validation-dynamic-messages.yaml
@@ -27,7 +27,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: name
           - provider: static
@@ -51,7 +51,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: port
           - provider: static

--- a/examples/resolvers/validation.yaml
+++ b/examples/resolvers/validation.yaml
@@ -24,7 +24,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: email
           - provider: static
@@ -52,7 +52,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: port
           - provider: static
@@ -77,7 +77,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: password
           - provider: static
@@ -117,7 +117,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: url
           - provider: static
@@ -141,7 +141,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: tags
           - provider: static

--- a/examples/solutions/execution-aware-actions/solution.yaml
+++ b/examples/solutions/execution-aware-actions/solution.yaml
@@ -28,7 +28,7 @@ spec:
       resolve:
         with:
           - provider: parameter
-            onError: continue
+            continueOnError: true
             inputs:
               key: environment
           - provider: static

--- a/examples/solutions/github-provider-validation/solution.yaml
+++ b/examples/solutions/github-provider-validation/solution.yaml
@@ -216,7 +216,7 @@ spec:
         description: Create a test label
         displayName: Create Label
         provider: github
-        onError: continue
+        continueOnError: true
         inputs:
           operation: create_label
           owner: {rslvr: org}
@@ -229,7 +229,7 @@ spec:
         description: Create a test milestone
         displayName: Create Milestone
         provider: github
-        onError: continue
+        continueOnError: true
         inputs:
           operation: create_milestone
           owner: {rslvr: org}
@@ -256,7 +256,7 @@ spec:
         description: Set custom properties on the repository
         displayName: Set Custom Properties
         provider: github
-        onError: continue
+        continueOnError: true
         inputs:
           operation: set_custom_properties
           owner: {rslvr: org}
@@ -299,7 +299,7 @@ spec:
         displayName: Cleanup Label
         provider: github
         dependsOn: [update-label]
-        onError: continue
+        continueOnError: true
         inputs:
           operation: delete_label
           owner: {rslvr: org}
@@ -327,7 +327,7 @@ spec:
         displayName: Restore Custom Properties
         provider: github
         dependsOn: [set-custom-properties]
-        onError: continue
+        continueOnError: true
         inputs:
           operation: set_custom_properties
           owner: {rslvr: org}
@@ -483,7 +483,7 @@ spec:
         displayName: Close PR
         provider: github
         dependsOn: [find-validation-pr]
-        onError: continue
+        continueOnError: true
         when: {expr: "size(__actions['find-validation-pr'].results.result) > 0"}
         inputs:
           operation: close_pull_request
@@ -496,7 +496,7 @@ spec:
         displayName: Delete Branch
         provider: github
         dependsOn: [close-validation-pr]
-        onError: continue
+        continueOnError: true
         inputs:
           operation: delete_branch
           owner: {rslvr: org}

--- a/examples/solutions/lint-stress-test/solution.yaml
+++ b/examples/solutions/lint-stress-test/solution.yaml
@@ -150,6 +150,17 @@ spec:
             inputs:
               expression: "_.bad_provider + _.guarded"
 
+    # orvalue-on-non-optional (concrete receiver, missing optional marker)
+    bad_orvalue:
+      type: string
+      description: Calls orValue on a concrete (non-optional) value
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                expr: '__self.orValue("fallback")'
+
     # transform-shape-mismatch (transform accesses __self.body but static fallback returns [])
     shape_mismatch:
       description: Resolver with mismatched transform shape
@@ -182,8 +193,7 @@ spec:
         - empty_validate
         - loose_schema
         - no_desc
-        - conditional_only
-        - shape_mismatch
+        - bad_orvalue
       resolve:
         with:
           - provider: static

--- a/pkg/action/context.go
+++ b/pkg/action/context.go
@@ -230,6 +230,19 @@ func (c *Context) MarkStreamed(name string) {
 	}
 }
 
+// RecordAttempts stores the number of execution attempts performed for an
+// action. It is recorded after retry completes so the continue-on-error
+// decision (and any later re-evaluation) can build an __error context with the
+// real attempt count instead of a hard-coded placeholder.
+func (c *Context) RecordAttempts(name string, attempts int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if existing, ok := c.actions[name]; ok {
+		existing.Attempts = attempts
+	}
+}
+
 // MarkFailed marks an action as failed with an error message.
 func (c *Context) MarkFailed(name, errMsg string) {
 	c.mu.Lock()

--- a/pkg/action/continue_on_error_test.go
+++ b/pkg/action/continue_on_error_test.go
@@ -1,0 +1,122 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package action
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func boolCond(expr string) *spec.Condition {
+	e := celexp.Expression(expr)
+	return &spec.Condition{Expr: &e}
+}
+
+func TestEffectiveOnErrorPolicy(t *testing.T) {
+	cond := boolCond("true")
+	feCond := boolCond("false")
+
+	t.Run("non-forEach uses action-level fields", func(t *testing.T) {
+		action := &ExpandedAction{Action: &Action{ContinueOnError: cond, OnError: spec.OnErrorContinue}}
+		gotCond, gotFallback := effectiveOnErrorPolicy(action)
+		assert.Same(t, cond, gotCond)
+		assert.Equal(t, spec.OnErrorContinue, gotFallback)
+	})
+
+	t.Run("forEach continueOnError wins over action-level", func(t *testing.T) {
+		action := &ExpandedAction{
+			Action:          &Action{ContinueOnError: cond, ForEach: &spec.ForEachClause{ContinueOnError: feCond}},
+			ForEachMetadata: &ForEachExpansionMetadata{ExpandedFrom: "deploy", Index: 0},
+		}
+		gotCond, _ := effectiveOnErrorPolicy(action)
+		assert.Same(t, feCond, gotCond)
+	})
+
+	t.Run("forEach deprecated onError wins over action-level", func(t *testing.T) {
+		action := &ExpandedAction{
+			Action:          &Action{ContinueOnError: cond, ForEach: &spec.ForEachClause{OnError: spec.OnErrorContinue}},
+			ForEachMetadata: &ForEachExpansionMetadata{ExpandedFrom: "deploy", Index: 1},
+		}
+		gotCond, gotFallback := effectiveOnErrorPolicy(action)
+		assert.Nil(t, gotCond)
+		assert.Equal(t, spec.OnErrorContinue, gotFallback)
+	})
+
+	t.Run("forEach without policy falls back to action-level", func(t *testing.T) {
+		action := &ExpandedAction{
+			Action:          &Action{ContinueOnError: cond, ForEach: &spec.ForEachClause{}},
+			ForEachMetadata: &ForEachExpansionMetadata{ExpandedFrom: "deploy", Index: 2},
+		}
+		gotCond, _ := effectiveOnErrorPolicy(action)
+		assert.Same(t, cond, gotCond)
+	})
+}
+
+func TestContinueOnErrorVars(t *testing.T) {
+	e := &Executor{}
+
+	t.Run("binds real attempt and maxAttempts", func(t *testing.T) {
+		action := &ExpandedAction{Action: &Action{}}
+		vars := e.continueOnErrorVars(action, errors.New("boom"), 3, 5)
+		errMap, ok := vars[celexp.VarError].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, 3, errMap["attempt"])
+		assert.Equal(t, 5, errMap["maxAttempts"])
+		assert.NotContains(t, vars, celexp.VarItem)
+	})
+
+	t.Run("includes forEach iteration vars and aliases", func(t *testing.T) {
+		action := &ExpandedAction{
+			Action: &Action{ForEach: &spec.ForEachClause{Item: "region", Index: "i"}},
+			ForEachMetadata: &ForEachExpansionMetadata{
+				ExpandedFrom: "deploy",
+				Index:        2,
+				Item:         "us-east",
+			},
+		}
+		vars := e.continueOnErrorVars(action, errors.New("boom"), 1, 1)
+		assert.Equal(t, "us-east", vars[celexp.VarItem])
+		assert.Equal(t, 2, vars[celexp.VarIndex])
+		assert.Equal(t, "us-east", vars["region"])
+		assert.Equal(t, 2, vars["i"])
+	})
+
+	t.Run("nil error omits error context", func(t *testing.T) {
+		action := &ExpandedAction{Action: &Action{}}
+		vars := e.continueOnErrorVars(action, nil, 1, 1)
+		assert.NotContains(t, vars, celexp.VarError)
+	})
+}
+
+func TestActionShouldContinue_ForEachCEL(t *testing.T) {
+	e := &Executor{resolverData: map[string]any{}}
+	action := &ExpandedAction{
+		Action: &Action{
+			ForEach: &spec.ForEachClause{ContinueOnError: boolCond(`__item == "skip" && __error.attempt == 1`)},
+		},
+		ForEachMetadata: &ForEachExpansionMetadata{ExpandedFrom: "deploy", Index: 0, Item: "skip"},
+	}
+
+	t.Run("matching item and attempt continues", func(t *testing.T) {
+		cont, err := e.actionShouldContinue(context.Background(), action, errors.New("boom"), 1, 1)
+		require.NoError(t, err)
+		assert.True(t, cont)
+	})
+
+	t.Run("non-matching item aborts", func(t *testing.T) {
+		other := &ExpandedAction{
+			Action:          action.Action,
+			ForEachMetadata: &ForEachExpansionMetadata{ExpandedFrom: "deploy", Index: 1, Item: "keep"},
+		}
+		cont, err := e.actionShouldContinue(context.Background(), other, errors.New("boom"), 1, 1)
+		require.NoError(t, err)
+		assert.False(t, cont)
+	})
+}

--- a/pkg/action/executor.go
+++ b/pkg/action/executor.go
@@ -5,6 +5,7 @@ package action
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -383,7 +384,30 @@ func (e *Executor) executePhases(ctx context.Context, graph *Graph, phases [][]s
 			allContinue := true
 			for _, name := range phase {
 				action := graph.Actions[name]
-				if action != nil && action.OnError.OrDefault() != spec.OnErrorContinue {
+				if action == nil {
+					continue
+				}
+				var actionErr error
+				attempts := 1
+				if ar, ok := e.actionContext.GetResult(name); ok && ar.Error != "" {
+					actionErr = errors.New(ar.Error)
+					if ar.Attempts > 0 {
+						attempts = ar.Attempts
+					}
+				}
+				// Only consult continueOnError for actions that actually failed.
+				// A successful action must not gate workflow continuation, and
+				// evaluating a continueOnError expression that references __error
+				// would fail with an undefined-variable error.
+				if actionErr == nil {
+					continue
+				}
+				// Reuse the action's recorded attempt count (and its configured
+				// maxAttempts) so this re-check matches the decision executeAction
+				// already made, including expressions that read __error.attempt.
+				maxAttempts := NewRetryExecutor(action.Retry).MaxAttempts()
+				cont, decideErr := e.actionShouldContinue(ctx, action, actionErr, attempts, maxAttempts)
+				if decideErr != nil || !cont {
 					allContinue = false
 					break
 				}
@@ -405,6 +429,76 @@ func (e *Executor) executePhases(ctx context.Context, graph *Graph, phases [][]s
 	}
 
 	return nil
+}
+
+// actionShouldContinue reports whether a failed action should allow the workflow
+// to continue. The effective continue-on-error policy is resolved by
+// effectiveOnErrorPolicy: for forEach iterations the loop-level
+// forEach.continueOnError/onError take precedence; otherwise the action-level
+// fields apply. When the policy is a CEL expression it is evaluated with the
+// structured error bound as __error (carrying the real attempt/maxAttempts) and,
+// for forEach iterations, the iteration variables (__item/__index plus any
+// configured aliases). A truthy result continues the workflow.
+func (e *Executor) actionShouldContinue(ctx context.Context, action *ExpandedAction, actionErr error, attempt, maxAttempts int) (bool, error) {
+	cond, fallback := effectiveOnErrorPolicy(action)
+	if cond != nil && cond.Expr != nil {
+		additionalVars := e.continueOnErrorVars(action, actionErr, attempt, maxAttempts)
+		result, evalErr := celexp.EvaluateExpression(ctx, string(*cond.Expr), e.resolverData, additionalVars)
+		if evalErr != nil {
+			return false, fmt.Errorf("continueOnError condition evaluation failed: %w", evalErr)
+		}
+		cont, ok := result.(bool)
+		if !ok {
+			return false, fmt.Errorf("continueOnError condition must evaluate to boolean, got %T", result)
+		}
+		return cont, nil
+	}
+	return fallback.OrDefault() == spec.OnErrorContinue, nil
+}
+
+// effectiveOnErrorPolicy resolves the continue-on-error condition and deprecated
+// onError fallback that govern a failed action. For a forEach iteration the
+// loop-level policy wins when the forEach clause sets either continueOnError or
+// the deprecated onError, because the user attached the error policy to the
+// loop; it falls back to the action-level fields only when the loop specifies
+// neither. For a non-forEach action the action-level fields always apply.
+func effectiveOnErrorPolicy(action *ExpandedAction) (*spec.Condition, spec.OnErrorBehavior) {
+	if action.IsForEachIteration() && action.ForEach != nil {
+		fe := action.ForEach
+		//nolint:staticcheck // deprecated onError still supported for back-compat
+		if fe.ContinueOnError != nil || fe.OnError != "" {
+			//nolint:staticcheck // deprecated onError still supported for back-compat
+			return fe.ContinueOnError, fe.OnError
+		}
+	}
+	//nolint:staticcheck // deprecated onError still supported for back-compat
+	return action.ContinueOnError, action.OnError
+}
+
+// continueOnErrorVars builds the additional CEL variables for a continueOnError
+// expression: the structured __error context (with the real attempt count) and,
+// for forEach iterations, the iteration variables (__item/__index and any
+// configured aliases) so the expression can branch on the failing item.
+func (e *Executor) continueOnErrorVars(action *ExpandedAction, actionErr error, attempt, maxAttempts int) map[string]any {
+	vars := make(map[string]any, 4)
+	if actionErr != nil {
+		errCtx := NewErrorContext(actionErr, attempt, maxAttempts)
+		vars[celexp.VarError] = errCtx.ToMap()
+	}
+	if action.IsForEachIteration() && action.ForEachMetadata != nil {
+		meta := action.ForEachMetadata
+		vars[celexp.VarItem] = meta.Item
+		vars[celexp.VarIndex] = meta.Index
+		if action.ForEach != nil {
+			if action.ForEach.Item != "" {
+				vars[action.ForEach.Item] = meta.Item
+			}
+			if action.ForEach.Index != "" {
+				vars[action.ForEach.Index] = meta.Index
+			}
+		}
+	}
+	return vars
 }
 
 // executePhase executes all actions in a phase with concurrency control.
@@ -632,7 +726,9 @@ func (e *Executor) executeAction(ctx context.Context, graph *Graph, actionName s
 		retryCallback = &progressRetryAdapter{callback: e.progressCallback, actionName: actionName}
 	}
 
-	output, err := retryExecutor.ExecuteWithRetry(actionCtx, actionName, execFunc, retryCallback)
+	output, attempts, err := retryExecutor.ExecuteWithRetry(actionCtx, actionName, execFunc, retryCallback)
+	maxAttempts := retryExecutor.MaxAttempts()
+	e.actionContext.RecordAttempts(actionName, attempts)
 
 	// Handle results
 	if actionCtx.Err() == context.DeadlineExceeded {
@@ -653,7 +749,13 @@ func (e *Executor) executeAction(ctx context.Context, graph *Graph, actionName s
 		}
 
 		// Check if we should continue on error
-		if action.OnError.OrDefault() == spec.OnErrorContinue {
+		cont, decideErr := e.actionShouldContinue(ctx, action, err, attempts, maxAttempts)
+		if decideErr != nil {
+			// An invalid continueOnError expression/config is itself a failure;
+			// surface it (and record it on the span) instead of masking it
+			// behind the original action error.
+			err = errors.Join(err, decideErr)
+		} else if cont {
 			return nil
 		}
 		span.RecordError(err)
@@ -684,7 +786,13 @@ func (e *Executor) executeAction(ctx context.Context, graph *Graph, actionName s
 					if e.progressCallback != nil {
 						e.progressCallback.OnActionFailed(actionName, validationErr)
 					}
-					if action.OnError.OrDefault() == spec.OnErrorContinue {
+					cont, decideErr := e.actionShouldContinue(ctx, action, validationErr, attempts, maxAttempts)
+					if decideErr != nil {
+						// Surface an invalid continueOnError expression/config
+						// rather than masking it behind the schema failure.
+						return errors.Join(fmt.Errorf("result schema validation failed: %w", validationErr), decideErr)
+					}
+					if cont {
 						return nil
 					}
 					return fmt.Errorf("result schema validation failed: %w", validationErr)

--- a/pkg/action/executor_test.go
+++ b/pkg/action/executor_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/duration"
 	"github.com/oakwood-commons/scafctl/pkg/fingerprint"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -378,6 +379,118 @@ func TestExecutor_Execute_OnErrorContinue(t *testing.T) {
 	assert.Equal(t, ExecutionPartialSuccess, result.FinalStatus)
 	assert.Contains(t, result.FailedActions, "fail-action")
 	assert.Equal(t, StatusSucceeded, result.Actions["success-action"].Status)
+}
+
+func TestExecutor_Execute_ContinueOnErrorDecisionErrorSurfaced(t *testing.T) {
+	registry := newExecMockRegistry()
+	registry.register(&execMockProvider{
+		name: "test-provider",
+		execute: func(_ context.Context, _ any) (*provider.Output, error) {
+			return nil, errors.New("intentional failure")
+		},
+	})
+
+	executor := NewExecutor(
+		WithRegistry(registry),
+		WithDefaultTimeout(5*time.Second),
+	)
+
+	// continueOnError evaluates to a non-boolean, so the decision itself
+	// errors. That decision error must be surfaced rather than swallowed.
+	badExpr := celexp.Expression(`"not-a-bool"`)
+
+	workflow := &Workflow{
+		Actions: map[string]*Action{
+			"fail-action": {
+				Provider:        "test-provider",
+				ContinueOnError: &spec.Condition{Expr: &badExpr},
+				Inputs: map[string]*spec.ValueRef{
+					"name": {Literal: "fail-action"},
+				},
+			},
+		},
+	}
+
+	result, err := executor.Execute(context.Background(), workflow)
+
+	require.Error(t, err)
+	assert.Equal(t, ExecutionFailed, result.FinalStatus)
+	// The original action error must remain visible...
+	assert.ErrorContains(t, err, "intentional failure")
+	// ...and the continueOnError decision error must be surfaced too.
+	assert.ErrorContains(t, err, "continueOnError condition must evaluate to boolean")
+}
+
+// TestExecutor_Execute_ContinueOnErrorSucceededActionNotGated guards against a
+// regression where the phase-level continuation check consulted
+// continueOnError for actions that did NOT fail. A successful action whose
+// continueOnError expression references __error would fail to evaluate (the
+// variable is unbound) and wrongly abort subsequent phases. Successful actions
+// must be ignored by the continuation check.
+func TestExecutor_Execute_ContinueOnErrorSucceededActionNotGated(t *testing.T) {
+	registry := newExecMockRegistry()
+	registry.register(&execMockProvider{
+		name: "test-provider",
+		execute: func(ctx context.Context, input any) (*provider.Output, error) {
+			inputs, _ := input.(map[string]any)
+			name, _ := inputs["name"].(string)
+			if name == "slow" {
+				// Block until the action times out.
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case <-time.After(5 * time.Second):
+					return &provider.Output{Data: map[string]any{"done": true}}, nil
+				}
+			}
+			return &provider.Output{Data: map[string]any{"done": true}}, nil
+		},
+	})
+
+	executor := NewExecutor(WithRegistry(registry))
+
+	timeout := duration.New(50 * time.Millisecond)
+	// "slow" times out but tolerates it; "fast" succeeds but its
+	// continueOnError references __error, which is only valid when the action
+	// actually failed.
+	tolerate := celexp.Expression("true")
+	refError := celexp.Expression(`__error.message != ""`)
+
+	workflow := &Workflow{
+		Actions: map[string]*Action{
+			"slow": {
+				Provider:        "test-provider",
+				Timeout:         &timeout,
+				ContinueOnError: &spec.Condition{Expr: &tolerate},
+				Inputs: map[string]*spec.ValueRef{
+					"name": {Literal: "slow"},
+				},
+			},
+			"fast": {
+				Provider:        "test-provider",
+				ContinueOnError: &spec.Condition{Expr: &refError},
+				Inputs: map[string]*spec.ValueRef{
+					"name": {Literal: "fast"},
+				},
+			},
+			"downstream": {
+				Provider:  "test-provider",
+				DependsOn: []string{"fast"},
+				Inputs: map[string]*spec.ValueRef{
+					"name": {Literal: "downstream"},
+				},
+			},
+		},
+	}
+
+	result, err := executor.Execute(context.Background(), workflow)
+	require.NoError(t, err)
+
+	// "slow" timed out, "fast" succeeded, and because "fast" did not fail its
+	// continueOnError must not be consulted -- so the downstream phase runs.
+	assert.Equal(t, StatusTimeout, result.Actions["slow"].Status)
+	assert.Equal(t, StatusSucceeded, result.Actions["fast"].Status)
+	assert.Equal(t, StatusSucceeded, result.Actions["downstream"].Status)
 }
 
 func TestExecutor_Execute_DependencyFailure(t *testing.T) {

--- a/pkg/action/foreach.go
+++ b/pkg/action/foreach.go
@@ -71,7 +71,7 @@ func FromForEachClause(clause *spec.ForEachClause, progressCallback RetryObserve
 	}
 	return NewForEachExecutor(
 		WithForEachConcurrency(clause.Concurrency),
-		WithForEachOnError(clause.OnError),
+		WithForEachOnError(clause.EffectiveOnError()),
 		WithForEachProgressCallback(progressCallback),
 	)
 }

--- a/pkg/action/renderer.go
+++ b/pkg/action/renderer.go
@@ -99,8 +99,13 @@ type RenderedAction struct {
 	// Can be a boolean (already evaluated) or a DeferredValue (requires runtime evaluation).
 	When any `json:"when,omitempty" yaml:"when,omitempty" doc:"Execution condition (bool or deferred)"`
 
+	// ContinueOnError contains the continue-on-error condition.
+	ContinueOnError any `json:"continueOnError,omitempty" yaml:"continueOnError,omitempty" doc:"Continue-on-error condition (bool or expression)"`
+
 	// OnError defines behavior when this action fails.
-	OnError string `json:"onError,omitempty" yaml:"onError,omitempty" doc:"Error handling behavior" example:"fail"`
+	//
+	// Deprecated: use ContinueOnError instead.
+	OnError string `json:"onError,omitempty" yaml:"onError,omitempty" doc:"DEPRECATED: use continueOnError. Error handling behavior" example:"fail"`
 
 	// Timeout is the maximum execution duration as a string.
 	Timeout string `json:"timeout,omitempty" yaml:"timeout,omitempty" doc:"Max duration" example:"30s"`
@@ -283,6 +288,11 @@ func renderAction(action *ExpandedAction) *RenderedAction {
 		rendered.When = renderCondition(action.When)
 	}
 
+	// Render continueOnError
+	if action.ContinueOnError != nil {
+		rendered.ContinueOnError = renderCondition(action.ContinueOnError)
+	}
+
 	// Render onError
 	if action.OnError != "" {
 		rendered.OnError = string(action.OnError)
@@ -380,9 +390,7 @@ func renderForEachMetadata(action *ExpandedAction) *RenderedForEachMetadata {
 	// Include forEach clause settings if available from the original action
 	if action.ForEach != nil {
 		rendered.Concurrency = action.ForEach.Concurrency
-		if action.ForEach.OnError != "" {
-			rendered.OnError = string(action.ForEach.OnError)
-		}
+		rendered.OnError = string(action.ForEach.EffectiveOnError())
 	}
 
 	return rendered

--- a/pkg/action/retry.go
+++ b/pkg/action/retry.go
@@ -191,19 +191,22 @@ type RetryCallback interface {
 // - callback: Optional callback for retry events (can be nil)
 //
 // Returns the output from a successful execution or the last error if all attempts fail.
+// The returned int is the number of attempts actually performed, which callers
+// use to build an accurate __error context (attempt/maxAttempts) for
+// continueOnError decisions made after the action ultimately fails.
 func (r *RetryExecutor) ExecuteWithRetry(
 	ctx context.Context,
 	actionName string,
 	execute ExecuteFunc,
 	callback RetryCallback,
-) (*provider.Output, error) {
+) (*provider.Output, int, error) {
 	maxAttempts := r.MaxAttempts()
 	var lastErr error
 
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		// Check for cancellation before each attempt
 		if ctx.Err() != nil {
-			return nil, fmt.Errorf("execution cancelled: %w", ctx.Err())
+			return nil, attempt - 1, fmt.Errorf("execution cancelled: %w", ctx.Err())
 		}
 
 		// If this is a retry (not the first attempt), wait and notify callback
@@ -219,7 +222,7 @@ func (r *RetryExecutor) ExecuteWithRetry(
 			if delay > 0 {
 				select {
 				case <-ctx.Done():
-					return nil, fmt.Errorf("execution cancelled during retry delay: %w", ctx.Err())
+					return nil, attempt - 1, fmt.Errorf("execution cancelled during retry delay: %w", ctx.Err())
 				case <-time.After(delay):
 					// Continue with retry
 				}
@@ -229,7 +232,7 @@ func (r *RetryExecutor) ExecuteWithRetry(
 		// Execute the action
 		output, err := execute(ctx)
 		if err == nil {
-			return output, nil
+			return output, attempt, nil
 		}
 
 		lastErr = err
@@ -238,15 +241,15 @@ func (r *RetryExecutor) ExecuteWithRetry(
 		shouldRetry, retryErr := r.ShouldRetry(ctx, err, attempt)
 		if retryErr != nil {
 			// Expression evaluation failed - fail the action with both errors
-			return nil, fmt.Errorf("action failed and retryIf evaluation failed: %w (original error: %w)", retryErr, err)
+			return nil, attempt, fmt.Errorf("action failed and retryIf evaluation failed: %w (original error: %w)", retryErr, err)
 		}
 		if !shouldRetry {
 			// Return actual attempt count, not maxAttempts
-			return nil, fmt.Errorf("action failed after %d attempt(s): %w", attempt, lastErr)
+			return nil, attempt, fmt.Errorf("action failed after %d attempt(s): %w", attempt, lastErr)
 		}
 	}
 
-	return nil, fmt.Errorf("action failed after %d attempt(s): %w", maxAttempts, lastErr)
+	return nil, maxAttempts, fmt.Errorf("action failed after %d attempt(s): %w", maxAttempts, lastErr)
 }
 
 // RetryResult contains information about a retry execution.

--- a/pkg/action/retry_test.go
+++ b/pkg/action/retry_test.go
@@ -312,7 +312,7 @@ func TestRetryExecutor_ExecuteWithRetry(t *testing.T) {
 		executor := NewRetryExecutor(&RetryConfig{MaxAttempts: 3})
 
 		calls := 0
-		output, err := executor.ExecuteWithRetry(
+		output, attempts, err := executor.ExecuteWithRetry(
 			context.Background(),
 			"test-action",
 			func(_ context.Context) (*provider.Output, error) {
@@ -325,6 +325,7 @@ func TestRetryExecutor_ExecuteWithRetry(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "success", output.Data)
 		assert.Equal(t, 1, calls)
+		assert.Equal(t, 1, attempts)
 	})
 
 	t.Run("success on second attempt", func(t *testing.T) {
@@ -335,7 +336,7 @@ func TestRetryExecutor_ExecuteWithRetry(t *testing.T) {
 		})
 
 		calls := 0
-		output, err := executor.ExecuteWithRetry(
+		output, attempts, err := executor.ExecuteWithRetry(
 			context.Background(),
 			"test-action",
 			func(_ context.Context) (*provider.Output, error) {
@@ -351,6 +352,7 @@ func TestRetryExecutor_ExecuteWithRetry(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "success", output.Data)
 		assert.Equal(t, 2, calls)
+		assert.Equal(t, 2, attempts)
 	})
 
 	t.Run("all attempts fail", func(t *testing.T) {
@@ -361,7 +363,7 @@ func TestRetryExecutor_ExecuteWithRetry(t *testing.T) {
 		})
 
 		calls := 0
-		output, err := executor.ExecuteWithRetry(
+		output, attempts, err := executor.ExecuteWithRetry(
 			context.Background(),
 			"test-action",
 			func(_ context.Context) (*provider.Output, error) {
@@ -374,6 +376,7 @@ func TestRetryExecutor_ExecuteWithRetry(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, output)
 		assert.Equal(t, 3, calls)
+		assert.Equal(t, 3, attempts)
 		assert.Contains(t, err.Error(), "failed after 3 attempt(s)")
 		assert.Contains(t, err.Error(), "persistent error")
 	})
@@ -382,7 +385,7 @@ func TestRetryExecutor_ExecuteWithRetry(t *testing.T) {
 		executor := NewRetryExecutor(nil)
 
 		calls := 0
-		output, err := executor.ExecuteWithRetry(
+		output, attempts, err := executor.ExecuteWithRetry(
 			context.Background(),
 			"test-action",
 			func(_ context.Context) (*provider.Output, error) {
@@ -395,6 +398,7 @@ func TestRetryExecutor_ExecuteWithRetry(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, output)
 		assert.Equal(t, 1, calls)
+		assert.Equal(t, 1, attempts)
 	})
 
 	t.Run("cancelled during retry delay", func(t *testing.T) {
@@ -412,7 +416,7 @@ func TestRetryExecutor_ExecuteWithRetry(t *testing.T) {
 			cancel()
 		}()
 
-		output, err := executor.ExecuteWithRetry(
+		output, _, err := executor.ExecuteWithRetry(
 			ctx,
 			"test-action",
 			func(_ context.Context) (*provider.Output, error) {
@@ -434,7 +438,7 @@ func TestRetryExecutor_ExecuteWithRetry(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		output, err := executor.ExecuteWithRetry(
+		output, _, err := executor.ExecuteWithRetry(
 			ctx,
 			"test-action",
 			func(_ context.Context) (*provider.Output, error) {
@@ -472,7 +476,7 @@ func TestRetryExecutor_ExecuteWithRetry(t *testing.T) {
 		}
 
 		calls := 0
-		_, _ = executor.ExecuteWithRetry(
+		_, _, _ = executor.ExecuteWithRetry(
 			context.Background(),
 			"my-action",
 			func(_ context.Context) (*provider.Output, error) {
@@ -788,7 +792,7 @@ func TestRetryExecutor_ExecuteWithRetry_WithRetryIf(t *testing.T) {
 		executor := NewRetryExecutor(config)
 
 		calls := 0
-		_, err := executor.ExecuteWithRetry(
+		_, attempts, err := executor.ExecuteWithRetry(
 			context.Background(),
 			"test-action",
 			func(_ context.Context) (*provider.Output, error) {
@@ -801,6 +805,7 @@ func TestRetryExecutor_ExecuteWithRetry_WithRetryIf(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Equal(t, 1, calls) // Should only try once, no retries
+		assert.Equal(t, 1, attempts)
 	})
 
 	t.Run("retries when retryIf returns true then succeeds", func(t *testing.T) {
@@ -814,7 +819,7 @@ func TestRetryExecutor_ExecuteWithRetry_WithRetryIf(t *testing.T) {
 		executor := NewRetryExecutor(config)
 
 		calls := 0
-		output, err := executor.ExecuteWithRetry(
+		output, attempts, err := executor.ExecuteWithRetry(
 			context.Background(),
 			"test-action",
 			func(_ context.Context) (*provider.Output, error) {
@@ -830,5 +835,6 @@ func TestRetryExecutor_ExecuteWithRetry_WithRetryIf(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "success", output.Data)
 		assert.Equal(t, 3, calls) // 2 failures + 1 success
+		assert.Equal(t, 3, attempts)
 	})
 }

--- a/pkg/action/types.go
+++ b/pkg/action/types.go
@@ -105,9 +105,17 @@ type Action struct {
 	// If false, the action is skipped with SkipReasonCondition.
 	When *spec.Condition `json:"when,omitempty" yaml:"when,omitempty" doc:"Condition for execution (skipped if false)"`
 
+	// ContinueOnError controls whether a failure of this action allows the
+	// workflow to continue. It accepts a boolean or a CEL expression evaluated
+	// with the structured error bound as __error. Truthy continues the workflow;
+	// falsy stops it. Overrides the deprecated OnError field.
+	ContinueOnError *spec.Condition `json:"continueOnError,omitempty" yaml:"continueOnError,omitempty" doc:"Whether to continue the workflow when this action fails. Accepts a boolean or a CEL expression evaluated with the error bound as __error. Overrides the deprecated onError field."`
+
 	// OnError defines behavior when this action fails.
 	// Default is "fail" which stops workflow execution.
-	OnError spec.OnErrorBehavior `json:"onError,omitempty" yaml:"onError,omitempty" doc:"Error handling behavior" maxLength:"16" example:"fail" default:"fail"`
+	//
+	// Deprecated: use ContinueOnError instead.
+	OnError spec.OnErrorBehavior `json:"onError,omitempty" yaml:"onError,omitempty" deprecated:"true" deprecatedReplacement:"continueOnError" doc:"DEPRECATED: use continueOnError instead. Error handling behavior (continue, fail)" maxLength:"16" example:"fail" default:"fail"`
 
 	// Timeout limits how long the action can run.
 	// If exceeded, the action fails with StatusTimeout.
@@ -352,6 +360,11 @@ type ActionResult struct {
 
 	// Error contains the error message if Status is StatusFailed or StatusTimeout.
 	Error string `json:"error,omitempty" yaml:"error,omitempty" doc:"Error message (if failed)" maxLength:"4096" example:"command exited with code 1"`
+
+	// Attempts is the number of execution attempts performed (including retries).
+	// It is 1 for actions without retry, or the final attempt count when retry
+	// is configured. Used to build the __error context for continueOnError.
+	Attempts int `json:"attempts,omitempty" yaml:"attempts,omitempty" doc:"Number of execution attempts performed (including retries)" maximum:"100" example:"1"`
 
 	// Streamed indicates the provider already wrote its output to the terminal.
 	// When true, the CLI output layer should not re-print the action's results.

--- a/pkg/action/validation.go
+++ b/pkg/action/validation.go
@@ -784,13 +784,14 @@ func parseQuotedString(s string) string {
 func validateForEach(action *Action, section string, errs *AggregatedValidationError) {
 	forEach := action.ForEach
 
-	// Rule 13: forEach.onError must be valid
+	// Rule 13: forEach.onError must be valid (deprecated field, still validated for back-compat)
+	//nolint:staticcheck // validating the deprecated field while it remains supported
 	if forEach.OnError != "" && !forEach.OnError.IsValid() {
 		errs.AddError(&ValidationError{
 			Section:    section,
 			ActionName: action.Name,
 			Field:      "forEach.onError",
-			Message:    fmt.Sprintf("forEach.onError must be 'fail' or 'continue', got %q", forEach.OnError),
+			Message:    fmt.Sprintf("forEach.onError must be 'fail' or 'continue', got %q", forEach.OnError), //nolint:staticcheck // validating the deprecated field while it remains supported
 		})
 	}
 

--- a/pkg/celexp/context.go
+++ b/pkg/celexp/context.go
@@ -49,6 +49,11 @@ const (
 	// Example: __plan["myResolver"].phase
 	VarPlan = "__plan"
 
+	// VarError is the variable name for the error text bound in failure contexts.
+	// Available as __error in messages.error and continueOnError conditions.
+	// Example: __error.contains("timeout")
+	VarError = "__error"
+
 	// VarParams is the variable name for CLI parameters passed via -r flags.
 	// Available in state backend input expressions so that dynamic backend
 	// configuration (paths, URLs) can reference runtime values explicitly.

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -969,11 +969,18 @@ func (o *sharedResolverOptions) handleStateLoadError(ctx context.Context, loadEr
 
 // extractParameterKeys collects the CLI parameter keys accepted by a set of resolvers.
 // It scans all resolve-phase provider sources for the "parameter" provider and
-// extracts the literal "key" input value, which is the actual name the user
-// must pass via -r key=value.
+// extracts the literal "key" input value plus every entry in the "keys" alias
+// list, which together are the names the user may pass via -r key=value.
 func extractParameterKeys(resolvers []*resolver.Resolver) []string {
 	seen := make(map[string]bool)
 	var keys []string
+	add := func(name string) {
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		keys = append(keys, name)
+	}
 	for _, r := range resolvers {
 		if r.Resolve == nil {
 			continue
@@ -982,13 +989,19 @@ func extractParameterKeys(resolvers []*resolver.Resolver) []string {
 			if src.Provider != "parameter" {
 				continue
 			}
-			keyRef, ok := src.Inputs["key"]
-			if !ok || keyRef == nil || keyRef.Literal == nil {
-				continue
+			if keyRef, ok := src.Inputs["key"]; ok && keyRef != nil {
+				if s, ok := keyRef.Literal.(string); ok {
+					add(s)
+				}
 			}
-			if s, ok := keyRef.Literal.(string); ok && s != "" && !seen[s] {
-				seen[s] = true
-				keys = append(keys, s)
+			if keysRef, ok := src.Inputs["keys"]; ok && keysRef != nil {
+				if list, ok := keysRef.Literal.([]any); ok {
+					for _, item := range list {
+						if s, ok := item.(string); ok {
+							add(s)
+						}
+					}
+				}
 			}
 		}
 	}

--- a/pkg/cmd/scafctl/run/common_test.go
+++ b/pkg/cmd/scafctl/run/common_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/state"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -78,6 +79,72 @@ func TestAutoResolveProviderByName_FetcherFails(t *testing.T) {
 func TestLoadLockPlugins_MissingFile(t *testing.T) {
 	result := loadLockPlugins("/nonexistent/path/solution.yaml")
 	assert.Nil(t, result)
+}
+
+func TestExtractParameterKeys(t *testing.T) {
+	strRef := func(s string) *resolver.ValueRef { return &resolver.ValueRef{Literal: s} }
+	listRef := func(items ...any) *resolver.ValueRef { return &resolver.ValueRef{Literal: items} }
+
+	tests := []struct {
+		name      string
+		resolvers []*resolver.Resolver
+		want      []string
+	}{
+		{
+			name: "single key input",
+			resolvers: []*resolver.Resolver{{
+				Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*resolver.ValueRef{"key": strRef("name")}},
+				}},
+			}},
+			want: []string{"name"},
+		},
+		{
+			name: "keys alias list",
+			resolvers: []*resolver.Resolver{{
+				Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*resolver.ValueRef{"keys": listRef("environment", "e", "env")}},
+				}},
+			}},
+			want: []string{"environment", "e", "env"},
+		},
+		{
+			name: "key and keys combined with dedup",
+			resolvers: []*resolver.Resolver{{
+				Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*resolver.ValueRef{
+						"key":  strRef("environment"),
+						"keys": listRef("environment", "e"),
+					}},
+				}},
+			}},
+			want: []string{"environment", "e"},
+		},
+		{
+			name: "non-parameter providers ignored",
+			resolvers: []*resolver.Resolver{{
+				Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*resolver.ValueRef{"key": strRef("ignored")}},
+				}},
+			}},
+			want: nil,
+		},
+		{
+			name: "non-string keys entries skipped",
+			resolvers: []*resolver.Resolver{{
+				Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*resolver.ValueRef{"keys": listRef("env", 42, "region")}},
+				}},
+			}},
+			want: []string{"env", "region"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractParameterKeys(tt.resolvers)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }
 
 func TestBuildParamFlagHint(t *testing.T) {

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -251,7 +251,7 @@ func DescriptionFromPath(exPath string) string {
 		"actions/sequential-chain.yaml":         "Actions executed sequentially using dependsOn",
 		"actions/parallel-with-deps.yaml":       "Parallel actions with dependency ordering",
 		"actions/conditional-execution.yaml":    "Actions with conditional execution (when clauses)",
-		"actions/error-handling.yaml":           "Error handling with onError behavior",
+		"actions/error-handling.yaml":           "Error handling with continueOnError",
 		"actions/finally-cleanup.yaml":          "Finally block for cleanup actions",
 		"actions/foreach-deploy.yaml":           "ForEach iteration over collections",
 		"actions/retry-backoff.yaml":            "Retry with exponential backoff",
@@ -276,6 +276,7 @@ func DescriptionFromPath(exPath string) string {
 		"resolvers/feature-flags.yaml":       "Feature flag resolver pattern",
 		"resolvers/identity.yaml":            "Identity/auth resolver pattern",
 		"resolvers/secrets.yaml":             "Secrets resolver pattern",
+		"resolvers/error-recovery.yaml":      "Conditional error recovery with continueOnError",
 
 		// Providers
 		"providers/static-hello.yaml":                "Static provider — simple static string value",

--- a/pkg/lint/deprecated.go
+++ b/pkg/lint/deprecated.go
@@ -1,0 +1,162 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+)
+
+// deprecatedFieldMeta describes a deprecated struct field discovered via the
+// struct tags read by reflection. It is the bridge between the Go type system
+// (where deprecation is declared via `deprecated:"true"` and friends) and the
+// linter (which reports findings against YAML keys).
+type deprecatedFieldMeta struct {
+	yamlName    string
+	replacement string
+	message     string
+}
+
+// lookupDeprecatedField inspects the struct type of proto for the given Go field
+// name and returns its deprecation metadata when the field is marked deprecated.
+// proto may be a value or pointer to a struct. This keeps the deprecation rule
+// generic: it derives its messaging entirely from struct tags, so deprecating a
+// new field only requires tagging it (deprecated, deprecatedReplacement,
+// deprecatedMessage) and adding a traversal call below.
+func lookupDeprecatedField(proto any, goFieldName string) (deprecatedFieldMeta, bool) {
+	t := reflect.TypeOf(proto)
+	for t != nil && t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	if t == nil || t.Kind() != reflect.Struct {
+		return deprecatedFieldMeta{}, false
+	}
+	f, ok := t.FieldByName(goFieldName)
+	if !ok || f.Tag.Get("deprecated") != "true" {
+		return deprecatedFieldMeta{}, false
+	}
+	return deprecatedFieldMeta{
+		yamlName:    yamlTagName(f),
+		replacement: f.Tag.Get("deprecatedReplacement"),
+		message:     f.Tag.Get("deprecatedMessage"),
+	}, true
+}
+
+// yamlTagName extracts the YAML key name from a struct field's yaml/json tag,
+// falling back to the lowercased Go field name.
+func yamlTagName(f reflect.StructField) string {
+	for _, key := range []string{"yaml", "json"} {
+		if tag := f.Tag.Get(key); tag != "" {
+			if name := strings.Split(tag, ",")[0]; name != "" && name != "-" {
+				return name
+			}
+		}
+	}
+	return strings.ToLower(f.Name)
+}
+
+// emitDeprecated records a finding when a deprecated field is set. When the
+// replacement field is also set on the same object it emits a conflict error
+// (the replacement wins at runtime, so the deprecated key should be removed);
+// otherwise it emits a deprecation warning that names the replacement.
+func emitDeprecated(result *Result, proto any, goFieldName string, deprecatedSet, replacementSet bool, location string) { //nolint:unparam // goFieldName is parameterized so the helper is reusable for future deprecated fields
+	if !deprecatedSet {
+		return
+	}
+	meta, ok := lookupDeprecatedField(proto, goFieldName)
+	if !ok {
+		return
+	}
+	fieldLoc := location + "." + meta.yamlName
+
+	if replacementSet && meta.replacement != "" {
+		result.addFinding(SeverityError, "deprecation", fieldLoc,
+			fmt.Sprintf("both '%s' (deprecated) and '%s' are set; '%s' takes precedence",
+				meta.yamlName, meta.replacement, meta.replacement),
+			fmt.Sprintf("Remove the deprecated '%s' field and keep '%s'.", meta.yamlName, meta.replacement),
+			"deprecated-field-conflict")
+		return
+	}
+
+	msg := fmt.Sprintf("field '%s' is deprecated", meta.yamlName)
+	if meta.replacement != "" {
+		msg += fmt.Sprintf("; use '%s' instead", meta.replacement)
+	}
+	if meta.message != "" {
+		msg += ". " + meta.message
+	}
+	suggestion := ""
+	if meta.replacement != "" {
+		suggestion = fmt.Sprintf("Replace '%s' with '%s'.", meta.yamlName, meta.replacement)
+	}
+	result.addFinding(SeverityWarning, "deprecation", fieldLoc, msg, suggestion, "deprecated-field")
+}
+
+// lintDeprecatedFields walks the parsed solution and reports use of deprecated
+// fields. Because it traverses the typed spec (not the raw YAML), each check is
+// inherently scoped to the correct struct type — an unrelated map key that
+// happens to share a deprecated field's name will not trigger a false positive.
+func lintDeprecatedFields(sol *solution.Solution, result *Result) {
+	srcProto := resolver.ProviderSource{}
+	transformProto := resolver.ProviderTransform{}
+	actionProto := action.Action{}
+	forEachProto := spec.ForEachClause{}
+
+	for name, res := range sol.Spec.Resolvers {
+		if res == nil {
+			continue
+		}
+		loc := fmt.Sprintf("resolvers.%s", name)
+
+		if res.Resolve != nil {
+			for i := range res.Resolve.With {
+				s := &res.Resolve.With[i]
+				emitDeprecated(result, srcProto, "OnError",
+					s.OnError != "", s.ContinueOnError != nil,
+					fmt.Sprintf("%s.resolve.with[%d]", loc, i))
+			}
+		}
+		if res.Transform != nil {
+			for i := range res.Transform.With {
+				t := &res.Transform.With[i]
+				emitDeprecated(result, transformProto, "OnError",
+					t.OnError != "", t.ContinueOnError != nil,
+					fmt.Sprintf("%s.transform.with[%d]", loc, i))
+			}
+		}
+	}
+
+	if sol.Spec.Workflow == nil {
+		return
+	}
+	for name, act := range sol.Spec.Workflow.Actions {
+		emitActionDeprecations(result, act, actionProto, forEachProto,
+			fmt.Sprintf("workflow.actions.%s", name))
+	}
+	for name, act := range sol.Spec.Workflow.Finally {
+		emitActionDeprecations(result, act, actionProto, forEachProto,
+			fmt.Sprintf("workflow.finally.%s", name))
+	}
+}
+
+func emitActionDeprecations(result *Result, act *action.Action, actionProto action.Action, forEachProto spec.ForEachClause, location string) {
+	if act == nil {
+		return
+	}
+	//nolint:staticcheck // intentionally reading the deprecated field to report its use
+	emitDeprecated(result, actionProto, "OnError",
+		act.OnError != "", act.ContinueOnError != nil, location)
+	if act.ForEach != nil {
+		//nolint:staticcheck // intentionally reading the deprecated field to report its use
+		emitDeprecated(result, forEachProto, "OnError",
+			act.ForEach.OnError != "", act.ForEach.ContinueOnError != nil,
+			location+".forEach")
+	}
+}

--- a/pkg/lint/deprecated_test.go
+++ b/pkg/lint/deprecated_test.go
@@ -1,0 +1,153 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+)
+
+func resolverBoolCondition(v string) *resolver.Condition {
+	expr := celexp.Expression(v)
+	return &resolver.Condition{Expr: &expr}
+}
+
+func TestLintDeprecatedFields_ResolverSourceOnError(t *testing.T) {
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"r": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "http",
+							OnError:  resolver.ErrorBehaviorContinue,
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	result := Solution(sol, "test.yaml", provider.NewRegistry())
+
+	findings := filterFindingsByRule(result, "deprecated-field")
+	require.Len(t, findings, 1)
+	assert.Equal(t, SeverityWarning, findings[0].Severity)
+	assert.Contains(t, findings[0].Message, "onError")
+	assert.Contains(t, findings[0].Message, "continueOnError")
+	assert.Equal(t, "resolvers.r.resolve.with[0].onError", findings[0].Location)
+}
+
+func TestLintDeprecatedFields_ResolverTransformOnError(t *testing.T) {
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"r": {
+					Transform: &resolver.TransformPhase{
+						With: []resolver.ProviderTransform{{
+							Provider: "cel",
+							OnError:  resolver.ErrorBehaviorFail,
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	result := Solution(sol, "test.yaml", provider.NewRegistry())
+
+	findings := filterFindingsByRule(result, "deprecated-field")
+	require.Len(t, findings, 1)
+	assert.Equal(t, "resolvers.r.transform.with[0].onError", findings[0].Location)
+}
+
+func TestLintDeprecatedFields_Conflict(t *testing.T) {
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"r": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider:        "http",
+							OnError:         resolver.ErrorBehaviorContinue,
+							ContinueOnError: resolverBoolCondition("true"),
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	result := Solution(sol, "test.yaml", provider.NewRegistry())
+
+	conflicts := filterFindingsByRule(result, "deprecated-field-conflict")
+	require.Len(t, conflicts, 1)
+	assert.Equal(t, SeverityError, conflicts[0].Severity)
+	assert.Contains(t, conflicts[0].Message, "takes precedence")
+
+	// When the replacement is also set, only the conflict error is emitted,
+	// not the plain deprecation warning.
+	assert.Empty(t, filterFindingsByRule(result, "deprecated-field"))
+}
+
+func TestLintDeprecatedFields_ActionAndForEach(t *testing.T) {
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Workflow: &action.Workflow{
+				Actions: map[string]*action.Action{
+					"deploy": {
+						Provider: "exec",
+						OnError:  spec.OnErrorContinue,
+						ForEach: &spec.ForEachClause{
+							OnError: spec.OnErrorFail,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result := Solution(sol, "test.yaml", provider.NewRegistry())
+
+	findings := filterFindingsByRule(result, "deprecated-field")
+	require.Len(t, findings, 2)
+
+	locations := map[string]bool{}
+	for _, f := range findings {
+		locations[f.Location] = true
+	}
+	assert.True(t, locations["workflow.actions.deploy.onError"])
+	assert.True(t, locations["workflow.actions.deploy.forEach.onError"])
+}
+
+func TestLintDeprecatedFields_NoDeprecatedUsage(t *testing.T) {
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"r": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider:        "http",
+							ContinueOnError: resolverBoolCondition("true"),
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	result := Solution(sol, "test.yaml", provider.NewRegistry())
+
+	assert.Empty(t, filterFindingsByRule(result, "deprecated-field"))
+	assert.Empty(t, filterFindingsByRule(result, "deprecated-field-conflict"))
+}

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -30,6 +31,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/solution/walk"
 	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
+	exprpb "google.golang.org/genproto/googleapis/api/expr/v1alpha1"
 	yaml "gopkg.in/yaml.v3"
 )
 
@@ -113,6 +115,7 @@ func Solution(sol *solution.Solution, filePath string, registry *provider.Regist
 	lintImmutableResolvers(sol, result)
 	lintTests(sol, filePath, result)
 	lintProviderInputs(sol, result, registry)
+	lintDeprecatedFields(sol, result)
 
 	// Apply suppression directives parsed from inline YAML comments.
 	suppressions := ParseDirectives(sol.RawContent(), filePath).WithSourceMap(result.sourceMap)
@@ -1004,11 +1007,14 @@ func lintExpressions(inputs map[string]*spec.ValueRef, location string, result *
 		inputLoc := fmt.Sprintf("%s.inputs.%s", location, key)
 
 		if val.Expr != nil && string(*val.Expr) != "" {
-			if err := validateCELSyntax(string(*val.Expr)); err != nil {
+			ast, err := parseCELForLint(string(*val.Expr))
+			if err != nil {
 				result.addFinding(SeverityError, "expression", inputLoc,
 					fmt.Sprintf("invalid CEL expression: %v", err),
 					"Fix the expression syntax",
 					"invalid-expression")
+			} else {
+				lintOrValueOnConcrete(ast, inputLoc, result)
 			}
 		}
 
@@ -1061,20 +1067,172 @@ func lintTemplateUnderscorePrefix(tmpl, location string, result *Result) {
 	}
 }
 
-// validateCELSyntax checks if a CEL expression is syntactically valid.
-// The env enables cel.OptionalTypes() so that optional access syntax
-// (_.?name, _[?"name"]) parses successfully, matching the env used by the
-// reference collector and runtime evaluation in pkg/celexp.
-func validateCELSyntax(expr string) error {
-	env, err := cel.NewEnv(cel.OptionalTypes())
+// celLintEnv holds the shared CEL environment used for all lint-time parsing.
+// It enables cel.OptionalTypes() so optional access syntax (_.?name, _[?"name"])
+// parses successfully, matching the env used by the reference collector and
+// runtime evaluation in pkg/celexp. The env is immutable and safe for
+// concurrent use, so it is built once and reused across every expression
+// instead of being rebuilt per call.
+var (
+	celLintEnv     *cel.Env
+	celLintEnvErr  error
+	celLintEnvOnce sync.Once
+)
+
+// lintCELEnv returns the shared lint CEL environment, building it on first use.
+func lintCELEnv() (*cel.Env, error) {
+	celLintEnvOnce.Do(func() {
+		celLintEnv, celLintEnvErr = cel.NewEnv(cel.OptionalTypes())
+	})
+	return celLintEnv, celLintEnvErr
+}
+
+// parseCELForLint parses expr with the shared lint env and returns the parsed
+// AST. This is the single parse used for both syntax validation and the
+// orValue-on-concrete check, so callers must not re-parse the same expression.
+func parseCELForLint(expr string) (*cel.Ast, error) {
+	env, err := lintCELEnv()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	_, issues := env.Parse(expr)
+	ast, issues := env.Parse(expr)
 	if issues != nil && issues.Err() != nil {
-		return issues.Err()
+		return nil, issues.Err()
 	}
-	return nil
+	return ast, nil
+}
+
+// validateCELSyntax checks if a CEL expression is syntactically valid.
+// It delegates to parseCELForLint and discards the AST, for callers that only
+// need a syntax check (e.g. when conditions) without the orValue analysis.
+func validateCELSyntax(expr string) error {
+	_, err := parseCELForLint(expr)
+	return err
+}
+
+// lintOrValueOnConcrete flags CEL expressions that call .orValue(...) on a
+// provably-concrete (non-optional) receiver. In CEL, orValue() only has an
+// overload on optional types, so calling it on a concrete value (e.g.
+// __self.orValue([]) or _.field.orValue("")) errors at runtime. The check is
+// deliberately conservative: it only flags receivers it can prove are concrete
+// (plain identifiers, plain field-access chains, and literals). Anything that
+// could produce an optional -- optional access (_.?name, _[?"name"]),
+// optional.of/none/ofNonZeroValue, or any function-call result -- is left
+// alone, so every finding is a guaranteed runtime failure with no false
+// positives.
+//
+// It accepts the already-parsed AST (produced by parseCELForLint) so the
+// expression is parsed exactly once per lint run rather than re-parsed here.
+func lintOrValueOnConcrete(ast *cel.Ast, location string, result *Result) {
+	parsedExpr, err := cel.AstToParsedExpr(ast)
+	if err != nil {
+		return
+	}
+
+	seen := make(map[string]struct{})
+	for _, receiver := range findConcreteOrValueReceivers(parsedExpr.GetExpr()) {
+		if _, dup := seen[receiver]; dup {
+			continue
+		}
+		seen[receiver] = struct{}{}
+		result.addFinding(SeverityError, "expression", location,
+			fmt.Sprintf("'.orValue(...)' is called on non-optional value '%s'; orValue() only has an overload on optional types and will error at runtime", receiver),
+			orValueSuggestion(receiver),
+			"orvalue-on-non-optional")
+	}
+}
+
+// orValueSuggestion builds remediation guidance for an orValue()-on-concrete
+// finding. When the receiver is a plain "_."-rooted field access, it suggests
+// the equivalent optional-access form derived from that field. For any other
+// receiver (e.g. "__self", "__parent", or a literal) the "_.?" form cannot be
+// mechanically derived, so it falls back to generic guidance instead of
+// emitting an invalid example like "_.?__self".
+func orValueSuggestion(receiver string) string {
+	if field := strings.TrimPrefix(receiver, "_."); field != receiver && field != "" {
+		return fmt.Sprintf("Use optional access so the receiver is optional (e.g. '_.?%s'), or drop '.orValue(...)' and provide a fallback another way", field)
+	}
+	return "Use optional access so the receiver is optional (e.g. '_.?name' or '_[?\"name\"]'), or drop '.orValue(...)' and provide a fallback another way"
+}
+
+// findConcreteOrValueReceivers walks a parsed CEL expression and returns a
+// rendered description of every receiver on which orValue() is called when that
+// receiver is provably concrete.
+func findConcreteOrValueReceivers(expr *exprpb.Expr) []string {
+	if expr == nil {
+		return nil
+	}
+
+	var offenders []string
+	switch expr.GetExprKind().(type) {
+	case *exprpb.Expr_CallExpr:
+		call := expr.GetCallExpr()
+		if call.GetFunction() == "orValue" && call.GetTarget() != nil && isProvablyConcrete(call.GetTarget()) {
+			offenders = append(offenders, renderConcrete(call.GetTarget()))
+		}
+		// Recurse into target and args to catch nested expressions.
+		if call.GetTarget() != nil {
+			offenders = append(offenders, findConcreteOrValueReceivers(call.GetTarget())...)
+		}
+		for _, arg := range call.GetArgs() {
+			offenders = append(offenders, findConcreteOrValueReceivers(arg)...)
+		}
+	case *exprpb.Expr_SelectExpr:
+		offenders = append(offenders, findConcreteOrValueReceivers(expr.GetSelectExpr().GetOperand())...)
+	case *exprpb.Expr_ListExpr:
+		for _, el := range expr.GetListExpr().GetElements() {
+			offenders = append(offenders, findConcreteOrValueReceivers(el)...)
+		}
+	case *exprpb.Expr_StructExpr:
+		for _, entry := range expr.GetStructExpr().GetEntries() {
+			offenders = append(offenders, findConcreteOrValueReceivers(entry.GetValue())...)
+		}
+	case *exprpb.Expr_ComprehensionExpr:
+		comp := expr.GetComprehensionExpr()
+		offenders = append(offenders, findConcreteOrValueReceivers(comp.GetIterRange())...)
+		offenders = append(offenders, findConcreteOrValueReceivers(comp.GetAccuInit())...)
+		offenders = append(offenders, findConcreteOrValueReceivers(comp.GetLoopCondition())...)
+		offenders = append(offenders, findConcreteOrValueReceivers(comp.GetLoopStep())...)
+		offenders = append(offenders, findConcreteOrValueReceivers(comp.GetResult())...)
+	}
+	return offenders
+}
+
+// isProvablyConcrete reports whether an expression is guaranteed to be a
+// non-optional (concrete) value. Only literals, plain identifiers, and plain
+// field-access chains rooted at an identifier or literal qualify. Any call
+// (including optional access operators like _?._ and _[?_], optional.of, and a
+// prior orValue) is treated as not provably concrete so the check never flags
+// a value that might legitimately be optional.
+func isProvablyConcrete(expr *exprpb.Expr) bool {
+	switch expr.GetExprKind().(type) {
+	case *exprpb.Expr_ConstExpr:
+		return true
+	case *exprpb.Expr_IdentExpr:
+		return true
+	case *exprpb.Expr_SelectExpr:
+		// A regular field access is concrete only when its operand is concrete.
+		// (Optional select a.?b is parsed as a CallExpr, not a SelectExpr.)
+		return isProvablyConcrete(expr.GetSelectExpr().GetOperand())
+	default:
+		return false
+	}
+}
+
+// renderConcrete renders a provably-concrete expression back to a readable
+// source-like string for diagnostics (e.g. "_.config.host", "__self").
+func renderConcrete(expr *exprpb.Expr) string {
+	switch expr.GetExprKind().(type) {
+	case *exprpb.Expr_IdentExpr:
+		return expr.GetIdentExpr().GetName()
+	case *exprpb.Expr_SelectExpr:
+		sel := expr.GetSelectExpr()
+		return renderConcrete(sel.GetOperand()) + "." + sel.GetField()
+	case *exprpb.Expr_ConstExpr:
+		return "<literal>"
+	default:
+		return "<expr>"
+	}
 }
 
 // hyphensToCamelCase converts a hyphenated name to camelCase.

--- a/pkg/lint/lint_extra_test.go
+++ b/pkg/lint/lint_extra_test.go
@@ -109,6 +109,108 @@ func TestValidateCELSyntax_Invalid(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// ---- lintOrValueOnConcrete (orvalue-on-non-optional) ----
+
+func collectOrValueFindings(expr string) *Result {
+	result := &Result{}
+	ast, err := parseCELForLint(expr)
+	if err != nil {
+		return result
+	}
+	lintOrValueOnConcrete(ast, "test.location", result)
+	return result
+}
+
+func TestLintOrValueOnConcrete_FlagsConcreteReceivers(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+		want string // substring expected in the message
+	}{
+		{"plain ident", `__self.orValue([])`, "__self"},
+		{"field access", `_.field.orValue("")`, "_.field"},
+		{"nested field access", `_.config.host.orValue("")`, "_.config.host"},
+		{"literal receiver", `"x".orValue("")`, "<literal>"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := collectOrValueFindings(tc.expr)
+			require.Len(t, result.Findings, 1)
+			f := result.Findings[0]
+			assert.Equal(t, SeverityError, f.Severity)
+			assert.Equal(t, "orvalue-on-non-optional", f.RuleName)
+			assert.Equal(t, "expression", f.Category)
+			assert.Contains(t, f.Message, tc.want)
+		})
+	}
+}
+
+func TestLintOrValueOnConcrete_AllowsOptionalReceivers(t *testing.T) {
+	cases := []string{
+		`_.?field.orValue("")`,
+		`_[?"field"].orValue("")`,
+		`_.?config.host.orValue("")`,
+		`optional.of("x").orValue("")`,
+		`optional.ofNonZeroValue(_.field).orValue("")`,
+		// Result of another call is not provably concrete.
+		`_.field.split(",").orValue([])`,
+	}
+	for _, expr := range cases {
+		t.Run(expr, func(t *testing.T) {
+			result := collectOrValueFindings(expr)
+			assert.Empty(t, result.Findings, "expected no findings for %q", expr)
+		})
+	}
+}
+
+func TestLintOrValueOnConcrete_NoOrValueCall(t *testing.T) {
+	result := collectOrValueFindings(`_.field + "x"`)
+	assert.Empty(t, result.Findings)
+}
+
+func TestLintOrValueOnConcrete_FlagsNestedOccurrence(t *testing.T) {
+	// orValue on a concrete receiver buried inside a larger expression.
+	result := collectOrValueFindings(`[1, 2, _.field.orValue("")]`)
+	require.Len(t, result.Findings, 1)
+	assert.Contains(t, result.Findings[0].Message, "_.field")
+}
+
+func TestLintOrValueOnConcrete_DeduplicatesSameReceiver(t *testing.T) {
+	result := collectOrValueFindings(`_.field.orValue("") + _.field.orValue("x")`)
+	assert.Len(t, result.Findings, 1)
+}
+
+func TestLintOrValueOnConcrete_IgnoresSyntaxErrors(t *testing.T) {
+	// Invalid syntax must not panic and must produce no findings (callers
+	// run validateCELSyntax first and skip this check on parse failure).
+	result := collectOrValueFindings(`1 +++ %%%`)
+	assert.Empty(t, result.Findings)
+}
+
+func TestOrValueSuggestion(t *testing.T) {
+	cases := []struct {
+		name        string
+		receiver    string
+		wantExample string // substring expected in the suggestion
+	}{
+		{"underscore-rooted field", "_.field", "'_.?field'"},
+		{"underscore-rooted nested", "_.config.host", "'_.?config.host'"},
+		{"self receiver", "__self", "'_.?name'"},
+		{"parent receiver", "__parent", "'_.?name'"},
+		{"literal receiver", "<literal>", "'_.?name'"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := orValueSuggestion(tc.receiver)
+			assert.Contains(t, got, tc.wantExample)
+			// Never emit an invalid example that splices a non-"_."-rooted
+			// receiver in after "_.?".
+			assert.NotContains(t, got, "_.?__")
+			assert.NotContains(t, got, "_.?<literal>")
+		})
+	}
+}
+
 // ---- validateTemplateSyntax ----
 
 func TestValidateTemplateSyntax_Valid(t *testing.T) {

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -35,6 +35,28 @@ type RuleMeta struct {
 // KnownRules is the canonical registry of all lint rules.
 // Every addFinding call in lint.go MUST use a key from this map.
 var KnownRules = map[string]RuleMeta{
+	"deprecated-field": {
+		Rule:        "deprecated-field",
+		Severity:    string(SeverityWarning),
+		Category:    "deprecation",
+		Description: "A field that has been marked deprecated is used. The solution still works, but the field will be removed in a future major version.",
+		Why:         "Deprecated fields are retained for backward compatibility but should be migrated to their replacement. Keeping them increases the risk of breakage when the field is eventually removed.",
+		Fix:         "Replace the deprecated field with the suggested replacement field. Run get_solution_schema to see the replacement, or check the field's [DEPRECATED] marker.",
+		Examples: []string{
+			"# Deprecated:\n- provider: http\n  onError: continue\n\n# Replacement:\n- provider: http\n  continueOnError: true",
+		},
+	},
+	"deprecated-field-conflict": {
+		Rule:        "deprecated-field-conflict",
+		Severity:    string(SeverityError),
+		Category:    "deprecation",
+		Description: "Both a deprecated field and its replacement are set on the same object.",
+		Why:         "When both are present the replacement takes precedence at runtime and the deprecated field is silently ignored, which is confusing and error-prone.",
+		Fix:         "Remove the deprecated field and keep only its replacement.",
+		Examples: []string{
+			"# Conflict (remove onError):\n- provider: http\n  onError: continue\n  continueOnError: true",
+		},
+	},
 	"empty-solution": {
 		Rule:        "empty-solution",
 		Severity:    string(SeverityError),
@@ -89,6 +111,14 @@ var KnownRules = map[string]RuleMeta{
 		Description: "A CEL expression (in a 'when' clause or 'expr' input) has a syntax error and cannot be parsed.",
 		Why:         "Invalid CEL expressions will cause runtime failures. Common issues include missing quotes around strings, unbalanced parentheses, and using unknown functions.",
 		Fix:         "Use validate_expression with type 'cel' to check the expression syntax. Use list_cel_functions to see available functions. Use evaluate_cel to test the expression with sample data.",
+	},
+	"orvalue-on-non-optional": {
+		Rule:        "orvalue-on-non-optional",
+		Severity:    string(SeverityError),
+		Category:    "expression",
+		Description: "A CEL expression calls '.orValue(...)' on a provably non-optional (concrete) value, such as '__self.orValue([])' or '_.field.orValue(\"\")'.",
+		Why:         "orValue() only has an overload on CEL optional types. Calling it on a concrete value (a plain identifier or field-access chain) has no matching overload and fails at runtime, even though the expression parses and lints for syntax. This commonly happens when an optional marker ('.?') is dropped during editing or conversion.",
+		Fix:         "Make the receiver optional so orValue() applies (e.g. '_.?field.orValue(\"\")' or '_[?\"field\"].orValue(\"\")'), or remove '.orValue(...)' and supply the fallback another way (e.g. a ternary or a separate resolver source).",
 	},
 	"invalid-template": {
 		Rule:        "invalid-template",

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 50 rules — update this when new rules are added
-	assert.Equal(t, 50, len(KnownRules), "expected 50 known lint rules")
+	// We expect exactly 53 rules — update this when new rules are added
+	assert.Equal(t, 53, len(KnownRules), "expected 53 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/mcp/prompts.go
+++ b/pkg/mcp/prompts.go
@@ -507,7 +507,7 @@ func (s *Server) handleAddActionPrompt(_ context.Context, request mcp.GetPromptR
 	featureHints = append(featureHints, "dependsOn: explicit ordering for same-section actions. If inputs or when already reference __actions.<name> within the same section, that dependency is auto-inferred and dependsOn is optional (still required for ordering without a data dependency)")
 	featureHints = append(featureHints, "dependsOn in workflow.finally: can only reference other finally actions—never actions in workflow.actions. To read results from a main action in finally, use __actions.<name> in inputs or when; the reference appears in crossSectionRefs on the rendered graph (informational only—cross-section ordering is guaranteed structurally)")
 	featureHints = append(featureHints, "when: CEL expression for conditional execution")
-	featureHints = append(featureHints, "onError: 'fail' (default) or 'continue'")
+	featureHints = append(featureHints, "continueOnError: bool or CEL expression (error bound as __error) — truthy continues the workflow when this action fails, falsy stops it. Replaces the deprecated onError enum ('fail'/'continue'); continueOnError wins when both are set")
 	featureHints = append(featureHints, "retry: { maxAttempts, backoff: fixed|linear|exponential, initialDelay, maxDelay }")
 	featureHints = append(featureHints, "forEach: { in: <ValueRef>, item: 'item', index: 'index', concurrency: N }")
 	featureHints = append(featureHints, "timeout: duration string (e.g., '30s', '5m')")

--- a/pkg/mcp/tools_action.go
+++ b/pkg/mcp/tools_action.go
@@ -164,6 +164,7 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 		ForEach            *forEachPreview     `json:"forEach,omitempty"`
 		Retry              *retryPreview       `json:"retry,omitempty"`
 		Timeout            string              `json:"timeout,omitempty"`
+		ContinueOnError    string              `json:"continueOnError,omitempty"`
 		OnError            string              `json:"onError,omitempty"`
 		Exclusive          []string            `json:"exclusive,omitempty"`
 		SourcePos          *sourcepos.Position `json:"sourcePos,omitempty"`
@@ -230,8 +231,12 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 		if ea.Timeout != nil {
 			preview.Timeout = ea.Timeout.String()
 		}
+		if ea.ContinueOnError != nil && ea.ContinueOnError.Expr != nil {
+			preview.ContinueOnError = string(*ea.ContinueOnError.Expr)
+		}
+		//nolint:staticcheck // surfacing the deprecated field in the preview while it remains supported
 		if ea.OnError != "" {
-			preview.OnError = string(ea.OnError)
+			preview.OnError = string(ea.OnError) //nolint:staticcheck // surfacing the deprecated field in the preview while it remains supported
 		}
 		if ea.Retry != nil {
 			preview.Retry = &retryPreview{

--- a/pkg/mcp/tools_action_test.go
+++ b/pkg/mcp/tools_action_test.go
@@ -169,4 +169,51 @@ spec:
 		text := result.Content[0].(mcp.TextContent).Text
 		assert.Contains(t, text, "nonexistent")
 	})
+
+	t.Run("surfaces continueOnError in preview", func(t *testing.T) {
+		dir := t.TempDir()
+		solFile := filepath.Join(dir, "solution.yaml")
+		err := os.WriteFile(solFile, []byte(`apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: continue-on-error
+  version: "1.0.0"
+spec:
+  resolvers:
+    val:
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "'x'"
+  workflow:
+    actions:
+      optional:
+        provider: message
+        continueOnError: '__error.message.contains("boom")'
+        inputs:
+          message: "optional"
+`), 0o644)
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_action"
+		request.Params.Arguments = map[string]any{
+			"path": solFile,
+		}
+
+		result, err := srv.handlePreviewAction(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError, "unexpected error: %v", result.Content)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		actions := output["actions"].([]any)
+		require.NotEmpty(t, actions)
+		first := actions[0].(map[string]any)
+		assert.Equal(t, `__error.message.contains("boom")`, first["continueOnError"],
+			"preview should surface the continueOnError condition")
+	})
 }

--- a/pkg/provider/builtin/parameterprovider/parameter.go
+++ b/pkg/provider/builtin/parameterprovider/parameter.go
@@ -100,11 +100,16 @@ func NewParameterProvider(opts ...Option) *ParameterProvider {
 			Capabilities: []provider.Capability{
 				provider.CapabilityFrom,
 			},
-			Schema: schemahelper.ObjectSchema([]string{"key"}, map[string]*jsonschema.Schema{
-				"key": schemahelper.StringProp("Name of the parameter to retrieve (exact match)",
+			Schema: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+				"key": schemahelper.StringProp("Name of the parameter to retrieve (exact match). Provide either key or keys; key takes precedence over keys when both are set.",
 					schemahelper.WithMaxLength(*ptrs.IntPtr(256)),
 					schemahelper.WithPattern(`^[A-Za-z_][A-Za-z0-9_.\-]*$`),
 					schemahelper.WithExample("env")),
+				"keys": schemahelper.ArrayProp("Ordered list of parameter names (aliases) for a single logical parameter. The first name that was provided via CLI wins. Evaluated after key. Use this to accept a parameter under any of several flag names (e.g. environment, e, env).",
+					schemahelper.WithItems(schemahelper.StringProp("Parameter name (exact match)",
+						schemahelper.WithMaxLength(*ptrs.IntPtr(256)),
+						schemahelper.WithPattern(`^[A-Za-z_][A-Za-z0-9_.\-]*$`))),
+					schemahelper.WithMaxItems(50)),
 				"default": schemahelper.AnyProp("Default value to return when the parameter is not provided via CLI. Must be a literal value -- ValueRef expressions are resolved by the executor before Execute is called, so a ValueRef default would be evaluated even when the parameter exists.",
 					schemahelper.WithExample("fallback")),
 				"type": schemahelper.StringProp("Force the parameter value to be returned verbatim as a string, suppressing automatic type inference (boolean, number, JSON, CSV, file://, http://). The only supported value is \"string\".",
@@ -132,6 +137,14 @@ inputs:
 					YAML: `provider: parameter
 inputs:
   key: env
+  default: development`,
+				},
+				{
+					Name:        "Accept a parameter under any of several names (aliases)",
+					Description: "Resolve a single logical parameter from the first provided alias (first-match-wins), falling back to a default",
+					YAML: `provider: parameter
+inputs:
+  keys: [environment, e, env]
   default: development`,
 				},
 				{
@@ -193,9 +206,15 @@ func (p *ParameterProvider) Execute(ctx context.Context, input any) (*provider.O
 
 	lgr.V(1).Info("executing provider", "provider", ProviderName)
 
-	key, ok := inputs["key"].(string)
-	if !ok || key == "" {
-		return nil, fmt.Errorf("%s: key is required and must be a string", ProviderName)
+	// Build the ordered list of parameter names to look up. "key" (when set)
+	// takes precedence, followed by each name in "keys" in declared order.
+	// Duplicates are removed so a name is only attempted once.
+	candidates, err := candidateKeys(inputs)
+	if err != nil {
+		return nil, err
+	}
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("%s: at least one non-empty parameter name is required (provide key or keys)", ProviderName)
 	}
 
 	// Determine whether the caller wants to suppress type coercion and keep
@@ -210,16 +229,17 @@ func (p *ParameterProvider) Execute(ctx context.Context, input any) (*provider.O
 
 	// Check for dry-run mode
 	if dryRun := provider.DryRunFromContext(ctx); dryRun {
-		return p.executeDryRun(key, forceString)
+		return p.executeDryRun(candidates[0], forceString)
 	}
 
-	// Look up the parameter
-	rawValue, exists := params[key]
+	// Look up the parameter, trying each candidate name in order. The first
+	// name that was provided via CLI wins (first-match-wins).
+	matchedKey, rawValue, exists := firstProvided(candidates, params)
 	if !exists {
 		if def, hasDefault := inputs["default"]; hasDefault {
 			parsedDefault, err := p.resolveValue(ctx, def, forceString)
 			if err != nil {
-				return nil, fmt.Errorf("%s: failed to parse default for parameter %q: %w", ProviderName, key, err)
+				return nil, fmt.Errorf("%s: failed to parse default for parameter %q: %w", ProviderName, candidates[0], err)
 			}
 			lgr.V(1).Info("provider completed", "provider", ProviderName)
 			return &provider.Output{
@@ -230,13 +250,13 @@ func (p *ParameterProvider) Execute(ctx context.Context, input any) (*provider.O
 				},
 			}, nil
 		}
-		return nil, fmt.Errorf("%s: parameter %q not provided", ProviderName, key)
+		return nil, fmt.Errorf("%s: parameter %q not provided", ProviderName, candidates[0])
 	}
 
 	// Parse the value according to precedence rules
 	parsedValue, err := p.resolveValue(ctx, rawValue, forceString)
 	if err != nil {
-		return nil, fmt.Errorf("%s: failed to parse parameter %q: %w", ProviderName, key, err)
+		return nil, fmt.Errorf("%s: failed to parse parameter %q: %w", ProviderName, matchedKey, err)
 	}
 
 	lgr.V(1).Info("provider completed", "provider", ProviderName)
@@ -422,4 +442,66 @@ func wantsStringType(inputs map[string]any) bool {
 		return false
 	}
 	return t == TypeString
+}
+
+// candidateKeys returns the ordered list of parameter names to look up for a
+// single logical parameter. "key" (when a non-empty string) comes first,
+// followed by each name in "keys" in declared order. Duplicates are removed so
+// each name is attempted at most once. An error is returned when "key" or
+// "keys" is present but not the expected type.
+func candidateKeys(inputs map[string]any) ([]string, error) {
+	seen := make(map[string]struct{})
+	candidates := make([]string, 0, 4)
+
+	add := func(name string) {
+		if name == "" {
+			return
+		}
+		if _, dup := seen[name]; dup {
+			return
+		}
+		seen[name] = struct{}{}
+		candidates = append(candidates, name)
+	}
+
+	if raw, present := inputs["key"]; present {
+		key, ok := raw.(string)
+		if !ok {
+			return nil, fmt.Errorf("%s: key must be a string, got %T", ProviderName, raw)
+		}
+		add(key)
+	}
+
+	if raw, present := inputs["keys"]; present {
+		switch list := raw.(type) {
+		case []string:
+			for _, name := range list {
+				add(name)
+			}
+		case []any:
+			for i, item := range list {
+				name, ok := item.(string)
+				if !ok {
+					return nil, fmt.Errorf("%s: keys[%d] must be a string, got %T", ProviderName, i, item)
+				}
+				add(name)
+			}
+		default:
+			return nil, fmt.Errorf("%s: keys must be a list of strings, got %T", ProviderName, raw)
+		}
+	}
+
+	return candidates, nil
+}
+
+// firstProvided returns the first candidate name that exists in params, along
+// with its raw value. The returned name is the one that matched, enabling
+// accurate error messages.
+func firstProvided(candidates []string, params map[string]any) (string, any, bool) {
+	for _, name := range candidates {
+		if v, exists := params[name]; exists {
+			return name, v, true
+		}
+	}
+	return "", nil, false
 }

--- a/pkg/provider/builtin/parameterprovider/parameter_test.go
+++ b/pkg/provider/builtin/parameterprovider/parameter_test.go
@@ -89,7 +89,135 @@ func TestParameterProvider_Execute_NoKey(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, output)
-	assert.Contains(t, err.Error(), "key is required")
+	assert.Contains(t, err.Error(), "at least one non-empty parameter name is required")
+}
+
+func TestParameterProvider_Execute_Keys_FirstMatchWins(t *testing.T) {
+	tests := []struct {
+		name     string
+		inputs   map[string]any
+		params   map[string]any
+		expected any
+		exists   bool
+	}{
+		{
+			name:     "first alias provided wins",
+			inputs:   map[string]any{"keys": []any{"environment", "e", "env"}},
+			params:   map[string]any{"environment": "prod"},
+			expected: "prod",
+			exists:   true,
+		},
+		{
+			name:     "earlier alias wins over later when both provided",
+			inputs:   map[string]any{"keys": []any{"environment", "e", "env"}},
+			params:   map[string]any{"e": "qa", "env": "dev"},
+			expected: "qa",
+			exists:   true,
+		},
+		{
+			name:     "later alias used when earlier absent",
+			inputs:   map[string]any{"keys": []any{"environment", "e", "env"}},
+			params:   map[string]any{"env": "dev"},
+			expected: "dev",
+			exists:   true,
+		},
+		{
+			name:     "keys accepts []string from coerced array inputs",
+			inputs:   map[string]any{"keys": []string{"environment", "e", "env"}},
+			params:   map[string]any{"e": "qa"},
+			expected: "qa",
+			exists:   true,
+		},
+		{
+			name:     "key takes precedence over keys",
+			inputs:   map[string]any{"key": "appName", "keys": []any{"app_name"}},
+			params:   map[string]any{"appName": "alpha", "app_name": "beta"},
+			expected: "alpha",
+			exists:   true,
+		},
+		{
+			name:     "falls through to key alias when primary absent",
+			inputs:   map[string]any{"key": "appName", "keys": []any{"app_name"}},
+			params:   map[string]any{"app_name": "beta"},
+			expected: "beta",
+			exists:   true,
+		},
+		{
+			name:     "default used when no alias provided",
+			inputs:   map[string]any{"keys": []any{"environment", "e", "env"}, "default": "development"},
+			params:   map[string]any{},
+			expected: "development",
+			exists:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParameterProvider()
+			ctx := provider.WithParameters(context.Background(), tt.params)
+
+			output, err := p.Execute(ctx, tt.inputs)
+
+			require.NoError(t, err)
+			require.NotNil(t, output)
+			assert.Equal(t, tt.expected, output.Data)
+			assert.Equal(t, tt.exists, output.Metadata["exists"])
+		})
+	}
+}
+
+func TestParameterProvider_Execute_Keys_NoneProvided_NoDefault(t *testing.T) {
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{})
+
+	output, err := p.Execute(ctx, map[string]any{
+		"keys": []any{"environment", "env"},
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, output)
+	assert.Contains(t, err.Error(), "not provided")
+	// Error references the first candidate name.
+	assert.Contains(t, err.Error(), "environment")
+}
+
+func TestParameterProvider_Execute_Keys_InvalidType(t *testing.T) {
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{})
+
+	tests := []struct {
+		name   string
+		inputs map[string]any
+	}{
+		{"keys not a list", map[string]any{"keys": "environment"}},
+		{"keys element not a string", map[string]any{"keys": []any{"env", 42}}},
+		{"key not a string", map[string]any{"key": 42}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := p.Execute(ctx, tt.inputs)
+			assert.Error(t, err)
+			assert.Nil(t, output)
+		})
+	}
+}
+
+func TestParameterProvider_Execute_Keys_DuplicatesDeduped(t *testing.T) {
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{
+		"env": "prod",
+	})
+
+	output, err := p.Execute(ctx, map[string]any{
+		"key":  "env",
+		"keys": []any{"env", "environment"},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, "prod", output.Data)
+	assert.Equal(t, true, output.Metadata["exists"])
 }
 
 func TestParameterProvider_Execute_ForceString(t *testing.T) {
@@ -447,9 +575,12 @@ func TestParameterProvider_Descriptor(t *testing.T) {
 	assert.Equal(t, "CLI Parameters", desc.DisplayName)
 	assert.Contains(t, desc.Capabilities, provider.CapabilityFrom)
 
-	// Check schema
+	// Check schema: neither key nor keys is required at the schema level
+	// (Execute enforces that at least one is provided), so a parameter can be
+	// declared with a single key or an alias list.
 	assert.Contains(t, desc.Schema.Properties, "key")
-	assert.Contains(t, desc.Schema.Required, "key")
+	assert.NotContains(t, desc.Schema.Required, "key")
+	assert.Contains(t, desc.Schema.Properties, "keys")
 	assert.Contains(t, desc.Schema.Properties, "default")
 	assert.NotContains(t, desc.Schema.Required, "default")
 }

--- a/pkg/resolver/executor.go
+++ b/pkg/resolver/executor.go
@@ -890,6 +890,60 @@ func (e *Executor) evaluateConditionWithSelf(ctx context.Context, cond *Conditio
 	return boolResult, nil
 }
 
+// evaluateContinueCondition evaluates a continueOnError condition with the
+// failing error bound as the top-level __error variable (matching how __self and
+// __plan are exposed to other condition evaluators). It returns true when the
+// condition is truthy, meaning execution should continue (the error is recovered).
+func (e *Executor) evaluateContinueCondition(ctx context.Context, cond *Condition, srcErr error) (bool, error) {
+	if cond == nil || cond.Expr == nil {
+		return false, nil
+	}
+
+	resolverCtx, _ := FromContext(ctx)
+	data := resolverCtx.ToMap()
+
+	additionalVars := map[string]any{
+		celexp.VarError: srcErr.Error(),
+	}
+	if plan, ok := data[celexp.VarPlan]; ok {
+		additionalVars[celexp.VarPlan] = plan
+		delete(data, celexp.VarPlan)
+	}
+
+	result, err := celexp.EvaluateExpression(ctx, string(*cond.Expr), data, additionalVars)
+	if err != nil {
+		return false, fmt.Errorf("continueOnError condition evaluation failed: %w", err)
+	}
+
+	boolResult, ok := result.(bool)
+	if !ok {
+		return false, fmt.Errorf("continueOnError condition must evaluate to boolean, got %T", result)
+	}
+	return boolResult, nil
+}
+
+// effectiveShouldFail decides whether a failing source/transform step should fail
+// the resolver.
+//   - When continueOnError is set it wins: the step is recovered (continue) when
+//     the condition is truthy, otherwise the resolver fails.
+//   - Otherwise baseFail decides. baseFail is derived from the deprecated onError
+//     enum or the phase default.
+//
+// A condition evaluation error always fails the resolver.
+func (e *Executor) effectiveShouldFail(ctx context.Context, continueOnError *Condition, srcErr error, baseFail bool) (bool, error) {
+	// A nil condition, or a non-nil condition with no expression (e.g. from
+	// `continueOnError: null`), is treated as unset: fall back to baseFail
+	// instead of forcing a hard failure.
+	if continueOnError == nil || continueOnError.Expr == nil {
+		return baseFail, nil
+	}
+	cont, err := e.evaluateContinueCondition(ctx, continueOnError, srcErr)
+	if err != nil {
+		return true, err
+	}
+	return !cont, nil
+}
+
 // executeResolvePhase executes the resolve phase with provider fallback chain
 func (e *Executor) executeResolvePhase(ctx context.Context, phase *ResolvePhase) (any, int, error) {
 	if phase == nil {
@@ -951,7 +1005,11 @@ func (e *Executor) executeResolvePhase(ctx context.Context, phase *ResolvePhase)
 					"source", i+1,
 					logKeyProvider, source.Provider,
 					"error", err)
-				if source.OnError == ErrorBehaviorFail {
+				shouldFail, decideErr := e.effectiveShouldFail(ctx, source.ContinueOnError, err, source.OnError == ErrorBehaviorFail)
+				if decideErr != nil {
+					return nil, providerCallCount, fmt.Errorf("source %d (%s) forEach: %w", i+1, source.Provider, decideErr)
+				}
+				if shouldFail {
 					return nil, providerCallCount, fmt.Errorf("source %d (%s) forEach failed: %w", i+1, source.Provider, err)
 				}
 				lastErr = err
@@ -978,12 +1036,19 @@ func (e *Executor) executeResolvePhase(ctx context.Context, phase *ResolvePhase)
 
 			lastErr = err
 
-			// Handle error behavior: resolve phase defaults to continue (fallback chain)
-			if source.OnError == ErrorBehaviorFail {
+			// Handle error behavior: resolve phase defaults to continue (fallback
+			// chain). continueOnError, when set, refines this: recover (try the next
+			// source) only when the condition is truthy for the thrown error; otherwise
+			// fail the resolver.
+			shouldFail, decideErr := e.effectiveShouldFail(ctx, source.ContinueOnError, err, source.OnError == ErrorBehaviorFail)
+			if decideErr != nil {
+				return nil, providerCallCount, fmt.Errorf("source %d (%s): %w", i+1, source.Provider, decideErr)
+			}
+			if shouldFail {
 				return nil, providerCallCount, fmt.Errorf("source %d (%s) failed: %w", i+1, source.Provider, err)
 			}
 
-			continue // Default: try next source
+			continue // Try next source
 		}
 
 		// Success - check until condition with __self set to current value
@@ -1044,7 +1109,11 @@ func (e *Executor) executeTransformPhase(ctx context.Context, phase *TransformPh
 			transformed, calls, err := e.executeForEachTransform(ctx, &transform, currentValue, i)
 			providerCallCount += calls
 			if err != nil {
-				if transform.OnError == ErrorBehaviorContinue {
+				shouldFail, decideErr := e.effectiveShouldFail(ctx, transform.ContinueOnError, err, transform.OnError != ErrorBehaviorContinue)
+				if decideErr != nil {
+					return currentValue, providerCallCount, fmt.Errorf("step %d (%s) forEach: %w", i+1, transform.Provider, decideErr)
+				}
+				if !shouldFail {
 					lgr.V(1).Info("forEach transform failed, continuing",
 						logKeyStep, i+1,
 						logKeyProvider, transform.Provider,
@@ -1094,8 +1163,14 @@ func (e *Executor) executeTransformPhase(ctx context.Context, phase *TransformPh
 			// Track failed attempt
 			e.trackFailedAttempt(resolverCtx, transform.Provider, "transform", err, attemptDuration, string(transform.OnError), i)
 
-			// Handle error behavior
-			if transform.OnError == ErrorBehaviorContinue {
+			// Handle error behavior. Transform defaults to fail; continueOnError, when
+			// set, refines this: recover (skip this step, keep the current value) only
+			// when the condition is truthy for the thrown error; otherwise fail.
+			shouldFail, decideErr := e.effectiveShouldFail(ctx, transform.ContinueOnError, err, transform.OnError != ErrorBehaviorContinue)
+			if decideErr != nil {
+				return currentValue, providerCallCount, fmt.Errorf("step %d (%s): %w", i+1, transform.Provider, decideErr)
+			}
+			if !shouldFail {
 				continue // Skip this transform, keep current value
 			}
 
@@ -1820,7 +1895,7 @@ func resolveCustomErrorMessage(ctx context.Context, r *Resolver, originalErr err
 	// Pass __error as the self parameter so it's available as __self in CEL/templates,
 	// and also add it to resolverData so it's available as _.__error or _["__error"].
 	errorMsg := originalErr.Error()
-	resolverData["__error"] = errorMsg
+	resolverData[celexp.VarError] = errorMsg
 
 	resolved, err := r.Messages.Error.Resolve(ctx, resolverData, errorMsg)
 	if err != nil {

--- a/pkg/resolver/executor_test.go
+++ b/pkg/resolver/executor_test.go
@@ -632,6 +632,225 @@ func TestExecutor_Execute_OnErrorContinue(t *testing.T) {
 	assert.Equal(t, 2, callCount) // Both providers should be called
 }
 
+func TestExecutor_Execute_ContinueOnError(t *testing.T) {
+	// failing provider returns a configurable error message based on the "msg"
+	// input; the "ok" provider always succeeds and echoes its "value" input.
+	newReg := func() *mockRegistry {
+		registry := newMockRegistry()
+		require.NoError(t, registry.Register(&mockProvider{
+			name: "failing",
+			executeFunc: func(ctx context.Context, inputs map[string]any) (*provider.Output, error) {
+				msg, _ := inputs["msg"].(string)
+				return nil, fmt.Errorf("%s", msg)
+			},
+		}))
+		require.NoError(t, registry.Register(&mockProvider{
+			name: "ok",
+			executeFunc: func(ctx context.Context, inputs map[string]any) (*provider.Output, error) {
+				return &provider.Output{Data: inputs["value"]}, nil
+			},
+		}))
+		return registry
+	}
+
+	t.Run("resolve: matching continueOnError recovers to next source", func(t *testing.T) {
+		executor := NewExecutor(newReg())
+		resolvers := []*Resolver{
+			{
+				Name: "r",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{
+							Provider:        "failing",
+							Inputs:          map[string]*ValueRef{"msg": {Literal: "timeout contacting host"}},
+							ContinueOnError: &Condition{Expr: celExpPtr(`__error.contains("timeout")`)},
+						},
+						{
+							Provider: "ok",
+							Inputs:   map[string]*ValueRef{"value": {Literal: "recovered"}},
+						},
+					},
+				},
+			},
+		}
+
+		ctx, err := executor.Execute(context.Background(), resolvers, nil)
+		require.NoError(t, err)
+		result, _ := FromContext(ctx)
+		value, ok := result.Get("r")
+		require.True(t, ok)
+		assert.Equal(t, "recovered", value)
+	})
+
+	t.Run("resolve: non-matching continueOnError fails the resolver", func(t *testing.T) {
+		executor := NewExecutor(newReg())
+		resolvers := []*Resolver{
+			{
+				Name: "r",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{
+							Provider:        "failing",
+							Inputs:          map[string]*ValueRef{"msg": {Literal: "fatal misconfiguration"}},
+							ContinueOnError: &Condition{Expr: celExpPtr(`__error.contains("timeout")`)},
+						},
+						{
+							Provider: "ok",
+							Inputs:   map[string]*ValueRef{"value": {Literal: "should-not-be-used"}},
+						},
+					},
+				},
+			},
+		}
+
+		ctx, err := executor.Execute(context.Background(), resolvers, nil)
+		require.Error(t, err)
+		result, _ := FromContext(ctx)
+		execResult, ok := result.GetResult("r")
+		require.True(t, ok)
+		assert.Equal(t, ExecutionStatusFailed, execResult.Status)
+	})
+
+	t.Run("transform: matching continueOnError keeps current value", func(t *testing.T) {
+		executor := NewExecutor(newReg())
+		resolvers := []*Resolver{
+			{
+				Name: "r",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{Provider: "ok", Inputs: map[string]*ValueRef{"value": {Literal: "base"}}},
+					},
+				},
+				Transform: &TransformPhase{
+					With: []ProviderTransform{
+						{
+							Provider:        "failing",
+							Inputs:          map[string]*ValueRef{"msg": {Literal: "timeout during transform"}},
+							ContinueOnError: &Condition{Expr: celExpPtr(`__error.contains("timeout")`)},
+						},
+					},
+				},
+			},
+		}
+
+		ctx, err := executor.Execute(context.Background(), resolvers, nil)
+		require.NoError(t, err)
+		result, _ := FromContext(ctx)
+		value, ok := result.Get("r")
+		require.True(t, ok)
+		assert.Equal(t, "base", value)
+	})
+
+	t.Run("transform: non-matching continueOnError fails the resolver", func(t *testing.T) {
+		executor := NewExecutor(newReg())
+		resolvers := []*Resolver{
+			{
+				Name: "r",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{Provider: "ok", Inputs: map[string]*ValueRef{"value": {Literal: "base"}}},
+					},
+				},
+				Transform: &TransformPhase{
+					With: []ProviderTransform{
+						{
+							Provider:        "failing",
+							Inputs:          map[string]*ValueRef{"msg": {Literal: "fatal during transform"}},
+							ContinueOnError: &Condition{Expr: celExpPtr(`__error.contains("timeout")`)},
+						},
+					},
+				},
+			},
+		}
+
+		ctx, err := executor.Execute(context.Background(), resolvers, nil)
+		require.Error(t, err)
+		result, _ := FromContext(ctx)
+		execResult, ok := result.GetResult("r")
+		require.True(t, ok)
+		assert.Equal(t, ExecutionStatusFailed, execResult.Status)
+	})
+}
+
+func TestExecutor_Execute_ContinueOnError_NilExprIsUnset(t *testing.T) {
+	newReg := func() *mockRegistry {
+		registry := newMockRegistry()
+		require.NoError(t, registry.Register(&mockProvider{
+			name: "failing",
+			executeFunc: func(ctx context.Context, inputs map[string]any) (*provider.Output, error) {
+				msg, _ := inputs["msg"].(string)
+				return nil, fmt.Errorf("%s", msg)
+			},
+		}))
+		require.NoError(t, registry.Register(&mockProvider{
+			name: "ok",
+			executeFunc: func(ctx context.Context, inputs map[string]any) (*provider.Output, error) {
+				return &provider.Output{Data: inputs["value"]}, nil
+			},
+		}))
+		return registry
+	}
+
+	t.Run("resolve: nil-expr continueOnError falls back to phase default (continue)", func(t *testing.T) {
+		executor := NewExecutor(newReg())
+		resolvers := []*Resolver{
+			{
+				Name: "r",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{
+							Provider:        "failing",
+							Inputs:          map[string]*ValueRef{"msg": {Literal: "boom"}},
+							ContinueOnError: &Condition{}, // non-nil, nil Expr -> unset
+						},
+						{
+							Provider: "ok",
+							Inputs:   map[string]*ValueRef{"value": {Literal: "recovered"}},
+						},
+					},
+				},
+			},
+		}
+
+		ctx, err := executor.Execute(context.Background(), resolvers, nil)
+		require.NoError(t, err)
+		result, _ := FromContext(ctx)
+		value, ok := result.Get("r")
+		require.True(t, ok)
+		assert.Equal(t, "recovered", value)
+	})
+
+	t.Run("transform: nil-expr continueOnError falls back to phase default (fail)", func(t *testing.T) {
+		executor := NewExecutor(newReg())
+		resolvers := []*Resolver{
+			{
+				Name: "r",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{
+						{Provider: "ok", Inputs: map[string]*ValueRef{"value": {Literal: "base"}}},
+					},
+				},
+				Transform: &TransformPhase{
+					With: []ProviderTransform{
+						{
+							Provider:        "failing",
+							Inputs:          map[string]*ValueRef{"msg": {Literal: "boom"}},
+							ContinueOnError: &Condition{}, // non-nil, nil Expr -> unset
+						},
+					},
+				},
+			},
+		}
+
+		ctx, err := executor.Execute(context.Background(), resolvers, nil)
+		require.Error(t, err)
+		result, _ := FromContext(ctx)
+		execResult, ok := result.GetResult("r")
+		require.True(t, ok)
+		assert.Equal(t, ExecutionStatusFailed, execResult.Status)
+	})
+}
+
 func TestExecutor_Execute_WithValidateAll(t *testing.T) {
 	registry := newMockRegistry()
 

--- a/pkg/resolver/graph.go
+++ b/pkg/resolver/graph.go
@@ -463,6 +463,11 @@ func extractDepsFromResolvePhase(phase *ResolvePhase, deps map[string]bool, look
 			extractDepsFromExpression(string(*source.When.Expr), deps)
 		}
 
+		// Extract from continueOnError condition
+		if source.ContinueOnError != nil && source.ContinueOnError.Expr != nil {
+			extractDepsFromExpression(string(*source.ContinueOnError.Expr), deps)
+		}
+
 		// Extract from forEach.In (if using forEach with custom source)
 		if source.ForEach != nil && source.ForEach.In != nil {
 			extractDepsFromValueRef(source.ForEach.In, deps)
@@ -561,6 +566,11 @@ func extractDepsFromTransformPhase(phase *TransformPhase, deps map[string]bool, 
 		// Extract from when condition
 		if transform.When != nil && transform.When.Expr != nil {
 			extractDepsFromExpression(string(*transform.When.Expr), deps)
+		}
+
+		// Extract from continueOnError condition
+		if transform.ContinueOnError != nil && transform.ContinueOnError.Expr != nil {
+			extractDepsFromExpression(string(*transform.ContinueOnError.Expr), deps)
 		}
 
 		// Extract from forEach.In (if using forEach with custom source)

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -4,6 +4,7 @@
 package resolver
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -45,6 +46,8 @@ const (
 //   - String shorthand: when: "_.environment == 'prod'"
 //   - Boolean literal:  when: true / when: false
 //   - Object form:      when: { expr: "_.environment == 'prod'" }
+//   - Expression alias: when: { expression: "_.environment == 'prod'" }
+//   - Null:             when: null (treated as unset, nil Expr)
 type Condition struct {
 	Expr *celexp.Expression `json:"expr" yaml:"expr" doc:"CEL expression that must evaluate to boolean" example:"_.environment == 'prod'"`
 }
@@ -61,6 +64,10 @@ func (c *Condition) UnmarshalYAML(unmarshal func(any) error) error {
 	}
 
 	switch v := raw.(type) {
+	case nil:
+		// Null -> zero-value Condition (nil Expr), consistent with spec.Condition.
+		c.Expr = nil
+		return nil
 	case string:
 		expr := celexp.Expression(v)
 		c.Expr = &expr
@@ -76,20 +83,30 @@ func (c *Condition) UnmarshalYAML(unmarshal func(any) error) error {
 		c.Expr = &expr
 		return nil
 	case map[string]any:
-		// Object form: extract "expr" field
-		exprVal, ok := v["expr"]
-		if !ok {
-			return fmt.Errorf("invalid condition object: missing \"expr\" field (valid forms: string, bool, or {expr: \"...\"})")
+		// Object form: extract "expr" or its "expression" alias.
+		exprVal, hasExpr := v["expr"]
+		expressionVal, hasExpression := v["expression"]
+		if hasExpr && hasExpression {
+			return fmt.Errorf("invalid condition object: specify either \"expr\" or \"expression\", not both")
 		}
-		exprStr, ok := exprVal.(string)
+		if !hasExpr && !hasExpression {
+			return fmt.Errorf("invalid condition object: missing \"expr\" field (valid forms: string, bool, or {expr: \"...\"} / {expression: \"...\"})")
+		}
+		val := exprVal
+		key := "expr"
+		if hasExpression {
+			val = expressionVal
+			key = "expression"
+		}
+		exprStr, ok := val.(string)
 		if !ok {
-			return fmt.Errorf("invalid condition object: \"expr\" must be a string, got %T", exprVal)
+			return fmt.Errorf("invalid condition object: \"%s\" must be a string, got %T", key, val)
 		}
 		expr := celexp.Expression(exprStr)
 		c.Expr = &expr
 		return nil
 	default:
-		return fmt.Errorf("invalid condition: expected string, bool, or {expr: \"...\"} object, got %T", raw)
+		return fmt.Errorf("invalid condition: expected string, bool, or {expr: \"...\"} / {expression: \"...\"} object, got %T", raw)
 	}
 }
 
@@ -98,6 +115,12 @@ func (c *Condition) UnmarshalYAML(unmarshal func(any) error) error {
 //   - bool   → converted to literal "true" or "false" CEL expression
 //   - object → standard {expr: "..."} form
 func (c *Condition) UnmarshalJSON(data []byte) error {
+	// Null -> zero-value Condition (nil Expr), consistent with spec.Condition.
+	if string(bytes.TrimSpace(data)) == "null" {
+		c.Expr = nil
+		return nil
+	}
+
 	// Try string first
 	var s string
 	if err := json.Unmarshal(data, &s); err == nil {
@@ -120,16 +143,25 @@ func (c *Condition) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	// Try object form {expr: "..."}
-	type conditionAlias Condition
-	var obj conditionAlias
+	// Try object form {expr: "..."} or its {expression: "..."} alias.
+	var obj struct {
+		Expr       *celexp.Expression `json:"expr"`
+		Expression *celexp.Expression `json:"expression"`
+	}
 	if err := json.Unmarshal(data, &obj); err != nil {
-		return fmt.Errorf("invalid condition: expected string, bool, or {\"expr\": \"...\"} object: %w", err)
+		return fmt.Errorf("invalid condition: expected string, bool, or {\"expr\": \"...\"} / {\"expression\": \"...\"} object: %w", err)
 	}
-	if obj.Expr == nil {
-		return fmt.Errorf("invalid condition object: missing \"expr\" field (valid forms: string, bool, or {\"expr\": \"...\"})")
+	if obj.Expr != nil && obj.Expression != nil {
+		return fmt.Errorf("invalid condition object: specify either \"expr\" or \"expression\", not both")
 	}
-	*c = Condition(obj)
+	expr := obj.Expr
+	if obj.Expression != nil {
+		expr = obj.Expression
+	}
+	if expr == nil {
+		return fmt.Errorf("invalid condition object: missing \"expr\" field (valid forms: string, bool, or {\"expr\": \"...\"} / {\"expression\": \"...\"})")
+	}
+	c.Expr = expr
 	return nil
 }
 
@@ -215,20 +247,22 @@ type ValidatePhase struct {
 
 // ProviderSource represents a single source in the resolve phase
 type ProviderSource struct {
-	Provider string               `json:"provider" yaml:"provider" doc:"Provider name" example:"parameter" maxLength:"100" pattern:"^[a-zA-Z][a-zA-Z0-9_-]*$" patternDescription:"Must start with a letter, followed by letters, numbers, underscores, or hyphens"`
-	Inputs   map[string]*ValueRef `json:"inputs,omitempty" yaml:"inputs,omitempty" doc:"Provider inputs" required:"false"`
-	When     *Condition           `json:"when,omitempty" yaml:"when,omitempty" doc:"Source-level condition"`
-	OnError  ErrorBehavior        `json:"onError,omitempty" yaml:"onError,omitempty" doc:"Behavior when provider fails (continue, fail). Defaults to continue (fallback chain semantics). Use fail to stop on first error." example:"continue" default:"continue"`
-	ForEach  *ForEachClause       `json:"forEach,omitempty" yaml:"forEach,omitempty" doc:"Iterate over array, executing provider for each element. Requires forEach.in (no __self in resolve phase)."`
+	Provider        string               `json:"provider" yaml:"provider" doc:"Provider name" example:"parameter" maxLength:"100" pattern:"^[a-zA-Z][a-zA-Z0-9_-]*$" patternDescription:"Must start with a letter, followed by letters, numbers, underscores, or hyphens"`
+	Inputs          map[string]*ValueRef `json:"inputs,omitempty" yaml:"inputs,omitempty" doc:"Provider inputs" required:"false"`
+	When            *Condition           `json:"when,omitempty" yaml:"when,omitempty" doc:"Source-level condition"`
+	ContinueOnError *Condition           `json:"continueOnError,omitempty" yaml:"continueOnError,omitempty" doc:"Whether to continue (recover) when the provider fails. Accepts a boolean or a CEL expression evaluated with the error text bound as __error. Truthy skips this source and continues the fallback chain; falsy fails the resolver. Overrides the deprecated onError field."`
+	OnError         ErrorBehavior        `json:"onError,omitempty" yaml:"onError,omitempty" deprecated:"true" deprecatedReplacement:"continueOnError" doc:"DEPRECATED: use continueOnError instead. Behavior when provider fails (continue, fail). Defaults to continue (fallback chain semantics). Use fail to stop on first error." example:"continue" default:"continue"`
+	ForEach         *ForEachClause       `json:"forEach,omitempty" yaml:"forEach,omitempty" doc:"Iterate over array, executing provider for each element. Requires forEach.in (no __self in resolve phase)."`
 }
 
 // ProviderTransform represents a single transform step
 type ProviderTransform struct {
-	Provider string               `json:"provider" yaml:"provider" doc:"Provider name" example:"cel" maxLength:"100" pattern:"^[a-zA-Z][a-zA-Z0-9_-]*$" patternDescription:"Must start with a letter, followed by letters, numbers, underscores, or hyphens"`
-	Inputs   map[string]*ValueRef `json:"inputs,omitempty" yaml:"inputs,omitempty" doc:"Provider inputs" required:"false"`
-	When     *Condition           `json:"when,omitempty" yaml:"when,omitempty" doc:"Step-level condition"`
-	OnError  ErrorBehavior        `json:"onError,omitempty" yaml:"onError,omitempty" doc:"Behavior when provider fails (continue, fail)" example:"fail" default:"fail"`
-	ForEach  *ForEachClause       `json:"forEach,omitempty" yaml:"forEach,omitempty" doc:"Iterate over array, executing provider for each element"`
+	Provider        string               `json:"provider" yaml:"provider" doc:"Provider name" example:"cel" maxLength:"100" pattern:"^[a-zA-Z][a-zA-Z0-9_-]*$" patternDescription:"Must start with a letter, followed by letters, numbers, underscores, or hyphens"`
+	Inputs          map[string]*ValueRef `json:"inputs,omitempty" yaml:"inputs,omitempty" doc:"Provider inputs" required:"false"`
+	When            *Condition           `json:"when,omitempty" yaml:"when,omitempty" doc:"Step-level condition"`
+	ContinueOnError *Condition           `json:"continueOnError,omitempty" yaml:"continueOnError,omitempty" doc:"Whether to continue (recover) when the provider fails. Accepts a boolean or a CEL expression evaluated with the error text bound as __error. Truthy skips this step and keeps the current value; falsy fails the resolver. Overrides the deprecated onError field."`
+	OnError         ErrorBehavior        `json:"onError,omitempty" yaml:"onError,omitempty" deprecated:"true" deprecatedReplacement:"continueOnError" doc:"DEPRECATED: use continueOnError instead. Behavior when provider fails (continue, fail)" example:"fail" default:"fail"`
+	ForEach         *ForEachClause       `json:"forEach,omitempty" yaml:"forEach,omitempty" doc:"Iterate over array, executing provider for each element"`
 }
 
 // ProviderValidation represents a single validation rule

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -383,6 +383,72 @@ func TestCondition_UnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestCondition_UnmarshalYAML_ExpressionAlias(t *testing.T) {
+	t.Parallel()
+
+	t.Run("expression alias", func(t *testing.T) {
+		t.Parallel()
+		var cond Condition
+		err := yaml.Unmarshal([]byte("expression: \"_.env == 'prod'\""), &cond)
+		require.NoError(t, err)
+		require.NotNil(t, cond.Expr)
+		assert.Equal(t, "_.env == 'prod'", string(*cond.Expr))
+	})
+
+	t.Run("both expr and expression rejected", func(t *testing.T) {
+		t.Parallel()
+		var cond Condition
+		err := yaml.Unmarshal([]byte("expr: \"a\"\nexpression: \"b\""), &cond)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not both")
+	})
+
+	t.Run("null is unset", func(t *testing.T) {
+		t.Parallel()
+		var cond Condition
+		err := yaml.Unmarshal([]byte("null"), &cond)
+		require.NoError(t, err)
+		assert.Nil(t, cond.Expr)
+	})
+
+	t.Run("object missing expr and expression", func(t *testing.T) {
+		t.Parallel()
+		var cond Condition
+		err := yaml.Unmarshal([]byte("other: value"), &cond)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing")
+	})
+}
+
+func TestCondition_UnmarshalJSON_ExpressionAlias(t *testing.T) {
+	t.Parallel()
+
+	t.Run("expression alias", func(t *testing.T) {
+		t.Parallel()
+		var cond Condition
+		err := json.Unmarshal([]byte(`{"expression": "_.env == 'prod'"}`), &cond)
+		require.NoError(t, err)
+		require.NotNil(t, cond.Expr)
+		assert.Equal(t, "_.env == 'prod'", string(*cond.Expr))
+	})
+
+	t.Run("both expr and expression rejected", func(t *testing.T) {
+		t.Parallel()
+		var cond Condition
+		err := json.Unmarshal([]byte(`{"expr": "a", "expression": "b"}`), &cond)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not both")
+	})
+
+	t.Run("null is unset", func(t *testing.T) {
+		t.Parallel()
+		var cond Condition
+		err := json.Unmarshal([]byte(`null`), &cond)
+		require.NoError(t, err)
+		assert.Nil(t, cond.Expr)
+	})
+}
+
 func TestCondition_UnmarshalYAML_InResolver(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/schema/format.go
+++ b/pkg/schema/format.go
@@ -138,6 +138,9 @@ func (f *Formatter) formatFields(fields []FieldInfo, depth int) {
 		deprecatedStr := ""
 		if field.Deprecated {
 			deprecatedStr = " [DEPRECATED]"
+			if field.DeprecatedReplacement != "" {
+				deprecatedStr += " (use " + field.DeprecatedReplacement + ")"
+			}
 		}
 
 		// Field line

--- a/pkg/schema/introspect.go
+++ b/pkg/schema/introspect.go
@@ -72,6 +72,14 @@ type FieldInfo struct {
 	// Deprecated from the "deprecated" tag
 	Deprecated bool `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 
+	// DeprecatedReplacement from the "deprecatedReplacement" tag names the
+	// field that supersedes this one.
+	DeprecatedReplacement string `json:"deprecatedReplacement,omitempty" yaml:"deprecatedReplacement,omitempty"`
+
+	// DeprecatedMessage from the "deprecatedMessage" tag provides additional
+	// migration guidance.
+	DeprecatedMessage string `json:"deprecatedMessage,omitempty" yaml:"deprecatedMessage,omitempty"`
+
 	// Omitempty indicates if the field has omitempty in json tag
 	Omitempty bool `json:"omitempty,omitempty" yaml:"omitempty,omitempty"`
 
@@ -337,6 +345,8 @@ func introspectFieldWithSeen(f reflect.StructField, depth int, seen map[reflect.
 	if dep := f.Tag.Get("deprecated"); dep == "true" {
 		info.Deprecated = true
 	}
+	info.DeprecatedReplacement = f.Tag.Get("deprecatedReplacement")
+	info.DeprecatedMessage = f.Tag.Get("deprecatedMessage")
 
 	// Omitempty from json tag
 	jsonTag := f.Tag.Get("json")

--- a/pkg/schema/solution_schema.go
+++ b/pkg/schema/solution_schema.go
@@ -194,6 +194,67 @@ func patchSchema(doc map[string]any) {
 	patchSkipValue(defs)
 	patchMapKeyNames(defs)
 	patchJSONSchemaType(defs)
+	patchCondition(defs)
+}
+
+// patchCondition replaces every "*Condition" $def with a schema that accepts
+// all forms supported by Condition.UnmarshalYAML: a non-empty CEL expression
+// string, a boolean literal, or the explicit object form using either an
+// "expr" or "expression" key. Huma only reflects the object form's "expr"
+// field from the struct, which causes false-positive schema violations on the
+// string and boolean shorthands (and on the "expression" alias) used by when,
+// until, and continueOnError. Empty strings are excluded because
+// Condition.UnmarshalYAML rejects them.
+func patchCondition(defs map[string]any) {
+	for key := range defs {
+		if !strings.HasSuffix(key, "Condition") {
+			continue
+		}
+		objectForm, ok := defs[key].(map[string]any)
+		if !ok {
+			continue
+		}
+		defs[key] = map[string]any{
+			"description": "A condition: a non-empty CEL expression string, a boolean " +
+				"literal, or an object {expr: \"...\"} (\"expression\" is also accepted).",
+			"anyOf": []any{
+				map[string]any{"type": "string", "minLength": 1},
+				map[string]any{"type": "boolean"},
+				conditionObjectSchema(objectForm),
+			},
+		}
+	}
+}
+
+// conditionObjectSchema returns the object form for a Condition, extending the
+// Huma-reflected schema (which only exposes "expr") to also accept the
+// "expression" key alias supported by Condition.UnmarshalYAML. Either key
+// satisfies the requirement, matching the runtime which accepts one or the
+// other (but not both).
+func conditionObjectSchema(objectForm map[string]any) map[string]any {
+	props, ok := objectForm["properties"].(map[string]any)
+	if !ok {
+		return objectForm
+	}
+	exprSchema, ok := props["expr"]
+	if !ok {
+		return objectForm
+	}
+	if _, exists := props["expression"]; !exists {
+		props["expression"] = exprSchema
+	}
+	// Replace the reflected "required: [expr]" with a constraint that accepts
+	// either the "expr" or "expression" key, but not both (the runtime
+	// Condition unmarshallers reject specifying both keys).
+	delete(objectForm, "required")
+	objectForm["anyOf"] = []any{
+		map[string]any{"required": []any{"expr"}},
+		map[string]any{"required": []any{"expression"}},
+	}
+	objectForm["not"] = map[string]any{
+		"required": []any{"expr", "expression"},
+	}
+	return objectForm
 }
 
 // patchMapKeyNames removes "name" from the required list for types where

--- a/pkg/schema/validate_test.go
+++ b/pkg/schema/validate_test.go
@@ -86,6 +86,97 @@ func TestValidateSolutionAgainstSchema(t *testing.T) {
 	})
 }
 
+func TestValidateSolutionAgainstSchema_ConditionShorthand(t *testing.T) {
+	// Conditions (when, until, continueOnError) support a CEL string, a boolean
+	// literal, or the object form using either an "expr" or "expression" key.
+	// All forms must validate against the generated schema.
+	conditionForms := map[string]any{
+		"string":            "1 == 1",
+		"bool":              true,
+		"object":            map[string]any{"expr": "1 == 1"},
+		"object expression": map[string]any{"expression": "1 == 1"},
+	}
+
+	for name, cond := range conditionForms {
+		t.Run("source when "+name, func(t *testing.T) {
+			resetSolutionSchemaOnce()
+			data := conditionSolution(map[string]any{"when": cond})
+			violations, err := ValidateSolutionAgainstSchema(data)
+			require.NoError(t, err)
+			assert.Empty(t, violations, "%s when shorthand should validate", name)
+		})
+
+		t.Run("source continueOnError "+name, func(t *testing.T) {
+			resetSolutionSchemaOnce()
+			data := conditionSolution(map[string]any{"continueOnError": cond})
+			violations, err := ValidateSolutionAgainstSchema(data)
+			require.NoError(t, err)
+			assert.Empty(t, violations, "%s continueOnError shorthand should validate", name)
+		})
+	}
+
+	t.Run("invalid condition type is flagged", func(t *testing.T) {
+		resetSolutionSchemaOnce()
+		// An array is not a valid condition form.
+		data := conditionSolution(map[string]any{"when": []any{"1 == 1"}})
+		violations, err := ValidateSolutionAgainstSchema(data)
+		require.NoError(t, err)
+		assert.NotEmpty(t, violations, "array condition should produce violations")
+	})
+
+	t.Run("empty string condition is flagged", func(t *testing.T) {
+		resetSolutionSchemaOnce()
+		// Condition.UnmarshalYAML rejects empty strings, so the schema must too.
+		data := conditionSolution(map[string]any{"when": ""})
+		violations, err := ValidateSolutionAgainstSchema(data)
+		require.NoError(t, err)
+		assert.NotEmpty(t, violations, "empty string condition should produce violations")
+	})
+
+	t.Run("both expr and expression keys are flagged", func(t *testing.T) {
+		resetSolutionSchemaOnce()
+		// The runtime Condition unmarshallers reject specifying both keys, so
+		// the schema must reject it too.
+		data := conditionSolution(map[string]any{
+			"when": map[string]any{"expr": "1 == 1", "expression": "1 == 1"},
+		})
+		violations, err := ValidateSolutionAgainstSchema(data)
+		require.NoError(t, err)
+		assert.NotEmpty(t, violations, "specifying both expr and expression should produce violations")
+	})
+}
+
+// conditionSolution builds a minimal solution whose single source carries the
+// supplied extra keys (e.g., a when or continueOnError condition).
+func conditionSolution(sourceExtra map[string]any) map[string]any {
+	source := map[string]any{
+		"provider": "static",
+		"inputs":   map[string]any{"value": "hi"},
+	}
+	for k, v := range sourceExtra {
+		source[k] = v
+	}
+	return map[string]any{
+		"apiVersion": "scafctl.io/v1",
+		"kind":       "Solution",
+		"metadata": map[string]any{
+			"name":    "test-solution",
+			"version": "1.0.0",
+		},
+		"spec": map[string]any{
+			"resolvers": map[string]any{
+				"a": map[string]any{
+					"name":        "a",
+					"description": "d",
+					"resolve": map[string]any{
+						"with": []any{source},
+					},
+				},
+			},
+		},
+	}
+}
+
 func TestJsonPointerToDotPath(t *testing.T) {
 	tests := []struct {
 		pointer  string

--- a/pkg/spec/foreach.go
+++ b/pkg/spec/foreach.go
@@ -25,9 +25,19 @@ type ForEachClause struct {
 	// 0 (default) means unlimited parallelism.
 	Concurrency int `json:"concurrency,omitempty" yaml:"concurrency,omitempty" doc:"Maximum parallel iterations (0=unlimited)" minimum:"0" example:"5"`
 
+	// ContinueOnError controls whether a failed iteration allows execution to
+	// continue. It accepts a boolean or a CEL expression evaluated per iteration
+	// with the structured error bound as __error and the iteration variables
+	// (__item/__index plus any configured aliases) in scope. Truthy continues
+	// with the remaining iterations; falsy aborts. Overrides the deprecated
+	// OnError field. This field is only used by actions; resolvers ignore it.
+	ContinueOnError *Condition `json:"continueOnError,omitempty" yaml:"continueOnError,omitempty" doc:"Whether to continue when an iteration fails (actions only). Accepts a boolean or a CEL expression evaluated per iteration with __error and the iteration variables in scope. Overrides the deprecated onError field."`
+
 	// OnError defines behavior when an iteration fails.
 	// This field is only used by actions; resolvers ignore it.
-	OnError OnErrorBehavior `json:"onError,omitempty" yaml:"onError,omitempty" doc:"Error handling behavior (actions only)" example:"fail" default:"fail"`
+	//
+	// Deprecated: use ContinueOnError instead.
+	OnError OnErrorBehavior `json:"onError,omitempty" yaml:"onError,omitempty" deprecated:"true" deprecatedReplacement:"continueOnError" doc:"DEPRECATED: use continueOnError instead. Error handling behavior (actions only)" example:"fail" default:"fail"`
 
 	// KeepSkipped controls whether items skipped by a when condition are
 	// retained as nil entries in the output array.
@@ -35,4 +45,28 @@ type ForEachClause struct {
 	// only the items that were actually processed. Set to true when you need
 	// the output array to remain index-aligned with the input array.
 	KeepSkipped bool `json:"keepSkipped,omitempty" yaml:"keepSkipped,omitempty" doc:"Retain nil entries for items skipped by when condition (default: false)"`
+}
+
+// EffectiveOnError returns the static, render-time error-handling behavior for
+// the clause. A literal boolean continueOnError maps directly (true =>
+// OnErrorContinue, false => OnErrorFail); a non-literal CEL expression cannot be
+// reduced to a static behavior here, so the deprecated OnError enum is used as
+// the display value. This method is only a rendering approximation: the
+// authoritative per-iteration decision -- including non-literal CEL
+// continueOnError expressions evaluated against the iteration's
+// __error/__item/__index context -- is made at runtime by the action executor
+// (see Executor.actionShouldContinue / effectiveOnErrorPolicy).
+func (f *ForEachClause) EffectiveOnError() OnErrorBehavior {
+	if f == nil {
+		return OnErrorFail
+	}
+	if f.ContinueOnError != nil && f.ContinueOnError.Expr != nil {
+		switch string(*f.ContinueOnError.Expr) {
+		case "true":
+			return OnErrorContinue
+		case "false":
+			return OnErrorFail
+		}
+	}
+	return f.OnError.OrDefault()
 }

--- a/pkg/spec/foreach_test.go
+++ b/pkg/spec/foreach_test.go
@@ -6,6 +6,7 @@ package spec
 import (
 	"testing"
 
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,4 +36,34 @@ func TestForEachClause_WithValues(t *testing.T) {
 	assert.Equal(t, inRef, f.In)
 	assert.Equal(t, 5, f.Concurrency)
 	assert.Equal(t, OnErrorContinue, f.OnError)
+}
+
+func condExpr(expr string) *Condition {
+	e := celexp.Expression(expr)
+	return &Condition{Expr: &e}
+}
+
+func TestForEachClause_EffectiveOnError(t *testing.T) {
+	tests := []struct {
+		name string
+		fe   *ForEachClause
+		want OnErrorBehavior
+	}{
+		{"nil clause defaults to fail", nil, OnErrorFail},
+		{"empty clause defaults to fail", &ForEachClause{}, OnErrorFail},
+		{"literal true continueOnError", &ForEachClause{ContinueOnError: condExpr("true")}, OnErrorContinue},
+		{"literal false continueOnError", &ForEachClause{ContinueOnError: condExpr("false")}, OnErrorFail},
+		{
+			"non-literal CEL falls back to onError",
+			&ForEachClause{ContinueOnError: condExpr(`__item != ""`), OnError: OnErrorContinue},
+			OnErrorContinue,
+		},
+		{"deprecated onError continue", &ForEachClause{OnError: OnErrorContinue}, OnErrorContinue},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.fe.EffectiveOnError())
+		})
+	}
 }

--- a/tests/integration/solutions/actions/continue-on-error/solution.yaml
+++ b/tests/integration/solutions/actions/continue-on-error/solution.yaml
@@ -1,0 +1,186 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-action-continue-on-error
+  version: 1.0.0
+  description: |
+    Functional tests for action-level and forEach continueOnError.
+    A truthy continueOnError (boolean or a CEL condition evaluated with the
+    structured error bound as __error) lets the workflow proceed past a failed
+    action; a falsy condition stops it. The deprecated onError enum is also
+    exercised to confirm it still works for back-compat, and forEach
+    continueOnError is verified through the rendered EffectiveOnError value.
+
+spec:
+  resolvers:
+    # Gates the non-recovering action so the default run stays green while a
+    # dedicated negative case (-r failHard=true) exercises the failure path.
+    failHard:
+      description: Whether to include the non-recovering action
+      resolve:
+        with:
+          - provider: parameter
+            continueOnError: true
+            inputs:
+              key: failHard
+          - provider: static
+            inputs:
+              value: false
+
+    targets:
+      description: forEach targets
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - alpha
+                - bravo
+                - gamma
+
+  workflow:
+    actions:
+      independent:
+        description: Independent action that always succeeds
+        provider: exec
+        inputs:
+          command: "echo independent-ok"
+
+      boolContinue:
+        description: Failing action recovered by a boolean continueOnError
+        provider: exec
+        continueOnError: true
+        inputs:
+          command: "sh -c 'exit 1'"
+
+      celRecover:
+        description: Failing action recovered by a CEL continueOnError using __error
+        provider: exec
+        # __error.attempt carries the real attempt count (1 here, since no retry
+        # is configured), so this condition reliably recovers while still
+        # exercising the __error binding.
+        continueOnError: '__error.attempt == 1'
+        inputs:
+          command: "sh -c 'exit 1'"
+
+      deprecatedContinue:
+        description: Failing action recovered by the deprecated onError enum
+        provider: exec
+        onError: continue
+        inputs:
+          command: "sh -c 'exit 1'"
+
+      foreachContinue:
+        description: forEach action carrying a continueOnError clause
+        provider: exec
+        forEach:
+          in:
+            expr: "_.targets"
+          continueOnError: true
+        inputs:
+          command:
+            expr: "'echo deploying ' + __item"
+
+      foreachCelRecover:
+        description: forEach whose failing iterations recover via a CEL continueOnError
+        provider: exec
+        forEach:
+          in:
+            expr: "_.targets"
+          # Every iteration fails; the CEL condition recovers each one using the
+          # per-iteration __item/__error context wired through at runtime.
+          continueOnError: '__item != "" && __error.attempt == 1'
+        inputs:
+          command:
+            expr: "'sh -c \"echo ' + __item + ' >&2; exit 1\"'"
+
+      hardFail:
+        description: Failing action whose continueOnError never matches (aborts)
+        provider: exec
+        when:
+          expr: "_.failHard == true"
+        continueOnError: '__error.attempt == 99'
+        inputs:
+          command: "sh -c 'exit 1'"
+
+  testing:
+    cases:
+      _run-base:
+        description: Base template for run tests (default run excludes hardFail)
+        command: [run, solution]
+        args: ["-o", "json"]
+        tags: [action, continueonerror]
+        assertions:
+          - expression: __exitCode == 0
+
+      _render-base:
+        description: Base template for render tests
+        command: [render, solution]
+        args: ["-o", "json"]
+        tags: [action, continueonerror, render]
+        assertions:
+          - expression: __exitCode == 0
+
+      workflow-continues:
+        description: Recovered failures do not abort the workflow
+        extends: [_run-base]
+        tags: [smoke]
+        assertions:
+          - expression: __output.actions["independent"].status == "succeeded"
+            message: "Independent action should still run and succeed"
+          - expression: __output.status == "partial-success"
+            message: "Overall status should be partial-success when actions recover"
+
+      bool-continue-recovers:
+        description: Boolean continueOnError recovers a failed action
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["boolContinue"].status == "failed"
+            message: "Recovered action keeps a failed status but does not abort"
+
+      cel-continue-recovers:
+        description: CEL continueOnError using __error recovers a failed action
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["celRecover"].status == "failed"
+            message: "Matching __error condition should recover without aborting"
+
+      deprecated-onerror-recovers:
+        description: Deprecated onError continue still recovers a failed action
+        extends: [_run-base]
+        tags: [deprecated]
+        assertions:
+          - expression: __output.actions["deprecatedContinue"].status == "failed"
+            message: "Deprecated onError: continue should still recover"
+
+      foreach-continue-effective:
+        description: forEach continueOnError maps to the effective continue behavior
+        extends: [_render-base]
+        assertions:
+          - expression: >
+              __output.actions.exists(k,
+                __output.actions[k].forEach.expandedFrom == "foreachContinue" &&
+                __output.actions[k].forEach.onError == "continue")
+            message: "forEach continueOnError: true should render as onError continue"
+
+      foreach-cel-continue-recovers:
+        description: A CEL forEach continueOnError recovers every failed iteration
+        extends: [_run-base]
+        assertions:
+          - expression: __output.actions["foreachCelRecover[0]"].status == "failed"
+            message: "Failed forEach iteration keeps a failed status"
+          - expression: __output.actions["foreachCelRecover[2]"].status == "failed"
+            message: "All failed forEach iterations keep a failed status"
+          - expression: __output.status == "partial-success"
+            message: "A matching CEL forEach continueOnError must not abort the workflow"
+
+      non-matching-fails:
+        description: A non-matching continueOnError aborts the workflow
+        command: [run, solution]
+        args: ["-o", "json", "-r", "failHard=true"]
+        tags: [action, continueonerror, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+            message: "Non-matching continueOnError should fail the workflow"

--- a/tests/integration/solutions/resolvers/continueonerror/solution.yaml
+++ b/tests/integration/solutions/resolvers/continueonerror/solution.yaml
@@ -1,0 +1,151 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-resolver-continueonerror
+  version: 1.0.0
+  description: |
+    Functional tests for continueOnError conditional error recovery on
+    resolver sources and transforms. The failing error text is bound to
+    the top-level __error variable. A truthy condition recovers
+    (source skipped / transform value kept); a falsy condition fails the
+    resolver, overriding the phase default behavior. The deprecated onError
+    field is also exercised to confirm it still works for back-compat.
+
+spec:
+  resolvers:
+    # Source-level: condition matches the real error -> recover to fallback.
+    sourceRecover:
+      description: Recoverable source error falls through to the static fallback
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: ./missing-source-file.txt
+            continueOnError: '__error.contains("file does not exist")'
+          - provider: static
+            inputs:
+              value: "recovered-fallback"
+
+    # Source-level: condition does not match -> resolver fails, even though
+    # the resolve phase would normally fall through to the next source.
+    sourceFail:
+      description: Non-matching source error fails the resolver
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: ./missing-source-file.txt
+            continueOnError: '__error.contains("timeout")'
+          - provider: static
+            inputs:
+              value: "should-not-be-reached"
+
+    # Transform-level: condition matches -> keep the upstream value.
+    transformRecover:
+      description: Recoverable transform error keeps the current value
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "base-value"
+      transform:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: ./missing-transform-file.txt
+            continueOnError: '__error.contains("file does not exist")'
+
+    # Transform-level: condition does not match -> resolver fails, overriding
+    # the transform default (the transform default is fail anyway, but this
+    # documents that continueOnError takes precedence when set).
+    transformFail:
+      description: Non-matching transform error fails the resolver
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "base-value"
+      transform:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: ./missing-transform-file.txt
+            continueOnError: '__error.contains("timeout")'
+
+    # Deprecated onError field still works: onError: continue recovers the
+    # source to the fallback (back-compat path).
+    deprecatedOnError:
+      description: Deprecated onError still recovers the source to the fallback
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: ./missing-source-file.txt
+            onError: continue
+          - provider: static
+            inputs:
+              value: "deprecated-fallback"
+
+  testing:
+    config:
+      # sourceFail and transformFail intentionally fail to resolve.
+      skipBuiltins: [resolve-defaults]
+
+    cases:
+      source-recover:
+        description: Matching continueOnError recovers the source to the fallback
+        command: [run, resolver, sourceRecover]
+        args: ["-o", "json"]
+        tags: [resolver, continueonerror, smoke]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: '__output.sourceRecover == "recovered-fallback"'
+            message: "Matching condition should skip the failed source"
+
+      source-fail:
+        description: Non-matching continueOnError fails the resolver
+        command: [run, resolver, sourceFail]
+        args: ["-o", "json"]
+        tags: [resolver, continueonerror, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+          - expression: '__stderr.contains("file does not exist")'
+            message: "Original error should surface when the condition does not match"
+
+      transform-recover:
+        description: Matching continueOnError keeps the upstream transform value
+        command: [run, resolver, transformRecover]
+        args: ["-o", "json"]
+        tags: [resolver, continueonerror]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: '__output.transformRecover == "base-value"'
+            message: "Matching condition should keep the current value"
+
+      transform-fail:
+        description: Non-matching continueOnError fails the resolver in transform
+        command: [run, resolver, transformFail]
+        args: ["-o", "json"]
+        tags: [resolver, continueonerror, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+          - expression: '__stderr.contains("file does not exist")'
+            message: "Original transform error should surface on no match"
+
+      deprecated-onerror:
+        description: Deprecated onError continue still recovers the source
+        command: [run, resolver, deprecatedOnError]
+        args: ["-o", "json"]
+        tags: [resolver, continueonerror, deprecated]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: '__output.deprecatedOnError == "deprecated-fallback"'
+            message: "Deprecated onError: continue should still skip the failed source"

--- a/tests/integration/solutions/resolvers/param-keys/solution.yaml
+++ b/tests/integration/solutions/resolvers/param-keys/solution.yaml
@@ -1,0 +1,80 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-resolver-param-keys
+  version: 1.0.0
+  description: |
+    Functional tests for the parameter provider "keys" alias list.
+    Verifies first-match-wins ordering across alias names, default
+    fallback when no alias is provided, and that every alias name is
+    accepted by CLI parameter-key validation.
+
+spec:
+  resolvers:
+    environment:
+      description: Target environment, accepted under several alias names
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              keys: [environment, e, env]
+              default: dev
+
+  testing:
+    cases:
+      _base:
+        description: Base template
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [resolver, parameter, keys]
+        assertions:
+          - expression: __exitCode == 0
+
+      default-when-no-alias:
+        description: Falls back to default when no alias is provided
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: '__output.environment == "dev"'
+            message: "Should use the default value"
+
+      primary-key-accepted:
+        description: The primary alias name resolves
+        extends: [_base]
+        args: ["-o", "json", "-r", "environment=prod"]
+        assertions:
+          - expression: '__output.environment == "prod"'
+
+      secondary-alias-accepted:
+        description: A secondary alias name resolves and is a valid key
+        extends: [_base]
+        args: ["-o", "json", "-r", "e=staging"]
+        assertions:
+          - expression: '__output.environment == "staging"'
+            message: "Alias 'e' should be accepted and resolve"
+
+      third-alias-accepted:
+        description: A third alias name resolves and is a valid key
+        extends: [_base]
+        args: ["-o", "json", "-r", "env=qa"]
+        assertions:
+          - expression: '__output.environment == "qa"'
+
+      first-match-wins:
+        description: When multiple aliases are provided, the earliest in the list wins
+        extends: [_base]
+        args: ["-o", "json", "-r", "e=staging", "-r", "environment=prod"]
+        assertions:
+          - expression: '__output.environment == "prod"'
+            message: "Primary 'environment' precedes 'e' in the keys list"
+
+      unknown-key-rejected:
+        description: A name not in the keys list is rejected by validation
+        command: [run, resolver]
+        args: ["-o", "json", "-r", "zzzzz=value"]
+        tags: [resolver, parameter, keys, negative]
+        assertions:
+          - expression: __exitCode != 0
+          - expression: '__stderr.contains("does not accept input")'
+            message: "Names outside the keys list are not accepted"


### PR DESCRIPTION
Introduce a CEL/boolean continueOnError field across resolver sources, transform steps, actions, and forEach clauses, deprecating the onError enum. Add parameter aliasing and two new lint rules.

- Add ContinueOnError (*Condition) to resolver ProviderSource, ProviderTransform, action Action, and spec ForEachClause; accepts a bool or CEL expression with the error bound as __error
- Deprecate onError via struct tags (deprecated, deprecatedReplacement); continueOnError takes precedence when both are set
- Add ForEachClause.EffectiveOnError to fold continueOnError into the clause-level default
- Add parameter provider "keys" input for first-match-wins aliases so a logical parameter can be supplied under any of several names
- Extend extractParameterKeys to surface "keys" aliases for -r hints
- Add lint rule that flags deprecated fields by reflecting struct tags and warns (or errors on conflict) when a deprecated field is set
- Add lint rule that flags .orValue(...) on provably-concrete CEL receivers, which fail at runtime since orValue only overloads optionals
- Update schema, MCP action tools, examples, and tutorials accordingly

BREAKING CHANGE: onError is deprecated in favor of continueOnError on resolver sources, transform steps, actions, and forEach clauses.