### PR TITLE
feat(auth): add host-side hostname resolution and per-handler config

### DIFF
--- a/docs/design/hostname-resolution.md
+++ b/docs/design/hostname-resolution.md
@@ -1,0 +1,283 @@
+---
+title: "Host-Aware Login and Hostname Resolution"
+weight: 24
+---
+
+# Host-Aware Login and Hostname Resolution
+
+**Issues**:
+[#569](https://github.com/oakwood-commons/scafctl/issues/569),
+[#570](https://github.com/oakwood-commons/scafctl/issues/570),
+[#571](https://github.com/oakwood-commons/scafctl/issues/571),
+[#572](https://github.com/oakwood-commons/scafctl/issues/572)
+**Status**: Implemented (not yet released)
+
+---
+
+## Problem
+
+Some auth handlers (notably an OpenShift/Kubernetes-style handler) authenticate
+against a specific endpoint. Users must pass the concrete API server URL at
+login:
+
+~~~bash
+scafctl auth login openshift --hostname https://api.cluster-01.example.com:6443
+~~~
+
+For a large fleet (hundreds of clusters) this is error-prone and unmemorable.
+Users want to log in with a short selector:
+
+~~~bash
+scafctl auth login openshift --hostname cluster-01
+~~~
+
+The mapping from selector to endpoint must be:
+
+- **Configurable per handler** -- different handlers have different fleets.
+- **Static or dynamic** -- small teams alias a handful of endpoints by hand;
+  large orgs have a live inventory endpoint listing every cluster.
+- **Shape-blind in the core** -- scafctl must not hardcode any organization's
+  inventory JSON format. Each org adapts its own shape.
+- **Non-interactive at resolution time** -- resolving a selector must never
+  trigger a browser login on its own.
+
+Two supporting configuration capabilities were needed to make this ergonomic:
+
+- A CLI to manage static aliases without hand-editing YAML (#569).
+- A drop-in `config.d` layering mechanism so tooling can supply handler and
+  hostname config without clobbering the user's main file (#571), plus a way
+  for embedders to discover the config directory (#572).
+
+---
+
+## Design
+
+### Configuration model (#570)
+
+Per-handler configuration lives under `auth.handlers.<name>`. The host consumes
+a reserved `hostname` block; every other key is forwarded opaquely to the
+handler plugin.
+
+~~~yaml
+auth:
+  handlers:
+    openshift:
+      hostname:
+        aliases:
+          prod: https://api.prod.example.com:6443
+        resolver:
+          source:
+            url: https://clusters.example.com/inventory
+            authProvider: entra
+            authScope: api://fleet-inventory/.default
+            headers:
+              Accept: application/json
+          transform: |
+            _.map(k, _[k].status != "deleted", {
+              "name": k,
+              "url": _[k].apiServerURL,
+            })
+          ttl: 1h
+      # Any other key (not "hostname") is passed to the plugin unchanged.
+      apiTimeout: 30s
+~~~
+
+Types (in `pkg/config/types.go`):
+
+- `GlobalAuthConfig.Handlers map[string]HandlerConfig`
+- `HandlerConfig{ Hostname *HostnameConfig; Settings map[string]any }`
+  -- `Settings` uses `mapstructure:",remain"` to capture passthrough keys.
+- `HostnameConfig{ Aliases map[string]string; Resolver *HostnameResolverConfig }`
+- `HostnameResolverConfig{ Source HostnameResolverSource; Transform string; TTL string }`
+- `HostnameResolverSource{ URL, AuthProvider, AuthScope string; Headers map[string]string }`
+
+The core is shape-blind: an organization adapts its inventory response entirely
+through the CEL `transform`. The canonical normalized contract is a
+**list of `{name, url}` objects**.
+
+### Resolution precedence
+
+For a given `--hostname <selector>`, the host resolves in this order (first
+match wins):
+
+1. **Concrete URL** -- the selector already parses as an `http`/`https` URL;
+   forward unchanged.
+2. **Static alias** -- a `hostname.aliases` entry.
+3. **Dynamic resolver** -- fetch the inventory, run the transform, match by
+   `name`.
+4. Otherwise fail, listing the available selectors.
+
+Static aliases overlay the dynamic inventory: if both define the same selector,
+the alias wins.
+
+### Host resolution package (`pkg/auth/hostname`)
+
+The resolver is a small, dependency-injected core so it is fully unit-testable
+without network or disk:
+
+~~~go
+func ResolveWith(
+    ctx context.Context,
+    cfg *config.HostnameConfig,
+    handler, selector string,
+    deps Deps,
+) (string, error)
+~~~
+
+`Deps` carries `Fetch`, `Token`, `Transform`, `Cache`, and `Now`, each with a
+production default via `withDefaults()`. `Resolve(ctx, handler, selector)` is
+the thin production entry point: it pulls the handler's `HostnameConfig` from
+`config.FromContext(ctx)` and calls `ResolveWith` with disk-backed defaults.
+
+Sentinel errors (`errors.go`): `ErrSelectorNotFound`, `ErrResolverLoop`,
+`ErrTransformShape`, `ErrNoCredentials`.
+
+- **Fetch** (`fetch.go`) -- validates the URL scheme, builds an `httpc` client
+  from the app HTTP config, GETs with `Accept: application/json`, static
+  headers, and an optional `Bearer` token, and reads a size-limited body.
+- **Transform** (`transform.go`) -- JSON-unmarshals the body, evaluates the CEL
+  transform (`celexp.EvaluateExpression`) with the body bound to `_`, then
+  round-trips the result through JSON into `[]Entry`, validating that each entry
+  has a non-empty `name` and `url`. Any other shape yields `ErrTransformShape`.
+- **Token** (`token.go`) -- `tokenprovider.GetToken` with
+  `Caller: callerscope.ServerCaller`. This is cached and non-interactive: if the
+  user is not already logged in to the `authProvider`, it errors (wrapped as
+  `ErrNoCredentials` with a hint to run `auth login <provider>` first) rather
+  than opening a browser.
+
+**Loop guard**: a resolver whose `source.authProvider` equals the handler being
+logged into is rejected (`ErrResolverLoop`) -- a handler cannot bootstrap its
+own inventory token.
+
+### On-disk TTL cache
+
+A single-shot CLI process cannot benefit from an in-memory cache, so the
+inventory cache is a dedicated on-disk JSON store under
+`paths.CacheDir()/hostname/`.
+
+- Key: `sha256(handler \0 source.URL \0 transform)`.
+- File: `{ ExpiresAt time.Time, Entries []Entry }`, written `0600` in a `0700`
+  directory.
+- `Get` treats expired or corrupt entries as a miss (and removes expired ones);
+  `Set` is skipped when `ttl <= 0`.
+- `ttl` parsing treats `""`, `"0"`, negative, and unparseable values as "no
+  caching".
+
+### Login hook (`pkg/cmd/scafctl/auth/login.go`)
+
+After the existing `--hostname`/`CapHostname` capability gate, the command
+resolves the selector before delegating to the handler:
+
+~~~go
+if hostname != "" {
+    resolved, err := hostnameresolver.Resolve(ctx, handlerName, hostname)
+    // ErrSelectorNotFound / ErrResolverLoop / ErrTransformShape -> InvalidInput
+    // otherwise -> GeneralError
+    hostname = resolved
+}
+~~~
+
+The resolved concrete URL is what the plugin receives. Resolution failures never
+call the handler.
+
+### `auth alias` command (#569)
+
+A thin CLI over the static `aliases` map, written to the user's main
+`config.yaml`:
+
+~~~bash
+scafctl auth alias set openshift prod https://api.prod.example.com:6443
+scafctl auth alias list openshift          # kvx table / -o json / -o yaml
+scafctl auth alias remove openshift prod   # prunes empty hostname/handler entries
+~~~
+
+All subcommands gate on `auth.CapHostname` via `getHandler` + `HasCapability`.
+The command follows scafctl conventions: `writer.FromContext` for status
+output, `kvx` for structured `list` output, and `settings.CliBinaryName` ->
+`cliParams.BinaryName` substitution so embedders get their own binary name in
+help text.
+
+### Config layering: `config.d` (#571) and `ConfigDir` (#572)
+
+`Manager.Load()` merges `*.yaml`/`*.yml` fragments from a `config.d/` directory
+next to the main config file, in lexical filename order, **between** the
+embedder base layer and the user's `config.yaml`.
+
+Precedence (lowest to highest):
+
+1. Built-in defaults
+2. Embedder base config (`WithBaseConfig`)
+3. `config.d/*.yaml` fragments (lexical order)
+4. `config.yaml` (user's main file)
+5. Environment variables (`SCAFCTL_*`)
+6. Command-line flags
+
+Maps deep-merge across layers; arrays (e.g. `catalogs`) are replaced by the
+highest-precedence layer that defines them. A missing `config.d` is not an
+error; a malformed fragment fails the load with the offending filename.
+
+`Manager.ConfigDir()` returns the directory containing the config file -- the
+anchor for `config.d` and for embedders that need to locate config-relative
+resources.
+
+---
+
+## Key decisions
+
+1. **Cache backend: dedicated on-disk JSON, not in-memory LRU.** A single-shot
+   CLI invocation has no long-lived process, so an in-memory TTL cache never
+   hits. The on-disk store honors `resolver.ttl` across invocations.
+2. **Token caller scope: reuse `callerscope.ServerCaller`.** Matches the
+   existing non-interactive enumerator precedent -- resolution reads cached
+   tokens only and never triggers interactive login.
+3. **`auth alias set` writes to the main `config.yaml`.** Aliases are
+   user-owned state; they belong in the user's primary file, not a `config.d`
+   fragment (which is for tooling-supplied layers).
+4. **#572 scope is minimal.** `ConfigDir()` plus `WithBaseConfig`/`config.d`
+   cover the need; no new merge path was introduced.
+
+### Serialization note
+
+`HandlerConfig.Settings` is `mapstructure:",remain"` for decode and
+`yaml:",inline"` for encode. The inline tag is required so opaque passthrough
+settings survive a save round-trip (e.g. when `auth alias` rewrites
+`config.yaml`); without it viper's `WriteConfig` would drop them. Viper
+lowercases all config keys, so plugins receive lowercased setting names.
+
+---
+
+## Security considerations
+
+- **No interactive login during resolution.** Inventory token acquisition is
+  cached-only; unauthenticated providers fail with a clear hint.
+- **Trusted-config fetch.** The inventory URL comes from admin-owned config; the
+  fetch validates the scheme (`http`/`https`) and bounds the response size.
+- **Loop protection.** A resolver cannot use the handler it configures as its
+  own `authProvider`.
+- **Cache isolation.** Cache files are keyed by handler + URL + transform and
+  written with restrictive permissions (`0600` in a `0700` directory).
+
+---
+
+## Testing
+
+- `pkg/auth/hostname` -- precedence matrix, loop guard, no-credentials path,
+  transform-shape errors, token injection, cache hit/miss/expiry, TTL parsing,
+  URL validation. Includes the map-keyed transform
+  (`_.map(k, {"name": k, "url": _[k].apiServerURL})`).
+- `pkg/cmd/scafctl/auth` -- login hook (alias resolved, selector-not-found,
+  concrete-URL passthrough, embedder binary name) and the `auth alias` command
+  (set/list/remove, capability rejection, prune, opaque-settings round-trip,
+  embedder binary name).
+- `pkg/config` -- `config.d` merge order and precedence, missing/ malformed
+  fragments, and `ConfigDir` for explicit and default paths.
+
+---
+
+## Related
+
+- [Authentication](auth.md)
+- [Multi-Profile Authentication](multi-profile-auth.md)
+- [Identity Provider](identity-provider.md)
+- Examples: `examples/auth/hostname-resolution.md`,
+  `examples/auth/README.md`, `examples/config/README.md`

--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -30,6 +30,7 @@ This tutorial walks you through setting up and using authentication in scafctl. 
    - [GCP Service Account Key](#gcp-service-account-key-authentication-cicd)
    - [GCP Workload Identity Federation](#gcp-workload-identity-federation)
    - [GCP Metadata Server](#gcp-metadata-server-gcegkecloud-run)
+   - [Host-Aware Login: Hostname Aliases and Dynamic Resolution](#host-aware-login-hostname-aliases-and-dynamic-resolution)
 3. [Checking Auth Status](#checking-auth-status)
 4. [Listing and Sorting Cached Tokens](#listing-and-sorting-cached-tokens)
 5. [Using Auth in HTTP Providers](#using-auth-in-http-providers)
@@ -871,6 +872,93 @@ Invoke-RestMethod "$issuer/.well-known/openid-configuration"
 ```
 {{% /tab %}}
 {{< /tabs >}}
+
+---
+
+## Host-Aware Login: Hostname Aliases and Dynamic Resolution
+
+Handlers that advertise the `hostname` capability accept a `--hostname <selector>`
+argument at login. Instead of memorizing a long API server URL, you log in with a
+short selector (e.g. `prod`) and the scafctl host resolves it into a concrete
+endpoint URL **before** delegating to the handler.
+
+Resolution is host-side and shape-blind: the core never hardcodes any
+organization's inventory format. For a given `--hostname <selector>`, the host
+resolves in this order (first match wins):
+
+1. **Concrete URL** -- if the selector already parses as an `http`/`https` URL,
+   it is forwarded unchanged.
+2. **Static alias** -- a `hostname.aliases` entry mapping selector to URL.
+3. **Dynamic resolver** -- `hostname.resolver` fetches an inventory and
+   normalizes it into `{name, url}` entries; the selector is matched by `name`.
+4. Otherwise, login fails and lists the available selectors.
+
+### Static aliases
+
+Manage aliases with the `auth alias` command. They are written to your
+`config.yaml` under `auth.handlers.<handler>.hostname.aliases`:
+
+```bash
+scafctl auth alias set openshift prod https://api.prod.example.com:6443
+scafctl auth alias set openshift stg  https://api.stg.example.com:6443
+scafctl auth alias list openshift
+scafctl auth alias remove openshift stg
+scafctl auth login openshift --hostname prod
+```
+
+Equivalent config:
+
+```yaml
+auth:
+  handlers:
+    openshift:
+      hostname:
+        aliases:
+          prod: https://api.prod.example.com:6443
+          stg: https://api.stg.example.com:6443
+```
+
+Only handlers that declare the `hostname` capability accept aliases; `auth alias set`
+fails fast otherwise.
+
+### Dynamic resolution
+
+When a fleet has too many endpoints to alias by hand, configure a resolver. At
+login time the host performs an HTTPS GET, runs a CEL transform to normalize the
+response into a list of `{name, url}` entries, and caches the result for the
+configured TTL:
+
+```yaml
+auth:
+  handlers:
+    openshift:
+      hostname:
+        resolver:
+          source:
+            url: https://clusters.example.com/inventory
+            # Optional: inject a bearer token from another auth handler.
+            authProvider: entra
+            authScope: api://fleet-inventory/.default
+          # CEL transform: normalize the fetched JSON (bound to `_`) into a
+          # list of {name, url} objects. Filter out anything not usable.
+          transform: |
+            _.map(k, _[k].status != "deleted", {
+              "name": k,
+              "url": _[k].apiServerURL,
+            })
+          ttl: 1h
+```
+
+The transform must return a list of objects, each with a non-empty `name` and
+`url`; any other shape fails with a clear "transform shape" error. Entries may
+also carry optional per-cluster OIDC metadata (`audience`, `authType`, `caData`,
+`consoleUrl`, `insecureSkipTls`) so a single inventory can drive both
+`auth login --hostname` and `kube login`.
+
+For the full transform contract, caching behavior, authenticated inventory
+endpoints, and troubleshooting, see the
+[hostname resolution example](../../examples/auth/hostname-resolution.md) and the
+[hostname resolution design doc](../design/hostname-resolution.md).
 
 ---
 

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -262,6 +262,52 @@ scafctl auth logout entra --force
 
 ---
 
+## Host-Aware Login and Hostname Aliases
+
+Some auth handlers (those that advertise the `hostname` capability, e.g. an
+OpenShift/Kubernetes handler) accept a `--hostname` selector at login. The host
+resolves that selector into a concrete endpoint URL **before** authenticating,
+using per-handler configuration under `auth.handlers.<name>.hostname`.
+
+Resolution precedence (first match wins):
+
+1. **Concrete URL** -- if `--hostname` is already a URL (`https://...`), it is
+   used as-is.
+2. **Static alias** -- a `hostname.aliases` entry mapping the selector to a URL.
+3. **Dynamic resolver** -- `hostname.resolver` fetches a live inventory and
+   normalizes it into `{name, url}` entries via a CEL transform.
+4. Otherwise login fails with the list of available selectors.
+
+### Managing static aliases
+
+```bash
+# Add or update an alias
+scafctl auth alias set openshift prod https://api.prod.example.com:6443
+
+# List a handler's aliases
+scafctl auth alias list openshift
+scafctl auth alias list openshift -o json
+
+# Remove an alias
+scafctl auth alias remove openshift prod
+
+# Log in using the alias
+scafctl auth login openshift --hostname prod
+```
+
+Aliases are stored in your main `config.yaml` under
+`auth.handlers.<handler>.hostname.aliases`. Only handlers that declare the
+`hostname` capability accept aliases.
+
+### Dynamic hostname resolution
+
+For fleets with many clusters, configure a resolver that fetches the endpoint
+inventory at login time and caches it for a TTL. See
+[hostname-resolution.md](hostname-resolution.md) for a full walkthrough
+(including an authenticated inventory endpoint and the CEL transform contract).
+
+---
+
 ## Handler Lifecycle Management
 
 Official auth handler plugins are downloaded automatically on first use.

--- a/examples/auth/hostname-resolution.md
+++ b/examples/auth/hostname-resolution.md
@@ -1,0 +1,167 @@
+# Host-Aware Login: Hostname Aliases and Dynamic Resolution
+
+Some auth handlers advertise the `hostname` capability, meaning they accept a
+`--hostname <selector>` argument at login. The scafctl host resolves that
+selector into a concrete endpoint URL **before** delegating to the handler
+plugin. This lets users log in with a short, memorable selector (e.g. `prod`)
+instead of a long API server URL.
+
+Resolution is entirely host-side and shape-blind: the core never hardcodes any
+organization's inventory format. Organizations adapt their inventory shape with
+a single CEL transform.
+
+## Resolution precedence
+
+For a given `--hostname <selector>`, the host resolves in this order (first
+match wins):
+
+1. **Concrete URL** -- if the selector already parses as an `http`/`https` URL,
+   it is forwarded unchanged.
+2. **Static alias** -- a `hostname.aliases` entry mapping selector to URL.
+3. **Dynamic resolver** -- `hostname.resolver` fetches an inventory and
+   normalizes it into `{name, url}` entries; the selector is matched by `name`.
+4. Otherwise, login fails and lists the available selectors.
+
+## Static aliases
+
+Manage aliases with the `auth alias` command (they are written to your main
+`config.yaml`):
+
+```bash
+scafctl auth alias set openshift prod https://api.prod.example.com:6443
+scafctl auth alias set openshift stg  https://api.stg.example.com:6443
+scafctl auth alias list openshift
+scafctl auth login openshift --hostname prod
+```
+
+Equivalent config:
+
+```yaml
+auth:
+  handlers:
+    openshift:
+      hostname:
+        aliases:
+          prod: https://api.prod.example.com:6443
+          stg: https://api.stg.example.com:6443
+```
+
+## Dynamic resolution
+
+When a fleet has too many endpoints to alias by hand, configure a resolver. At
+login time the host performs an HTTPS GET, runs a CEL transform to normalize the
+response into a list of `{name, url}` entries, and caches the result for the
+configured TTL.
+
+```yaml
+auth:
+  handlers:
+    openshift:
+      hostname:
+        # Static aliases still win over the resolver when both match.
+        aliases:
+          sandbox: https://api.sandbox.example.com:6443
+        resolver:
+          source:
+            url: https://clusters.example.com/inventory
+            # Optional: inject a bearer token from another auth handler.
+            authProvider: entra
+            authScope: api://fleet-inventory/.default
+            headers:
+              Accept: application/json
+          # CEL transform: normalize the fetched JSON (bound to `_`) into a
+          # list of {name, url} objects. Filter out anything not usable.
+          transform: |
+            _.map(k, _[k].status != "deleted", {
+              "name": k,
+              "url": _[k].apiServerURL,
+            })
+          # Cache the resolved inventory for this long. "0" or empty disables
+          # caching (re-fetch on every login).
+          ttl: 1h
+```
+
+### The transform contract
+
+- The fetched response body is parsed as JSON and bound to `_`.
+- The transform must produce a **list of objects**, each with a non-empty
+  `name` (string) and `url` (string).
+- Any other shape fails with a clear "transform shape" error.
+
+Each entry may also carry optional per-cluster OIDC metadata. These fields
+mirror the cluster model used by `kube login`, so a single inventory can drive
+both `auth login --hostname` and `kube login`:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `audience` | string | OIDC audience / client ID a token for this cluster targets |
+| `authType` | string | Login method: `""` (auto), `oauth`, or `oidc` |
+| `caData` | string | PEM-encoded CA bundle for the endpoint |
+| `consoleUrl` | string | Optional web console URL |
+| `insecureSkipTls` | bool | Disable endpoint TLS verification (dev only) |
+
+Omitted OIDC fields fall back to auto-detection at login time.
+
+The example above handles a **name-keyed map** response, e.g.:
+
+```json
+{
+  "cluster-01": { "clusterName": "cluster-01", "apiServerURL": "https://api.cluster-01.example.com:6443", "clientID": "api://cluster-01/.default", "status": "active" },
+  "cluster-02": { "clusterName": "cluster-02", "apiServerURL": "https://api.cluster-02.example.com:6443", "clientID": "api://cluster-02/.default", "status": "deleted" }
+}
+```
+
+`_.map(k, cond, expr)` iterates the map keys `k`, keeps those where `cond` is
+true, and emits `expr`. To surface OIDC metadata, add the optional fields to the
+emitted object:
+
+```yaml
+transform: |
+  _.map(k, _[k].status != "deleted", {
+    "name": k,
+    "url": _[k].apiServerURL,
+    "audience": _[k].clientID,
+    "authType": "oidc"
+  })
+```
+
+If instead your endpoint returns a **JSON array**, use a list comprehension:
+
+```yaml
+transform: |
+  _.filter(c, c.state == "ready").map(c, {"name": c.id, "url": c.endpoint})
+```
+
+## Caching
+
+Resolved inventories are cached on disk under the scafctl cache directory
+(`hostname/`), keyed by a hash of the handler name, source URL, and transform.
+The cache honors the resolver `ttl`; expired or corrupt entries are ignored and
+re-fetched. Set `ttl: "0"` (or omit it) to disable caching entirely.
+
+## Authenticated inventory endpoints
+
+When `source.authProvider` is set, the host requests a **cached, non-interactive**
+token from that handler and injects it as a `Bearer` header. If you are not
+already logged in to that provider, resolution fails with a hint to run
+`auth login <provider>` first -- the inventory fetch never triggers an
+interactive browser login on its own.
+
+To avoid a resolver depending on the very handler it configures (an infinite
+loop), the host rejects a resolver whose `authProvider` equals the handler being
+logged into.
+
+## Troubleshooting
+
+- **`selector not found`** -- run `auth alias list <handler>` to see static
+  aliases, or check the resolver `source.url` and `transform`. The error lists
+  the selectors the resolver produced.
+- **`transform shape`** -- the CEL transform did not return a list of
+  `{name, url}` objects. Validate it against a sample of the endpoint response.
+- **`no credentials`** -- the resolver's `authProvider` is not logged in. Run
+  `auth login <authProvider>` first.
+
+## Related
+
+- [Auth examples README](README.md) -- `auth alias` quick reference
+- [Auth Tutorial](../../docs/tutorials/auth-tutorial.md)

--- a/examples/config/README.md
+++ b/examples/config/README.md
@@ -66,6 +66,52 @@ Action execution: timeouts, grace period, concurrency.
 ### `catalogs`
 List of registered catalogs (filesystem, http, oci).
 
+### `auth.handlers`
+Per-handler configuration namespaces keyed by handler name (e.g. `openshift`).
+The reserved `hostname` block (aliases + dynamic resolver) is consumed by the
+host to resolve `--hostname` selectors at login; every other key is forwarded
+opaquely to the handler plugin. See
+[Host-Aware Login](../auth/hostname-resolution.md) for the full walkthrough.
+
+```yaml
+auth:
+  handlers:
+    openshift:
+      hostname:
+        aliases:
+          prod: https://api.prod.example.com:6443
+      # Any other keys are passed through to the handler plugin unchanged.
+      apiTimeout: 30s
+```
+
+## Drop-in Config Directory (`config.d`)
+
+In addition to the main `config.yaml`, scafctl merges any `*.yaml`/`*.yml`
+fragments placed in a `config.d/` directory next to it. This lets tooling,
+provisioners, or teams layer configuration without editing the user's main file.
+
+```text
+~/.config/scafctl/
+  config.yaml          # user config (highest file precedence)
+  config.d/
+    10-catalogs.yaml   # merged first
+    20-telemetry.yaml  # merged after 10-*, overrides it
+```
+
+Precedence, lowest to highest:
+
+1. Built-in defaults
+2. Embedder base config (when scafctl is embedded in another CLI)
+3. `config.d/*.yaml` fragments, in lexical filename order
+4. `config.yaml` (the user's main file)
+5. Environment variables (`SCAFCTL_*`)
+6. Command-line flags
+
+Maps are deep-merged across layers; arrays (such as `catalogs`) are replaced
+wholesale by the highest-precedence layer that defines them. A missing
+`config.d` directory is not an error; a malformed fragment fails the load with
+the offending filename.
+
 ## Environment Variables
 
 All config values can be overridden via environment variables:

--- a/pkg/auth/hostname/cache.go
+++ b/pkg/auth/hostname/cache.go
@@ -1,0 +1,122 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hostname
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
+)
+
+// cacheDirName is the subdirectory under the XDG cache dir holding resolved
+// hostname inventories.
+const cacheDirName = "hostname"
+
+// cacheFilePerm and cacheDirPerm restrict cached inventories to the owner.
+const (
+	cacheFilePerm = 0o600
+	cacheDirPerm  = 0o700
+)
+
+// cacheKey derives a stable, filesystem-safe cache key for a handler's
+// resolver. It incorporates every input that affects the fetched inventory --
+// the handler name, source URL, transform, auth provider/scope, and any static
+// request headers -- so a change to any of them invalidates the entry and a
+// same-URL inventory selected by a header or scope is never served stale.
+func cacheKey(handler string, rc *config.HostnameResolverConfig) string {
+	h := sha256.New()
+	write := func(s string) {
+		h.Write([]byte(s))
+		h.Write([]byte{0})
+	}
+	write(handler)
+	write(rc.Source.URL)
+	write(rc.Transform)
+	write(rc.Source.AuthProvider)
+	write(rc.Source.AuthScope)
+
+	// Headers in sorted key order so the digest is independent of map iteration.
+	headerKeys := make([]string, 0, len(rc.Source.Headers))
+	for k := range rc.Source.Headers {
+		headerKeys = append(headerKeys, k)
+	}
+	sort.Strings(headerKeys)
+	for _, k := range headerKeys {
+		write(k)
+		write(rc.Source.Headers[k])
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// diskCache is an on-disk InventoryCache honoring the resolver TTL across CLI
+// invocations. A single-shot CLI cannot use an in-memory cache, so resolved
+// inventories persist under the XDG cache dir.
+type diskCache struct {
+	baseDir string
+	now     func() time.Time
+}
+
+// newDiskCache returns the default on-disk inventory cache.
+func newDiskCache() *diskCache {
+	return &diskCache{
+		baseDir: filepath.Join(paths.CacheDir(), cacheDirName),
+		now:     time.Now,
+	}
+}
+
+// cacheFile is the on-disk representation of a cached inventory.
+type cacheFile struct {
+	ExpiresAt time.Time `json:"expiresAt"`
+	Entries   []Entry   `json:"entries"`
+}
+
+func (c *diskCache) path(key string) string {
+	return filepath.Join(c.baseDir, key+".json")
+}
+
+// Get returns the cached entries when present and unexpired. Missing, corrupt,
+// or expired files are treated as a miss (fail-open to re-fetch).
+func (c *diskCache) Get(_ context.Context, key string) ([]Entry, bool) {
+	data, err := os.ReadFile(c.path(key)) //nolint:gosec // key is a sha256 hex digest, path is fixed
+	if err != nil {
+		return nil, false
+	}
+	var cf cacheFile
+	if err := json.Unmarshal(data, &cf); err != nil {
+		return nil, false
+	}
+	if !c.now().Before(cf.ExpiresAt) {
+		_ = os.Remove(c.path(key))
+		return nil, false
+	}
+	return cf.Entries, true
+}
+
+// Set writes the entries with an expiry of now+ttl. Write failures are silent:
+// caching is best-effort and must not break resolution.
+func (c *diskCache) Set(_ context.Context, key string, entries []Entry, ttl time.Duration) {
+	if ttl <= 0 {
+		return
+	}
+	if err := os.MkdirAll(c.baseDir, cacheDirPerm); err != nil {
+		return
+	}
+	cf := cacheFile{
+		ExpiresAt: c.now().Add(ttl),
+		Entries:   entries,
+	}
+	data, err := json.Marshal(cf)
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(c.path(key), data, cacheFilePerm)
+}

--- a/pkg/auth/hostname/cache_test.go
+++ b/pkg/auth/hostname/cache_test.go
@@ -1,0 +1,142 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hostname
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/config"
+)
+
+func newTestCache(t *testing.T, now func() time.Time) *diskCache {
+	t.Helper()
+	return &diskCache{baseDir: filepath.Join(t.TempDir(), cacheDirName), now: now}
+}
+
+func TestDiskCache_SetGetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCache(t, time.Now)
+	entries := []Entry{{Name: "pd1020", URL: "https://api.pd1020.example.com:6443"}}
+	c.Set(context.Background(), "key1", entries, time.Hour)
+
+	got, ok := c.Get(context.Background(), "key1")
+	require.True(t, ok)
+	assert.Equal(t, entries, got)
+}
+
+func TestDiskCache_Miss(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCache(t, time.Now)
+	_, ok := c.Get(context.Background(), "absent")
+	assert.False(t, ok)
+}
+
+func TestDiskCache_Expired(t *testing.T) {
+	t.Parallel()
+
+	base := time.Now()
+	current := base
+	c := newTestCache(t, func() time.Time { return current })
+
+	c.Set(context.Background(), "key1", []Entry{{Name: "a", URL: "https://a"}}, time.Minute)
+
+	// Advance past expiry.
+	current = base.Add(2 * time.Minute)
+	_, ok := c.Get(context.Background(), "key1")
+	assert.False(t, ok, "expired entry must be a miss")
+
+	// File should be removed on expired read.
+	_, statErr := os.Stat(c.path("key1"))
+	assert.True(t, os.IsNotExist(statErr), "expired file should be removed")
+}
+
+func TestDiskCache_ZeroTTLDisablesCaching(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCache(t, time.Now)
+	c.Set(context.Background(), "key1", []Entry{{Name: "a", URL: "https://a"}}, 0)
+
+	_, ok := c.Get(context.Background(), "key1")
+	assert.False(t, ok, "zero TTL must not persist an entry")
+}
+
+func TestDiskCache_CorruptFileIsMiss(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCache(t, time.Now)
+	require.NoError(t, os.MkdirAll(c.baseDir, cacheDirPerm))
+	require.NoError(t, os.WriteFile(c.path("key1"), []byte("{ not json"), cacheFilePerm))
+
+	_, ok := c.Get(context.Background(), "key1")
+	assert.False(t, ok, "corrupt file must be treated as a miss")
+}
+
+func TestCacheKey_StableAndSensitive(t *testing.T) {
+	t.Parallel()
+
+	rc := &config.HostnameResolverConfig{
+		Source:    config.HostnameResolverSource{URL: "https://inv.example.com"},
+		Transform: "_",
+	}
+	k1 := cacheKey("openshift", rc)
+	k2 := cacheKey("openshift", rc)
+	assert.Equal(t, k1, k2, "same inputs yield same key")
+
+	// Different handler.
+	assert.NotEqual(t, k1, cacheKey("other", rc))
+
+	// Different URL.
+	rc2 := &config.HostnameResolverConfig{
+		Source:    config.HostnameResolverSource{URL: "https://other.example.com"},
+		Transform: "_",
+	}
+	assert.NotEqual(t, k1, cacheKey("openshift", rc2))
+
+	// Different transform.
+	rc3 := &config.HostnameResolverConfig{
+		Source:    config.HostnameResolverSource{URL: "https://inv.example.com"},
+		Transform: "_.map(k, k)",
+	}
+	assert.NotEqual(t, k1, cacheKey("openshift", rc3))
+
+	// Different auth provider.
+	rc4 := &config.HostnameResolverConfig{
+		Source:    config.HostnameResolverSource{URL: "https://inv.example.com", AuthProvider: "entra"},
+		Transform: "_",
+	}
+	assert.NotEqual(t, k1, cacheKey("openshift", rc4))
+
+	// Different auth scope.
+	rc5 := &config.HostnameResolverConfig{
+		Source:    config.HostnameResolverSource{URL: "https://inv.example.com", AuthScope: "api://x/.default"},
+		Transform: "_",
+	}
+	assert.NotEqual(t, k1, cacheKey("openshift", rc5))
+
+	// Different headers.
+	rc6 := &config.HostnameResolverConfig{
+		Source:    config.HostnameResolverSource{URL: "https://inv.example.com", Headers: map[string]string{"X-Env": "prod"}},
+		Transform: "_",
+	}
+	k6 := cacheKey("openshift", rc6)
+	assert.NotEqual(t, k1, k6)
+	// Header key order must not matter (sorted internally).
+	rc6b := &config.HostnameResolverConfig{
+		Source: config.HostnameResolverSource{
+			URL:     "https://inv.example.com",
+			Headers: map[string]string{"X-Env": "prod"},
+		},
+		Transform: "_",
+	}
+	assert.Equal(t, k6, cacheKey("openshift", rc6b), "same headers yield same key")
+}

--- a/pkg/auth/hostname/errors.go
+++ b/pkg/auth/hostname/errors.go
@@ -1,0 +1,28 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hostname
+
+import "errors"
+
+// Sentinel errors returned by the resolver. Callers map these to exit codes:
+// selector/loop/shape errors are invalid-input; credential/fetch errors are
+// general failures.
+var (
+	// ErrSelectorNotFound indicates the hostname selector was not found in the
+	// static aliases or the resolved inventory.
+	ErrSelectorNotFound = errors.New("hostname: selector not found")
+
+	// ErrResolverLoop indicates the resolver's source auth provider is the same
+	// handler being resolved, which would recurse.
+	ErrResolverLoop = errors.New("hostname: resolver loop detected")
+
+	// ErrTransformShape indicates the CEL transform did not produce a list of
+	// {name, url} entries.
+	ErrTransformShape = errors.New("hostname: transform did not produce a list of {name, url} entries")
+
+	// ErrNoCredentials indicates the resolver's auth provider is set but no
+	// cached credentials are available. The host never triggers an interactive
+	// login to satisfy a resolver.
+	ErrNoCredentials = errors.New("hostname: no cached credentials for resolver auth provider")
+)

--- a/pkg/auth/hostname/fetch.go
+++ b/pkg/auth/hostname/fetch.go
@@ -1,0 +1,88 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hostname
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+
+	"github.com/go-logr/logr"
+
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/httpc"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+// maxInventoryBytes caps the inventory response body read to guard against
+// oversized or malicious responses. Real inventories are tens of KB.
+const maxInventoryBytes = 8 << 20 // 8 MiB
+
+// defaultFetch retrieves the inventory body over HTTP(S) using the scafctl
+// HTTP client, injecting static headers and an optional bearer token.
+func defaultFetch(ctx context.Context, src config.HostnameResolverSource, bearer string) ([]byte, error) {
+	u, err := url.Parse(src.URL)
+	if err != nil || (u.Scheme != "https" && u.Scheme != "http") || u.Host == "" {
+		return nil, fmt.Errorf("invalid inventory source URL %q: must be an absolute http(s) URL", src.URL)
+	}
+
+	// Refuse to leak a bearer token over plaintext HTTP. Loopback hosts are
+	// exempt since the token never leaves the machine.
+	if bearer != "" && u.Scheme != "https" && !isLoopbackHost(u.Hostname()) {
+		return nil, fmt.Errorf("refusing to send bearer token to non-HTTPS inventory URL %q: use https", src.URL)
+	}
+
+	var httpCfg *config.HTTPClientConfig
+	if c := config.FromContext(ctx); c != nil {
+		httpCfg = &c.HTTPClient
+	}
+
+	lg := logr.Discard()
+	if l := logger.FromContext(ctx); l != nil {
+		lg = *l
+	}
+	client := httpc.NewClientFromAppConfig(httpCfg, lg)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, src.URL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating inventory request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	for k, v := range src.Headers {
+		req.Header.Set(k, v)
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+
+	resp, err := client.Do(req) //nolint:gosec // URL from trusted admin config (auth.handlers.<name>.hostname.resolver.source.url)
+	if err != nil {
+		return nil, fmt.Errorf("inventory request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxInventoryBytes))
+	if err != nil {
+		return nil, fmt.Errorf("reading inventory response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("inventory endpoint returned status %d", resp.StatusCode)
+	}
+	return body, nil
+}
+
+// isLoopbackHost reports whether host is localhost or a loopback IP literal.
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
+}

--- a/pkg/auth/hostname/fetch_test.go
+++ b/pkg/auth/hostname/fetch_test.go
@@ -1,0 +1,109 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hostname
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/config"
+)
+
+func TestDefaultFetch_Success(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+		assert.Equal(t, "custom-value", r.Header.Get("X-Custom"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok": true}`))
+	}))
+	defer srv.Close()
+
+	src := config.HostnameResolverSource{
+		URL:     srv.URL,
+		Headers: map[string]string{"X-Custom": "custom-value"},
+	}
+
+	body, err := defaultFetch(context.Background(), src, "secret")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"ok": true}`, string(body))
+}
+
+func TestDefaultFetch_NoBearer(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	_, err := defaultFetch(context.Background(), config.HostnameResolverSource{URL: srv.URL}, "")
+	require.NoError(t, err)
+}
+
+func TestDefaultFetch_NonOKStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := defaultFetch(context.Background(), config.HostnameResolverSource{URL: srv.URL}, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "status 404")
+}
+
+func TestDefaultFetch_InvalidURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"",
+		"not-a-url",
+		"ftp://example.com/inventory",
+		"file:///etc/passwd",
+	}
+	for _, u := range tests {
+		t.Run(u, func(t *testing.T) {
+			t.Parallel()
+			_, err := defaultFetch(context.Background(), config.HostnameResolverSource{URL: u}, "")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid inventory source URL")
+		})
+	}
+}
+
+func TestDefaultFetch_RejectsBearerOverPlaintextHTTP(t *testing.T) {
+	t.Parallel()
+
+	// A bearer token must never be sent to a non-HTTPS, non-loopback host.
+	src := config.HostnameResolverSource{URL: "http://inventory.example.com/clusters"}
+	_, err := defaultFetch(context.Background(), src, "secret")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-HTTPS")
+}
+
+func TestDefaultFetch_AllowsBearerOverLoopbackHTTP(t *testing.T) {
+	t.Parallel()
+
+	// Loopback is exempt: the token never leaves the machine. httptest serves
+	// on 127.0.0.1, so a bearer over http here must be accepted.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer secret", r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	_, err := defaultFetch(context.Background(), config.HostnameResolverSource{URL: srv.URL}, "secret")
+	require.NoError(t, err)
+}

--- a/pkg/auth/hostname/hostname.go
+++ b/pkg/auth/hostname/hostname.go
@@ -1,0 +1,269 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package hostname resolves a user-supplied hostname selector (e.g. "cluster-01")
+// into a concrete endpoint URL for an auth handler at login time.
+//
+// Resolution precedence, highest to lowest:
+//
+//  1. The selector is already a concrete http(s):// URL -> returned unchanged.
+//  2. No hostname config exists for the handler -> selector returned unchanged
+//     (preserves plain-hostname handlers such as GitHub Enterprise).
+//  3. A static alias (auth.handlers.<name>.hostname.aliases) matches -> its URL.
+//  4. A dynamic resolver (auth.handlers.<name>.hostname.resolver) fetches an
+//     inventory, normalizes it with an org-owned CEL transform into a list of
+//     {name, url} entries, and the selector is looked up by name.
+//
+// Resolve returns just the endpoint URL. ResolveEntry returns the full Entry,
+// including optional per-cluster OIDC metadata (audience, authType, caData,
+// consoleUrl, insecureSkipTls) that a config-driven inventory can surface for
+// kube login.
+//
+// scafctl core stays shape-blind: all inventory normalization lives in the
+// org-owned CEL transform. The host only validates that the transform yields
+// the canonical list<{name, url}> contract.
+package hostname
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/config"
+)
+
+// Entry is one normalized inventory record. The CEL transform must yield a
+// list of these. Only name and url are required; the remaining fields carry
+// optional per-cluster OIDC metadata that mirrors kube.ClusterInfo so a
+// config-driven inventory can feed both auth login and kube login.
+type Entry struct {
+	// Name is the selector used to look up this entry (required).
+	Name string `json:"name"`
+
+	// URL is the concrete endpoint the selector resolves to (required).
+	URL string `json:"url"`
+
+	// Audience is the OIDC audience/client ID a token for this cluster targets.
+	Audience string `json:"audience,omitempty"`
+
+	// AuthType is the login method for this cluster: "" (auto), "oauth", or
+	// "oidc". It mirrors kube.AuthType.
+	AuthType string `json:"authType,omitempty"`
+
+	// CAData is a PEM-encoded CA bundle for the endpoint (preferred over
+	// InsecureSkipTLS).
+	CAData string `json:"caData,omitempty"`
+
+	// ConsoleURL is an optional web console URL for the cluster.
+	ConsoleURL string `json:"consoleUrl,omitempty"`
+
+	// InsecureSkipTLS disables endpoint TLS verification (dev only).
+	InsecureSkipTLS bool `json:"insecureSkipTls,omitempty"`
+}
+
+// FetchFunc retrieves the raw inventory body from the resolver source. The
+// bearer token is empty for unauthenticated sources.
+type FetchFunc func(ctx context.Context, src config.HostnameResolverSource, bearer string) ([]byte, error)
+
+// TokenFunc retrieves a bearer token for the given auth provider and scope
+// using cached, non-interactive credentials only.
+type TokenFunc func(ctx context.Context, provider, scope string) (string, error)
+
+// TransformFunc normalizes the raw inventory body into a list of entries using
+// the given CEL expression.
+type TransformFunc func(ctx context.Context, cel string, body []byte) ([]Entry, error)
+
+// InventoryCache caches resolved inventories across invocations. A nil cache
+// disables caching.
+type InventoryCache interface {
+	Get(ctx context.Context, key string) ([]Entry, bool)
+	Set(ctx context.Context, key string, entries []Entry, ttl time.Duration)
+}
+
+// Deps carries injectable collaborators. Zero-valued fields fall back to the
+// production defaults (httpc fetch, tokenprovider token, celexp transform).
+type Deps struct {
+	Fetch     FetchFunc
+	Token     TokenFunc
+	Transform TransformFunc
+	Cache     InventoryCache
+}
+
+func (d Deps) withDefaults() Deps {
+	if d.Fetch == nil {
+		d.Fetch = defaultFetch
+	}
+	if d.Token == nil {
+		d.Token = defaultToken
+	}
+	if d.Transform == nil {
+		d.Transform = defaultTransform
+	}
+	return d
+}
+
+// Resolve turns a hostname selector into a concrete endpoint URL for the given
+// handler, pulling config and collaborators from the context. It returns the
+// selector unchanged when it is already a URL or when the handler has no
+// hostname config.
+func Resolve(ctx context.Context, handler, selector string) (string, error) {
+	e, err := ResolveEntry(ctx, handler, selector)
+	if err != nil {
+		return "", err
+	}
+	return e.URL, nil
+}
+
+// ResolveEntry resolves a hostname selector into a full inventory Entry (the
+// endpoint URL plus any optional per-cluster OIDC metadata) for the given
+// handler, pulling config and collaborators from the context. For concrete
+// URLs and handlers without hostname config it returns an Entry whose Name and
+// URL are the selector itself.
+func ResolveEntry(ctx context.Context, handler, selector string) (*Entry, error) {
+	var cfg *config.HostnameConfig
+	if c := config.FromContext(ctx); c != nil {
+		if hc, ok := c.Auth.Handlers[handler]; ok {
+			cfg = hc.Hostname
+		}
+	}
+	return ResolveEntryWith(ctx, cfg, handler, selector, Deps{Cache: newDiskCache()})
+}
+
+// ResolveWith is the dependency-injected core of Resolve. It is exported for
+// tests and embedders that supply their own collaborators.
+func ResolveWith(ctx context.Context, cfg *config.HostnameConfig, handler, selector string, deps Deps) (string, error) {
+	e, err := ResolveEntryWith(ctx, cfg, handler, selector, deps)
+	if err != nil {
+		return "", err
+	}
+	return e.URL, nil
+}
+
+// ResolveEntryWith is the dependency-injected core of ResolveEntry. It is
+// exported for tests and embedders that supply their own collaborators.
+func ResolveEntryWith(ctx context.Context, cfg *config.HostnameConfig, handler, selector string, deps Deps) (*Entry, error) {
+	deps = deps.withDefaults()
+
+	// 1. Concrete URL passthrough.
+	if isConcreteURL(selector) {
+		return &Entry{Name: selector, URL: selector}, nil
+	}
+
+	// 2. No hostname config for this handler.
+	if cfg == nil {
+		return &Entry{Name: selector, URL: selector}, nil
+	}
+
+	// 3. Static alias wins over the dynamic resolver.
+	if u, ok := cfg.Aliases[selector]; ok {
+		return &Entry{Name: selector, URL: u}, nil
+	}
+
+	// 4. Dynamic resolver.
+	if cfg.Resolver != nil {
+		entries, err := resolveInventory(ctx, cfg.Resolver, handler, deps)
+		if err != nil {
+			return nil, err
+		}
+		for i := range entries {
+			if entries[i].Name == selector {
+				e := entries[i]
+				return &e, nil
+			}
+		}
+		return nil, fmt.Errorf("%w: %q (available: %s)", ErrSelectorNotFound, selector, availableNames(cfg, entries))
+	}
+
+	// 5. Not found in aliases and no resolver configured.
+	return nil, fmt.Errorf("%w: %q (available: %s)", ErrSelectorNotFound, selector, availableNames(cfg, nil))
+}
+
+// resolveInventory fetches, transforms, and caches the endpoint inventory.
+func resolveInventory(ctx context.Context, rc *config.HostnameResolverConfig, handler string, deps Deps) ([]Entry, error) {
+	// Loop guard: a resolver must not depend on the handler it resolves.
+	if rc.Source.AuthProvider != "" && rc.Source.AuthProvider == handler {
+		return nil, fmt.Errorf("%w: source authProvider %q equals the handler being resolved", ErrResolverLoop, handler)
+	}
+
+	key := cacheKey(handler, rc)
+	if deps.Cache != nil {
+		if entries, ok := deps.Cache.Get(ctx, key); ok {
+			return entries, nil
+		}
+	}
+
+	var bearer string
+	if rc.Source.AuthProvider != "" {
+		tok, err := deps.Token(ctx, rc.Source.AuthProvider, rc.Source.AuthScope)
+		if err != nil {
+			return nil, fmt.Errorf("%w: auth provider %q: run 'auth login %s' first: %w",
+				ErrNoCredentials, rc.Source.AuthProvider, rc.Source.AuthProvider, err)
+		}
+		bearer = tok
+	}
+
+	body, err := deps.Fetch(ctx, rc.Source, bearer)
+	if err != nil {
+		return nil, fmt.Errorf("fetching hostname inventory: %w", err)
+	}
+
+	entries, err := deps.Transform(ctx, rc.Transform, body)
+	if err != nil {
+		return nil, err
+	}
+
+	if deps.Cache != nil {
+		if ttl := parseTTL(rc.TTL); ttl > 0 {
+			deps.Cache.Set(ctx, key, entries, ttl)
+		}
+	}
+	return entries, nil
+}
+
+// isConcreteURL reports whether selector is already an absolute http(s) URL.
+func isConcreteURL(selector string) bool {
+	u, err := url.Parse(selector)
+	if err != nil {
+		return false
+	}
+	return (u.Scheme == "https" || u.Scheme == "http") && u.Host != ""
+}
+
+// parseTTL parses an optional cache TTL. Empty, "0", or unparseable values
+// disable caching (return 0).
+func parseTTL(s string) time.Duration {
+	if s == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d < 0 {
+		return 0
+	}
+	return d
+}
+
+// availableNames returns a sorted, comma-separated list of known selectors from
+// the static aliases and the resolved inventory, for error messages.
+func availableNames(cfg *config.HostnameConfig, entries []Entry) string {
+	seen := make(map[string]struct{})
+	if cfg != nil {
+		for name := range cfg.Aliases {
+			seen[name] = struct{}{}
+		}
+	}
+	for _, e := range entries {
+		seen[e.Name] = struct{}{}
+	}
+	if len(seen) == 0 {
+		return "none"
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}

--- a/pkg/auth/hostname/hostname_test.go
+++ b/pkg/auth/hostname/hostname_test.go
@@ -1,0 +1,403 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hostname
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/config"
+)
+
+// fakeCache is an in-memory InventoryCache for tests.
+type fakeCache struct {
+	store map[string][]Entry
+	sets  int
+}
+
+func (f *fakeCache) Get(_ context.Context, key string) ([]Entry, bool) {
+	e, ok := f.store[key]
+	return e, ok
+}
+
+func (f *fakeCache) Set(_ context.Context, key string, entries []Entry, _ time.Duration) {
+	if f.store == nil {
+		f.store = map[string][]Entry{}
+	}
+	f.store[key] = entries
+	f.sets++
+}
+
+func resolverCfg(authProvider string) *config.HostnameConfig {
+	return &config.HostnameConfig{
+		Resolver: &config.HostnameResolverConfig{
+			Source: config.HostnameResolverSource{
+				URL:          "https://inv.example.com",
+				AuthProvider: authProvider,
+			},
+			Transform: "_",
+			TTL:       "1h",
+		},
+	}
+}
+
+func TestResolveWith_Precedence(t *testing.T) {
+	t.Parallel()
+
+	inventory := []Entry{{Name: "pd1020", URL: "https://api.pd1020.example.com:6443"}}
+
+	tests := []struct {
+		name     string
+		cfg      *config.HostnameConfig
+		handler  string
+		selector string
+		fetch    FetchFunc
+		token    TokenFunc
+		want     string
+		wantErr  error
+	}{
+		{
+			name:     "concrete https URL passthrough",
+			cfg:      resolverCfg(""),
+			selector: "https://api.custom.example.com:6443",
+			want:     "https://api.custom.example.com:6443",
+		},
+		{
+			name:     "concrete http URL passthrough",
+			selector: "http://localhost:8080",
+			want:     "http://localhost:8080",
+		},
+		{
+			name:     "nil config returns selector unchanged",
+			cfg:      nil,
+			selector: "some-ghes-host",
+			want:     "some-ghes-host",
+		},
+		{
+			name:     "static alias wins",
+			cfg:      &config.HostnameConfig{Aliases: map[string]string{"prod": "https://api.prod.example.com:6443"}},
+			selector: "prod",
+			want:     "https://api.prod.example.com:6443",
+		},
+		{
+			name:     "dynamic resolver lookup",
+			cfg:      resolverCfg(""),
+			selector: "pd1020",
+			want:     "https://api.pd1020.example.com:6443",
+		},
+		{
+			name: "static alias overlays inventory entry with same name",
+			cfg: &config.HostnameConfig{
+				Aliases: map[string]string{"pd1020": "https://override.example.com:6443"},
+				Resolver: &config.HostnameResolverConfig{
+					Source:    config.HostnameResolverSource{URL: "https://inv.example.com"},
+					Transform: "_",
+				},
+			},
+			selector: "pd1020",
+			want:     "https://override.example.com:6443",
+		},
+		{
+			name:     "selector not found in aliases only",
+			cfg:      &config.HostnameConfig{Aliases: map[string]string{"prod": "https://api.prod.example.com"}},
+			selector: "staging",
+			wantErr:  ErrSelectorNotFound,
+		},
+		{
+			name:     "selector not found in inventory",
+			cfg:      resolverCfg(""),
+			selector: "missing",
+			wantErr:  ErrSelectorNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			deps := Deps{
+				Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) {
+					return []byte(`{}`), nil
+				},
+				Transform: func(context.Context, string, []byte) ([]Entry, error) {
+					return inventory, nil
+				},
+			}
+			got, err := ResolveWith(context.Background(), tt.cfg, "openshift", tt.selector, deps)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveWith_LoopGuard(t *testing.T) {
+	t.Parallel()
+
+	cfg := resolverCfg("openshift")
+	deps := Deps{
+		Token: func(context.Context, string, string) (string, error) { return "tok", nil },
+		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) { return []byte(`{}`), nil },
+		Transform: func(context.Context, string, []byte) ([]Entry, error) {
+			return nil, nil
+		},
+	}
+
+	_, err := ResolveWith(context.Background(), cfg, "openshift", "pd1020", deps)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrResolverLoop)
+}
+
+func TestResolveWith_NoCredentials(t *testing.T) {
+	t.Parallel()
+
+	cfg := resolverCfg("entra")
+	tokenErr := errors.New("not authenticated")
+	fetchCalled := false
+	deps := Deps{
+		Token: func(context.Context, string, string) (string, error) { return "", tokenErr },
+		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) {
+			fetchCalled = true
+			return nil, nil
+		},
+	}
+
+	_, err := ResolveWith(context.Background(), cfg, "openshift", "pd1020", deps)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoCredentials)
+	assert.False(t, fetchCalled, "fetch must not run when credentials are missing")
+}
+
+func TestResolveWith_TransformShapeError(t *testing.T) {
+	t.Parallel()
+
+	cfg := resolverCfg("")
+	deps := Deps{
+		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) { return []byte(`{}`), nil },
+		Transform: func(context.Context, string, []byte) ([]Entry, error) {
+			return nil, ErrTransformShape
+		},
+	}
+
+	_, err := ResolveWith(context.Background(), cfg, "openshift", "pd1020", deps)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrTransformShape)
+}
+
+func TestResolveWith_TokenInjectedIntoFetch(t *testing.T) {
+	t.Parallel()
+
+	cfg := resolverCfg("entra")
+	var gotBearer string
+	deps := Deps{
+		Token: func(_ context.Context, provider, scope string) (string, error) {
+			assert.Equal(t, "entra", provider)
+			return "secret-token", nil
+		},
+		Fetch: func(_ context.Context, _ config.HostnameResolverSource, bearer string) ([]byte, error) {
+			gotBearer = bearer
+			return []byte(`{}`), nil
+		},
+		Transform: func(context.Context, string, []byte) ([]Entry, error) {
+			return []Entry{{Name: "pd1020", URL: "https://api.pd1020.example.com:6443"}}, nil
+		},
+	}
+
+	got, err := ResolveWith(context.Background(), cfg, "openshift", "pd1020", deps)
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.pd1020.example.com:6443", got)
+	assert.Equal(t, "secret-token", gotBearer)
+}
+
+func TestResolveWith_CacheHitSkipsFetch(t *testing.T) {
+	t.Parallel()
+
+	cfg := resolverCfg("")
+	cache := &fakeCache{store: map[string][]Entry{}}
+	// Pre-seed the cache under the computed key.
+	key := cacheKey("openshift", cfg.Resolver)
+	cache.store[key] = []Entry{{Name: "pd1020", URL: "https://cached.example.com:6443"}}
+
+	fetchCalled := false
+	deps := Deps{
+		Cache: cache,
+		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) {
+			fetchCalled = true
+			return []byte(`{}`), nil
+		},
+		Transform: func(context.Context, string, []byte) ([]Entry, error) {
+			return nil, errors.New("should not be called")
+		},
+	}
+
+	got, err := ResolveWith(context.Background(), cfg, "openshift", "pd1020", deps)
+	require.NoError(t, err)
+	assert.Equal(t, "https://cached.example.com:6443", got)
+	assert.False(t, fetchCalled, "fetch must be skipped on cache hit")
+}
+
+func TestResolveWith_CacheMissStoresResult(t *testing.T) {
+	t.Parallel()
+
+	cfg := resolverCfg("")
+	cache := &fakeCache{store: map[string][]Entry{}}
+	deps := Deps{
+		Cache: cache,
+		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) { return []byte(`{}`), nil },
+		Transform: func(context.Context, string, []byte) ([]Entry, error) {
+			return []Entry{{Name: "pd1020", URL: "https://api.pd1020.example.com:6443"}}, nil
+		},
+	}
+
+	_, err := ResolveWith(context.Background(), cfg, "openshift", "pd1020", deps)
+	require.NoError(t, err)
+	assert.Equal(t, 1, cache.sets, "resolved inventory should be cached")
+}
+
+func TestParseTTL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", 0},
+		{"0", 0},
+		{"1h", time.Hour},
+		{"30m", 30 * time.Minute},
+		{"garbage", 0},
+		{"-5m", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, parseTTL(tt.in))
+		})
+	}
+}
+
+func TestIsConcreteURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"https://api.example.com:6443", true},
+		{"http://localhost:8080", true},
+		{"pd1020", false},
+		{"ftp://example.com", false},
+		{"", false},
+		{"api.example.com", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isConcreteURL(tt.in))
+		})
+	}
+}
+
+func TestResolve_UsesContextConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Auth: config.GlobalAuthConfig{
+			Handlers: map[string]config.HandlerConfig{
+				"openshift": {
+					Hostname: &config.HostnameConfig{
+						Aliases: map[string]string{"prod": "https://api.prod.example.com:6443"},
+					},
+				},
+			},
+		},
+	}
+	ctx := config.WithConfig(context.Background(), cfg)
+
+	got, err := Resolve(ctx, "openshift", "prod")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.prod.example.com:6443", got)
+}
+
+func TestResolve_NoConfigReturnsSelector(t *testing.T) {
+	t.Parallel()
+
+	got, err := Resolve(context.Background(), "github", "github.example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "github.example.com", got)
+}
+
+func TestResolveEntryWith_CarriesOIDCFields(t *testing.T) {
+	t.Parallel()
+
+	cfg := resolverCfg("")
+	want := Entry{
+		Name:            "cluster-01",
+		URL:             "https://api.cluster-01.example.com:6443",
+		Audience:        "api://cluster-01/.default",
+		AuthType:        "oidc",
+		CAData:          "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----",
+		ConsoleURL:      "https://console.cluster-01.example.com",
+		InsecureSkipTLS: false,
+	}
+	deps := Deps{
+		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) { return []byte(`{}`), nil },
+		Transform: func(context.Context, string, []byte) ([]Entry, error) {
+			return []Entry{want}, nil
+		},
+	}
+
+	got, err := ResolveEntryWith(context.Background(), cfg, "openshift", "cluster-01", deps)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, want, *got)
+}
+
+func TestResolveEntryWith_ConcreteURLPassthrough(t *testing.T) {
+	t.Parallel()
+
+	got, err := ResolveEntryWith(context.Background(), nil, "openshift", "https://api.custom.example.com:6443", Deps{})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "https://api.custom.example.com:6443", got.Name)
+	assert.Equal(t, "https://api.custom.example.com:6443", got.URL)
+	assert.Empty(t, got.Audience)
+	assert.Empty(t, got.AuthType)
+}
+
+func TestResolveEntryWith_StaticAliasEntry(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.HostnameConfig{Aliases: map[string]string{"prod": "https://api.prod.example.com:6443"}}
+	got, err := ResolveEntryWith(context.Background(), cfg, "openshift", "prod", Deps{})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "prod", got.Name)
+	assert.Equal(t, "https://api.prod.example.com:6443", got.URL)
+}
+
+func TestResolveEntryWith_NotFound(t *testing.T) {
+	t.Parallel()
+
+	cfg := resolverCfg("")
+	deps := Deps{
+		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) { return []byte(`{}`), nil },
+		Transform: func(context.Context, string, []byte) ([]Entry, error) {
+			return []Entry{{Name: "cluster-01", URL: "https://api.cluster-01.example.com:6443"}}, nil
+		},
+	}
+
+	got, err := ResolveEntryWith(context.Background(), cfg, "openshift", "missing", deps)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrSelectorNotFound)
+	assert.Nil(t, got)
+}

--- a/pkg/auth/hostname/token.go
+++ b/pkg/auth/hostname/token.go
@@ -1,0 +1,26 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hostname
+
+import (
+	"context"
+
+	"github.com/oakwood-commons/scafctl/pkg/tokenprovider"
+	"github.com/oakwood-commons/scafctl/pkg/tokenprovider/callerscope"
+)
+
+// defaultToken retrieves a bearer token for the given auth provider using
+// cached, non-interactive credentials only. It never triggers an interactive
+// login: if no valid cached token exists, the underlying provider returns an
+// error which the caller maps to ErrNoCredentials.
+func defaultToken(ctx context.Context, provider, scope string) (string, error) {
+	tok, err := tokenprovider.GetToken(ctx, provider, tokenprovider.RequestOptions{
+		Scope:  scope,
+		Caller: callerscope.ServerCaller,
+	})
+	if err != nil {
+		return "", err
+	}
+	return tok.AccessToken, nil
+}

--- a/pkg/auth/hostname/token_test.go
+++ b/pkg/auth/hostname/token_test.go
@@ -1,0 +1,79 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hostname
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/tokenprovider"
+)
+
+// stubTokenProvider is a minimal tokenprovider.TokenProvider used to exercise
+// defaultToken's success and error paths without real credentials.
+type stubTokenProvider struct {
+	name  string
+	token tokenprovider.Token
+	err   error
+}
+
+func (s stubTokenProvider) Name() string { return s.name }
+
+func (s stubTokenProvider) GetToken(context.Context, tokenprovider.RequestOptions) (tokenprovider.Token, error) {
+	return s.token, s.err
+}
+
+// registerStub returns a context carrying a registry with the given stub source.
+func registerStub(t *testing.T, src stubTokenProvider) context.Context {
+	t.Helper()
+	reg := tokenprovider.NewRegistry()
+	require.NoError(t, reg.Register(src))
+	return tokenprovider.WithRegistry(context.Background(), reg)
+}
+
+// TestDefaultToken_NoRegistryReturnsError verifies defaultToken surfaces the
+// underlying token-provider error (and no token) when no provider registry is
+// available, rather than triggering an interactive login.
+func TestDefaultToken_NoRegistryReturnsError(t *testing.T) {
+	t.Parallel()
+
+	tok, err := defaultToken(context.Background(), "entra", "api://example/.default")
+
+	require.Error(t, err)
+	assert.Empty(t, tok)
+}
+
+// TestDefaultToken_ReturnsAccessToken verifies the success path returns the
+// access token from the resolved provider.
+func TestDefaultToken_ReturnsAccessToken(t *testing.T) {
+	t.Parallel()
+
+	ctx := registerStub(t, stubTokenProvider{
+		name:  "entra",
+		token: tokenprovider.Token{AccessToken: "abc123"},
+	})
+
+	tok, err := defaultToken(ctx, "entra", "api://example/.default")
+
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", tok)
+}
+
+// TestDefaultToken_PropagatesProviderError verifies a provider error is
+// surfaced verbatim and no token is returned.
+func TestDefaultToken_PropagatesProviderError(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("cached token expired")
+	ctx := registerStub(t, stubTokenProvider{name: "entra", err: wantErr})
+
+	tok, err := defaultToken(ctx, "entra", "")
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Empty(t, tok)
+}

--- a/pkg/auth/hostname/transform.go
+++ b/pkg/auth/hostname/transform.go
@@ -1,0 +1,59 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hostname
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+)
+
+// defaultTransform runs the org-owned CEL expression against the fetched
+// inventory body and validates that the result matches the canonical
+// list<{name, url}> contract. Optional per-cluster OIDC fields (audience,
+// authType, caData, consoleUrl, insecureSkipTls) flow through untouched when
+// the transform emits them. The fetched JSON is available to the expression
+// as the root variable "_".
+func defaultTransform(ctx context.Context, cel string, body []byte) ([]Entry, error) {
+	if cel == "" {
+		return nil, fmt.Errorf("%w: no transform expression configured", ErrTransformShape)
+	}
+
+	var root any
+	if err := json.Unmarshal(body, &root); err != nil {
+		return nil, fmt.Errorf("parsing inventory JSON: %w", err)
+	}
+
+	result, err := celexp.EvaluateExpression(ctx, cel, root, nil)
+	if err != nil {
+		return nil, fmt.Errorf("evaluating hostname transform: %w", err)
+	}
+
+	return coerceEntries(result)
+}
+
+// coerceEntries converts the CEL result into a validated []Entry. It uses a
+// JSON round-trip so any CEL list-of-maps shape is accepted, then enforces the
+// {name, url} contract structurally (the host stays shape-blind beyond this).
+// Optional OIDC fields on Entry are preserved by the round-trip.
+func coerceEntries(result any) ([]Entry, error) {
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("%w: result is not serializable", ErrTransformShape)
+	}
+
+	var entries []Entry
+	if err := json.Unmarshal(raw, &entries); err != nil {
+		return nil, fmt.Errorf("%w: expected a list, got %s", ErrTransformShape, string(raw))
+	}
+
+	for i, e := range entries {
+		if e.Name == "" || e.URL == "" {
+			return nil, fmt.Errorf("%w: entry %d missing name or url", ErrTransformShape, i)
+		}
+	}
+	return entries, nil
+}

--- a/pkg/auth/hostname/transform_test.go
+++ b/pkg/auth/hostname/transform_test.go
@@ -1,0 +1,143 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hostname
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultTransform_MapKeyedShape(t *testing.T) {
+	t.Parallel()
+
+	// Mirrors the real clusters inventory: a top-level name-keyed map where each
+	// value carries an apiServerURL.
+	body := []byte(`{
+		"pd1020": {"clusterName": "pd1020", "apiServerURL": "https://api.pd1020.example.com:6443", "status": "in-use"},
+		"pd1030": {"clusterName": "pd1030", "apiServerURL": "https://api.pd1030.example.com:6443", "status": "in-use"}
+	}`)
+
+	cel := `_.map(k, {"name": k, "url": _[k].apiServerURL})`
+
+	entries, err := defaultTransform(context.Background(), cel, body)
+	require.NoError(t, err)
+	require.Len(t, entries, 2)
+
+	byName := map[string]string{}
+	for _, e := range entries {
+		byName[e.Name] = e.URL
+	}
+	assert.Equal(t, "https://api.pd1020.example.com:6443", byName["pd1020"])
+	assert.Equal(t, "https://api.pd1030.example.com:6443", byName["pd1030"])
+}
+
+func TestDefaultTransform_FiltersWithCEL(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"good": {"apiServerURL": "https://api.good.example.com:6443", "status": "in-use"},
+		"gone": {"apiServerURL": "https://api.gone.example.com:6443", "status": "deleted"}
+	}`)
+
+	cel := `_.map(k, _[k].status != "deleted", {"name": k, "url": _[k].apiServerURL})`
+
+	entries, err := defaultTransform(context.Background(), cel, body)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "good", entries[0].Name)
+}
+
+func TestDefaultTransform_Errors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cel     string
+		body    string
+		wantErr error
+	}{
+		{
+			name:    "empty transform",
+			cel:     "",
+			body:    `{}`,
+			wantErr: ErrTransformShape,
+		},
+		{
+			name:    "invalid JSON body",
+			cel:     "_",
+			body:    `{not json`,
+			wantErr: nil, // parse error, not a shape error
+		},
+		{
+			name:    "result is an object not a list",
+			cel:     `{"name": "x", "url": "https://x"}`,
+			body:    `{}`,
+			wantErr: ErrTransformShape,
+		},
+		{
+			name:    "entry missing url",
+			cel:     `[{"name": "x"}]`,
+			body:    `{}`,
+			wantErr: ErrTransformShape,
+		},
+		{
+			name:    "entry missing name",
+			cel:     `[{"url": "https://x"}]`,
+			body:    `{}`,
+			wantErr: ErrTransformShape,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := defaultTransform(context.Background(), tt.cel, []byte(tt.body))
+			require.Error(t, err)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDefaultTransform_EmptyListIsValid(t *testing.T) {
+	t.Parallel()
+
+	entries, err := defaultTransform(context.Background(), `[]`, []byte(`{}`))
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestDefaultTransform_CarriesOptionalOIDCFields(t *testing.T) {
+	t.Parallel()
+
+	body := []byte(`{
+		"cluster-01": {
+			"apiServerURL": "https://api.cluster-01.example.com:6443",
+			"clientID": "api://cluster-01/.default",
+			"authType": "oidc",
+			"console": "https://console.cluster-01.example.com"
+		}
+	}`)
+
+	cel := `_.map(k, {
+		"name": k,
+		"url": _[k].apiServerURL,
+		"audience": _[k].clientID,
+		"authType": _[k].authType,
+		"consoleUrl": _[k].console
+	})`
+
+	entries, err := defaultTransform(context.Background(), cel, body)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "cluster-01", entries[0].Name)
+	assert.Equal(t, "https://api.cluster-01.example.com:6443", entries[0].URL)
+	assert.Equal(t, "api://cluster-01/.default", entries[0].Audience)
+	assert.Equal(t, "oidc", entries[0].AuthType)
+	assert.Equal(t, "https://console.cluster-01.example.com", entries[0].ConsoleURL)
+}

--- a/pkg/cmd/scafctl/auth/alias.go
+++ b/pkg/cmd/scafctl/auth/alias.go
@@ -1,0 +1,276 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// aliasListSchema drives table rendering for 'auth alias list'. The root is an
+// array because the command writes a bare []map[string]any (one entry per
+// alias) to kvx.
+var aliasListSchema = []byte(`{
+	"type": "array",
+	"items": {
+		"type": "object",
+		"properties": {
+			"selector": { "type": "string", "title": "Selector", "maxLength": 40 },
+			"url":      { "type": "string", "title": "Endpoint URL", "maxLength": 80 }
+		}
+	}
+}`)
+
+// CommandAlias creates the 'auth alias' command group for managing static
+// hostname aliases (auth.handlers.<name>.hostname.aliases).
+func CommandAlias(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "alias",
+		Short: "Manage static hostname aliases for an auth handler",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Manage static hostname aliases for a host-aware auth handler.
+
+			An alias maps a short selector (e.g. "prod") to a concrete endpoint URL
+			(e.g. "https://api.prod.example.com:6443"). At login time, passing
+			'--hostname <selector>' resolves the alias to its URL before
+			authenticating. Static aliases take precedence over any dynamic
+			hostname resolver configured for the handler.
+
+			Aliases are stored in config under auth.handlers.<handler>.hostname.aliases.
+			Only handlers that declare the hostname capability accept aliases.
+
+			Examples:
+			  # Add or update an alias
+			  scafctl auth alias set openshift prod https://api.prod.example.com:6443
+
+			  # List a handler's aliases
+			  scafctl auth alias list openshift
+
+			  # Remove an alias
+			  scafctl auth alias remove openshift prod
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		SilenceUsage: true,
+	}
+
+	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
+	cmd.AddCommand(commandAliasSet(cliParams, ioStreams, cmdPath))
+	cmd.AddCommand(commandAliasList(cliParams, ioStreams, cmdPath))
+	cmd.AddCommand(commandAliasRemove(cliParams, ioStreams, cmdPath))
+	return cmd
+}
+
+// requireHostnameCapability returns an error when the named handler does not
+// support hostname aliasing.
+func requireHostnameCapability(cmd *cobra.Command, handlerName string) error {
+	handler, err := getHandler(cmd.Context(), handlerName)
+	if err != nil {
+		return exitcode.WithCode(fmt.Errorf("failed to initialize auth handler: %w", err), exitcode.GeneralError)
+	}
+	if !auth.HasCapability(handler.Capabilities(), auth.CapHostname) {
+		return exitcode.WithCode(
+			fmt.Errorf("the %q auth handler does not support hostname aliases", handlerName),
+			exitcode.InvalidInput,
+		)
+	}
+	return nil
+}
+
+// configPathFromCmd returns the value of the root --config flag, if set.
+func configPathFromCmd(cmd *cobra.Command) string {
+	if f := cmd.Root().Flag("config"); f != nil {
+		return f.Value.String()
+	}
+	return ""
+}
+
+func commandAliasSet(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <handler> <selector> <url>",
+		Short: "Add or update a hostname alias",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Add or update a static hostname alias for an auth handler.
+
+			Example:
+			  scafctl auth alias set openshift prod https://api.prod.example.com:6443
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			w := writer.FromContext(ctx)
+			handlerName, selector, url := args[0], args[1], args[2]
+
+			if err := requireHostnameCapability(cmd, handlerName); err != nil {
+				return err
+			}
+
+			mgr := config.NewManager(configPathFromCmd(cmd))
+			cfg, err := mgr.Load()
+			if err != nil {
+				return exitcode.WithCode(fmt.Errorf("loading config: %w", err), exitcode.GeneralError)
+			}
+
+			hn := ensureHostnameConfig(cfg, handlerName)
+			if hn.Aliases == nil {
+				hn.Aliases = map[string]string{}
+			}
+			hn.Aliases[selector] = url
+
+			if err := mgr.Save(); err != nil {
+				return exitcode.WithCode(fmt.Errorf("saving config: %w", err), exitcode.GeneralError)
+			}
+			if w != nil {
+				w.Successf("Set alias %q -> %q for handler %q", selector, url, handlerName)
+			}
+			return nil
+		},
+	}
+}
+
+func commandAliasList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	var outputFlags flags.KvxOutputFlags
+	cmd := &cobra.Command{
+		Use:   "list <handler>",
+		Short: "List a handler's hostname aliases",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			List the static hostname aliases configured for an auth handler.
+
+			Example:
+			  scafctl auth alias list openshift
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			outputFlags.AppName = cliParams.BinaryName
+			handlerName := args[0]
+
+			mgr := config.NewManager(configPathFromCmd(cmd))
+			cfg, err := mgr.Load()
+			if err != nil {
+				return exitcode.WithCode(fmt.Errorf("loading config: %w", err), exitcode.GeneralError)
+			}
+
+			aliases := handlerAliases(cfg, handlerName)
+			selectors := make([]string, 0, len(aliases))
+			for s := range aliases {
+				selectors = append(selectors, s)
+			}
+			sort.Strings(selectors)
+
+			items := make([]map[string]any, 0, len(selectors))
+			for _, s := range selectors {
+				items = append(items, map[string]any{"selector": s, "url": aliases[s]})
+			}
+
+			outputOpts := flags.ToKvxOutputOptions(&outputFlags,
+				kvx.WithIOStreams(ioStreams),
+				kvx.WithOutputColumnOrder([]string{"selector", "url"}),
+				kvx.WithOutputSchemaJSON(aliasListSchema),
+			)
+			return outputOpts.Write(items)
+		},
+	}
+	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
+	return cmd
+}
+
+func commandAliasRemove(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cobra.Command {
+	return &cobra.Command{
+		Use:     "remove <handler> <selector>",
+		Aliases: []string{"rm", "delete"},
+		Short:   "Remove a hostname alias",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Remove a static hostname alias from an auth handler.
+
+			Example:
+			  scafctl auth alias remove openshift prod
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		SilenceUsage: true,
+		Args:         cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			w := writer.FromContext(ctx)
+			handlerName, selector := args[0], args[1]
+
+			if err := requireHostnameCapability(cmd, handlerName); err != nil {
+				return err
+			}
+
+			mgr := config.NewManager(configPathFromCmd(cmd))
+			cfg, err := mgr.Load()
+			if err != nil {
+				return exitcode.WithCode(fmt.Errorf("loading config: %w", err), exitcode.GeneralError)
+			}
+
+			aliases := handlerAliases(cfg, handlerName)
+			if _, ok := aliases[selector]; !ok {
+				return exitcode.WithCode(
+					fmt.Errorf("no alias %q found for handler %q", selector, handlerName),
+					exitcode.InvalidInput,
+				)
+			}
+			delete(aliases, selector)
+			pruneEmptyHostname(cfg, handlerName)
+
+			if err := mgr.Save(); err != nil {
+				return exitcode.WithCode(fmt.Errorf("saving config: %w", err), exitcode.GeneralError)
+			}
+			if w != nil {
+				w.Successf("Removed alias %q from handler %q", selector, handlerName)
+			}
+			return nil
+		},
+	}
+}
+
+// ensureHostnameConfig returns the handler's HostnameConfig, allocating the
+// Handlers map, HandlerConfig entry, and HostnameConfig as needed.
+func ensureHostnameConfig(cfg *config.Config, handlerName string) *config.HostnameConfig {
+	if cfg.Auth.Handlers == nil {
+		cfg.Auth.Handlers = map[string]config.HandlerConfig{}
+	}
+	hc := cfg.Auth.Handlers[handlerName]
+	if hc.Hostname == nil {
+		hc.Hostname = &config.HostnameConfig{}
+	}
+	cfg.Auth.Handlers[handlerName] = hc
+	return hc.Hostname
+}
+
+// handlerAliases returns the alias map for a handler, or nil when absent.
+func handlerAliases(cfg *config.Config, handlerName string) map[string]string {
+	hc, ok := cfg.Auth.Handlers[handlerName]
+	if !ok || hc.Hostname == nil {
+		return nil
+	}
+	return hc.Hostname.Aliases
+}
+
+// pruneEmptyHostname removes empty Hostname/HandlerConfig entries so config
+// stays tidy after the last alias is removed.
+func pruneEmptyHostname(cfg *config.Config, handlerName string) {
+	hc, ok := cfg.Auth.Handlers[handlerName]
+	if !ok || hc.Hostname == nil {
+		return
+	}
+	if len(hc.Hostname.Aliases) == 0 && hc.Hostname.Resolver == nil {
+		hc.Hostname = nil
+		cfg.Auth.Handlers[handlerName] = hc
+	}
+	if hc.Hostname == nil && len(hc.Settings) == 0 {
+		delete(cfg.Auth.Handlers, handlerName)
+	}
+}

--- a/pkg/cmd/scafctl/auth/alias_test.go
+++ b/pkg/cmd/scafctl/auth/alias_test.go
@@ -1,0 +1,205 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/adrg/xdg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+)
+
+// aliasFixture seeds an isolated XDG home and a mock handler with the given
+// capabilities, returning a context wired for the auth alias command.
+func aliasFixture(t *testing.T, handlerName string, caps ...auth.Capability) context.Context {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_STATE_HOME", tmp)
+	xdg.Reload()
+
+	ctx, _ := newTestContext(t)
+	mock := auth.NewMockHandler(handlerName)
+	mock.CapabilitiesValue = caps
+	ctx = withTestHandler(ctx, mock)
+	ctx = configureAuthAndTokenRegistry(t, ctx, mock)
+	return ctx
+}
+
+func runAlias(t *testing.T, ctx context.Context, args ...string) (string, error) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	cmd := CommandAlias(settings.NewCliParams(), ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+// TestCommandAliasSet_PersistsNestedAlias verifies 'set' allocates the nested
+// config structure and persists the alias to disk.
+func TestCommandAliasSet_PersistsNestedAlias(t *testing.T) {
+	ctx := aliasFixture(t, "openshift", auth.CapHostname)
+
+	_, err := runAlias(t, ctx, "set", "openshift", "prod", "https://api.prod.example.com:6443")
+	require.NoError(t, err)
+
+	cfg, err := config.NewManager("").Load()
+	require.NoError(t, err)
+	hc, ok := cfg.Auth.Handlers["openshift"]
+	require.True(t, ok, "handler entry must be persisted")
+	require.NotNil(t, hc.Hostname)
+	assert.Equal(t, "https://api.prod.example.com:6443", hc.Hostname.Aliases["prod"])
+}
+
+// TestCommandAliasSet_UpdatesExistingAlias verifies 'set' overwrites an
+// existing selector.
+func TestCommandAliasSet_UpdatesExistingAlias(t *testing.T) {
+	ctx := aliasFixture(t, "openshift", auth.CapHostname)
+
+	_, err := runAlias(t, ctx, "set", "openshift", "prod", "https://old.example.com:6443")
+	require.NoError(t, err)
+	_, err = runAlias(t, ctx, "set", "openshift", "prod", "https://new.example.com:6443")
+	require.NoError(t, err)
+
+	cfg, err := config.NewManager("").Load()
+	require.NoError(t, err)
+	assert.Equal(t, "https://new.example.com:6443", cfg.Auth.Handlers["openshift"].Hostname.Aliases["prod"])
+}
+
+// TestCommandAliasSet_RejectsHandlerWithoutHostnameCap verifies the capability
+// gate blocks handlers that do not support hostname aliasing.
+func TestCommandAliasSet_RejectsHandlerWithoutHostnameCap(t *testing.T) {
+	ctx := aliasFixture(t, "github") // no CapHostname
+
+	_, err := runAlias(t, ctx, "set", "github", "prod", "https://api.prod.example.com:6443")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support hostname aliases")
+}
+
+// TestCommandAliasList_RendersAliases verifies 'list' emits configured aliases.
+func TestCommandAliasList_RendersAliases(t *testing.T) {
+	ctx := aliasFixture(t, "openshift", auth.CapHostname)
+	_, err := runAlias(t, ctx, "set", "openshift", "prod", "https://api.prod.example.com:6443")
+	require.NoError(t, err)
+	_, err = runAlias(t, ctx, "set", "openshift", "staging", "https://api.staging.example.com:6443")
+	require.NoError(t, err)
+
+	out, err := runAlias(t, ctx, "list", "openshift", "-o", "json")
+	require.NoError(t, err)
+
+	var items []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &items))
+	require.Len(t, items, 2)
+	assert.Equal(t, "prod", items[0]["selector"])
+	assert.Equal(t, "https://api.prod.example.com:6443", items[0]["url"])
+	assert.Equal(t, "staging", items[1]["selector"])
+}
+
+// TestCommandAliasList_EmptyIsNotAnError verifies listing a handler with no
+// aliases succeeds and renders nothing.
+func TestCommandAliasList_EmptyIsNotAnError(t *testing.T) {
+	ctx := aliasFixture(t, "openshift", auth.CapHostname)
+
+	out, err := runAlias(t, ctx, "list", "openshift", "-o", "json")
+	require.NoError(t, err)
+
+	var items []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &items))
+	assert.Empty(t, items)
+}
+
+// TestCommandAliasRemove_DeletesAndPrunes verifies 'remove' deletes the alias
+// and prunes the now-empty hostname/handler entry.
+func TestCommandAliasRemove_DeletesAndPrunes(t *testing.T) {
+	ctx := aliasFixture(t, "openshift", auth.CapHostname)
+	_, err := runAlias(t, ctx, "set", "openshift", "prod", "https://api.prod.example.com:6443")
+	require.NoError(t, err)
+
+	_, err = runAlias(t, ctx, "remove", "openshift", "prod")
+	require.NoError(t, err)
+
+	cfg, err := config.NewManager("").Load()
+	require.NoError(t, err)
+	_, ok := cfg.Auth.Handlers["openshift"]
+	assert.False(t, ok, "empty handler entry must be pruned after last alias removed")
+}
+
+// TestCommandAliasRemove_UnknownSelectorErrors verifies removing a missing
+// alias fails clearly.
+func TestCommandAliasRemove_UnknownSelectorErrors(t *testing.T) {
+	ctx := aliasFixture(t, "openshift", auth.CapHostname)
+	_, err := runAlias(t, ctx, "set", "openshift", "prod", "https://api.prod.example.com:6443")
+	require.NoError(t, err)
+
+	_, err = runAlias(t, ctx, "remove", "openshift", "staging")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no alias")
+}
+
+// TestCommandAliasRemove_RejectsHandlerWithoutHostnameCap verifies the
+// capability gate blocks 'remove' for handlers that do not support hostname
+// aliasing, matching the 'set' semantics.
+func TestCommandAliasRemove_RejectsHandlerWithoutHostnameCap(t *testing.T) {
+	ctx := aliasFixture(t, "github") // no CapHostname
+
+	_, err := runAlias(t, ctx, "remove", "github", "prod")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not support hostname aliases")
+}
+
+// TestCommandAliasSet_PreservesOpaqueSettings verifies that a save-through of
+// the alias write does not drop passthrough handler settings.
+func TestCommandAliasSet_PreservesOpaqueSettings(t *testing.T) {
+	ctx := aliasFixture(t, "openshift", auth.CapHostname)
+
+	// Seed a config file with opaque handler settings.
+	seed := config.NewManager("")
+	cfg, err := seed.Load()
+	require.NoError(t, err)
+	// viper lowercases config keys, so the passthrough key round-trips as "apitimeout".
+	cfg.Auth.Handlers = map[string]config.HandlerConfig{
+		"openshift": {Settings: map[string]any{"apitimeout": "30s"}},
+	}
+	require.NoError(t, seed.Save())
+
+	_, err = runAlias(t, ctx, "set", "openshift", "prod", "https://api.prod.example.com:6443")
+	require.NoError(t, err)
+
+	reloaded, err := config.NewManager("").Load()
+	require.NoError(t, err)
+	hc := reloaded.Auth.Handlers["openshift"]
+	assert.Equal(t, "https://api.prod.example.com:6443", hc.Hostname.Aliases["prod"])
+	assert.Equal(t, "30s", hc.Settings["apitimeout"], "opaque handler settings must survive an alias write")
+}
+
+// TestCommandAliasSet_Embedder verifies the command works under a non-default
+// embedder binary name.
+func TestCommandAliasSet_Embedder(t *testing.T) {
+	ctx := aliasFixture(t, "openshift", auth.CapHostname)
+
+	params := settings.NewCliParams()
+	params.BinaryName = "mycli"
+	buf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	cmd := CommandAlias(params, ioStreams, "mycli/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"set", "openshift", "prod", "https://api.prod.example.com:6443"})
+	require.NoError(t, cmd.Execute())
+
+	cfg, err := config.NewManager("").Load()
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.prod.example.com:6443", cfg.Auth.Handlers["openshift"].Hostname.Aliases["prod"])
+}

--- a/pkg/cmd/scafctl/auth/auth.go
+++ b/pkg/cmd/scafctl/auth/auth.go
@@ -41,6 +41,7 @@ func CommandAuth(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 	}
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
+	cmd.AddCommand(CommandAlias(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandDiagnose(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandHandlers(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandList(cliParams, ioStreams, cmdPath))

--- a/pkg/cmd/scafctl/auth/auth_test.go
+++ b/pkg/cmd/scafctl/auth/auth_test.go
@@ -25,12 +25,13 @@ func TestCommandAuth(t *testing.T) {
 
 	// Verify subcommands are added
 	subCmds := cmd.Commands()
-	require.Len(t, subCmds, 10)
+	require.Len(t, subCmds, 11)
 
 	cmdNames := make([]string, len(subCmds))
 	for i, c := range subCmds {
 		cmdNames[i] = c.Use
 	}
+	assert.Contains(t, cmdNames, "alias")
 	assert.Contains(t, cmdNames, "diagnose")
 	assert.Contains(t, cmdNames, "list [handler]")
 	assert.Contains(t, cmdNames, "login <handler>")

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -14,6 +15,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	hostnameresolver "github.com/oakwood-commons/scafctl/pkg/auth/hostname"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/config"
@@ -228,6 +230,25 @@ func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cob
 				err := fmt.Errorf("--hostname is not supported by the %q auth handler", handlerName)
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+
+			// Resolve a hostname selector (static alias or dynamic inventory)
+			// into a concrete endpoint URL before login. Returns the value
+			// unchanged when it is already a URL or when the handler has no
+			// hostname config, so plain-hostname handlers are unaffected.
+			if hostname != "" {
+				resolved, rErr := hostnameresolver.Resolve(ctx, handlerName, hostname)
+				if rErr != nil {
+					w.Errorf("%v", rErr)
+					code := exitcode.GeneralError
+					if errors.Is(rErr, hostnameresolver.ErrSelectorNotFound) ||
+						errors.Is(rErr, hostnameresolver.ErrResolverLoop) ||
+						errors.Is(rErr, hostnameresolver.ErrTransformShape) {
+						code = exitcode.InvalidInput
+					}
+					return exitcode.WithCode(rErr, code)
+				}
+				hostname = resolved
 			}
 			if federatedToken != "" && !auth.HasCapability(caps, auth.CapFederatedToken) {
 				err := fmt.Errorf("--federated-token is not supported by the %q auth handler", handlerName)

--- a/pkg/cmd/scafctl/auth/login_hostname_test.go
+++ b/pkg/cmd/scafctl/auth/login_hostname_test.go
@@ -1,0 +1,126 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/adrg/xdg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+)
+
+// hostnameLoginFixture builds a not-authenticated mock handler with CapHostname
+// and a context seeded with the given hostname config for that handler.
+func hostnameLoginFixture(t *testing.T, hn *config.HostnameConfig) (context.Context, *auth.MockHandler) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_STATE_HOME", tmp)
+	xdg.Reload()
+
+	ctx, _ := newTestContext(t)
+
+	const handlerName = "openshift"
+	mock := auth.NewMockHandler(handlerName)
+	mock.CapabilitiesValue = []auth.Capability{auth.CapHostname}
+	mock.SetNotAuthenticated()
+	mock.LoginResult = &auth.Result{Claims: &auth.Claims{Email: "user@example.com"}}
+	ctx = withTestHandler(ctx, mock)
+	ctx = configureAuthAndTokenRegistry(t, ctx, mock)
+
+	cfg := &config.Config{
+		Auth: config.GlobalAuthConfig{
+			Handlers: map[string]config.HandlerConfig{
+				handlerName: {Hostname: hn},
+			},
+		},
+	}
+	ctx = config.WithConfig(ctx, cfg)
+	return ctx, mock
+}
+
+// TestCommandLogin_HostnameAliasResolved verifies that a static alias is
+// resolved to a concrete endpoint URL and forwarded to the handler.
+func TestCommandLogin_HostnameAliasResolved(t *testing.T) {
+	ctx, mock := hostnameLoginFixture(t, &config.HostnameConfig{
+		Aliases: map[string]string{"prod": "https://api.prod.example.com:6443"},
+	})
+
+	buf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	cmd := CommandLogin(settings.NewCliParams(), ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"openshift", "--hostname", "prod"})
+
+	require.NoError(t, cmd.Execute())
+	require.Len(t, mock.LoginCalls, 1)
+	assert.Equal(t, "https://api.prod.example.com:6443", mock.LoginCalls[0].Hostname)
+}
+
+// TestCommandLogin_HostnameSelectorNotFound verifies that an unknown selector
+// fails with an invalid-input error and never calls the handler.
+func TestCommandLogin_HostnameSelectorNotFound(t *testing.T) {
+	ctx, mock := hostnameLoginFixture(t, &config.HostnameConfig{
+		Aliases: map[string]string{"prod": "https://api.prod.example.com:6443"},
+	})
+
+	buf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	cmd := CommandLogin(settings.NewCliParams(), ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"openshift", "--hostname", "staging"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "selector not found")
+	assert.Empty(t, mock.LoginCalls, "handler must not be called when selector resolution fails")
+}
+
+// TestCommandLogin_HostnameConcreteURLPassthrough verifies that an already
+// concrete URL is forwarded unchanged even when aliases exist.
+func TestCommandLogin_HostnameConcreteURLPassthrough(t *testing.T) {
+	ctx, mock := hostnameLoginFixture(t, &config.HostnameConfig{
+		Aliases: map[string]string{"prod": "https://api.prod.example.com:6443"},
+	})
+
+	buf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	cmd := CommandLogin(settings.NewCliParams(), ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"openshift", "--hostname", "https://api.custom.example.com:6443"})
+
+	require.NoError(t, cmd.Execute())
+	require.Len(t, mock.LoginCalls, 1)
+	assert.Equal(t, "https://api.custom.example.com:6443", mock.LoginCalls[0].Hostname)
+}
+
+// TestCommandLogin_HostnameResolvedForEmbedder verifies the hook works under a
+// non-default embedder binary name.
+func TestCommandLogin_HostnameResolvedForEmbedder(t *testing.T) {
+	ctx, mock := hostnameLoginFixture(t, &config.HostnameConfig{
+		Aliases: map[string]string{"prod": "https://api.prod.example.com:6443"},
+	})
+
+	params := settings.NewCliParams()
+	params.BinaryName = "mycli"
+
+	buf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	cmd := CommandLogin(params, ioStreams, "mycli/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"openshift", "--hostname", "prod"})
+
+	require.NoError(t, cmd.Execute())
+	require.Len(t, mock.LoginCalls, 1)
+	assert.Equal(t, "https://api.prod.example.com:6443", mock.LoginCalls[0].Hostname)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -25,6 +27,11 @@ const (
 
 	// DefaultConfigFileType is the default config file type.
 	DefaultConfigFileType = "yaml"
+
+	// ConfigDirName is the drop-in directory (relative to the config file's
+	// directory) whose *.yaml/*.yml fragments are merged in lexical order
+	// between the embedder base layer and the user's config file.
+	ConfigDirName = "config.d"
 
 	// EnvPrefix is the environment variable prefix.
 	EnvPrefix = "SCAFCTL"
@@ -65,6 +72,13 @@ type Manager struct {
 	baseConfig []byte
 	envPrefix  string
 	config     *Config
+
+	// dropIn holds the merged config.d fragment values (lowercased keys), and
+	// userSettings holds the values read from the user's config file alone. Save
+	// uses them to avoid baking tooling-supplied drop-in values into the user's
+	// config file, which would defeat config.d layering.
+	dropIn       map[string]any
+	userSettings map[string]any
 }
 
 // NewManager creates a new configuration manager.
@@ -113,6 +127,18 @@ func (m *Manager) Load() (*Config, error) {
 		}
 	}
 
+	// Merge drop-in config fragments from the config.d directory (after the
+	// embedder base layer, before the user's config file). Fragments are
+	// merged in lexical filename order, so later files override earlier ones.
+	// Precedence: defaults -> base -> config.d -> config.yaml -> env -> flags.
+	if err := m.mergeConfigDir(filepath.Dir(configPath)); err != nil {
+		return nil, err
+	}
+
+	// Capture the user config file's own values (no defaults, base, config.d, or
+	// env) so Save can distinguish user-owned keys from drop-in values.
+	m.userSettings = readUserSettings(configPath)
+
 	// Read user config file (not an error if it doesn't exist).
 	// MergeInConfig is used unconditionally so that when a base config layer
 	// is present the user file merges on top rather than replacing it.
@@ -149,6 +175,84 @@ func (m *Manager) Load() (*Config, error) {
 
 	m.config = &cfg
 	return &cfg, nil
+}
+
+// mergeConfigDir merges every *.yaml/*.yml fragment in the config.d directory
+// located next to the main config file. Fragments are merged in lexical
+// filename order (later files override earlier ones). A missing config.d
+// directory is not an error; individual fragments that fail to parse are.
+func (m *Manager) mergeConfigDir(baseDir string) error {
+	if baseDir == "" {
+		return nil
+	}
+	dir := filepath.Join(baseDir, ConfigDirName)
+
+	var fragments []string
+	for _, pattern := range []string{"*.yaml", "*.yml"} {
+		matches, err := filepath.Glob(filepath.Join(dir, pattern))
+		if err != nil {
+			return fmt.Errorf("failed to scan %s: %w", dir, err)
+		}
+		fragments = append(fragments, matches...)
+	}
+	if len(fragments) == 0 {
+		return nil
+	}
+	sort.Strings(fragments)
+
+	// Track drop-in values (parsed with documented yaml-tag casing) so Save can
+	// identify and skip them, keeping config.d fragments out of the persisted
+	// user config file. Deep-merged in lexical order to mirror the viper merge.
+	dropMap := map[string]any{}
+
+	for _, fragment := range fragments {
+		data, err := os.ReadFile(fragment) //nolint:gosec // path derived from trusted config dir
+		if err != nil {
+			return fmt.Errorf("failed to read config fragment %s: %w", fragment, err)
+		}
+		if err := m.v.MergeConfig(bytes.NewReader(data)); err != nil {
+			return fmt.Errorf("failed to merge config fragment %s: %w", fragment, err)
+		}
+		var fragMap map[string]any
+		if err := yaml.Unmarshal(data, &fragMap); err != nil {
+			return fmt.Errorf("failed to parse config fragment %s: %w", fragment, err)
+		}
+		deepMergeMap(dropMap, fragMap)
+	}
+	m.dropIn = dropMap
+	return nil
+}
+
+// deepMergeMap recursively merges src into dst, with src winning on conflicts.
+// Nested maps are merged; all other values (including slices) are replaced.
+func deepMergeMap(dst, src map[string]any) {
+	for k, v := range src {
+		if sv, ok := v.(map[string]any); ok {
+			if dv, ok := dst[k].(map[string]any); ok {
+				deepMergeMap(dv, sv)
+				continue
+			}
+		}
+		dst[k] = v
+	}
+}
+
+// readUserSettings reads the user's config file alone (excluding defaults, the
+// embedder base layer, config.d, and env vars) and returns its settings map
+// keyed by documented (yaml-tag) names. A missing or unreadable file yields nil.
+func readUserSettings(configPath string) map[string]any {
+	if configPath == "" {
+		return nil
+	}
+	data, err := os.ReadFile(configPath) //nolint:gosec // path is the configured config file
+	if err != nil {
+		return nil
+	}
+	var settings map[string]any
+	if err := yaml.Unmarshal(data, &settings); err != nil {
+		return nil
+	}
+	return settings
 }
 
 // setDefaults sets default configuration values.
@@ -458,7 +562,7 @@ func (m *Manager) Save() error {
 	m.v.Set("auth", m.config.Auth)
 	m.v.Set("build", m.config.Build)
 
-	return m.v.WriteConfig()
+	return m.writeConfig(m.v, "")
 }
 
 // SaveAs saves the configuration to a specific path.
@@ -486,7 +590,89 @@ func (m *Manager) SaveAs(path string) error {
 	m.v.Set("auth", m.config.Auth)
 	m.v.Set("build", m.config.Build)
 
-	return m.v.WriteConfigAs(path)
+	return m.writeConfig(m.v, path)
+}
+
+// writeConfig persists the configuration, pruning any values that came solely
+// from the config.d drop-in layer so they are not baked into the user's config
+// file (which would defeat config.d layering). When path is empty the manager's
+// current config file is used. With no drop-in layer present it writes v
+// directly, preserving the original output byte-for-byte.
+func (m *Manager) writeConfig(v *viper.Viper, path string) error {
+	if len(m.dropIn) == 0 {
+		if path == "" {
+			return v.WriteConfig()
+		}
+		return v.WriteConfigAs(path)
+	}
+
+	// Normalize the effective config to documented (yaml-tag) casing so it can
+	// be compared against the fragment/user maps, then drop pure drop-in values.
+	effBytes, err := yaml.Marshal(m.config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config for save: %w", err)
+	}
+	var effMap map[string]any
+	if err := yaml.Unmarshal(effBytes, &effMap); err != nil {
+		return fmt.Errorf("failed to normalize config for save: %w", err)
+	}
+
+	pruned := pruneDropIn(effMap, m.dropIn, m.userSettings)
+	outBytes, err := yaml.Marshal(pruned)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config for save: %w", err)
+	}
+
+	target := path
+	if target == "" {
+		target = v.ConfigFileUsed()
+	}
+	if target == "" {
+		return fmt.Errorf("no config file path available for save")
+	}
+	if err := os.WriteFile(target, outBytes, 0o600); err != nil {
+		return fmt.Errorf("failed to write config file %s: %w", target, err)
+	}
+	return nil
+}
+
+// pruneDropIn returns a copy of effective with keys whose values came solely
+// from the config.d drop-in layer removed. A key is dropped only when its value
+// equals the drop-in value and the user's own config file did not set it; keys
+// the user set, or values that differ from the drop-in, are always kept. Nested
+// maps are pruned recursively.
+func pruneDropIn(effective, dropIn, user map[string]any) map[string]any {
+	out := make(map[string]any, len(effective))
+	for k, v := range effective {
+		dv, inDrop := dropIn[k]
+		if !inDrop {
+			out[k] = v
+			continue
+		}
+
+		uv, inUser := user[k]
+
+		// Recurse into nested maps so partially user-owned subtrees survive.
+		if vm, ok := v.(map[string]any); ok {
+			if dm, ok := dv.(map[string]any); ok {
+				um, _ := uv.(map[string]any)
+				if pruned := pruneDropIn(vm, dm, um); len(pruned) > 0 {
+					out[k] = pruned
+				}
+				continue
+			}
+		}
+
+		if inUser {
+			out[k] = v
+			continue
+		}
+		if reflect.DeepEqual(v, dv) {
+			continue // pure drop-in value; the fragment re-supplies it on load
+		}
+		out[k] = v
+	}
+	return out
 }
 
 // Get returns a configuration value by key.
@@ -618,6 +804,18 @@ func (m *Manager) Config() *Config {
 func (m *Manager) ConfigPath() string {
 	p, _ := m.configPathOrError()
 	return p
+}
+
+// ConfigDir returns the directory containing the config file. This is the
+// anchor for the config.d drop-in directory and for resolving relative paths
+// referenced from configuration. Returns an empty string only when the config
+// path cannot be determined.
+func (m *Manager) ConfigDir() string {
+	p, err := m.configPathOrError()
+	if err != nil || p == "" {
+		return ""
+	}
+	return filepath.Dir(p)
 }
 
 // configPathOrError resolves the config file path, returning an error with the

--- a/pkg/config/configdir_test.go
+++ b/pkg/config/configdir_test.go
@@ -1,0 +1,178 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+}
+
+// TestManager_Load_ConfigDir_MergesFragments verifies that fragments in the
+// config.d directory are merged beneath the user's config file.
+func TestManager_Load_ConfigDir_MergesFragments(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	writeFile(t, configPath, "settings:\n  defaultCatalog: user-catalog\n")
+	writeFile(t, filepath.Join(dir, ConfigDirName, "10-telemetry.yaml"),
+		"telemetry:\n  serviceName: from-fragment\n")
+
+	cfg, err := NewManager(configPath).Load()
+	require.NoError(t, err)
+
+	// User config wins for keys it defines.
+	assert.Equal(t, "user-catalog", cfg.Settings.DefaultCatalog)
+	// Fragment supplies keys the user config does not define.
+	assert.Equal(t, "from-fragment", cfg.Telemetry.ServiceName)
+}
+
+// TestManager_Load_ConfigDir_UserFileOverridesFragment verifies precedence:
+// config.yaml overrides config.d fragments.
+func TestManager_Load_ConfigDir_UserFileOverridesFragment(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	writeFile(t, configPath, "telemetry:\n  serviceName: from-user\n")
+	writeFile(t, filepath.Join(dir, ConfigDirName, "10-telemetry.yaml"),
+		"telemetry:\n  serviceName: from-fragment\n")
+
+	cfg, err := NewManager(configPath).Load()
+	require.NoError(t, err)
+	assert.Equal(t, "from-user", cfg.Telemetry.ServiceName)
+}
+
+// TestManager_Load_ConfigDir_LexicalOrder verifies later fragments override
+// earlier ones in lexical filename order.
+func TestManager_Load_ConfigDir_LexicalOrder(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	writeFile(t, configPath, "settings:\n  defaultCatalog: user-catalog\n")
+	writeFile(t, filepath.Join(dir, ConfigDirName, "10-a.yaml"),
+		"telemetry:\n  serviceName: first\n")
+	writeFile(t, filepath.Join(dir, ConfigDirName, "20-b.yml"),
+		"telemetry:\n  serviceName: second\n")
+
+	cfg, err := NewManager(configPath).Load()
+	require.NoError(t, err)
+	assert.Equal(t, "second", cfg.Telemetry.ServiceName)
+}
+
+// TestManager_Load_ConfigDir_MissingIsNotError verifies a missing config.d
+// directory is not an error.
+func TestManager_Load_ConfigDir_MissingIsNotError(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	writeFile(t, configPath, "settings:\n  defaultCatalog: user-catalog\n")
+
+	cfg, err := NewManager(configPath).Load()
+	require.NoError(t, err)
+	assert.Equal(t, "user-catalog", cfg.Settings.DefaultCatalog)
+}
+
+// TestManager_Load_ConfigDir_InvalidFragmentErrors verifies a malformed
+// fragment surfaces an error.
+func TestManager_Load_ConfigDir_InvalidFragmentErrors(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	writeFile(t, configPath, "settings:\n  defaultCatalog: user-catalog\n")
+	writeFile(t, filepath.Join(dir, ConfigDirName, "bad.yaml"), "telemetry: [unterminated\n")
+
+	_, err := NewManager(configPath).Load()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad.yaml")
+}
+
+// TestManager_ConfigDir verifies ConfigDir returns the directory of the config
+// file, for both an explicit path and after loading the default.
+func TestManager_ConfigDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	mgr := NewManager(configPath)
+	assert.Equal(t, dir, mgr.ConfigDir())
+
+	writeFile(t, configPath, "settings:\n  defaultCatalog: user-catalog\n")
+	_, err := mgr.Load()
+	require.NoError(t, err)
+	assert.Equal(t, dir, mgr.ConfigDir())
+}
+
+// TestManager_Save_DoesNotBakeConfigDirValues verifies that values supplied
+// only by a config.d fragment are not written into the user's config file on
+// Save, so drop-in layering stays overridable.
+func TestManager_Save_DoesNotBakeConfigDirValues(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	writeFile(t, configPath, "settings:\n  defaultCatalog: user-catalog\n")
+	writeFile(t, filepath.Join(dir, ConfigDirName, "10-telemetry.yaml"),
+		"telemetry:\n  serviceName: from-fragment\n")
+
+	mgr := NewManager(configPath)
+	cfg, err := mgr.Load()
+	require.NoError(t, err)
+	require.Equal(t, "from-fragment", cfg.Telemetry.ServiceName)
+
+	// Mutate an unrelated user-owned value and save.
+	cfg.Logging.Level = "error"
+	require.NoError(t, mgr.Save())
+
+	// The fragment value must not be baked into the user's config file.
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "from-fragment",
+		"config.d fragment value must not be persisted to the user config file")
+
+	// Changing the fragment afterward must still take effect (proves the value
+	// was not made sticky by the save).
+	writeFile(t, filepath.Join(dir, ConfigDirName, "10-telemetry.yaml"),
+		"telemetry:\n  serviceName: changed-fragment\n")
+	cfg2, err := NewManager(configPath).Load()
+	require.NoError(t, err)
+	assert.Equal(t, "changed-fragment", cfg2.Telemetry.ServiceName)
+	assert.Equal(t, "error", cfg2.Logging.Level)
+}
+
+// TestManager_Save_KeepsUserOverrideOfFragmentKey verifies that when the user
+// config sets the same key a fragment provides, Save persists the user's value.
+func TestManager_Save_KeepsUserOverrideOfFragmentKey(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	writeFile(t, configPath, "telemetry:\n  serviceName: from-user\n")
+	writeFile(t, filepath.Join(dir, ConfigDirName, "10-telemetry.yaml"),
+		"telemetry:\n  serviceName: from-fragment\n")
+
+	mgr := NewManager(configPath)
+	cfg, err := mgr.Load()
+	require.NoError(t, err)
+	require.Equal(t, "from-user", cfg.Telemetry.ServiceName)
+
+	cfg.Logging.Level = "error"
+	require.NoError(t, mgr.Save())
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "from-user",
+		"user-owned value that shadows a fragment key must be persisted")
+}

--- a/pkg/config/handlers_test.go
+++ b/pkg/config/handlers_test.go
@@ -1,0 +1,96 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestManager_Load_AuthHandlersNamespace verifies that the open
+// auth.handlers.<name> namespace round-trips through viper/mapstructure: the
+// reserved "hostname" block is parsed into typed fields, and every other key is
+// captured into the opaque Settings passthrough map.
+func TestManager_Load_AuthHandlersNamespace(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+version: 1
+auth:
+  handlers:
+    openshift:
+      hostname:
+        aliases:
+          pd1020: https://api.pd1020.example.com:6443
+        resolver:
+          source:
+            url: https://clusters.example.com
+            authProvider: entra
+            authScope: api://fleet/.default
+          transform: '_.map(k, {"name": k, "url": _[k].apiServerURL})'
+          ttl: 1h
+      apiTimeout: 30
+      caBundlePath: /etc/ssl/corp.pem
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o600))
+
+	mgr := NewManager(configPath)
+	cfg, err := mgr.Load()
+	require.NoError(t, err)
+
+	handler, ok := cfg.Auth.Handlers["openshift"]
+	require.True(t, ok, "expected openshift handler entry")
+
+	// Host-consumed hostname block parsed into typed fields.
+	require.NotNil(t, handler.Hostname)
+	assert.Equal(t, "https://api.pd1020.example.com:6443", handler.Hostname.Aliases["pd1020"])
+	require.NotNil(t, handler.Hostname.Resolver)
+	assert.Equal(t, "https://clusters.example.com", handler.Hostname.Resolver.Source.URL)
+	assert.Equal(t, "entra", handler.Hostname.Resolver.Source.AuthProvider)
+	assert.Equal(t, "api://fleet/.default", handler.Hostname.Resolver.Source.AuthScope)
+	assert.Equal(t, "1h", handler.Hostname.Resolver.TTL)
+	assert.NotEmpty(t, handler.Hostname.Resolver.Transform)
+
+	// Opaque passthrough: every key other than "hostname" lands in Settings.
+	// Viper lowercases keys.
+	require.NotNil(t, handler.Settings)
+	assert.NotContains(t, handler.Settings, "hostname", "hostname must not leak into opaque Settings")
+	assert.Contains(t, handler.Settings, "apitimeout")
+	assert.Contains(t, handler.Settings, "cabundlepath")
+}
+
+// TestManager_GetUnknownKeys_AuthHandlersAllowed verifies that arbitrary keys
+// under the open auth.handlers.<name> namespace are not flagged as unknown.
+func TestManager_GetUnknownKeys_AuthHandlersAllowed(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+version: 1
+auth:
+  handlers:
+    openshift:
+      hostname:
+        aliases:
+          pd1020: https://api.pd1020.example.com:6443
+      apiTimeout: 30
+      nested:
+        deeply:
+          custom: value
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o600))
+
+	mgr := NewManager(configPath)
+	_, err := mgr.Load()
+	require.NoError(t, err)
+
+	for _, key := range mgr.GetUnknownKeys() {
+		assert.NotContains(t, key, "auth.handlers", "auth.handlers.* keys must not be flagged as unknown: %s", key)
+	}
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -414,11 +414,85 @@ type GlobalAuthConfig struct {
 	// CustomOAuth2 contains user-defined OAuth2 auth handlers.
 	CustomOAuth2 []CustomOAuth2Config `json:"customOAuth2,omitempty" yaml:"customOAuth2,omitempty" mapstructure:"customOAuth2" doc:"User-defined OAuth2 auth handlers for any OAuth2 service" maxItems:"20"`
 
+	// Handlers holds per-handler configuration namespaces keyed by handler name
+	// (e.g. "openshift"). The host consumes the reserved "hostname" block for
+	// alias/endpoint resolution; every other key is delivered opaquely to the
+	// handler plugin via its provider Settings. scafctl core is shape-blind to
+	// these passthrough settings.
+	Handlers map[string]HandlerConfig `json:"handlers,omitempty" yaml:"handlers,omitempty" mapstructure:"handlers" doc:"Per-handler configuration namespaces keyed by handler name; the reserved 'hostname' block is host-consumed, all other keys are forwarded opaquely to the handler plugin"`
+
 	// TrustedVerificationDomains are additional domains trusted for device code
 	// verification URIs across all auth handlers. These supplement the hardcoded
 	// per-handler domains from the official auth handler registry. Use this for
 	// org-specific identity providers (e.g., custom GHES hostnames, corporate IDPs).
 	TrustedVerificationDomains []string `json:"trustedVerificationDomains,omitempty" yaml:"trustedVerificationDomains,omitempty" mapstructure:"trustedVerificationDomains" doc:"Additional trusted domains for device code verification URIs" maxItems:"50"`
+}
+
+// HandlerConfig is the per-handler configuration namespace under
+// auth.handlers.<name>. scafctl core is shape-blind to handler settings: the
+// host consumes the reserved Hostname block for alias/endpoint resolution and
+// forwards every other key opaquely to the handler plugin via its provider
+// Settings.
+type HandlerConfig struct {
+	// Hostname configures host-side hostname alias and endpoint resolution for
+	// this handler. It is consumed by the host and is NOT forwarded to the
+	// plugin.
+	Hostname *HostnameConfig `json:"hostname,omitempty" yaml:"hostname,omitempty" mapstructure:"hostname" doc:"Host-side hostname alias/endpoint resolution"`
+
+	// Settings captures every handler-specific key other than "hostname" and is
+	// forwarded opaquely to the handler plugin. The host does not interpret it.
+	// Note: viper lowercases all keys, so plugins receive lowercased setting
+	// names. The yaml `,inline` tag ensures passthrough keys survive a
+	// config save round-trip (e.g. when 'auth alias' rewrites the file).
+	Settings map[string]any `json:"-" yaml:",inline" mapstructure:",remain"`
+}
+
+// HostnameConfig configures host-side resolution of a user-supplied hostname
+// selector into a concrete endpoint for an auth handler. Static Aliases take
+// precedence over the dynamic Resolver.
+type HostnameConfig struct {
+	// Aliases maps a short hostname selector (e.g. "cluster-01") to a concrete
+	// endpoint URL. Static aliases win over the dynamic resolver.
+	Aliases map[string]string `json:"aliases,omitempty" yaml:"aliases,omitempty" mapstructure:"aliases" doc:"Static map of hostname selector to concrete endpoint URL"`
+
+	// Resolver dynamically fetches and normalizes an endpoint inventory at login
+	// time. It is overlaid by Aliases (static wins).
+	Resolver *HostnameResolverConfig `json:"resolver,omitempty" yaml:"resolver,omitempty" mapstructure:"resolver" doc:"Dynamic hostname inventory resolver"`
+}
+
+// HostnameResolverConfig declares where to fetch a hostname inventory and how
+// to normalize it into a list of {name, url} entries. The host runs this
+// in-process at login time and caches the result for TTL.
+type HostnameResolverConfig struct {
+	// Source declares where to fetch the inventory.
+	Source HostnameResolverSource `json:"source,omitempty" yaml:"source,omitempty" mapstructure:"source" doc:"Where to fetch the hostname inventory"`
+
+	// Transform is a CEL expression that normalizes the fetched body into a list
+	// of {name, url} entries. Entries may also carry optional per-cluster OIDC
+	// fields (audience, authType, caData, consoleUrl, insecureSkipTls). The
+	// fetched JSON is available as `_`.
+	Transform string `json:"transform,omitempty" yaml:"transform,omitempty" mapstructure:"transform" doc:"CEL expression normalizing the inventory into a list of {name,url} entries" maxLength:"8192"`
+
+	// TTL caches the resolved inventory for this duration (e.g. "1h"). Empty or
+	// "0" disables caching (re-fetch every login).
+	TTL string `json:"ttl,omitempty" yaml:"ttl,omitempty" mapstructure:"ttl" doc:"Cache duration for the resolved inventory (e.g. 1h); 0 disables caching" maxLength:"32"`
+}
+
+// HostnameResolverSource declares an HTTP endpoint to fetch a hostname
+// inventory from, with optional bearer-token injection via an auth handler.
+type HostnameResolverSource struct {
+	// URL is the inventory endpoint (HTTPS GET returning JSON).
+	URL string `json:"url,omitempty" yaml:"url,omitempty" mapstructure:"url" doc:"Inventory endpoint URL (HTTPS GET returning JSON)" maxLength:"2048" example:"https://clusters.example.com"`
+
+	// AuthProvider is the auth handler used to inject a bearer token (e.g.
+	// entra, gcp). Empty means the endpoint is unauthenticated.
+	AuthProvider string `json:"authProvider,omitempty" yaml:"authProvider,omitempty" mapstructure:"authProvider" doc:"Auth handler name for bearer token injection; empty for unauthenticated endpoints" maxLength:"64" example:"entra"`
+
+	// AuthScope is the OAuth scope requested when AuthProvider is set.
+	AuthScope string `json:"authScope,omitempty" yaml:"authScope,omitempty" mapstructure:"authScope" doc:"OAuth scope for the auth provider token request" maxLength:"1024" example:"api://fleet/.default"`
+
+	// Headers are additional static request headers.
+	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty" mapstructure:"headers" doc:"Additional static request headers"`
 }
 
 // EntraAuthConfig contains Entra-specific configuration.

--- a/pkg/config/unknown_keys.go
+++ b/pkg/config/unknown_keys.go
@@ -70,6 +70,19 @@ func isKnownKey(key string, knownKeys map[string]bool) bool {
 		}
 	}
 
+	// Check open-namespace map wildcards (e.g. "catalogs.*.metadata.*",
+	// "auth.handlers.*"). Maps hold arbitrary user-defined keys, so any key
+	// under such a prefix is allowed rather than flagged as a typo.
+	for known := range knownKeys {
+		if !strings.HasSuffix(known, ".*") {
+			continue
+		}
+		prefix := strings.TrimSuffix(known, "*") // retains trailing "."
+		if strings.HasPrefix(normalizedKey, prefix) {
+			return true
+		}
+	}
+
 	return false
 }
 
@@ -169,8 +182,10 @@ func extractKeys(t reflect.Type, prefix string, keys map[string]bool) {
 
 		// Handle maps (only add the key itself, not nested paths for arbitrary keys)
 		if fieldType.Kind() == reflect.Map {
-			// For maps, we just register the map key itself
-			// Users can put arbitrary keys in maps like "metadata"
+			// Maps hold arbitrary user-defined keys (e.g. metadata,
+			// auth.handlers, profiles). Register an open-namespace wildcard so
+			// sub-keys are recognized rather than flagged as unknown.
+			keys[fullKey+".*"] = true
 			continue
 		}
 

--- a/pkg/kube/login/login.go
+++ b/pkg/kube/login/login.go
@@ -220,6 +220,13 @@ func Login(ctx context.Context, deps Deps, req Request) (*Result, error) {
 	if info.OIDCAudience != "" && auth.HasCapability(handler.Capabilities(), auth.CapScopesOnLogin) {
 		loginOpts.Scopes = []string{info.OIDCAudience}
 	}
+	// Forward the resolved API server URL so the handler knows which cluster to
+	// authenticate against. Handlers that advertise CapHostname (e.g. the
+	// openshift OAuth handler, which discovers the cluster's OAuth server from
+	// this URL) rely on it; handlers without the capability ignore Hostname.
+	if info.APIServerURL != "" && auth.HasCapability(handler.Capabilities(), auth.CapHostname) {
+		loginOpts.Hostname = info.APIServerURL
+	}
 	if _, err := handler.Login(ctx, loginOpts); err != nil {
 		return nil, fmt.Errorf("login with handler %q: %w", handler.Name(), err)
 	}

--- a/pkg/kube/login/login_test.go
+++ b/pkg/kube/login/login_test.go
@@ -251,6 +251,38 @@ func TestLogin_ScopesOnLogin(t *testing.T) {
 	assert.NotContains(t, kc.writeIn.ExecArgs, "--scope")
 }
 
+func TestLogin_HostnameForwardedWhenCapable(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{name: "openshift", caps: []auth.Capability{auth.CapHostname}}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+	deps := Deps{Handler: handler, Kubeconfig: kc}
+
+	_, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.example.com:6443", handler.loginOpts.Hostname,
+		"resolved API server URL must be forwarded to CapHostname handlers")
+}
+
+func TestLogin_HostnameNotForwardedWithoutCapability(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{name: "plain"}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+	deps := Deps{Handler: handler, Kubeconfig: kc}
+
+	_, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, handler.loginOpts.Hostname,
+		"handlers without CapHostname must not receive the API server URL")
+}
+
 func TestLogin_WriteError(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/plugin/wrapper_auth.go
+++ b/pkg/plugin/wrapper_auth.go
@@ -474,7 +474,15 @@ func injectAuthHandlerSettings(ctx context.Context, handlerName string, cfg *Pro
 		resolved := auth.ResolveGCPConfig(appCfg.Auth.GCP, profile)
 		raw, err = json.Marshal(resolved) //nolint:gosec // G117: intentionally forwarding host config (including clientSecret) to plugin over local gRPC
 	default:
-		return
+		// Open per-handler namespace (auth.handlers.<name>). scafctl core is
+		// shape-blind to these settings: the reserved "hostname" block is
+		// consumed by the host (not here), and every other key is forwarded
+		// opaquely to the handler plugin.
+		handlerCfg, ok := appCfg.Auth.Handlers[handlerName]
+		if !ok || len(handlerCfg.Settings) == 0 {
+			return
+		}
+		raw, err = json.Marshal(handlerCfg.Settings) //nolint:gosec // G117: intentionally forwarding opaque host config to plugin over local gRPC
 	}
 
 	if err != nil || len(raw) == 0 || string(raw) == "{}" {

--- a/pkg/plugin/wrapper_auth_test.go
+++ b/pkg/plugin/wrapper_auth_test.go
@@ -71,6 +71,42 @@ func TestInjectAuthHandlerSettings(t *testing.T) {
 			wantValue: "gcp-client-id",
 		},
 		{
+			name:        "open handler namespace forwarded",
+			handlerName: "openshift",
+			appCfg: &config.Config{
+				Auth: config.GlobalAuthConfig{
+					Handlers: map[string]config.HandlerConfig{
+						"openshift": {
+							Settings: map[string]any{
+								"apitimeout":   float64(30),
+								"cabundlepath": "/etc/ssl/corp.pem",
+							},
+						},
+					},
+				},
+			},
+			wantKey:   "openshift",
+			wantField: "cabundlepath",
+			wantValue: "/etc/ssl/corp.pem",
+		},
+		{
+			name:        "host-consumed hostname block not forwarded",
+			handlerName: "openshift",
+			appCfg: &config.Config{
+				Auth: config.GlobalAuthConfig{
+					Handlers: map[string]config.HandlerConfig{
+						"openshift": {
+							Hostname: &config.HostnameConfig{
+								Aliases: map[string]string{"pd1020": "https://api.example.com:6443"},
+							},
+						},
+					},
+				},
+			},
+			// wantKey empty: a handler with only a hostname block (and no
+			// opaque settings) delivers nothing to the plugin.
+		},
+		{
 			name:        "nil github config skipped",
 			handlerName: "github",
 			appCfg:      &config.Config{},

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2057,6 +2057,56 @@ func TestIntegration_AuthListHelp(t *testing.T) {
 	assert.Contains(t, stdout, "refresh")
 }
 
+func TestIntegration_AuthAliasHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "alias", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "set")
+	assert.Contains(t, stdout, "list")
+	assert.Contains(t, stdout, "remove")
+}
+
+func TestIntegration_AuthLoginHelp_ShowsHostname(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "login", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	// The --hostname flag drives host-aware login (alias / dynamic resolution).
+	assert.Contains(t, stdout, "--hostname")
+}
+
+func TestIntegration_AuthAliasList_Seeded(t *testing.T) {
+	t.Parallel()
+	// 'auth alias list' reads config directly and does not require a live
+	// handler, so a seeded config file exercises the full read + render path.
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	seed := `auth:
+  handlers:
+    openshift:
+      hostname:
+        aliases:
+          prod: https://api.prod.example.com:6443
+          stg: https://api.stg.example.com:6443
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(seed), 0o600))
+
+	stdout, stderr, exitCode := runScafctl(t, "--config", configPath, "auth", "alias", "list", "openshift", "-o", "json")
+	require.Equal(t, 0, exitCode, "stderr: %s", stderr)
+
+	var items []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &items))
+	require.Len(t, items, 2)
+
+	bySelector := map[string]string{}
+	for _, it := range items {
+		bySelector[fmt.Sprint(it["selector"])] = fmt.Sprint(it["url"])
+	}
+	assert.Equal(t, "https://api.prod.example.com:6443", bySelector["prod"])
+	assert.Equal(t, "https://api.stg.example.com:6443", bySelector["stg"])
+}
+
 func TestIntegration_AuthTokenHelp(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "auth", "token", "--help")


### PR DESCRIPTION
Add host-managed hostname alias and dynamic endpoint resolution for auth handlers, letting users log in with short selectors that resolve to concrete cluster/instance URLs. Introduce per-handler configuration namespaces that forward opaque settings to handler plugins, and add config.d drop-in layering for split-brain-free multi-writer config.

- add pkg/auth/hostname: static-alias and dynamic-resolver resolution with CEL transform, HTTP inventory fetch, TTL caching, and typed Entry output (audience, authType, caData, consoleUrl, insecureSkipTls)
- add `auth alias set/list/remove` to manage per-handler hostname aliases (list reads config directly; mutations require the hostname capability)
- register `auth login --hostname` and gate it on the handler's hostname capability
- add auth.handlers.<name> config namespace: reserved `hostname` block is host-consumed, all other keys forwarded opaquely to the plugin via provider Settings
- add config.d/*.yaml drop-in fragments merged in lexical order (defaults -> base -> config.d -> config.yaml -> env -> flags)
- expose Manager.ConfigDir() and recognize open-namespace map wildcards so auth.handlers.* keys are not flagged as unknown
- forward the resolved kube API server URL to hostname-capable handlers during kube login
- add tutorial, design doc, and examples for hostname resolution
- add CLI integration tests for auth alias/login help and seeded alias listing

Closes #569
Closes #570
Closes #571
Relates to #572