### PR TITLE
fix(plugin)!: give the plugin pool a lifetime context and fix teardown races

### DIFF
--- a/pkg/api/endpoints/providers_test.go
+++ b/pkg/api/endpoints/providers_test.go
@@ -230,7 +230,7 @@ func TestEnsureAPIProvider_NilPool(t *testing.T) {
 
 func TestEnsureAPIProvider_NilOfficialProviders(t *testing.T) {
 	reg := provider.NewRegistry()
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 	defer pool.Shutdown()
 
 	hctx := &api.HandlerContext{
@@ -245,7 +245,7 @@ func TestEnsureAPIProvider_NilOfficialProviders(t *testing.T) {
 func TestEnsureAPIProvider_UnknownProvider(t *testing.T) {
 	reg := provider.NewRegistry()
 	officialReg := official.NewRegistry()
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 	defer pool.Shutdown()
 
 	hctx := &api.HandlerContext{
@@ -261,7 +261,7 @@ func TestEnsureAPIProvider_UnknownProvider(t *testing.T) {
 func TestEnsureAPIProvider_NoFetcher(t *testing.T) {
 	reg := provider.NewRegistry()
 	officialReg := official.NewRegistry()
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 	defer pool.Shutdown()
 
 	hctx := &api.HandlerContext{
@@ -285,7 +285,7 @@ func TestEnsureAPIProvider_RegistryMiss(t *testing.T) {
 	// Mark the name as known in the pool's registry so Ensure passes
 	poolReg.MarkKnown("exec")
 
-	pool := plugin.NewPool(nil, poolReg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, poolReg, logr.Discard(), plugin.WithIdleTimeout(0))
 	defer pool.Shutdown()
 
 	hctx := &api.HandlerContext{
@@ -303,7 +303,7 @@ func TestGetProvider_AutoResolve_Fallback(t *testing.T) {
 	_, testAPI := humatest.New(t)
 	reg := provider.NewRegistry()
 	officialReg := official.NewRegistry()
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 	defer pool.Shutdown()
 
 	var shutting int32
@@ -326,7 +326,7 @@ func TestGetProviderSchema_AutoResolve_Fallback(t *testing.T) {
 	_, testAPI := humatest.New(t)
 	reg := provider.NewRegistry()
 	officialReg := official.NewRegistry()
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 	defer pool.Shutdown()
 
 	var shutting int32
@@ -367,7 +367,7 @@ func TestEnsureAPIProvider_Success(t *testing.T) {
 	// handler's registry, ensureAPIProvider should return the provider.
 	reg := newRegistryWithProvider(t, "exec")
 	officialReg := official.NewRegistry()
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 	defer pool.Shutdown()
 
 	// Adopt a mock client so EnsureAndAcquire succeeds
@@ -394,7 +394,7 @@ func TestGetProvider_AutoResolve_Adopted(t *testing.T) {
 	_, testAPI := humatest.New(t)
 	reg := provider.NewRegistry()
 	officialReg := official.NewRegistry()
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 	defer pool.Shutdown()
 
 	// Adopt entry but do NOT register provider — simulates post-spawn
@@ -425,7 +425,7 @@ func TestGetProviderSchema_AutoResolve_Adopted(t *testing.T) {
 	_, testAPI := humatest.New(t)
 	reg := provider.NewRegistry()
 	officialReg := official.NewRegistry()
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 	defer pool.Shutdown()
 
 	dep := solution.PluginDependency{Name: "exec", Kind: solution.PluginKindProvider}

--- a/pkg/api/server_test.go
+++ b/pkg/api/server_test.go
@@ -92,7 +92,7 @@ func TestServer_WithPluginClients_Shutdown(t *testing.T) {
 
 func TestServer_WithPluginPool_Shutdown(t *testing.T) {
 	reg := provider.NewRegistry()
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 
 	srv, err := NewServer(WithServerPluginPool(pool))
 	require.NoError(t, err)
@@ -104,7 +104,7 @@ func TestServer_WithPluginPool_Shutdown(t *testing.T) {
 
 func TestServer_HandlerCtx_PluginPool(t *testing.T) {
 	reg := provider.NewRegistry()
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 	defer pool.Shutdown()
 
 	srv, err := NewServer(WithServerPluginPool(pool), WithServerRegistry(reg))

--- a/pkg/cmd/scafctl/mcp/serve.go
+++ b/pkg/cmd/scafctl/mcp/serve.go
@@ -236,6 +236,6 @@ func buildMCPPluginPool(ctx context.Context, cfg *config.Config, reg *provider.R
 	if cfg != nil && cfg.Plugins.GRPCMaxMessageSize > 0 {
 		poolOpts = append(poolOpts, plugin.WithClientOptions(plugin.WithGRPCMaxMessageSize(cfg.Plugins.GRPCMaxMessageSize)))
 	}
-	pool := plugin.NewPool(pluginFetcher, reg, *lgr, poolOpts...)
+	pool := plugin.NewPool(ctx, pluginFetcher, reg, *lgr, poolOpts...)
 	return pool, ctx
 }

--- a/pkg/cmd/scafctl/serve/serve.go
+++ b/pkg/cmd/scafctl/serve/serve.go
@@ -462,7 +462,7 @@ func buildPluginPool(ctx context.Context, cfg *config.Config, fetcher *plugin.Fe
 	if cfg.Plugins.GRPCMaxMessageSize > 0 {
 		poolOpts = append(poolOpts, plugin.WithClientOptions(plugin.WithGRPCMaxMessageSize(cfg.Plugins.GRPCMaxMessageSize)))
 	}
-	pool := plugin.NewPool(fetcher, reg, *lgr, poolOpts...)
+	pool := plugin.NewPool(ctx, fetcher, reg, *lgr, poolOpts...)
 	for _, c := range preloaded {
 		// Query the client for provider names it registered so the pool can
 		// unregister them on eviction/death.

--- a/pkg/mcp/prepare_options.go
+++ b/pkg/mcp/prepare_options.go
@@ -27,6 +27,15 @@ func (s *Server) prepareOptions(ctx context.Context, extra ...prepare.Option) []
 		prepare.WithRegistry(s.registry),
 	}
 
+	// In server mode, delegate provider plugin lifecycle to the shared pool so
+	// plugin processes survive across tool calls. Without this, prepare would
+	// fetch, register, and kill plugin clients on every call, leaving dead-backed
+	// provider wrappers in the shared registry that break subsequent calls with
+	// "grpc: the client connection is closing".
+	if s.pluginPool != nil {
+		opts = append(opts, prepare.WithPluginPool(s.pluginPool))
+	}
+
 	// Wire plugin auto-fetch so that bundle.plugins declarations and official
 	// plugin providers trigger automatic download from configured catalogs.
 	if fetcher, err := prepare.BuildPluginFetcher(ctx); err == nil {

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -425,7 +425,7 @@ func TestHandler_ReturnsCachedInstance(t *testing.T) {
 
 func TestNewServer_PluginPoolRequiresRegistry(t *testing.T) {
 	reg := provider.NewRegistry()
-	pool := plugin.NewPool(nil, reg, logr.Discard())
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard())
 	defer pool.Shutdown()
 
 	t.Run("pool without registry returns error", func(t *testing.T) {

--- a/pkg/mcp/tools_provider_test.go
+++ b/pkg/mcp/tools_provider_test.go
@@ -689,7 +689,7 @@ func TestEnsureProvider(t *testing.T) {
 		// The official registry is always auto-injected; known providers
 		// proceed to the pool load stage which fails without a fetcher.
 		reg := provider.NewRegistry()
-		pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+		pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 		defer pool.Shutdown()
 
 		srv, err := NewServer(
@@ -708,7 +708,7 @@ func TestEnsureProvider(t *testing.T) {
 	t.Run("returns error for unknown provider", func(t *testing.T) {
 		reg := provider.NewRegistry()
 		officialReg := official.NewRegistry()
-		pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+		pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 		defer pool.Shutdown()
 
 		ctx := official.WithRegistry(context.Background(), officialReg)
@@ -729,7 +729,7 @@ func TestEnsureProvider(t *testing.T) {
 	t.Run("returns error when pool has no fetcher", func(t *testing.T) {
 		reg := provider.NewRegistry()
 		officialReg := official.NewRegistry()
-		pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+		pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 		defer pool.Shutdown()
 
 		ctx := official.WithRegistry(context.Background(), officialReg)
@@ -922,7 +922,7 @@ func TestHandleRunProvider_AutoResolve_PoolError(t *testing.T) {
 	reg := provider.NewRegistry()
 	officialReg := official.NewRegistry()
 	ctx := official.WithRegistry(context.Background(), officialReg)
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 	defer pool.Shutdown()
 
 	srv, err := NewServer(
@@ -954,7 +954,7 @@ func TestHandleRunProvider_AutoResolve_RegistryMiss(t *testing.T) {
 	reg := provider.NewRegistry()
 	officialReg := official.NewRegistry()
 	ctx := official.WithRegistry(context.Background(), officialReg)
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 	defer pool.Shutdown()
 
 	// Adopt a mock client so EnsureAndAcquire succeeds
@@ -990,7 +990,7 @@ func TestHandleGetProviderSchema_AutoResolve_RegistryMiss(t *testing.T) {
 	reg := provider.NewRegistry()
 	officialReg := official.NewRegistry()
 	ctx := official.WithRegistry(context.Background(), officialReg)
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 	defer pool.Shutdown()
 
 	// Adopt so EnsureAndAcquire succeeds
@@ -1026,7 +1026,7 @@ func TestHandleGetProviderOutputShape_AutoResolve_RegistryMiss(t *testing.T) {
 	reg := provider.NewRegistry()
 	officialReg := official.NewRegistry()
 	ctx := official.WithRegistry(context.Background(), officialReg)
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 	defer pool.Shutdown()
 
 	// Adopt so EnsureAndAcquire succeeds
@@ -1178,7 +1178,7 @@ func TestServerClose_IsNoOp(t *testing.T) {
 
 func TestServerClose_WithExternalPool(t *testing.T) {
 	reg := provider.NewRegistry()
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 
 	srv, err := NewServer(
 		WithServerRegistry(reg),

--- a/pkg/plugin/fetcher.go
+++ b/pkg/plugin/fetcher.go
@@ -723,6 +723,14 @@ func RegisterFetchedAuthHandlerPlugins(ctx context.Context, registry *auth.Regis
 		}
 
 		registered := configureAndRegisterAuthHandlers(ctx, registry, client, handlers, cfg)
+		if len(registered) == 0 {
+			// This plugin registered no new handlers -- every name it exposes
+			// was already present in the registry. Kill the just-started process
+			// immediately so long-lived servers that prepare the same bundle
+			// repeatedly do not leak plugin subprocesses.
+			client.Kill()
+			continue
+		}
 		propagateStartupLatency(ctx, registry, client, registered)
 
 		clients = append(clients, client)

--- a/pkg/plugin/fetcher_test.go
+++ b/pkg/plugin/fetcher_test.go
@@ -8,8 +8,12 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
@@ -1009,4 +1013,88 @@ func TestCachedVersionSatisfies(t *testing.T) {
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// ── RegisterFetchedAuthHandlerPlugins subprocess-lifecycle tests ──────────────
+
+var (
+	testAuthPluginOnce sync.Once
+	testAuthPluginPath string
+	testAuthPluginErr  error
+)
+
+// buildTestAuthHandlerPlugin compiles the minimal auth-handler fixture in
+// testdata/authhandler and returns its path. The binary is built once and
+// reused across tests.
+func buildTestAuthHandlerPlugin(t *testing.T) string {
+	t.Helper()
+	testAuthPluginOnce.Do(func() {
+		binName := "scafctl-plugin-test-auth"
+		if runtime.GOOS == "windows" {
+			binName += ".exe"
+		}
+		tmpDir, err := os.MkdirTemp("", "scafctl-test-authhandler-*")
+		if err != nil {
+			testAuthPluginErr = err
+			return
+		}
+		binPath := filepath.Join(tmpDir, binName)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, "go", "build", "-o", binPath, ".")
+		cmd.Dir = filepath.Join("testdata", "authhandler")
+		if out, buildErr := cmd.CombinedOutput(); buildErr != nil {
+			testAuthPluginErr = fmt.Errorf("building test auth handler plugin: %w\n%s", buildErr, out)
+			return
+		}
+		testAuthPluginPath = binPath
+	})
+	require.NoError(t, testAuthPluginErr)
+	require.NotEmpty(t, testAuthPluginPath, "test auth handler plugin build failed")
+	return testAuthPluginPath
+}
+
+func TestRegisterFetchedAuthHandlerPlugins_RegistersAndKeepsClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping auth handler plugin test in short mode (requires go build)")
+	}
+	binPath := buildTestAuthHandlerPlugin(t)
+
+	ctx := context.Background()
+	reg := auth.NewRegistry()
+	results := []FetchResult{
+		{Name: "test-auth", Kind: solution.PluginKindAuthHandler, Path: binPath},
+	}
+
+	clients, err := RegisterFetchedAuthHandlerPlugins(ctx, reg, results, nil)
+	require.NoError(t, err)
+	require.Len(t, clients, 1, "handler with a new name must be registered and its client kept alive")
+	t.Cleanup(func() {
+		for _, c := range clients {
+			c.Kill()
+		}
+	})
+	assert.True(t, reg.Has("test-auth"))
+}
+
+func TestRegisterFetchedAuthHandlerPlugins_KillsClientWhenNoNewHandlers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping auth handler plugin test in short mode (requires go build)")
+	}
+	binPath := buildTestAuthHandlerPlugin(t)
+
+	ctx := context.Background()
+	reg := auth.NewRegistry()
+	// Pre-register a handler with the same name the plugin exposes so the
+	// plugin registers zero new handlers on load.
+	require.NoError(t, reg.Register(auth.NewMockHandler("test-auth")))
+
+	results := []FetchResult{
+		{Name: "test-auth", Kind: solution.PluginKindAuthHandler, Path: binPath},
+	}
+
+	clients, err := RegisterFetchedAuthHandlerPlugins(ctx, reg, results, nil)
+	require.NoError(t, err)
+	assert.Empty(t, clients,
+		"a plugin that registers no new handlers must have its subprocess killed and not be returned")
 }

--- a/pkg/plugin/pool.go
+++ b/pkg/plugin/pool.go
@@ -70,6 +70,12 @@ type poolEntry struct {
 	ready chan struct{}
 	// err holds any error from the spawn attempt (only valid after ready is closed).
 	err error
+	// pendingKill is set when teardown was requested (eviction or death) while
+	// the entry still had active references (refCount > 0). The client's
+	// providers are unregistered immediately so no new lookups resolve to it,
+	// but the process Kill is deferred until the final Release drains the last
+	// reference. This prevents tearing down a plugin mid-request.
+	pendingKill bool
 }
 
 // poolOptions holds Pool configuration.
@@ -77,6 +83,7 @@ type poolOptions struct {
 	idleTimeout     time.Duration
 	maxPlugins      int
 	healthInterval  time.Duration
+	spawnTimeout    time.Duration    // bounds the whole spawn (fetch+handshake+configure)
 	clock           func() time.Time // for testing
 	allowedPlugins  map[string]bool  // nil means allow all
 	disableExternal bool             // reject all non-adopted plugins
@@ -90,6 +97,7 @@ func defaultPoolOptions() poolOptions {
 		idleTimeout:    5 * time.Minute,
 		maxPlugins:     50,
 		healthInterval: 30 * time.Second,
+		spawnTimeout:   2 * time.Minute,
 		clock:          time.Now,
 		sanitizeEnv:    true,
 	}
@@ -118,6 +126,15 @@ func WithMaxPlugins(n int) PoolOption {
 // detected when a caller invokes Ping or when a request fails.
 func WithHealthCheckInterval(d time.Duration) PoolOption {
 	return func(o *poolOptions) { o.healthInterval = d }
+}
+
+// WithSpawnTimeout bounds the entire spawn sequence for a single plugin --
+// fetch, process start, gRPC handshake, provider registration, and configure.
+// Spawns run under the pool-lifetime context (not the caller's request
+// context), so this timeout is the only bound on how long a lazy load may take.
+// Zero disables the bound (spawn is limited only by pool shutdown).
+func WithSpawnTimeout(d time.Duration) PoolOption {
+	return func(o *poolOptions) { o.spawnTimeout = d }
 }
 
 // withClock overrides the time source (for testing).
@@ -178,6 +195,14 @@ type PoolStats struct {
 //
 // Official providers pre-loaded at startup can be added via Adopt; external
 // plugins declared in bundle.plugins are loaded on-demand via Ensure.
+//
+// The pool owns a lifetime context (derived from the context passed to
+// NewPool). All long-lived plugin setup -- fetching binaries, starting
+// processes, registering provider wrappers, and configuring them -- runs under
+// this context, NOT the per-request context that happened to trigger the lazy
+// load. This ensures a registered wrapper is never backed by a client whose
+// initialization context died with a transient request. Per-request contexts
+// scope only per-operation Execute/ExecuteStream calls.
 type Pool struct {
 	mu       sync.Mutex
 	entries  map[string]*poolEntry // keyed by plugin name
@@ -189,15 +214,33 @@ type Pool struct {
 	stopOnce sync.Once
 	stop     chan struct{}
 	logger   logr.Logger
+
+	// ctx is the pool-lifetime context; cancel tears it down on Shutdown.
+	// Long-lived plugin setup (spawn) derives its context from ctx so request
+	// cancellation cannot invalidate a registered wrapper.
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 // NewPool creates a plugin pool backed by the given fetcher and registry.
 // The fetcher may be nil if only Adopt (pre-loaded) plugins are used.
-func NewPool(fetcher *Fetcher, registry *provider.Registry, logger logr.Logger, opts ...PoolOption) *Pool {
+//
+// ctx is the pool-lifetime context: it governs the background eviction loop and
+// all long-lived plugin initialization. Pass a long-lived context (e.g. the
+// server context) so plugin loads survive individual requests; the pool
+// cancels its derived child context on Shutdown. A nil ctx defaults to
+// context.Background().
+func NewPool(ctx context.Context, fetcher *Fetcher, registry *provider.Registry, logger logr.Logger, opts ...PoolOption) *Pool {
 	o := defaultPoolOptions()
 	for _, opt := range opts {
 		opt(&o)
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// cancel is retained in p.cancel and invoked by Shutdown; gosec cannot see
+	// the deferred ownership transfer across the struct field.
+	poolCtx, cancel := context.WithCancel(ctx) //nolint:gosec // G118: cancel stored in p.cancel, called by Shutdown
 	p := &Pool{
 		entries:  make(map[string]*poolEntry),
 		fetcher:  fetcher,
@@ -205,6 +248,8 @@ func NewPool(fetcher *Fetcher, registry *provider.Registry, logger logr.Logger, 
 		opts:     o,
 		stop:     make(chan struct{}),
 		logger:   logger,
+		ctx:      poolCtx,
+		cancel:   cancel,
 	}
 	if o.idleTimeout > 0 {
 		go p.evictionLoop()
@@ -241,7 +286,7 @@ func (p *Pool) Ensure(ctx context.Context, deps []solution.PluginDependency) err
 		if dep.Kind != solution.PluginKindProvider {
 			continue
 		}
-		if err := p.ensureOne(ctx, dep); err != nil {
+		if _, err := p.ensureOne(ctx, dep, false); err != nil {
 			return err
 		}
 	}
@@ -252,17 +297,25 @@ func (p *Pool) Ensure(ctx context.Context, deps []solution.PluginDependency) err
 // (increments their refcounts), preventing idle eviction for the duration
 // of the caller's work. Returns a release function that must be called when
 // the caller is done using the plugins (typically via defer).
+//
+// Acquisition happens atomically with readiness validation (under the entry
+// lock), closing the window where a just-readied plugin could be evicted or
+// torn down before the caller records its reference.
 func (p *Pool) EnsureAndAcquire(ctx context.Context, deps []solution.PluginDependency) (release func(), err error) {
-	if err := p.Ensure(ctx, deps); err != nil {
-		return nil, err
-	}
-
 	var acquired []string
 	for _, dep := range deps {
 		if dep.Kind != solution.PluginKindProvider {
 			continue
 		}
-		if p.Acquire(dep.Name) {
+		ok, eErr := p.ensureOne(ctx, dep, true)
+		if eErr != nil {
+			// Release anything already acquired before returning the error.
+			for _, name := range acquired {
+				p.Release(name)
+			}
+			return nil, eErr
+		}
+		if ok {
 			acquired = append(acquired, dep.Name)
 		}
 	}
@@ -274,55 +327,51 @@ func (p *Pool) EnsureAndAcquire(ctx context.Context, deps []solution.PluginDepen
 	}, nil
 }
 
-// ensureOne handles a single plugin dependency.
-func (p *Pool) ensureOne(ctx context.Context, dep solution.PluginDependency) error {
+// ensureOne handles a single plugin dependency. When acquire is true, a
+// reference is atomically taken on the ready entry (under the entry lock) so
+// eviction cannot tear it down before the caller records the reference; the
+// returned bool reports whether a reference was actually taken (false for
+// builtins/pre-registered providers that are not pool-managed).
+func (p *Pool) ensureOne(ctx context.Context, dep solution.PluginDependency, acquire bool) (bool, error) {
 	p.mu.Lock()
 	if p.closed {
 		p.mu.Unlock()
-		return ErrPoolClosed
+		return false, ErrPoolClosed
 	}
 
 	// Already in pool (pre-loaded or previously loaded)?
 	if entry, ok := p.entries[dep.Name]; ok {
 		p.mu.Unlock()
-		err := p.waitAndValidate(ctx, entry)
-		if err != nil {
-			// Remove dead entries so the plugin can be re-spawned on retry.
-			p.mu.Lock()
-			if entry.state == entryDead {
-				p.unregisterEntry(entry)
-				delete(p.entries, dep.Name)
-			}
-			p.mu.Unlock()
-		}
-		return err
+		return p.waitForEntry(ctx, dep.Name, entry, acquire)
 	}
 
 	// Check if already registered (builtin or pre-loaded without Adopt)
 	if p.registry.Has(dep.Name) {
 		p.mu.Unlock()
-		return nil
+		return false, nil
 	}
 
 	// Security: reject if external plugins are disabled entirely.
 	if p.opts.disableExternal {
 		p.mu.Unlock()
-		return fmt.Errorf("plugin %q: %w", dep.Name, ErrExternalDisabled)
+		return false, fmt.Errorf("plugin %q: %w", dep.Name, ErrExternalDisabled)
 	}
 
 	// Security: reject if allowlist is configured and plugin is not on it.
 	if p.opts.allowedPlugins != nil && !p.opts.allowedPlugins[dep.Name] {
 		p.mu.Unlock()
-		return fmt.Errorf("plugin %q: %w", dep.Name, ErrPluginNotAllowed)
+		return false, fmt.Errorf("plugin %q: %w", dep.Name, ErrPluginNotAllowed)
 	}
 
 	// Capacity check
 	if p.opts.maxPlugins > 0 && len(p.entries) >= p.opts.maxPlugins {
 		p.mu.Unlock()
-		return fmt.Errorf("plugin %q: %w", dep.Name, ErrPoolFull)
+		return false, fmt.Errorf("plugin %q: %w", dep.Name, ErrPoolFull)
 	}
 
-	// Create a placeholder entry; we'll spawn outside the lock.
+	// Create a placeholder entry; the spawn runs in the background under the
+	// pool-lifetime context (not the caller's request context) so a cancelled
+	// or short-lived request cannot invalidate a registered plugin wrapper.
 	entry := &poolEntry{
 		state: entryStarting,
 		dep:   dep,
@@ -331,26 +380,59 @@ func (p *Pool) ensureOne(ctx context.Context, dep solution.PluginDependency) err
 	p.entries[dep.Name] = entry
 	p.mu.Unlock()
 
-	// Spawn the plugin (may take time: fetch + exec + gRPC handshake).
-	p.spawn(ctx, entry)
+	spawnCtx, cancel := p.newSpawnContext()
+	go p.spawn(spawnCtx, entry, cancel)
 
-	if entry.err != nil {
-		// Remove failed entry
-		p.mu.Lock()
-		delete(p.entries, dep.Name)
-		p.mu.Unlock()
-		return fmt.Errorf("plugin %q: %w", dep.Name, entry.err)
-	}
-	return nil
+	return p.waitForEntry(ctx, dep.Name, entry, acquire)
 }
 
-// waitAndValidate waits for an entry to become ready and checks health.
-func (p *Pool) waitAndValidate(ctx context.Context, entry *poolEntry) error {
+// waitForEntry waits for an entry to become ready (bounded by the caller's
+// context), optionally acquiring a reference, and removes the entry if the
+// spawn failed so a later Ensure can retry. A context cancellation leaves the
+// entry intact -- the background spawn continues under the pool context.
+func (p *Pool) waitForEntry(ctx context.Context, name string, entry *poolEntry, acquire bool) (bool, error) {
+	acquired, err := p.waitAndValidate(ctx, entry, acquire)
+	if err != nil {
+		p.mu.Lock()
+		entry.mu.Lock()
+		dead := entry.state == entryDead
+		refs := atomic.LoadInt32(&entry.refCount)
+		entry.mu.Unlock()
+		// Only remove entries that genuinely failed and are unreferenced.
+		// Referenced dead entries stay in the map so their final Release can
+		// finalize the deferred teardown.
+		if dead && refs == 0 {
+			delete(p.entries, name)
+			p.mu.Unlock()
+			p.teardownEntry(entry)
+		} else {
+			p.mu.Unlock()
+		}
+	}
+	return acquired, err
+}
+
+// newSpawnContext derives a context for a background spawn from the pool
+// lifetime context, bounded by the configured spawn timeout. It is fully
+// decoupled from any request context so request cancellation cannot abort a
+// plugin load in progress; the pool context (cancelled on Shutdown) and the
+// spawn timeout are the only bounds.
+func (p *Pool) newSpawnContext() (context.Context, context.CancelFunc) {
+	if p.opts.spawnTimeout > 0 {
+		return context.WithTimeout(p.ctx, p.opts.spawnTimeout)
+	}
+	return context.WithCancel(p.ctx)
+}
+
+// waitAndValidate waits for an entry to become ready and checks health. When
+// acquire is true and the entry is ready, a reference is taken under the entry
+// lock (atomic with the readiness check) and the returned bool is true.
+func (p *Pool) waitAndValidate(ctx context.Context, entry *poolEntry, acquire bool) (bool, error) {
 	// Wait for entry to be ready (handles concurrent Ensure for same plugin).
 	select {
 	case <-entry.ready:
 	case <-ctx.Done():
-		return ctx.Err()
+		return false, ctx.Err()
 	}
 
 	entry.mu.Lock()
@@ -358,12 +440,16 @@ func (p *Pool) waitAndValidate(ctx context.Context, entry *poolEntry) error {
 
 	if entry.state == entryDead {
 		// Dead entries will be re-spawned on next Ensure after eviction.
-		return fmt.Errorf("plugin %q is dead: %w", entry.dep.Name, entry.err)
+		return false, fmt.Errorf("plugin %q is dead: %w", entry.dep.Name, entry.err)
 	}
 
 	// Touch last-used time
 	entry.lastUsed = p.opts.clock()
-	return nil
+	if acquire {
+		atomic.AddInt32(&entry.refCount, 1)
+		return true, nil
+	}
+	return false, nil
 }
 
 // buildSpawnClientOpts builds the ClientOption slice used when spawning a
@@ -383,8 +469,11 @@ func buildSpawnClientOpts(sanitize bool, extraOpts []ClientOption) []ClientOptio
 	return opts
 }
 
-// spawn fetches and starts a plugin, updating the entry state.
-func (p *Pool) spawn(ctx context.Context, entry *poolEntry) {
+// spawn fetches and starts a plugin, updating the entry state. It runs in a
+// background goroutine under a pool-derived context; cancel releases that
+// context when the spawn completes.
+func (p *Pool) spawn(ctx context.Context, entry *poolEntry, cancel context.CancelFunc) {
+	defer cancel()
 	defer close(entry.ready)
 
 	if p.fetcher == nil {
@@ -494,7 +583,9 @@ func (p *Pool) Acquire(name string) bool {
 	return true
 }
 
-// Release decrements the reference count for a plugin.
+// Release decrements the reference count for a plugin. If this drains the last
+// reference on an entry whose teardown was deferred (pendingKill), the client is
+// killed now.
 func (p *Pool) Release(name string) {
 	p.mu.Lock()
 	entry, ok := p.entries[name]
@@ -502,7 +593,18 @@ func (p *Pool) Release(name string) {
 	if !ok {
 		return
 	}
-	atomic.AddInt32(&entry.refCount, -1)
+	entry.mu.Lock()
+	newCount := atomic.AddInt32(&entry.refCount, -1)
+	var client *Client
+	if newCount <= 0 && entry.pendingKill {
+		client = entry.client
+		entry.client = nil
+		entry.pendingKill = false
+	}
+	entry.mu.Unlock()
+	if client != nil {
+		client.Kill()
+	}
 }
 
 // Ping checks if a plugin is alive by issuing a lightweight RPC.
@@ -532,6 +634,8 @@ func (p *Pool) Ping(ctx context.Context, name string) bool {
 }
 
 // markDead transitions an entry to dead state and unregisters its providers.
+// The underlying client is killed immediately if unreferenced, or deferred to
+// the final Release if requests are still in flight.
 func (p *Pool) markDead(name string, entry *poolEntry, reason error) {
 	entry.mu.Lock()
 	if entry.state == entryDead {
@@ -540,32 +644,46 @@ func (p *Pool) markDead(name string, entry *poolEntry, reason error) {
 	}
 	entry.state = entryDead
 	entry.err = reason
-	client := entry.client
-	registered := entry.registeredProviders
 	entry.mu.Unlock()
 
-	for _, pName := range registered {
-		p.registry.Unregister(pName)
-	}
-	if client != nil {
-		client.Kill()
-	}
-
+	p.teardownEntry(entry)
 	p.logger.V(0).Info("plugin marked dead", "plugin", name, "reason", reason)
 }
 
-// unregisterEntry unregisters tracked providers and kills the client.
-func (p *Pool) unregisterEntry(entry *poolEntry) {
+// teardownEntry unregisters an entry's providers from the shared registry so no
+// new lookups resolve to it, then tears down the client. If the entry still has
+// active references (refCount > 0), the process Kill is deferred: pendingKill is
+// set and the final Release performs the Kill. Otherwise the client is killed
+// immediately. Safe to call multiple times.
+func (p *Pool) teardownEntry(entry *poolEntry) {
 	entry.mu.Lock()
 	registered := entry.registeredProviders
+	entry.registeredProviders = nil
 	client := entry.client
-	entry.mu.Unlock()
-
-	for _, pName := range registered {
-		p.registry.Unregister(pName)
+	if client == nil {
+		entry.mu.Unlock()
+		p.unregisterProviders(registered)
+		return
 	}
-	if client != nil {
-		client.Kill()
+	if atomic.LoadInt32(&entry.refCount) > 0 {
+		// Deferred teardown: keep the client so the last Release can kill it,
+		// but stop new lookups by unregistering providers now.
+		entry.pendingKill = true
+		entry.mu.Unlock()
+		p.unregisterProviders(registered)
+		return
+	}
+	// No references: safe to kill now. Clear the client to prevent double-kill.
+	entry.client = nil
+	entry.mu.Unlock()
+	p.unregisterProviders(registered)
+	client.Kill()
+}
+
+// unregisterProviders removes the given provider names from the shared registry.
+func (p *Pool) unregisterProviders(names []string) {
+	for _, pName := range names {
+		p.registry.Unregister(pName)
 	}
 }
 
@@ -578,51 +696,46 @@ func (p *Pool) evictionLoop() {
 		select {
 		case <-p.stop:
 			return
+		case <-p.ctx.Done():
+			return
 		case <-ticker.C:
 			p.evict()
 		}
 	}
 }
 
-// evict removes idle and dead entries.
+// evict removes idle and dead entries that have no active references. Entries
+// still in use (refCount > 0) are left in place; their teardown is handled by
+// the final Release.
 func (p *Pool) evict() {
 	now := p.opts.clock()
 	p.mu.Lock()
-	var toEvict []string
+	var names []string
+	var entries []*poolEntry
 	for name, entry := range p.entries {
 		entry.mu.Lock()
+		refs := atomic.LoadInt32(&entry.refCount)
 		idle := entry.state == entryReady &&
-			atomic.LoadInt32(&entry.refCount) == 0 &&
+			refs == 0 &&
 			p.opts.idleTimeout > 0 &&
 			now.Sub(entry.lastUsed) > p.opts.idleTimeout
-		dead := entry.state == entryDead
+		dead := entry.state == entryDead && refs == 0
 		entry.mu.Unlock()
 
 		if idle || dead {
-			toEvict = append(toEvict, name)
+			names = append(names, name)
+			entries = append(entries, entry)
 		}
+	}
+	for _, name := range names {
+		delete(p.entries, name)
+		p.evicted++
 	}
 	p.mu.Unlock()
 
-	for _, name := range toEvict {
-		p.mu.Lock()
-		entry, ok := p.entries[name]
-		if !ok {
-			p.mu.Unlock()
-			continue
-		}
-		delete(p.entries, name)
-		p.evicted++
-		p.mu.Unlock()
-
-		entry.mu.Lock()
-		client := entry.client
-		entry.mu.Unlock()
-
-		if client != nil {
-			p.unregisterEntry(entry)
-		}
-		p.logger.V(1).Info("evicted plugin from pool", "plugin", name)
+	for i, entry := range entries {
+		p.teardownEntry(entry)
+		p.logger.V(1).Info("evicted plugin from pool", "plugin", names[i])
 	}
 }
 
@@ -670,6 +783,9 @@ func (p *Pool) ClientOptsLen() int {
 func (p *Pool) Shutdown() {
 	p.stopOnce.Do(func() {
 		close(p.stop)
+		if p.cancel != nil {
+			p.cancel()
+		}
 	})
 
 	p.mu.Lock()
@@ -683,8 +799,14 @@ func (p *Pool) Shutdown() {
 
 	for _, entry := range entries {
 		entry.mu.Lock()
+		registered := entry.registeredProviders
+		entry.registeredProviders = nil
 		client := entry.client
+		entry.client = nil
 		entry.mu.Unlock()
+		// Unregister providers before killing so the shared registry is not
+		// left holding dead-backed wrappers if it outlives the pool.
+		p.unregisterProviders(registered)
 		if client != nil {
 			client.Kill()
 		}

--- a/pkg/plugin/pool_test.go
+++ b/pkg/plugin/pool_test.go
@@ -12,8 +12,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,7 +23,7 @@ import (
 
 func TestNewPool(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard())
+	p := NewPool(context.Background(), nil, reg, logr.Discard())
 	defer p.Shutdown()
 
 	assert.NotNil(t, p)
@@ -31,7 +33,7 @@ func TestNewPool(t *testing.T) {
 
 func TestNewPool_Options(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(),
+	p := NewPool(context.Background(), nil, reg, logr.Discard(),
 		WithIdleTimeout(10*time.Minute),
 		WithMaxPlugins(100),
 		WithHealthCheckInterval(time.Minute),
@@ -46,7 +48,7 @@ func TestNewPool_Options(t *testing.T) {
 func TestNewPool_WithClientOptions(t *testing.T) {
 	reg := provider.NewRegistry()
 	opt1 := WithSanitizedEnv()
-	p := NewPool(nil, reg, logr.Discard(),
+	p := NewPool(context.Background(), nil, reg, logr.Discard(),
 		WithIdleTimeout(0),
 		WithClientOptions(opt1),
 	)
@@ -59,7 +61,7 @@ func TestNewPool_WithClientOptions_Multiple(t *testing.T) {
 	reg := provider.NewRegistry()
 	opt1 := WithSanitizedEnv()
 	opt2 := WithSanitizedEnv()
-	p := NewPool(nil, reg, logr.Discard(),
+	p := NewPool(context.Background(), nil, reg, logr.Discard(),
 		WithIdleTimeout(0),
 		WithClientOptions(opt1, opt2),
 	)
@@ -72,19 +74,19 @@ func TestNewPool_WithSanitizeEnv(t *testing.T) {
 	reg := provider.NewRegistry()
 
 	t.Run("defaults to true", func(t *testing.T) {
-		p := NewPool(nil, reg, logr.Discard())
+		p := NewPool(context.Background(), nil, reg, logr.Discard())
 		defer p.Shutdown()
 		assert.True(t, p.SanitizeEnv())
 	})
 
 	t.Run("can be disabled", func(t *testing.T) {
-		p := NewPool(nil, reg, logr.Discard(), WithSanitizeEnv(false))
+		p := NewPool(context.Background(), nil, reg, logr.Discard(), WithSanitizeEnv(false))
 		defer p.Shutdown()
 		assert.False(t, p.SanitizeEnv())
 	})
 
 	t.Run("can be explicitly enabled", func(t *testing.T) {
-		p := NewPool(nil, reg, logr.Discard(), WithSanitizeEnv(true))
+		p := NewPool(context.Background(), nil, reg, logr.Discard(), WithSanitizeEnv(true))
 		defer p.Shutdown()
 		assert.True(t, p.SanitizeEnv())
 	})
@@ -150,7 +152,7 @@ func TestBuildSpawnClientOpts(t *testing.T) {
 
 func TestPool_Adopt(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	mockClient := &Client{name: "test-plugin", path: "/fake/path"}
@@ -169,7 +171,7 @@ func TestPool_Adopt(t *testing.T) {
 
 func TestPool_Adopt_ClosedPool(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	p.Shutdown()
 
 	mockClient := &Client{name: "test-plugin", path: "/fake/path"}
@@ -187,7 +189,7 @@ func TestPool_Ensure_AlreadyRegistered(t *testing.T) {
 	reg := provider.NewRegistry()
 	reg.MarkKnown("existing-provider")
 
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	deps := []solution.PluginDependency{
@@ -205,7 +207,7 @@ func TestPool_Ensure_AlreadyRegistered(t *testing.T) {
 
 func TestPool_Ensure_ClosedPool(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	p.Shutdown()
 
 	deps := []solution.PluginDependency{
@@ -218,7 +220,7 @@ func TestPool_Ensure_ClosedPool(t *testing.T) {
 
 func TestPool_Ensure_PoolFull(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0), WithMaxPlugins(1))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0), WithMaxPlugins(1))
 	defer p.Shutdown()
 
 	// Adopt one plugin to fill the pool
@@ -235,7 +237,7 @@ func TestPool_Ensure_PoolFull(t *testing.T) {
 
 func TestPool_Ensure_NilFetcher(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	deps := []solution.PluginDependency{
@@ -249,7 +251,7 @@ func TestPool_Ensure_NilFetcher(t *testing.T) {
 
 func TestPool_Ensure_SkipsNonProvider(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	deps := []solution.PluginDependency{
@@ -267,7 +269,7 @@ func TestPool_Ensure_SkipsNonProvider(t *testing.T) {
 func TestPool_Ensure_ConcurrentSamePlugin(t *testing.T) {
 	reg := provider.NewRegistry()
 	// Pre-adopt a plugin so Ensure is a no-op wait
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	mockClient := &Client{name: "shared", path: "/fake"}
@@ -293,7 +295,7 @@ func TestPool_Ensure_ConcurrentSamePlugin(t *testing.T) {
 
 func TestPool_Ensure_ContextCancelled(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	// Create an entry stuck in entryStarting state
@@ -318,7 +320,7 @@ func TestPool_Ensure_ContextCancelled(t *testing.T) {
 
 func TestPool_AcquireRelease(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	mockClient := &Client{name: "acq", path: "/fake"}
@@ -339,7 +341,7 @@ func TestPool_AcquireRelease(t *testing.T) {
 
 func TestPool_Acquire_NotFound(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	ok := p.Acquire("nonexistent")
@@ -348,7 +350,7 @@ func TestPool_Acquire_NotFound(t *testing.T) {
 
 func TestPool_Acquire_Dead(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	ready := make(chan struct{})
@@ -368,7 +370,7 @@ func TestPool_Acquire_Dead(t *testing.T) {
 
 func TestPool_Release_NotFound(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	// Should not panic
@@ -377,7 +379,7 @@ func TestPool_Release_NotFound(t *testing.T) {
 
 func TestPool_markDead_AlreadyDead(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	entry := &poolEntry{
@@ -394,7 +396,7 @@ func TestPool_markDead_AlreadyDead(t *testing.T) {
 
 func TestPool_markDead_ReadyNoClient(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	entry := &poolEntry{
@@ -416,7 +418,7 @@ func TestPool_markDead_ReadyNoClient(t *testing.T) {
 
 func TestPool_markDead_ReadyWithClient(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	// Use a client with nil pluginClient and nil plugin — Kill is a no-op
@@ -455,7 +457,7 @@ func TestPoolEntry_failWith(t *testing.T) {
 
 func TestPool_Ping_NotFound(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	ok := p.Ping(context.Background(), "nonexistent")
@@ -464,7 +466,7 @@ func TestPool_Ping_NotFound(t *testing.T) {
 
 func TestPool_Ping_Dead(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	ready := make(chan struct{})
@@ -484,7 +486,7 @@ func TestPool_Ping_Dead(t *testing.T) {
 
 func TestPool_Stats(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	// Empty pool
@@ -540,7 +542,7 @@ func TestPool_Evict_IdleEntries(t *testing.T) {
 	clock := func() time.Time { return now }
 
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(),
+	p := NewPool(context.Background(), nil, reg, logr.Discard(),
 		WithIdleTimeout(5*time.Minute),
 		withClock(clock),
 	)
@@ -575,7 +577,7 @@ func TestPool_Evict_SkipsActiveEntries(t *testing.T) {
 	clock := func() time.Time { return now }
 
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(),
+	p := NewPool(context.Background(), nil, reg, logr.Discard(),
 		WithIdleTimeout(5*time.Minute),
 		withClock(clock),
 	)
@@ -605,7 +607,7 @@ func TestPool_Evict_SkipsActiveEntries(t *testing.T) {
 
 func TestPool_Evict_DeadEntries(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(),
+	p := NewPool(context.Background(), nil, reg, logr.Discard(),
 		WithIdleTimeout(5*time.Minute),
 	)
 	defer p.Shutdown()
@@ -632,7 +634,7 @@ func TestPool_Evict_DeadEntries(t *testing.T) {
 
 func TestPool_Shutdown(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 
 	mockClient := &Client{name: "shutdown-test", path: "/fake"}
 	dep := solution.PluginDependency{Name: "shutdown-test", Kind: solution.PluginKindProvider}
@@ -648,7 +650,7 @@ func TestPool_Shutdown(t *testing.T) {
 
 func TestPool_Shutdown_Idempotent(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 
 	// Should not panic when called multiple times
 	p.Shutdown()
@@ -656,9 +658,48 @@ func TestPool_Shutdown_Idempotent(t *testing.T) {
 	p.Shutdown()
 }
 
+func TestPool_Shutdown_UnregistersProviders(t *testing.T) {
+	reg := provider.NewRegistry()
+
+	// Register a real provider wrapper into the shared registry so the pool
+	// entry has something to unregister on shutdown.
+	mock := &MockProviderPlugin{
+		providers: []string{"test-provider"},
+		descriptors: map[string]*provider.Descriptor{
+			"test-provider": {
+				Name:         "test-provider",
+				DisplayName:  "Test Provider",
+				Description:  "A test provider",
+				APIVersion:   "v1",
+				Version:      semver.MustParse("1.0.0"),
+				Category:     "test",
+				Capabilities: []provider.Capability{provider.CapabilityFrom},
+				Schema:       schemahelper.ObjectSchema(nil, nil),
+			},
+		},
+	}
+	wrapper, err := NewProviderWrapper(&Client{plugin: mock, name: "test-provider"}, "test-provider")
+	require.NoError(t, err)
+	require.NoError(t, reg.Register(wrapper))
+	require.True(t, reg.Has("test-provider"))
+
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
+	mockClient := &Client{name: "test-provider", path: "/fake"}
+	dep := solution.PluginDependency{Name: "test-provider", Kind: solution.PluginKindProvider}
+	p.Adopt("test-provider", mockClient, dep, []string{"test-provider"})
+
+	p.Shutdown()
+
+	assert.False(t, reg.Has("test-provider"),
+		"Shutdown must unregister providers so the registry does not outlive the pool with dead-backed wrappers")
+	p.mu.Lock()
+	assert.Empty(t, p.entries)
+	p.mu.Unlock()
+}
+
 func BenchmarkPool_Ensure_HotPath(b *testing.B) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	mockClient := &Client{name: "bench", path: "/fake"}
@@ -677,7 +718,7 @@ func BenchmarkPool_Ensure_HotPath(b *testing.B) {
 
 func BenchmarkPool_Stats(b *testing.B) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	// Populate with 20 entries
@@ -704,7 +745,7 @@ func BenchmarkPool_Stats(b *testing.B) {
 
 func BenchmarkPool_AcquireRelease(b *testing.B) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	mockClient := &Client{name: "bench-ar", path: "/fake"}
@@ -723,7 +764,7 @@ func BenchmarkPool_AcquireRelease(b *testing.B) {
 
 func TestPool_Ensure_ExternalDisabled(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(),
+	p := NewPool(context.Background(), nil, reg, logr.Discard(),
 		WithIdleTimeout(0),
 		WithDisableExternal(true),
 	)
@@ -739,7 +780,7 @@ func TestPool_Ensure_ExternalDisabled(t *testing.T) {
 
 func TestPool_Ensure_ExternalDisabled_AdoptedBypasses(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(),
+	p := NewPool(context.Background(), nil, reg, logr.Discard(),
 		WithIdleTimeout(0),
 		WithDisableExternal(true),
 	)
@@ -756,7 +797,7 @@ func TestPool_Ensure_ExternalDisabled_AdoptedBypasses(t *testing.T) {
 
 func TestPool_Ensure_AllowedPlugins_Rejected(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(),
+	p := NewPool(context.Background(), nil, reg, logr.Discard(),
 		WithIdleTimeout(0),
 		WithAllowedPlugins([]string{"safe-plugin", "another-safe"}),
 	)
@@ -773,7 +814,7 @@ func TestPool_Ensure_AllowedPlugins_Rejected(t *testing.T) {
 func TestPool_Ensure_AllowedPlugins_Permitted(t *testing.T) {
 	reg := provider.NewRegistry()
 	// Use nil fetcher — plugin is allowed but will fail at fetch stage
-	p := NewPool(nil, reg, logr.Discard(),
+	p := NewPool(context.Background(), nil, reg, logr.Discard(),
 		WithIdleTimeout(0),
 		WithAllowedPlugins([]string{"safe-plugin"}),
 	)
@@ -792,7 +833,7 @@ func TestPool_Ensure_AllowedPlugins_Permitted(t *testing.T) {
 
 func TestPool_Ensure_AllowedPlugins_Empty_AllowsAll(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(),
+	p := NewPool(context.Background(), nil, reg, logr.Discard(),
 		WithIdleTimeout(0),
 		WithAllowedPlugins([]string{}), // empty = no restriction
 	)
@@ -810,7 +851,7 @@ func TestPool_Ensure_AllowedPlugins_Empty_AllowsAll(t *testing.T) {
 
 func TestPool_Ensure_AllowedPlugins_AdoptedBypasses(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(),
+	p := NewPool(context.Background(), nil, reg, logr.Discard(),
 		WithIdleTimeout(0),
 		WithAllowedPlugins([]string{"only-this"}),
 	)
@@ -827,7 +868,7 @@ func TestPool_Ensure_AllowedPlugins_AdoptedBypasses(t *testing.T) {
 
 func TestWithAllowedPlugins_Nil(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(),
+	p := NewPool(context.Background(), nil, reg, logr.Discard(),
 		WithIdleTimeout(0),
 		WithAllowedPlugins(nil),
 	)
@@ -838,7 +879,7 @@ func TestWithAllowedPlugins_Nil(t *testing.T) {
 
 func TestWithDisableExternal(t *testing.T) {
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(),
+	p := NewPool(context.Background(), nil, reg, logr.Discard(),
 		WithIdleTimeout(0),
 		WithDisableExternal(true),
 	)
@@ -873,7 +914,7 @@ func TestPoolErrorHTTPStatus(t *testing.T) {
 func TestPool_EnsureAndAcquire_Adopted(t *testing.T) {
 	t.Parallel()
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	mockClient := &Client{name: "adopted-plugin", path: "/fake"}
@@ -898,7 +939,7 @@ func TestPool_EnsureAndAcquire_Adopted(t *testing.T) {
 func TestPool_EnsureAndAcquire_Error(t *testing.T) {
 	t.Parallel()
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	// No fetcher — Ensure will fail
@@ -914,7 +955,7 @@ func TestPool_EnsureAndAcquire_Error(t *testing.T) {
 func TestPool_EnsureOne_RemovesDeadEntry(t *testing.T) {
 	t.Parallel()
 	reg := provider.NewRegistry()
-	p := NewPool(nil, reg, logr.Discard(), WithIdleTimeout(0))
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
 	defer p.Shutdown()
 
 	// Inject a dead entry directly
@@ -952,4 +993,165 @@ func TestPoolEntry_RegisteredProviders(t *testing.T) {
 		registeredProviders: []string{"exec", "git", "directory"},
 	}
 	assert.Equal(t, []string{"exec", "git", "directory"}, entry.registeredProviders)
+}
+
+// TestPool_markDead_DefersKillWhileReferenced is a regression test for the race
+// where a plugin was torn down (client killed) while a request still held a
+// reference, causing "grpc: the client connection is closing". Teardown must be
+// deferred until the final Release drains the last reference.
+func TestPool_markDead_DefersKillWhileReferenced(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	client := &Client{name: "busy", path: "/fake"}
+	dep := solution.PluginDependency{Name: "busy", Kind: solution.PluginKindProvider}
+	p.Adopt("busy", client, dep, nil)
+
+	// Acquire a reference (simulating an in-flight request).
+	require.True(t, p.Acquire("busy"))
+
+	p.mu.Lock()
+	entry := p.entries["busy"]
+	p.mu.Unlock()
+
+	// Mark dead while referenced: the kill must be deferred.
+	p.markDead("busy", entry, errors.New("health probe failed"))
+
+	entry.mu.Lock()
+	assert.Equal(t, entryDead, entry.state)
+	assert.True(t, entry.pendingKill, "kill should be deferred while referenced")
+	assert.NotNil(t, entry.client, "client must be retained until the last release")
+	entry.mu.Unlock()
+
+	// Releasing the last reference finalizes the deferred kill.
+	p.Release("busy")
+
+	entry.mu.Lock()
+	assert.False(t, entry.pendingKill)
+	assert.Nil(t, entry.client, "client must be cleared after the final release kills it")
+	entry.mu.Unlock()
+}
+
+// TestPool_markDead_KillsImmediatelyWhenUnreferenced verifies the common path:
+// when no request holds a reference, teardown kills the client immediately.
+func TestPool_markDead_KillsImmediatelyWhenUnreferenced(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	client := &Client{name: "idle", path: "/fake"}
+	dep := solution.PluginDependency{Name: "idle", Kind: solution.PluginKindProvider}
+	p.Adopt("idle", client, dep, nil)
+
+	p.mu.Lock()
+	entry := p.entries["idle"]
+	p.mu.Unlock()
+
+	p.markDead("idle", entry, errors.New("boom"))
+
+	entry.mu.Lock()
+	assert.Equal(t, entryDead, entry.state)
+	assert.False(t, entry.pendingKill)
+	assert.Nil(t, entry.client, "unreferenced client should be killed and cleared immediately")
+	entry.mu.Unlock()
+}
+
+// TestPool_Evict_SkipsReferencedDeadEntry verifies that a dead entry still in
+// use is not evicted from the map (so its final Release can finalize teardown),
+// and is removed once unreferenced.
+func TestPool_Evict_SkipsReferencedDeadEntry(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	ready := make(chan struct{})
+	close(ready)
+	entry := &poolEntry{
+		state:    entryDead,
+		client:   &Client{name: "d", path: "/fake"},
+		dep:      solution.PluginDependency{Name: "d", Kind: solution.PluginKindProvider},
+		ready:    ready,
+		refCount: 1,
+	}
+	p.mu.Lock()
+	p.entries["d"] = entry
+	p.mu.Unlock()
+
+	p.evict()
+	p.mu.Lock()
+	_, exists := p.entries["d"]
+	p.mu.Unlock()
+	assert.True(t, exists, "referenced dead entry must not be evicted")
+
+	// Drain the reference; now eviction removes it.
+	p.Release("d")
+	p.evict()
+	p.mu.Lock()
+	_, exists = p.entries["d"]
+	p.mu.Unlock()
+	assert.False(t, exists, "unreferenced dead entry should be evicted")
+}
+
+// TestPool_EnsureAndAcquire_AtomicAcquire verifies EnsureAndAcquire takes a
+// reference on a ready (adopted) provider atomically with readiness validation
+// and that the returned release drains it.
+func TestPool_EnsureAndAcquire_AtomicAcquire(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(0))
+	defer p.Shutdown()
+
+	dep := solution.PluginDependency{Name: "ad", Kind: solution.PluginKindProvider}
+	p.Adopt("ad", &Client{name: "ad", path: "/fake"}, dep, nil)
+
+	release, err := p.EnsureAndAcquire(context.Background(), []solution.PluginDependency{dep})
+	require.NoError(t, err)
+	require.NotNil(t, release)
+
+	p.mu.Lock()
+	entry := p.entries["ad"]
+	p.mu.Unlock()
+	assert.Equal(t, int32(1), atomic.LoadInt32(&entry.refCount))
+
+	release()
+	assert.Equal(t, int32(0), atomic.LoadInt32(&entry.refCount))
+}
+
+// TestPool_Shutdown_CancelsLifetimeContext verifies Shutdown cancels the
+// pool-lifetime context so background spawns and the eviction loop stop.
+func TestPool_Shutdown_CancelsLifetimeContext(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(context.Background(), nil, reg, logr.Discard(), WithIdleTimeout(time.Minute))
+
+	poolCtx := p.ctx
+	require.NotNil(t, poolCtx)
+	select {
+	case <-poolCtx.Done():
+		t.Fatal("pool context should be live before shutdown")
+	default:
+	}
+
+	p.Shutdown()
+
+	select {
+	case <-poolCtx.Done():
+		// expected
+	default:
+		t.Fatal("pool context should be cancelled after shutdown")
+	}
+}
+
+// TestNewPool_NilContextDefaultsToBackground verifies a nil context does not
+// panic and yields a live pool context.
+func TestNewPool_NilContextDefaultsToBackground(t *testing.T) {
+	reg := provider.NewRegistry()
+	p := NewPool(nil, nil, reg, logr.Discard(), WithIdleTimeout(0)) //nolint:staticcheck // intentionally testing nil ctx
+	defer p.Shutdown()
+
+	require.NotNil(t, p.ctx)
+	select {
+	case <-p.ctx.Done():
+		t.Fatal("pool context should be live")
+	default:
+	}
 }

--- a/pkg/plugin/testdata/authhandler/main.go
+++ b/pkg/plugin/testdata/authhandler/main.go
@@ -1,0 +1,68 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Command authhandler is a minimal auth-handler plugin used only by unit tests
+// in pkg/plugin. It exposes a single handler whose name is controlled by the
+// SCAFCTL_TEST_AUTH_HANDLER_NAME environment variable (default "test-auth") so
+// tests can exercise registration and de-duplication behavior.
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/oakwood-commons/scafctl-plugin-sdk/auth"
+	sdkplugin "github.com/oakwood-commons/scafctl-plugin-sdk/plugin"
+)
+
+type testAuthHandler struct{}
+
+func handlerName() string {
+	if n := os.Getenv("SCAFCTL_TEST_AUTH_HANDLER_NAME"); n != "" {
+		return n
+	}
+	return "test-auth"
+}
+
+func (h *testAuthHandler) GetAuthHandlers(_ context.Context) ([]sdkplugin.AuthHandlerInfo, error) {
+	return []sdkplugin.AuthHandlerInfo{{
+		Name:        handlerName(),
+		DisplayName: "Test Auth Handler",
+	}}, nil
+}
+
+func (h *testAuthHandler) ConfigureAuthHandler(_ context.Context, _ string, _ sdkplugin.ProviderConfig) error {
+	return nil
+}
+
+func (h *testAuthHandler) Login(_ context.Context, _ string, _ sdkplugin.LoginRequest, _ func(sdkplugin.DeviceCodePrompt)) (*sdkplugin.LoginResponse, error) {
+	return &sdkplugin.LoginResponse{}, nil
+}
+
+func (h *testAuthHandler) Logout(_ context.Context, _ string) error { return nil }
+
+func (h *testAuthHandler) GetStatus(_ context.Context, _ string) (*auth.Status, error) {
+	return &auth.Status{}, nil
+}
+
+func (h *testAuthHandler) GetToken(_ context.Context, _ string, _ sdkplugin.TokenRequest) (*sdkplugin.TokenResponse, error) {
+	return &sdkplugin.TokenResponse{}, nil
+}
+
+func (h *testAuthHandler) ListCachedTokens(_ context.Context, _ string) ([]*auth.CachedTokenInfo, error) {
+	return nil, nil
+}
+
+func (h *testAuthHandler) PurgeExpiredTokens(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+
+func (h *testAuthHandler) DetectAvailableFlows(_ context.Context, _ string) ([]sdkplugin.FlowAvailability, error) {
+	return nil, nil
+}
+
+func (h *testAuthHandler) StopAuthHandler(_ context.Context, _ string) error { return nil }
+
+func main() {
+	sdkplugin.ServeAuthHandler(&testAuthHandler{})
+}

--- a/pkg/plugin/wrapper_auth_lazy.go
+++ b/pkg/plugin/wrapper_auth_lazy.go
@@ -146,13 +146,16 @@ func (l *LazyAuthHandlerWrapper) init(ctx context.Context) (*AuthHandlerWrapper,
 }
 
 // storeBaseCtx captures the first non-background context for use by metadata
-// methods that lack a context parameter.
+// methods that lack a context parameter. The captured context is stripped of
+// cancellation via context.WithoutCancel so that a transient request context
+// cannot later invalidate long-lived metadata calls on this handler; only
+// values (e.g. host service identifiers) are retained.
 func (l *LazyAuthHandlerWrapper) storeBaseCtx(ctx context.Context) {
 	if ctx != nil && ctx != context.Background() && ctx != context.TODO() {
 		l.baseCtxMu.Lock()
 		defer l.baseCtxMu.Unlock()
 		if !l.baseCtxSet {
-			l.baseCtx = ctx
+			l.baseCtx = context.WithoutCancel(ctx)
 			l.baseCtxSet = true
 		}
 	}

--- a/pkg/plugin/wrapper_auth_lazy_test.go
+++ b/pkg/plugin/wrapper_auth_lazy_test.go
@@ -364,3 +364,37 @@ func TestLazyAuthHandlerWrapper_SetContext_IgnoresBackgroundContext(t *testing.T
 	lazy.SetContext(context.Background())
 	assert.Nil(t, lazy.baseCtx)
 }
+
+// TestLazyAuthHandlerWrapper_SetContext_StripsCancellation is a regression test
+// ensuring the captured base context retains values but is detached from the
+// caller's cancellation. A transient request context must not later invalidate
+// long-lived metadata calls on a shared, lazily-initialized auth handler.
+func TestLazyAuthHandlerWrapper_SetContext_StripsCancellation(t *testing.T) {
+	type ctxKey struct{}
+	base := context.WithValue(context.Background(), ctxKey{}, "kept")
+	cancelCtx, cancel := context.WithCancel(base)
+
+	lazy := &LazyAuthHandlerWrapper{
+		name:        "github",
+		displayName: "github",
+		initFn: func(_ context.Context) (*AuthHandlerWrapper, error) {
+			return nil, errors.New("init fails for test")
+		},
+	}
+	lazy.SetContext(cancelCtx)
+
+	// Cancel the original request context.
+	cancel()
+
+	stored := lazy.getBaseCtx()
+	require.NotNil(t, stored)
+	// Value is preserved...
+	assert.Equal(t, "kept", stored.Value(ctxKey{}))
+	// ...but cancellation is not propagated.
+	assert.NoError(t, stored.Err(), "captured context must not be cancelled by the caller")
+	select {
+	case <-stored.Done():
+		t.Fatal("captured context should not be done after caller cancellation")
+	default:
+	}
+}

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -55,6 +55,7 @@ type prepareConfig struct {
 	officialProviders    *official.Registry
 	officialAuthHandlers *authofficial.Registry
 	strict               bool
+	pluginPool           *plugin.Pool
 }
 
 // WithGetter provides a custom solution getter. If not set, one is created
@@ -173,6 +174,24 @@ func WithOfficialAuthHandlers(r *authofficial.Registry) Option {
 func WithStrict(strict bool) Option {
 	return func(c *prepareConfig) {
 		c.strict = strict
+	}
+}
+
+// WithPluginPool delegates provider plugin lifecycle to a shared, long-lived
+// plugin pool instead of fetching, registering, and killing plugin processes
+// per call. This is the correct mode for long-lived servers (MCP, HTTP API):
+// the pool registers provider wrappers into the shared registry exactly once
+// and keeps the processes alive across requests, while each prepared solution
+// merely acquires a reference for its lifetime and releases (never kills) it on
+// cleanup. This prevents registry poisoning where a per-request Kill would leave
+// dead-backed provider wrappers in a registry shared by future requests.
+//
+// The pool MUST have been constructed with the same provider registry passed
+// via WithRegistry. When nil, prepare falls back to the per-call
+// fetch/register/kill behavior suitable for one-shot CLI invocations.
+func WithPluginPool(p *plugin.Pool) Option {
+	return func(c *prepareConfig) {
+		c.pluginPool = p
 	}
 }
 
@@ -346,77 +365,108 @@ func Solution(ctx context.Context, path string, opts ...Option) (*Result, error)
 	// so external plugins can apply the same SSRF policy as the host.
 	injectHTTPClientSettings(ctx, cfg.pluginCfg)
 
-	// Auto-fetch and register plugin binaries from catalogs
-	var pluginClients []*plugin.Client
-	if len(sol.Bundle.Plugins) > 0 && cfg.pluginFetcher != nil {
-		fetchResults, fetchErr := cfg.pluginFetcher.FetchPlugins(ctx, sol.Bundle.Plugins, cfg.lockPlugins)
-		if fetchErr != nil {
+	// Provider plugin lifecycle. In pool mode (long-lived servers), the shared
+	// pool owns provider processes: it registers wrappers into the shared
+	// registry once and keeps them alive across requests. We merely acquire a
+	// reference for this prepared solution and release (never kill) on cleanup,
+	// which prevents registry poisoning. In per-call mode (one-shot CLI), we
+	// fetch, register, and kill the plugin processes ourselves.
+	if cfg.pluginPool != nil {
+		deps := providerPoolDeps(sol, cfg)
+		release, ensErr := cfg.pluginPool.EnsureAndAcquire(ctx, deps)
+		if ensErr != nil {
 			cleanup()
-			return nil, fmt.Errorf("auto-fetching plugins: %w", fetchErr)
+			return nil, fmt.Errorf("ensuring provider plugins via pool: %w", ensErr)
+		}
+		origCleanup := cleanup
+		cleanup = func() {
+			release()
+			origCleanup()
 		}
 
-		clients, regErr := plugin.RegisterFetchedPlugins(ctx, reg, fetchResults, cfg.pluginCfg, cfg.clientOpts...)
-		if regErr != nil {
-			cleanup()
-			return nil, fmt.Errorf("registering fetched plugins: %w", regErr)
-		}
-		pluginClients = clients
-
-		// Register auth handler plugins if auth registry is available
-		if cfg.authRegistry != nil {
-			authClients, authRegErr := plugin.RegisterFetchedAuthHandlerPlugins(ctx, cfg.authRegistry, fetchResults, cfg.pluginCfg, cfg.clientOpts...)
-			if authRegErr != nil {
+		// Auth handler plugins are not pool-managed. Register any declared in
+		// the bundle into the shared auth registry, but do NOT kill them per
+		// request -- the long-lived server owns their lifetime, and killing them
+		// would poison the shared auth registry for subsequent requests.
+		if cfg.authRegistry != nil && cfg.pluginFetcher != nil && len(sol.Bundle.Plugins) > 0 {
+			if _, ahErr := registerBundleAuthHandlers(ctx, sol, cfg); ahErr != nil {
 				cleanup()
-				return nil, fmt.Errorf("registering fetched auth handler plugins: %w", authRegErr)
+				return nil, ahErr
 			}
-			// Add auth handler client cleanup
-			origCleanup2 := cleanup
+		}
+	} else {
+		// Per-call mode: auto-fetch and register plugin binaries from catalogs.
+		var pluginClients []*plugin.Client
+		if len(sol.Bundle.Plugins) > 0 && cfg.pluginFetcher != nil {
+			fetchResults, fetchErr := cfg.pluginFetcher.FetchPlugins(ctx, sol.Bundle.Plugins, cfg.lockPlugins)
+			if fetchErr != nil {
+				cleanup()
+				return nil, fmt.Errorf("auto-fetching plugins: %w", fetchErr)
+			}
+
+			clients, regErr := plugin.RegisterFetchedPlugins(ctx, reg, fetchResults, cfg.pluginCfg, cfg.clientOpts...)
+			if regErr != nil {
+				cleanup()
+				return nil, fmt.Errorf("registering fetched plugins: %w", regErr)
+			}
+			pluginClients = clients
+
+			// Register auth handler plugins if auth registry is available
+			if cfg.authRegistry != nil {
+				authClients, authRegErr := plugin.RegisterFetchedAuthHandlerPlugins(ctx, cfg.authRegistry, fetchResults, cfg.pluginCfg, cfg.clientOpts...)
+				if authRegErr != nil {
+					cleanup()
+					return nil, fmt.Errorf("registering fetched auth handler plugins: %w", authRegErr)
+				}
+				// Add auth handler client cleanup
+				origCleanup2 := cleanup
+				cleanup = func() {
+					for _, c := range authClients {
+						c.Kill()
+					}
+					origCleanup2()
+				}
+			}
+
+			if lgr != nil {
+				for _, r := range fetchResults {
+					src := "catalog"
+					if r.FromCache {
+						src = "cache"
+					}
+					lgr.V(1).Info("plugin loaded",
+						"name", r.Name,
+						"version", r.Version,
+						"source", src)
+				}
+			}
+
+			// Add plugin cleanup to the cleanup chain
+			origCleanup := cleanup
 			cleanup = func() {
-				for _, c := range authClients {
+				for _, c := range pluginClients {
 					c.Kill()
 				}
-				origCleanup2()
+				origCleanup()
 			}
 		}
 
-		if lgr != nil {
-			for _, r := range fetchResults {
-				src := "catalog"
-				if r.FromCache {
-					src = "cache"
+		// Auto-resolve official providers that are referenced in the solution
+		// but not already registered. This runs after the explicit plugin fetch
+		// so that declared bundle.plugins always take precedence.
+		officialClients, officialErr := autoResolveOfficialProviders(ctx, sol, reg, cfg)
+		if officialErr != nil {
+			cleanup()
+			return nil, officialErr
+		}
+		if len(officialClients) > 0 {
+			origCleanup := cleanup
+			cleanup = func() {
+				for _, c := range officialClients {
+					c.Kill()
 				}
-				lgr.V(1).Info("plugin loaded",
-					"name", r.Name,
-					"version", r.Version,
-					"source", src)
+				origCleanup()
 			}
-		}
-
-		// Add plugin cleanup to the cleanup chain
-		origCleanup := cleanup
-		cleanup = func() {
-			for _, c := range pluginClients {
-				c.Kill()
-			}
-			origCleanup()
-		}
-	}
-
-	// Auto-resolve official providers that are referenced in the solution
-	// but not already registered. This runs after the explicit plugin fetch
-	// so that declared bundle.plugins always take precedence.
-	officialClients, officialErr := autoResolveOfficialProviders(ctx, sol, reg, cfg)
-	if officialErr != nil {
-		cleanup()
-		return nil, officialErr
-	}
-	if len(officialClients) > 0 {
-		origCleanup := cleanup
-		cleanup = func() {
-			for _, c := range officialClients {
-				c.Kill()
-			}
-			origCleanup()
 		}
 	}
 
@@ -427,7 +477,10 @@ func Solution(ctx context.Context, path string, opts ...Option) (*Result, error)
 		cleanup()
 		return nil, officialAuthErr
 	}
-	if len(officialAuthClients) > 0 {
+	// In pool mode, auth handler clients are owned by the long-lived server and
+	// must not be killed per request (doing so would poison the shared auth
+	// registry). In per-call mode, they are killed on cleanup.
+	if len(officialAuthClients) > 0 && cfg.pluginPool == nil {
 		origCleanup := cleanup
 		cleanup = func() {
 			for _, c := range officialAuthClients {
@@ -743,6 +796,65 @@ func autoResolveOfficialProviders(
 		return nil, fmt.Errorf("registering auto-resolved official providers: %w", regErr)
 	}
 
+	return clients, nil
+}
+
+// providerPoolDeps computes the provider plugin dependencies to acquire from
+// the shared pool for a solution: all provider-kind bundle plugins plus every
+// referenced official provider. Official providers are included whether or not
+// they are already registered so that pool-managed entries get a reference on
+// each request (preventing idle eviction of an in-use provider); the pool
+// deduplicates already-loaded entries internally. Note that a provider already
+// present in the shared registry but not tracked by the pool (e.g. a builtin or
+// one registered outside the pool) returns early from ensureOne without taking
+// a reference. Builtin providers referenced by the solution are intentionally
+// omitted -- they live outside the pool and are never evicted.
+func providerPoolDeps(sol *solution.Solution, cfg *prepareConfig) []solution.PluginDependency {
+	var deps []solution.PluginDependency
+	seen := make(map[string]bool)
+	for _, p := range sol.Bundle.Plugins {
+		if p.Kind == solution.PluginKindProvider {
+			deps = append(deps, p)
+			seen[p.Name] = true
+		}
+	}
+	if cfg.officialProviders != nil {
+		for _, name := range sol.Spec.ReferencedProviderNames() {
+			if seen[name] {
+				continue
+			}
+			if op, ok := cfg.officialProviders.Get(name); ok {
+				deps = append(deps, op.ToPluginDependency())
+				seen[name] = true
+			}
+		}
+	}
+	return deps
+}
+
+// registerBundleAuthHandlers fetches and registers any auth-handler-kind
+// plugins declared in the solution bundle into the shared auth registry. It is
+// used in pool mode, where the returned clients are owned by the long-lived
+// server and are intentionally NOT killed per request. Returns nil when the
+// bundle declares no auth handler plugins.
+func registerBundleAuthHandlers(ctx context.Context, sol *solution.Solution, cfg *prepareConfig) ([]*plugin.AuthHandlerClient, error) {
+	var authDeps []solution.PluginDependency
+	for _, p := range sol.Bundle.Plugins {
+		if p.Kind == solution.PluginKindAuthHandler {
+			authDeps = append(authDeps, p)
+		}
+	}
+	if len(authDeps) == 0 {
+		return nil, nil
+	}
+	fetchResults, err := cfg.pluginFetcher.FetchPlugins(ctx, authDeps, cfg.lockPlugins)
+	if err != nil {
+		return nil, fmt.Errorf("auto-fetching auth handler plugins: %w", err)
+	}
+	clients, err := plugin.RegisterFetchedAuthHandlerPlugins(ctx, cfg.authRegistry, fetchResults, cfg.pluginCfg, cfg.clientOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("registering fetched auth handler plugins: %w", err)
+	}
 	return clients, nil
 }
 

--- a/pkg/solution/prepare/prepare_test.go
+++ b/pkg/solution/prepare/prepare_test.go
@@ -1671,3 +1671,136 @@ func TestSignaturePolicyFromConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestProviderPoolDeps_BundleProvidersOnly(t *testing.T) {
+	t.Parallel()
+
+	sol := &solution.Solution{}
+	sol.Bundle.Plugins = []solution.PluginDependency{
+		{Name: "custom-a", Kind: solution.PluginKindProvider},
+		{Name: "custom-b", Kind: solution.PluginKindProvider},
+		{Name: "some-auth", Kind: solution.PluginKindAuthHandler},
+	}
+
+	deps := providerPoolDeps(sol, &prepareConfig{})
+
+	names := depNames(deps)
+	assert.ElementsMatch(t, []string{"custom-a", "custom-b"}, names,
+		"only provider-kind bundle plugins are pool deps; auth handlers excluded")
+}
+
+func TestProviderPoolDeps_IncludesReferencedOfficialProviders(t *testing.T) {
+	t.Parallel()
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"r": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{Provider: "github"}},
+					},
+				},
+			},
+		},
+	}
+	cfg := &prepareConfig{officialProviders: official.NewRegistry()}
+
+	deps := providerPoolDeps(sol, cfg)
+
+	names := depNames(deps)
+	assert.Contains(t, names, "github", "referenced official provider must be a pool dep")
+}
+
+func TestProviderPoolDeps_OmitsNonOfficialReferences(t *testing.T) {
+	t.Parallel()
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"r": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{Provider: "not-official"}},
+					},
+				},
+			},
+		},
+	}
+	cfg := &prepareConfig{officialProviders: official.NewRegistry()}
+
+	deps := providerPoolDeps(sol, cfg)
+
+	assert.Empty(t, deps, "unknown/non-official referenced providers are not pool deps")
+}
+
+func TestProviderPoolDeps_DedupsBundleAndOfficial(t *testing.T) {
+	t.Parallel()
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"r": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{Provider: "github"}},
+					},
+				},
+			},
+		},
+	}
+	sol.Bundle.Plugins = []solution.PluginDependency{
+		{Name: "github", Kind: solution.PluginKindProvider},
+	}
+	cfg := &prepareConfig{officialProviders: official.NewRegistry()}
+
+	deps := providerPoolDeps(sol, cfg)
+
+	assert.Len(t, deps, 1, "a provider present in both bundle and official set appears once")
+	assert.Equal(t, "github", deps[0].Name)
+}
+
+func TestProviderPoolDeps_NilOfficialRegistry(t *testing.T) {
+	t.Parallel()
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"r": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{Provider: "github"}},
+					},
+				},
+			},
+		},
+	}
+	sol.Bundle.Plugins = []solution.PluginDependency{
+		{Name: "custom", Kind: solution.PluginKindProvider},
+	}
+
+	deps := providerPoolDeps(sol, &prepareConfig{})
+
+	names := depNames(deps)
+	assert.Equal(t, []string{"custom"}, names,
+		"with no official registry, only bundle providers are pool deps")
+}
+
+func depNames(deps []solution.PluginDependency) []string {
+	names := make([]string, len(deps))
+	for i, d := range deps {
+		names[i] = d.Name
+	}
+	return names
+}
+
+func TestRegisterBundleAuthHandlers_NoAuthHandlers(t *testing.T) {
+	t.Parallel()
+
+	// A bundle with only provider-kind plugins (or none) declares no auth
+	// handlers, so the function returns early without touching the fetcher.
+	sol := &solution.Solution{}
+	sol.Bundle.Plugins = []solution.PluginDependency{
+		{Name: "custom-provider", Kind: solution.PluginKindProvider},
+	}
+
+	clients, err := registerBundleAuthHandlers(context.Background(), sol, &prepareConfig{})
+	require.NoError(t, err)
+	assert.Nil(t, clients, "no auth-handler plugins means no clients and no fetch")
+}

--- a/tests/integration/api_test.go
+++ b/tests/integration/api_test.go
@@ -1896,7 +1896,7 @@ func setupTestServerWithPool(t testing.TB, poolOpts ...plugin.PoolOption) *httpt
 	require.NoError(t, reg.Register(messageprovider.NewMessageProvider()))
 	require.NoError(t, reg.Register(fileprovider.NewFileProvider()))
 
-	pool := plugin.NewPool(nil, reg, logr.Discard(), poolOpts...)
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), poolOpts...)
 	t.Cleanup(pool.Shutdown)
 
 	srv, err := api.NewServer(
@@ -1998,7 +1998,7 @@ func TestAPI_SolutionRender_PluginPoolFull(t *testing.T) {
 	reg := provider.NewRegistry()
 	require.NoError(t, reg.Register(messageprovider.NewMessageProvider()))
 
-	pool := plugin.NewPool(nil, reg, logr.Discard(), plugin.WithIdleTimeout(0), plugin.WithMaxPlugins(1))
+	pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(), plugin.WithIdleTimeout(0), plugin.WithMaxPlugins(1))
 	t.Cleanup(pool.Shutdown)
 
 	// Adopt a nil client to fill the single slot
@@ -2069,7 +2069,7 @@ func TestAPI_SolutionRun_AllowedCatalogs_Rejected(t *testing.T) {
 	reg := provider.NewRegistry()
 	require.NoError(t, reg.Register(messageprovider.NewMessageProvider()))
 
-	pool := plugin.NewPool(fetcher, reg, logr.Discard(), plugin.WithIdleTimeout(0))
+	pool := plugin.NewPool(context.Background(), fetcher, reg, logr.Discard(), plugin.WithIdleTimeout(0))
 	t.Cleanup(pool.Shutdown)
 
 	srv, err := api.NewServer(


### PR DESCRIPTION
Plugin-backed providers failed with "grpc: the client connection is closing" under a long-lived MCP or API server because the pool bound long-lived plugin initialization to a per-request context and killed clients without checking active references. The prepare path also registered plugin wrappers into the shared registry then killed the backing clients on cleanup, leaving the registry poisoned with dead-backed wrappers for subsequent requests.

- Add a pool-lifetime context to the pool; NewPool now takes ctx as its first argument and Shutdown cancels the derived child context
- Spawn plugins in a background goroutine under the pool context with a configurable spawn timeout (WithSpawnTimeout, default 2m) so a request cancellation no longer invalidates a still-registered wrapper
- Make teardown refcount-aware: unregister providers immediately but defer client.Kill() until the last Release when a client is still in use; eviction skips referenced entries
- Acquire entries atomically under the entry lock in EnsureAndAcquire
- Add prepare.WithPluginPool so servers delegate provider plugin lifecycle to the shared pool (acquire/release) instead of fetch/register/kill; the CLI keeps the short-lived legacy path
- Strip cancellation from the retained lazy auth-handler base context via context.WithoutCancel while preserving its values
- Wire the MCP prepare options and both serve commands to the new pool signature

BREAKING CHANGE: plugin.NewPool now takes a context.Context as its first argument. External embedders constructing their own pool must pass a long-lived context (e.g. the server context).