### PR TITLE
feat(auth)!: resolve third-party auth handlers by name from catalogs

### DIFF
--- a/docs/design/auth.md
+++ b/docs/design/auth.md
@@ -34,20 +34,69 @@ scafctl provides built-in auth handlers for common identity providers:
 | `github` | ✅ Implemented | GitHub OAuth (Device Code + PAT) |
 | `gcp` | ✅ Implemented | Google Cloud Platform (ADC, Service Account, Metadata, Workload Identity, gcloud ADC, Impersonation) |
 
-**External Auth Handlers** can be distributed via the catalog for custom identity providers:
+**External (third-party) Auth Handlers** are distributed via the catalog as
+`auth-handler` artifacts and resolved by name, exactly like providers:
 
 ```bash
-# Push an auth handler to the catalog
-scafctl catalog push okta-handler@1.0.0 --catalog ghcr.io/myorg
+# Publish a third-party auth handler to a catalog
+scafctl build plugin --name openshift --kind auth-handler --version 0.1.0 \
+  --platform darwin/arm64=./dist/scafctl-plugin-auth-openshift
 
-# Pull an auth handler
-scafctl catalog pull ghcr.io/myorg/auth-handlers/okta-handler@1.0.0
-
-# The handler is then available for use
-scafctl auth login okta
+# Resolve and use it by name -- no allowlist gate
+scafctl auth handlers install openshift
+scafctl auth login openshift
+scafctl kube login prod --handler openshift
 ```
 
-External auth handlers use the same go-plugin mechanism as providers. See [Plugins](plugins.md) for architecture details.
+External auth handlers use the same go-plugin mechanism as providers. See
+[Plugins](plugins.md) for architecture details.
+
+### Auth Handler Resolution
+
+When a handler name is requested (via `auth login`, `auth token`,
+`auth handlers install`, `kube login --handler`, or the `kubectl`/`oc`
+exec-credential helper), scafctl resolves it by name in this order:
+
+1. **Config pin** -- if `auth.handlers.<name>.plugin` is set, its catalog
+   artifact `ref`/`version` is used.
+2. **Official allowlist** -- `entra`, `github`, and `gcp` resolve to their
+   first-party catalog artifacts. The official list is a convenience and trust
+   anchor, **not** a hard gate.
+3. **Bare catalog name** -- any other name is resolved directly against the
+   configured catalogs as an `auth-handler` artifact.
+
+Resolution is lazy: the plugin is fetched and started only when a handler is
+actually requested, so commands that never touch auth (e.g. `catalog tag`,
+`version`) incur no network I/O. All entry points funnel through the auth
+registry, so `kube login` and the exec-credential token path resolve third-party
+handlers the same way as `auth login`.
+
+Two settings gate resolution for locked-down embedders:
+
+| Setting | Effect |
+|---------|--------|
+| `settings.disableOfficialAuthHandlers` | Blocks auto-resolution of the official trio (`entra`, `github`, `gcp`), including by bare catalog name. |
+| `settings.disableThirdPartyAuthHandlers` | Blocks resolution of every non-official handler. Only the official trio resolves; all other names -- config-pinned (`auth.handlers.<name>.plugin`) and bare catalog names alike -- are rejected even if present in a catalog. |
+
+### Pinning a Third-Party Handler
+
+To pin the exact catalog artifact and declare trust for a third-party handler,
+use the `auth.handlers.<name>` namespace:
+
+```yaml
+auth:
+  handlers:
+    openshift:
+      # Pin the catalog artifact (ref defaults to the handler name, version to "latest").
+      plugin:
+        ref: openshift-auth
+        version: "^0.1.0"
+      # Third-party handlers do NOT inherit the hardcoded official trust
+      # domains; declare their device-code verification domains here.
+      trustedVerificationDomains:
+        - sso.openshift.example.com
+```
+
 
 ---
 

--- a/docs/tutorials/auth-migration-guide.md
+++ b/docs/tutorials/auth-migration-guide.md
@@ -98,6 +98,18 @@ auth:
     - "github.com"
 ~~~
 
+Third-party (non-official) handlers do **not** inherit the hardcoded official
+trust domains, so declare their device-code verification domains explicitly
+under the per-handler namespace:
+
+~~~yaml
+auth:
+  handlers:
+    openshift:
+      trustedVerificationDomains:
+        - "sso.openshift.example.com"
+~~~
+
 ## Telemetry
 
 The plugin auth system includes OpenTelemetry instrumentation:

--- a/docs/tutorials/config-tutorial.md
+++ b/docs/tutorials/config-tutorial.md
@@ -386,10 +386,15 @@ Override paths with XDG environment variables or SCAFCTL_SECRETS_DIR.
 | `action.concurrency` | int | `4` | Max parallel action execution |
 | `plugins.grpcMaxMessageSize` | int | `67108864` | Max gRPC message size in bytes for plugin communication (64 MB default). Increase for very large provider inputs/outputs |
 | `plugins.fetchCooldown` | duration | `5m` | Cooldown between failed plugin auto-fetch retries |
+| `settings.disableOfficialAuthHandlers` | bool | `false` | Disable auto-resolution of the official auth handlers (`entra`, `github`, `gcp`) |
+| `settings.disableThirdPartyAuthHandlers` | bool | `false` | Disable catalog-by-name resolution of non-official auth handlers (official-only policy) |
 | `auth.entra.*` | object | — | Entra (Azure AD) auth handler config |
 | `auth.github.hostname` | string | `github.com` | GitHub hostname (or GHES hostname) |
 | `auth.github.clientId` | string | built-in | OAuth App client ID |
 | `auth.github.defaultScopes` | []string | `[gist, read:org, repo, workflow]` | Default OAuth scopes |
+| `auth.handlers.<name>.plugin.ref` | string | handler name | Catalog artifact name for a pinned third-party auth handler |
+| `auth.handlers.<name>.plugin.version` | string | `latest` | Version constraint for a pinned third-party auth handler |
+| `auth.handlers.<name>.trustedVerificationDomains` | []string | — | Per-handler trusted device-code verification domains (required trust source for third-party handlers) |
 
 ### Config File Location
 

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -330,6 +330,18 @@ scafctl auth handlers remove github
 scafctl auth handlers remove entra
 ```
 
+Third-party handlers published to a configured catalog resolve by name too --
+no allowlist entry needed:
+
+```bash
+scafctl catalog list --kind auth-handler   # shows: openshift
+scafctl auth handlers install openshift
+scafctl auth login openshift
+```
+
+Pin the artifact and declare trust via `auth.handlers.<name>` -- see
+[third-party-handler-config.yaml](third-party-handler-config.yaml).
+
 ---
 
 ## Related
@@ -337,5 +349,6 @@ scafctl auth handlers remove entra
 - [Auth Tutorial](../../docs/tutorials/auth-tutorial.md) -- full walkthrough
 - [kubectl Exec Credential](kubectl-exec-credential.md) -- use scafctl as a Kubernetes credential plugin
 - [Kubernetes login / logout](kube-login.md) -- automate kubeconfig setup with `scafctl kube login`
+- [Third-party handler config](third-party-handler-config.yaml) -- pin a catalog auth handler and declare its trust domains
 - [HTTP Provider with Entra](../providers/http-entra.yaml) -- example HTTP call with Entra auth
 - [GitHub API Provider](../providers/github-api.yaml) -- example GitHub API call

--- a/examples/auth/handler-lifecycle.md
+++ b/examples/auth/handler-lifecycle.md
@@ -4,6 +4,10 @@ Official auth handlers (github, gcp, entra) are delivered as plugin binaries.
 They are downloaded automatically on first use, but you can manage them
 explicitly for air-gapped environments, debugging, or disk cleanup.
 
+Third-party auth handlers published to a configured catalog are resolved the
+same way -- by name -- with no official-allowlist gate. See
+[Third-Party Handlers](#third-party-handlers) below.
+
 ## Listing Handlers
 
 ~~~bash
@@ -40,6 +44,42 @@ scafctl auth handlers install entra
 # Force re-download (replaces cached binary)
 scafctl auth handlers install entra --force
 ~~~
+
+## Third-Party Handlers
+
+A non-official auth handler published to a configured catalog resolves by name,
+just like the official trio -- there is no allowlist to add it to.
+
+~~~bash
+# Publish a third-party handler into a catalog
+scafctl build plugin --name openshift --kind auth-handler --version 0.1.0 \
+  --platform darwin/arm64=./dist/scafctl-plugin-auth-openshift
+
+# It is now resolvable by name
+scafctl catalog list --kind auth-handler   # shows: openshift
+scafctl auth handlers install openshift
+scafctl auth login openshift
+scafctl kube login prod --handler openshift
+~~~
+
+To pin the exact artifact and declare trust (third-party handlers do not inherit
+the official device-code verification domains), use the per-handler config
+namespace -- see [third-party-handler-config.yaml](third-party-handler-config.yaml):
+
+~~~yaml
+auth:
+  handlers:
+    openshift:
+      plugin:
+        ref: openshift-auth
+        version: "^0.1.0"
+      trustedVerificationDomains:
+        - sso.openshift.example.com
+~~~
+
+Locked-down deployments can enforce an official-only policy with
+`settings.disableThirdPartyAuthHandlers: true`, which rejects any non-official
+handler name even if present in a catalog.
 
 ## Removing a Handler
 

--- a/examples/auth/kube-login.md
+++ b/examples/auth/kube-login.md
@@ -40,6 +40,14 @@ Pass `--handler` to override the resolver's default:
 scafctl kube login prod --handler oidc
 ```
 
+The named handler is resolved by name against your configured catalogs, so a
+third-party handler (for example `openshift`) published to a catalog works the
+same as the official ones -- no allowlist entry required. Pin its artifact and
+trust domains via `auth.handlers.<name>` (see
+[third-party-handler-config.yaml](third-party-handler-config.yaml)). Every
+subsequent `kubectl` / `oc` call mints tokens through the same handler via the
+exec-credential helper.
+
 Or point at an API server directly, without a resolver (name the handler since
 there is no resolver default):
 

--- a/examples/auth/third-party-handler-config.yaml
+++ b/examples/auth/third-party-handler-config.yaml
@@ -1,0 +1,49 @@
+# Example: Third-party (non-official) auth handler configuration
+#
+# This config shows how to use an auth handler that is NOT one of the official
+# handlers (entra, github, gcp). Third-party handlers published to a configured
+# catalog resolve by name -- there is no allowlist to add them to.
+#
+# Usage:
+#   # Publish the handler into a catalog (once):
+#   scafctl build plugin --name openshift --kind auth-handler --version 0.1.0 \
+#     --platform darwin/arm64=./dist/scafctl-plugin-auth-openshift
+#
+#   # Then use it by name, exactly like an official handler:
+#   scafctl auth handlers install openshift
+#   scafctl auth login openshift
+#   scafctl kube login prod --handler openshift
+#
+# Precedence when resolving a handler name:
+#   1. auth.handlers.<name>.plugin  (this config pin)
+#   2. official allowlist           (entra, github, gcp)
+#   3. bare catalog artifact name
+
+auth:
+  handlers:
+    # The key is the handler name you pass on the CLI (e.g. "openshift").
+    openshift:
+      # Optional: pin the exact catalog artifact backing this handler.
+      # Omit this block to resolve the bare handler name at "latest".
+      plugin:
+        # Catalog artifact name. Defaults to the handler name ("openshift").
+        ref: openshift-auth
+        # Semver constraint or "latest". Defaults to "latest".
+        version: "^0.1.0"
+
+      # REQUIRED for third-party device-code flows: trusted verification
+      # domains. Third-party handlers do NOT inherit the hardcoded official
+      # trust domains, so the device-code verification URL is only accepted if
+      # its host matches one of these (or a global auth.trustedVerificationDomains
+      # entry).
+      trustedVerificationDomains:
+        - sso.openshift.example.com
+
+  # Global trusted domains apply to every handler, official or third-party.
+  trustedVerificationDomains:
+    - login.example.com
+
+settings:
+  # Optional lockdown: reject any non-official handler name even if present in a
+  # catalog. Leave false (the default) to allow catalog-by-name resolution.
+  disableThirdPartyAuthHandlers: false

--- a/pkg/auth/context.go
+++ b/pkg/auth/context.go
@@ -33,7 +33,10 @@ func GetHandler(ctx context.Context, name string) (Handler, error) {
 		return nil, fmt.Errorf("%w: no auth registry in context", ErrHandlerNotFound)
 	}
 	handlerName, _ := ParseProfileKey(name)
-	return registry.Get(handlerName)
+	// Use GetContext so a catalog fetch triggered by the fallback resolver
+	// (e.g. during 'kube login' or 'auth token --exec-credential') honors the
+	// caller's timeout and cancellation instead of running uncancellable.
+	return registry.GetContext(ctx, handlerName)
 }
 
 // HasHandler checks if an auth handler exists in the context's registry.

--- a/pkg/auth/handlerdep/handlerdep.go
+++ b/pkg/auth/handlerdep/handlerdep.go
@@ -1,0 +1,182 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package handlerdep decides how an auth handler name maps to a plugin
+// dependency for catalog resolution. It centralizes the precedence rules —
+// config pin, official allowlist, then bare catalog name — used by the auth
+// registry fallback resolver and the CLI auth commands.
+//
+// Resolve performs NO network or filesystem I/O; it only decides the
+// dependency shape and reports which source produced it. The caller is
+// responsible for actually fetching and registering the plugin.
+package handlerdep
+
+import (
+	"context"
+	"errors"
+
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+)
+
+// defaultVersion is applied when neither a config pin nor an official entry
+// specifies a version constraint. "latest" lets the catalog resolver pick the
+// newest available version.
+const defaultVersion = "latest"
+
+// Source records where a handler dependency was resolved from.
+type Source int
+
+const (
+	// SourceUnknown is the zero value, used when resolution fails.
+	SourceUnknown Source = iota
+	// SourceConfigPin means the dependency came from auth.handlers.<name>.plugin.
+	SourceConfigPin
+	// SourceOfficial means the name matched the official handler allowlist.
+	SourceOfficial
+	// SourceCatalog means the name resolves as a bare catalog artifact name.
+	SourceCatalog
+)
+
+// String returns a human-readable name for the source.
+func (s Source) String() string {
+	switch s {
+	case SourceUnknown:
+		return "unknown"
+	case SourceConfigPin:
+		return "config-pin"
+	case SourceOfficial:
+		return "official"
+	case SourceCatalog:
+		return "catalog"
+	default:
+		return "unknown"
+	}
+}
+
+// ErrThirdPartyDisabled is returned by Resolve when the name resolves to a
+// non-official (catalog or config-pinned) handler but third-party auth handler
+// resolution is disabled via settings.disableThirdPartyAuthHandlers.
+var ErrThirdPartyDisabled = errors.New("third-party auth handlers are disabled")
+
+// ErrOfficialDisabled is returned by Resolve when the name matches an official
+// handler but official auth handler resolution is disabled via
+// settings.disableOfficialAuthHandlers.
+var ErrOfficialDisabled = errors.New("official auth handlers are disabled")
+
+// Resolve maps an auth handler name to the plugin dependency that should be
+// fetched from a configured catalog, and reports the source that produced it.
+//
+// Precedence:
+//  1. Config pin (auth.handlers.<name>.plugin) — explicit user mapping.
+//  2. Official allowlist — first-party trust anchor.
+//  3. Bare catalog name — resolve the name directly as a catalog artifact.
+//
+// Resolve honors the disable switches: an official name is rejected with
+// ErrOfficialDisabled when settings.disableOfficialAuthHandlers is set, and a
+// non-official (config-pinned or catalog) name is rejected with
+// ErrThirdPartyDisabled when settings.disableThirdPartyAuthHandlers is set.
+func Resolve(ctx context.Context, name string) (solution.PluginDependency, Source, error) {
+	cfg := config.FromContext(ctx)
+
+	source, dep := decide(ctx, name, cfg)
+
+	if err := gate(source, cfg); err != nil {
+		return solution.PluginDependency{}, SourceUnknown, err
+	}
+	return dep, source, nil
+}
+
+// IsKnown reports whether name is a resolvable official handler or config pin
+// under the current policy. It performs no catalog probe, so a bare catalog
+// name that exists only in a remote catalog returns false. It honors the
+// disable switches: a config pin is not "known" when
+// settings.disableThirdPartyAuthHandlers is set, and an official name is not
+// "known" when settings.disableOfficialAuthHandlers is set -- matching what
+// Resolve would allow. Use this for cheap pre-validation and shell completion,
+// not as an authoritative existence check.
+func IsKnown(ctx context.Context, name string) bool {
+	cfg := config.FromContext(ctx)
+	if cfg != nil {
+		if hc, ok := cfg.Auth.Handlers[name]; ok && hc.Plugin != nil {
+			// Config pins are third-party; policy may forbid resolving them.
+			return !cfg.Settings.DisableThirdPartyAuthHandlers
+		}
+	}
+	if reg := authofficial.RegistryFromContext(ctx); reg != nil && reg.Has(name) {
+		return cfg == nil || !cfg.Settings.DisableOfficialAuthHandlers
+	}
+	return false
+}
+
+// decide selects the source and dependency shape by precedence, ignoring the
+// disable switches (applied separately by gate).
+func decide(ctx context.Context, name string, cfg *config.Config) (Source, solution.PluginDependency) {
+	if cfg != nil {
+		if hc, ok := cfg.Auth.Handlers[name]; ok && hc.Plugin != nil {
+			ref := hc.Plugin.Ref
+			if ref == "" {
+				ref = name
+			}
+			version := hc.Plugin.Version
+			if version == "" {
+				version = defaultVersion
+			}
+			return SourceConfigPin, solution.PluginDependency{
+				Name:    ref,
+				Kind:    solution.PluginKindAuthHandler,
+				Version: version,
+			}
+		}
+	}
+
+	if h, ok := officialEntry(ctx, name); ok {
+		return SourceOfficial, h.ToPluginDependency()
+	}
+
+	return SourceCatalog, solution.PluginDependency{
+		Name:    name,
+		Kind:    solution.PluginKindAuthHandler,
+		Version: defaultVersion,
+	}
+}
+
+// officialEntry reports whether name is an official auth handler and returns
+// its catalog entry. It consults the official registry from context when
+// present (authoritative, including embedder overrides via
+// RootOptions.OfficialAuthHandlers). When no registry is attached -- which
+// happens when settings.disableOfficialAuthHandlers is set -- it falls back to
+// the canonical default official names so the disable gate can still classify
+// and block official handlers instead of letting them resolve as bare catalog
+// artifacts.
+func officialEntry(ctx context.Context, name string) (authofficial.AuthHandler, bool) {
+	if reg := authofficial.RegistryFromContext(ctx); reg != nil {
+		return reg.Get(name)
+	}
+	for _, h := range authofficial.DefaultAuthHandlers() {
+		if h.Name == name {
+			return h, true
+		}
+	}
+	return authofficial.AuthHandler{}, false
+}
+
+// gate applies the disable switches to a resolved source.
+func gate(source Source, cfg *config.Config) error {
+	if cfg == nil {
+		return nil
+	}
+	switch source {
+	case SourceOfficial:
+		if cfg.Settings.DisableOfficialAuthHandlers {
+			return ErrOfficialDisabled
+		}
+	case SourceConfigPin, SourceCatalog:
+		if cfg.Settings.DisableThirdPartyAuthHandlers {
+			return ErrThirdPartyDisabled
+		}
+	case SourceUnknown:
+	}
+	return nil
+}

--- a/pkg/auth/handlerdep/handlerdep_test.go
+++ b/pkg/auth/handlerdep/handlerdep_test.go
@@ -1,0 +1,276 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package handlerdep
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func officialCtx(t *testing.T, handlers ...authofficial.AuthHandler) context.Context {
+	t.Helper()
+	reg := authofficial.NewRegistryFrom(handlers)
+	return authofficial.WithRegistry(context.Background(), reg)
+}
+
+func githubEntry() authofficial.AuthHandler {
+	return authofficial.AuthHandler{Name: "github", CatalogRef: "github", DefaultVersion: "latest"}
+}
+
+func TestResolve_BareCatalogName(t *testing.T) {
+	ctx := officialCtx(t, githubEntry())
+
+	dep, source, err := Resolve(ctx, "openshift")
+	require.NoError(t, err)
+	assert.Equal(t, SourceCatalog, source)
+	assert.Equal(t, solution.PluginDependency{
+		Name:    "openshift",
+		Kind:    solution.PluginKindAuthHandler,
+		Version: "latest",
+	}, dep)
+}
+
+func TestResolve_OfficialName(t *testing.T) {
+	ctx := officialCtx(t, githubEntry())
+
+	dep, source, err := Resolve(ctx, "github")
+	require.NoError(t, err)
+	assert.Equal(t, SourceOfficial, source)
+	assert.Equal(t, "github", dep.Name)
+	assert.Equal(t, solution.PluginKindAuthHandler, dep.Kind)
+	assert.Equal(t, "latest", dep.Version)
+}
+
+func TestResolve_ConfigPinWinsOverCatalog(t *testing.T) {
+	ctx := officialCtx(t, githubEntry())
+	ctx = config.WithConfig(ctx, &config.Config{
+		Auth: config.GlobalAuthConfig{
+			Handlers: map[string]config.HandlerConfig{
+				"openshift": {Plugin: &config.HandlerPluginConfig{Ref: "openshift-auth", Version: "^0.2.0"}},
+			},
+		},
+	})
+
+	dep, source, err := Resolve(ctx, "openshift")
+	require.NoError(t, err)
+	assert.Equal(t, SourceConfigPin, source)
+	assert.Equal(t, "openshift-auth", dep.Name)
+	assert.Equal(t, "^0.2.0", dep.Version)
+	assert.Equal(t, solution.PluginKindAuthHandler, dep.Kind)
+}
+
+func TestResolve_ConfigPinWinsOverOfficial(t *testing.T) {
+	ctx := officialCtx(t, githubEntry())
+	ctx = config.WithConfig(ctx, &config.Config{
+		Auth: config.GlobalAuthConfig{
+			Handlers: map[string]config.HandlerConfig{
+				"github": {Plugin: &config.HandlerPluginConfig{Ref: "forked-github", Version: "1.2.3"}},
+			},
+		},
+	})
+
+	dep, source, err := Resolve(ctx, "github")
+	require.NoError(t, err)
+	assert.Equal(t, SourceConfigPin, source)
+	assert.Equal(t, "forked-github", dep.Name)
+	assert.Equal(t, "1.2.3", dep.Version)
+}
+
+func TestResolve_ConfigPinDefaults(t *testing.T) {
+	ctx := config.WithConfig(context.Background(), &config.Config{
+		Auth: config.GlobalAuthConfig{
+			Handlers: map[string]config.HandlerConfig{
+				// Empty Ref/Version: Ref defaults to the handler name, Version to "latest".
+				"openshift": {Plugin: &config.HandlerPluginConfig{}},
+			},
+		},
+	})
+
+	dep, source, err := Resolve(ctx, "openshift")
+	require.NoError(t, err)
+	assert.Equal(t, SourceConfigPin, source)
+	assert.Equal(t, "openshift", dep.Name)
+	assert.Equal(t, "latest", dep.Version)
+}
+
+func TestResolve_NoConfigNoOfficial(t *testing.T) {
+	// Nil config and no official registry: any name resolves as a bare catalog
+	// name (third-party enabled by default).
+	dep, source, err := Resolve(context.Background(), "openshift")
+	require.NoError(t, err)
+	assert.Equal(t, SourceCatalog, source)
+	assert.Equal(t, "openshift", dep.Name)
+}
+
+func TestResolve_ThirdPartyDisabled_Catalog(t *testing.T) {
+	ctx := officialCtx(t, githubEntry())
+	ctx = config.WithConfig(ctx, &config.Config{
+		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
+	})
+
+	_, _, err := Resolve(ctx, "openshift")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrThirdPartyDisabled)
+}
+
+func TestResolve_ThirdPartyDisabled_ConfigPin(t *testing.T) {
+	// A config pin is still third-party; the disable switch blocks it.
+	ctx := config.WithConfig(context.Background(), &config.Config{
+		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
+		Auth: config.GlobalAuthConfig{
+			Handlers: map[string]config.HandlerConfig{
+				"openshift": {Plugin: &config.HandlerPluginConfig{}},
+			},
+		},
+	})
+
+	_, _, err := Resolve(ctx, "openshift")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrThirdPartyDisabled)
+}
+
+func TestResolve_ThirdPartyDisabled_OfficialStillResolves(t *testing.T) {
+	ctx := officialCtx(t, githubEntry())
+	ctx = config.WithConfig(ctx, &config.Config{
+		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
+	})
+
+	dep, source, err := Resolve(ctx, "github")
+	require.NoError(t, err)
+	assert.Equal(t, SourceOfficial, source)
+	assert.Equal(t, "github", dep.Name)
+}
+
+func TestResolve_OfficialDisabled(t *testing.T) {
+	ctx := officialCtx(t, githubEntry())
+	ctx = config.WithConfig(ctx, &config.Config{
+		Settings: config.Settings{DisableOfficialAuthHandlers: true},
+	})
+
+	_, _, err := Resolve(ctx, "github")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrOfficialDisabled)
+}
+
+func TestResolve_OfficialDisabled_NoRegistryStillBlocks(t *testing.T) {
+	// Regression for the disable-policy bypass: when official handlers are
+	// disabled, root does not attach the official registry. An official name
+	// must still be classified as official (via the canonical default names)
+	// and blocked, not fall through to bare catalog resolution.
+	ctx := config.WithConfig(context.Background(), &config.Config{
+		Settings: config.Settings{DisableOfficialAuthHandlers: true},
+	})
+
+	for _, name := range []string{"github", "gcp", "entra"} {
+		t.Run(name, func(t *testing.T) {
+			_, source, err := Resolve(ctx, name)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ErrOfficialDisabled)
+			assert.Equal(t, SourceUnknown, source)
+		})
+	}
+}
+
+func TestResolve_OfficialDisabled_ThirdPartyStillResolves(t *testing.T) {
+	ctx := officialCtx(t, githubEntry())
+	ctx = config.WithConfig(ctx, &config.Config{
+		Settings: config.Settings{DisableOfficialAuthHandlers: true},
+	})
+
+	dep, source, err := Resolve(ctx, "openshift")
+	require.NoError(t, err)
+	assert.Equal(t, SourceCatalog, source)
+	assert.Equal(t, "openshift", dep.Name)
+}
+
+func TestResolve_ErrorsHaveNoBinaryName(t *testing.T) {
+	// Embedder contract: resolution errors must not hardcode "scafctl".
+	ctx := config.WithConfig(context.Background(), &config.Config{
+		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
+	})
+	_, _, err := Resolve(ctx, "openshift")
+	require.Error(t, err)
+	assert.NotContains(t, strings.ToLower(err.Error()), "scafctl")
+}
+
+func TestIsKnown(t *testing.T) {
+	pinned := config.WithConfig(
+		officialCtx(t, githubEntry()),
+		&config.Config{
+			Auth: config.GlobalAuthConfig{
+				Handlers: map[string]config.HandlerConfig{
+					"openshift": {Plugin: &config.HandlerPluginConfig{}},
+					// A handler entry without a plugin pin is NOT "known".
+					"other": {},
+				},
+			},
+		},
+	)
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"github", true},    // official
+		{"openshift", true}, // config-pinned
+		{"other", false},    // config entry without plugin pin
+		{"unknown", false},  // bare catalog name is not "known" (no probe)
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsKnown(pinned, tc.name))
+		})
+	}
+}
+
+func TestIsKnown_NilConfigAndRegistry(t *testing.T) {
+	assert.False(t, IsKnown(context.Background(), "github"))
+}
+
+func TestIsKnown_HonorsDisableSwitches(t *testing.T) {
+	base := func(s config.Settings) context.Context {
+		return config.WithConfig(
+			officialCtx(t, githubEntry()),
+			&config.Config{
+				Settings: s,
+				Auth: config.GlobalAuthConfig{
+					Handlers: map[string]config.HandlerConfig{
+						"openshift": {Plugin: &config.HandlerPluginConfig{}},
+					},
+				},
+			},
+		)
+	}
+
+	// Third-party disabled: config pins are not "known"; official still is.
+	tp := base(config.Settings{DisableThirdPartyAuthHandlers: true})
+	assert.False(t, IsKnown(tp, "openshift"), "config pin must be hidden when third-party disabled")
+	assert.True(t, IsKnown(tp, "github"), "official handler stays known")
+
+	// Official disabled (registry still attached in this synthetic ctx):
+	// official name is not "known"; the config pin remains known.
+	off := base(config.Settings{DisableOfficialAuthHandlers: true})
+	assert.False(t, IsKnown(off, "github"), "official handler hidden when official disabled")
+	assert.True(t, IsKnown(off, "openshift"), "config pin stays known")
+}
+
+func TestSourceString(t *testing.T) {
+	assert.Equal(t, "config-pin", SourceConfigPin.String())
+	assert.Equal(t, "official", SourceOfficial.String())
+	assert.Equal(t, "catalog", SourceCatalog.String())
+	assert.Equal(t, "unknown", SourceUnknown.String())
+	assert.Equal(t, "unknown", Source(99).String())
+}
+
+func TestResolve_SentinelErrorsAreDistinct(t *testing.T) {
+	assert.False(t, errors.Is(ErrThirdPartyDisabled, ErrOfficialDisabled))
+}

--- a/pkg/cmd/scafctl/auth/handler.go
+++ b/pkg/cmd/scafctl/auth/handler.go
@@ -10,7 +10,9 @@ import (
 	"sort"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/auth/handlerdep"
 	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/config"
 )
 
 // handlerContextKey is used for test injection of handlers.
@@ -87,6 +89,19 @@ func listKnownHandlers(ctx context.Context) []string {
 		}
 	}
 
+	// Config-pinned third-party handlers (auth.handlers.<name>.plugin) are also
+	// lazily resolvable and should surface in completions and error hints --
+	// but only when policy actually allows resolving them. handlerdep.IsKnown
+	// honors settings.disableThirdPartyAuthHandlers, so pins are omitted when
+	// third-party resolution is disabled.
+	if appCfg := config.FromContext(ctx); appCfg != nil {
+		for name, hc := range appCfg.Auth.Handlers {
+			if hc.Plugin != nil && handlerdep.IsKnown(ctx, name) {
+				seen[name] = struct{}{}
+			}
+		}
+	}
+
 	if len(seen) == 0 {
 		return nil
 	}
@@ -126,8 +141,10 @@ func listUnconfiguredOfficialHandlers(ctx context.Context) []string {
 	return unconfigured
 }
 
-// isHandlerRegistered checks if a handler name is registered or known to the
-// official auth handler registry (i.e., resolvable via the lazy fallback).
+// isHandlerRegistered checks if a handler name is registered or known to be
+// lazily resolvable (official allowlist or a config pin under
+// auth.handlers.<name>.plugin). It does not probe catalogs, so a bare catalog
+// name is not reported as known here.
 func isHandlerRegistered(ctx context.Context, name string) bool {
 	// Test-injected handlers match any name (since tests inject a single mock)
 	if h := handlerFromContext(ctx); h != nil {
@@ -138,21 +155,34 @@ func isHandlerRegistered(ctx context.Context, name string) bool {
 		return true
 	}
 
-	if official := authofficial.RegistryFromContext(ctx); official != nil && official.Has(name) {
-		return true
-	}
-
-	return false
+	// Official handlers and config-pinned third-party handlers are lazily
+	// resolvable via the registry fallback.
+	return handlerdep.IsKnown(ctx, name)
 }
 
-// validateHandlerName checks if a handler name is valid and returns a formatted error if not.
+// validateHandlerName checks if a handler name is plausibly resolvable and
+// returns a formatted error if not. A name that is registered, official, or
+// config-pinned passes immediately. Any other non-empty name is deferred to
+// getHandler, which performs the authoritative existence check by resolving the
+// handler against configured catalogs via the registry fallback. Only an empty
+// name or a name that policy forbids (e.g. third-party resolution disabled) is
+// rejected here.
 func validateHandlerName(ctx context.Context, handlerName string) error {
+	if handlerName == "" {
+		return fmt.Errorf("auth handler name is required")
+	}
 	if isHandlerRegistered(ctx, handlerName) {
 		return nil
 	}
-	handlers := listKnownHandlers(ctx)
-	if len(handlers) == 0 {
-		return fmt.Errorf("unknown auth handler: %s (no handlers registered)", handlerName)
+	// Not eagerly known. Defer to getHandler unless policy forbids resolving
+	// this name (handlerdep.Resolve returns an error when the matching
+	// official/third-party resolution is disabled).
+	if _, _, err := handlerdep.Resolve(ctx, handlerName); err != nil {
+		handlers := listKnownHandlers(ctx)
+		if len(handlers) == 0 {
+			return fmt.Errorf("unknown auth handler: %s: %w", handlerName, err)
+		}
+		return fmt.Errorf("unknown auth handler: %s (registered: %v): %w", handlerName, handlers, err)
 	}
-	return fmt.Errorf("unknown auth handler: %s (registered: %v)", handlerName, handlers)
+	return nil
 }

--- a/pkg/cmd/scafctl/auth/handler_test.go
+++ b/pkg/cmd/scafctl/auth/handler_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -80,12 +81,53 @@ func TestValidateHandlerName(t *testing.T) {
 	require.NoError(t, registry.Register(mock))
 	ctx := auth.WithRegistry(context.Background(), registry)
 
+	// Registered handler passes.
 	assert.NoError(t, validateHandlerName(ctx, "entra"))
 
+	// Empty name is rejected.
+	assert.Error(t, validateHandlerName(ctx, ""))
+
+	// An unknown name now defers to getHandler (catalog resolution) instead of
+	// failing early, so validation passes when third-party resolution is
+	// enabled (the default).
+	assert.NoError(t, validateHandlerName(ctx, "unknown"))
+}
+
+func TestValidateHandlerName_ThirdPartyDisabled(t *testing.T) {
+	registry := auth.NewRegistry()
+	mock := auth.NewMockHandler("entra")
+	require.NoError(t, registry.Register(mock))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	official := authofficial.NewRegistry()
+	ctx = authofficial.WithRegistry(ctx, official)
+	ctx = config.WithConfig(ctx, &config.Config{
+		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
+	})
+
+	// With third-party resolution disabled, an unknown (non-official) name is
+	// rejected up front.
 	err := validateHandlerName(ctx, "unknown")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown auth handler")
-	assert.Contains(t, err.Error(), "entra")
+
+	// Official names still resolve.
+	assert.NoError(t, validateHandlerName(ctx, "github"))
+}
+
+func TestValidateHandlerName_ConfigPinned(t *testing.T) {
+	registry := auth.NewRegistry()
+	ctx := auth.WithRegistry(context.Background(), registry)
+	ctx = config.WithConfig(ctx, &config.Config{
+		Auth: config.GlobalAuthConfig{
+			Handlers: map[string]config.HandlerConfig{
+				"openshift": {Plugin: &config.HandlerPluginConfig{}},
+			},
+		},
+	})
+
+	// A config-pinned handler is known even before installation.
+	assert.NoError(t, validateHandlerName(ctx, "openshift"))
 }
 
 func TestGetHandler_FromRegistry(t *testing.T) {
@@ -221,6 +263,42 @@ func TestListKnownHandlers_WithTestHandler(t *testing.T) {
 	assert.Equal(t, []string{"test"}, handlers)
 }
 
+func TestListKnownHandlers_IncludesConfigPins(t *testing.T) {
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(auth.NewMockHandler("entra")))
+	ctx := auth.WithRegistry(context.Background(), registry)
+	ctx = config.WithConfig(ctx, &config.Config{
+		Auth: config.GlobalAuthConfig{
+			Handlers: map[string]config.HandlerConfig{
+				"openshift": {Plugin: &config.HandlerPluginConfig{}},
+				// A handler entry without a plugin pin is not "known".
+				"other": {},
+			},
+		},
+	})
+
+	handlers := listKnownHandlers(ctx)
+	assert.ElementsMatch(t, []string{"entra", "openshift"}, handlers)
+}
+
+func TestListKnownHandlers_OmitsConfigPinsWhenThirdPartyDisabled(t *testing.T) {
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(auth.NewMockHandler("entra")))
+	ctx := auth.WithRegistry(context.Background(), registry)
+	ctx = config.WithConfig(ctx, &config.Config{
+		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
+		Auth: config.GlobalAuthConfig{
+			Handlers: map[string]config.HandlerConfig{
+				"openshift": {Plugin: &config.HandlerPluginConfig{}},
+			},
+		},
+	})
+
+	// The config pin is omitted because policy forbids resolving it.
+	handlers := listKnownHandlers(ctx)
+	assert.ElementsMatch(t, []string{"entra"}, handlers)
+}
+
 func TestListKnownHandlers_NoContext(t *testing.T) {
 	ctx := context.Background()
 	assert.Nil(t, listKnownHandlers(ctx))
@@ -235,8 +313,17 @@ func TestValidateHandlerName_OfficialHandler(t *testing.T) {
 
 	assert.NoError(t, validateHandlerName(ctx, "entra"))
 
-	err := validateHandlerName(ctx, "unknown")
+	// An unknown name defers to catalog resolution by default.
+	assert.NoError(t, validateHandlerName(ctx, "unknown"))
+
+	// With third-party resolution disabled, the unknown name is rejected while
+	// the official handler still resolves.
+	lockedCtx := config.WithConfig(ctx, &config.Config{
+		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
+	})
+	err := validateHandlerName(lockedCtx, "unknown")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown auth handler")
 	assert.Contains(t, err.Error(), "entra")
+	assert.NoError(t, validateHandlerName(lockedCtx, "entra"))
 }

--- a/pkg/cmd/scafctl/auth/handlers_install.go
+++ b/pkg/cmd/scafctl/auth/handlers_install.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	authpkg "github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/auth/handlerdep"
 	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -55,6 +56,13 @@ func commandHandlersInstall(cliParams *settings.Run, ioStreams *terminal.IOStrea
 			if len(args) > 0 {
 				return nil, cobra.ShellCompDirectiveNoFileComp
 			}
+			// Suggest official names plus config-pinned third-party handlers
+			// (auth.handlers.<name>.plugin). listKnownHandlers merges the auth
+			// registry, official registry, and config pins without probing
+			// catalogs.
+			if names := listKnownHandlers(cmd.Context()); len(names) > 0 {
+				return names, cobra.ShellCompDirectiveNoFileComp
+			}
 			reg := authofficial.RegistryFromContext(cmd.Context())
 			if reg == nil {
 				reg = authofficial.NewRegistry()
@@ -65,14 +73,13 @@ func commandHandlersInstall(cliParams *settings.Run, ioStreams *terminal.IOStrea
 			ctx := cmd.Context()
 			name := args[0]
 
-			officialReg := authofficial.RegistryFromContext(ctx)
-			if officialReg == nil {
-				return fmt.Errorf("official auth handler registry not available")
-			}
-
-			entry, ok := officialReg.Get(name)
-			if !ok {
-				return fmt.Errorf("unknown auth handler %q; available: %s", name, strings.Join(officialReg.Names(), ", "))
+			// Resolve the handler name to a plugin dependency: config pin >
+			// official allowlist > bare catalog name. This lets 'handlers install'
+			// fetch third-party handlers published to a configured catalog, not
+			// just the official trio.
+			dep, _, err := handlerdep.Resolve(ctx, name)
+			if err != nil {
+				return fmt.Errorf("cannot install auth handler %q: %w", name, err)
 			}
 
 			// Check if already cached on disk (skip with --force).
@@ -96,8 +103,6 @@ func commandHandlersInstall(cliParams *settings.Run, ioStreams *terminal.IOStrea
 					w.Infof("Downloading auth handler %q from catalog...", name)
 				}
 			}
-
-			dep := entry.ToPluginDependency()
 
 			fetcher, err := solprepare.BuildPluginFetcherWithConfig(ctx, solprepare.PluginFetcherOverrides{
 				NoCache: force,

--- a/pkg/cmd/scafctl/auth/handlers_install_test.go
+++ b/pkg/cmd/scafctl/auth/handlers_install_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/adrg/xdg"
 	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
@@ -19,19 +20,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCommandHandlersInstall_NoOfficialRegistry(t *testing.T) {
+func TestCommandHandlersInstall_ThirdPartyDisabledNoOfficial(t *testing.T) {
 	ctx, buf := newTestContext(t)
+	// Third-party catalog resolution disabled: a non-official (bare) name
+	// cannot be resolved and install is rejected by policy.
+	ctx = config.WithConfig(ctx, &config.Config{
+		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
+	})
 
 	cliParams := settings.NewCliParams()
 	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
 
 	cmd := commandHandlersInstall(cliParams, ioStreams)
 	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"github"})
+	cmd.SetArgs([]string{"openshift"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "official auth handler registry not available")
+	assert.Contains(t, err.Error(), "openshift")
+	assert.Contains(t, err.Error(), "disabled")
 }
 
 func TestCommandHandlersInstall_UnknownHandler(t *testing.T) {
@@ -41,6 +48,11 @@ func TestCommandHandlersInstall_UnknownHandler(t *testing.T) {
 		{Name: "github", CatalogRef: "github"},
 	})
 	ctx = authofficial.WithRegistry(ctx, officialReg)
+	// With third-party resolution disabled, a non-official name is rejected
+	// before any catalog fetch.
+	ctx = config.WithConfig(ctx, &config.Config{
+		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
+	})
 
 	cliParams := settings.NewCliParams()
 	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
@@ -51,8 +63,8 @@ func TestCommandHandlersInstall_UnknownHandler(t *testing.T) {
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown auth handler")
 	assert.Contains(t, err.Error(), "nonexistent")
+	assert.Contains(t, err.Error(), "disabled")
 }
 
 func TestCommandHandlersInstall_AlreadyCached(t *testing.T) {

--- a/pkg/cmd/scafctl/auth/login_test.go
+++ b/pkg/cmd/scafctl/auth/login_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -47,6 +48,11 @@ func configureAuthAndTokenRegistry(t *testing.T, ctx context.Context, mock *auth
 
 func TestCommandLogin_UnknownHandler(t *testing.T) {
 	ctx, _ := newTestContext(t)
+	// With third-party catalog resolution disabled, an unknown (non-official)
+	// handler name is rejected up front instead of being fetched from a catalog.
+	ctx = config.WithConfig(ctx, &config.Config{
+		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
+	})
 	cliParams := settings.NewCliParams()
 	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
 

--- a/pkg/cmd/scafctl/auth/logout_test.go
+++ b/pkg/cmd/scafctl/auth/logout_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -18,6 +19,9 @@ import (
 
 func TestCommandLogout_UnknownHandler(t *testing.T) {
 	ctx, _ := newTestContext(t)
+	ctx = config.WithConfig(ctx, &config.Config{
+		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
+	})
 	cliParams := settings.NewCliParams()
 	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
 

--- a/pkg/cmd/scafctl/auth/profile_delete_test.go
+++ b/pkg/cmd/scafctl/auth/profile_delete_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	authpkg "github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,9 @@ func TestCommandProfileDelete_NoArgs(t *testing.T) {
 
 func TestCommandProfileDelete_UnknownHandler(t *testing.T) {
 	ctx, _ := newTestContext(t)
+	ctx = config.WithConfig(ctx, &config.Config{
+		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
+	})
 	cliParams := settings.NewCliParams()
 	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
 

--- a/pkg/cmd/scafctl/auth/status_test.go
+++ b/pkg/cmd/scafctl/auth/status_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -18,6 +19,9 @@ import (
 
 func TestCommandStatus_UnknownHandler(t *testing.T) {
 	ctx, _ := newTestContext(t)
+	ctx = config.WithConfig(ctx, &config.Config{
+		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
+	})
 	cliParams := settings.NewCliParams()
 	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
 

--- a/pkg/cmd/scafctl/auth/switch_test.go
+++ b/pkg/cmd/scafctl/auth/switch_test.go
@@ -30,6 +30,9 @@ func TestCommandSwitch_NoArgs(t *testing.T) {
 
 func TestCommandSwitch_UnknownHandler(t *testing.T) {
 	ctx, _ := newTestContext(t)
+	ctx = appconfig.WithConfig(ctx, &appconfig.Config{
+		Settings: appconfig.Settings{DisableThirdPartyAuthHandlers: true},
+	})
 	cliParams := settings.NewCliParams()
 	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
 

--- a/pkg/cmd/scafctl/auth/token_test.go
+++ b/pkg/cmd/scafctl/auth/token_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/stretchr/testify/assert"
@@ -41,6 +42,9 @@ func newGitHubMock() *auth.MockHandler {
 
 func TestCommandToken_UnknownHandler(t *testing.T) {
 	ctx, _ := newTestContext(t)
+	ctx = config.WithConfig(ctx, &config.Config{
+		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
+	})
 	cliParams := settings.NewCliParams()
 	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
 

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/auth/handlerdep"
 	customoauth2 "github.com/oakwood-commons/scafctl/pkg/auth/oauth2"
 	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
@@ -595,12 +596,14 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 			}
 
 			// ── Wire lazy auth handler fallback resolver ──
-			// Instead of eagerly fetching all official auth handlers at startup,
-			// we configure a fallback resolver that fires only when a handler is
+			// Instead of eagerly fetching all auth handlers at startup, we
+			// configure a fallback resolver that fires only when a handler is
 			// actually requested via authRegistry.Get(name). This avoids network
 			// I/O for commands that never use auth handlers (e.g., local catalog
-			// tag, version, help).
-			if !cfg.Settings.DisableOfficialAuthHandlers {
+			// tag, version, help). The resolver handles both official handlers and
+			// third-party handlers resolved by name against configured catalogs;
+			// per-name policy is enforced by handlerdep.Resolve.
+			if !cfg.Settings.DisableOfficialAuthHandlers || !cfg.Settings.DisableThirdPartyAuthHandlers {
 				var cooldownDuration time.Duration
 				if cfg.Plugins.FetchCooldown != "" {
 					if d, parseErr := time.ParseDuration(cfg.Plugins.FetchCooldown); parseErr == nil {
@@ -632,21 +635,20 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 					// Values like the official provider registry are added to
 					// ctx *after* this closure is defined.
 					liveCtx := cCmd.Context()
-					officialReg := authofficial.RegistryFromContext(liveCtx)
-					if officialReg == nil {
-						return nil, fmt.Errorf("no official auth handler registry available")
-					}
-					h, ok := officialReg.Get(name)
-					if !ok {
-						return nil, fmt.Errorf("auth handler %q is not an official handler", name)
+
+					// Resolve the name to a plugin dependency: config pin > official
+					// allowlist > bare catalog name. handlerdep enforces the
+					// official/third-party disable switches per name.
+					dep, source, resolveErr := handlerdep.Resolve(liveCtx, name)
+					if resolveErr != nil {
+						return nil, resolveErr
 					}
 					if cooldown.OnCooldown(name) {
 						return nil, fmt.Errorf("auth handler %q fetch on cooldown", name)
 					}
 
-					lgr.V(0).Info("lazy-resolving official auth handler", "handler", name)
+					lgr.V(0).Info("lazy-resolving auth handler", "handler", name, "source", source.String())
 
-					dep := h.ToPluginDependency()
 					fetcher, fetcherErr := solprepare.BuildPluginFetcher(liveCtx)
 					if fetcherErr != nil {
 						_ = cooldown.RecordFailure(name)

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -119,6 +119,14 @@ type Settings struct {
 	// bundle.plugins. Embedders can set this when their CLI should not
 	// auto-fetch auth handler plugins from the scafctl community catalog.
 	DisableOfficialAuthHandlers bool `json:"disableOfficialAuthHandlers,omitempty" yaml:"disableOfficialAuthHandlers,omitempty" mapstructure:"disableOfficialAuthHandlers" doc:"Disable auto-resolution of official first-party auth handlers"`
+
+	// DisableThirdPartyAuthHandlers prevents catalog-by-name resolution of
+	// non-official auth handlers. When true, only official handlers resolve;
+	// every non-official name -- including config-pinned handlers
+	// (auth.handlers.<name>.plugin) and bare catalog names -- is rejected even
+	// if present in a configured catalog. Locked-down embedders can set this to
+	// enforce an official-only auth handler policy.
+	DisableThirdPartyAuthHandlers bool `json:"disableThirdPartyAuthHandlers,omitempty" yaml:"disableThirdPartyAuthHandlers,omitempty" mapstructure:"disableThirdPartyAuthHandlers" doc:"Disable catalog-by-name resolution of non-official auth handlers"`
 }
 
 // VersionCheckConfig holds version check configuration.
@@ -439,12 +447,35 @@ type HandlerConfig struct {
 	// plugin.
 	Hostname *HostnameConfig `json:"hostname,omitempty" yaml:"hostname,omitempty" mapstructure:"hostname" doc:"Host-side hostname alias/endpoint resolution"`
 
-	// Settings captures every handler-specific key other than "hostname" and is
+	// Plugin optionally pins the catalog artifact for a third-party auth
+	// handler. When set, catalog resolution uses this ref/version instead of
+	// resolving the bare handler name. It is host-consumed and NOT forwarded to
+	// the plugin.
+	Plugin *HandlerPluginConfig `json:"plugin,omitempty" yaml:"plugin,omitempty" mapstructure:"plugin" doc:"Catalog pin for a third-party auth handler plugin"`
+
+	// TrustedVerificationDomains are per-handler trusted device-code
+	// verification domains. For non-official handlers this is the primary trust
+	// source, since third-party handlers do not inherit the hardcoded official
+	// domains. It is host-consumed and NOT forwarded to the plugin.
+	TrustedVerificationDomains []string `json:"trustedVerificationDomains,omitempty" yaml:"trustedVerificationDomains,omitempty" mapstructure:"trustedVerificationDomains" doc:"Per-handler trusted device-code verification domains" maxItems:"50"`
+
+	// Settings captures every handler-specific key other than the host-consumed
+	// fields ("hostname", "plugin", "trustedVerificationDomains") and is
 	// forwarded opaquely to the handler plugin. The host does not interpret it.
 	// Note: viper lowercases all keys, so plugins receive lowercased setting
 	// names. The yaml `,inline` tag ensures passthrough keys survive a
 	// config save round-trip (e.g. when 'auth alias' rewrites the file).
 	Settings map[string]any `json:"-" yaml:",inline" mapstructure:",remain"`
+}
+
+// HandlerPluginConfig pins the catalog artifact backing a third-party auth
+// handler under auth.handlers.<name>.plugin.
+type HandlerPluginConfig struct {
+	// Ref is the catalog artifact name. Defaults to the handler name when empty.
+	Ref string `json:"ref,omitempty" yaml:"ref,omitempty" mapstructure:"ref" doc:"Catalog artifact name (defaults to the handler name)" maxLength:"100"`
+
+	// Version is a semver constraint or "latest". Defaults to "latest" when empty.
+	Version string `json:"version,omitempty" yaml:"version,omitempty" mapstructure:"version" doc:"Version constraint or 'latest' (defaults to 'latest')" maxLength:"50"`
 }
 
 // HostnameConfig configures host-side resolution of a user-supplied hostname

--- a/pkg/plugin/auth_grpc_client_test.go
+++ b/pkg/plugin/auth_grpc_client_test.go
@@ -1158,7 +1158,7 @@ func TestConfigureAndRegisterAuthHandlers_ConfigureError(t *testing.T) {
 func TestBuildTrustedDomains_NilRegistry(t *testing.T) {
 	t.Parallel()
 
-	domains := buildTrustedDomains("github", nil, nil)
+	domains := buildTrustedDomains("github", nil, nil, nil)
 	assert.Empty(t, domains)
 }
 
@@ -1169,14 +1169,14 @@ func TestBuildTrustedDomains_OfficialOnly(t *testing.T) {
 		{Name: "github", CatalogRef: "github", TrustedVerificationDomains: []string{"github.com"}},
 	})
 
-	domains := buildTrustedDomains("github", reg, nil)
+	domains := buildTrustedDomains("github", reg, nil, nil)
 	assert.Equal(t, []string{"github.com"}, domains)
 }
 
 func TestBuildTrustedDomains_ConfigOnly(t *testing.T) {
 	t.Parallel()
 
-	domains := buildTrustedDomains("github", nil, []string{"ghes.corp.example.com"})
+	domains := buildTrustedDomains("github", nil, []string{"ghes.corp.example.com"}, nil)
 	assert.Equal(t, []string{"ghes.corp.example.com"}, domains)
 }
 
@@ -1190,7 +1190,7 @@ func TestBuildTrustedDomains_Merged(t *testing.T) {
 	})
 	cfgDomains := []string{"my-idp.corp.example.com"}
 
-	domains := buildTrustedDomains("entra", reg, cfgDomains)
+	domains := buildTrustedDomains("entra", reg, cfgDomains, nil)
 	assert.Equal(t, []string{"login.microsoftonline.com", "login.microsoft.com", "my-idp.corp.example.com"}, domains)
 }
 
@@ -1203,8 +1203,34 @@ func TestBuildTrustedDomains_UnknownHandler(t *testing.T) {
 	cfgDomains := []string{"custom.example.com"}
 
 	// Handler not in registry — only config domains returned.
-	domains := buildTrustedDomains("unknown-handler", reg, cfgDomains)
+	domains := buildTrustedDomains("unknown-handler", reg, cfgDomains, nil)
 	assert.Equal(t, []string{"custom.example.com"}, domains)
+}
+
+func TestBuildTrustedDomains_PerHandlerDomains(t *testing.T) {
+	t.Parallel()
+
+	reg := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github", TrustedVerificationDomains: []string{"github.com"}},
+	})
+
+	// A non-official handler inherits no official domains; its trust comes from
+	// global config plus per-handler config domains.
+	domains := buildTrustedDomains("openshift", reg, []string{"global.example.com"}, []string{"sso.openshift.example.com"})
+	assert.Equal(t, []string{"global.example.com", "sso.openshift.example.com"}, domains)
+}
+
+func TestBuildTrustedDomains_PerHandlerNoOfficialInheritance(t *testing.T) {
+	t.Parallel()
+
+	reg := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github", TrustedVerificationDomains: []string{"github.com"}},
+	})
+
+	// Non-official handler with no config domains gets nothing — it must not
+	// silently inherit the official github.com domain.
+	domains := buildTrustedDomains("openshift", reg, nil, nil)
+	assert.Empty(t, domains)
 }
 
 func TestConfigureAndRegisterAuthHandlers_SetsTrustedDomains(t *testing.T) {

--- a/pkg/plugin/plugin_auth_test.go
+++ b/pkg/plugin/plugin_auth_test.go
@@ -1035,6 +1035,95 @@ func TestAuthHandlerWrapper_Login_DeviceCodeEmptyTrustedDomains(t *testing.T) {
 	assert.Equal(t, "https://any-provider.example.com/device", gotURI)
 }
 
+func TestAuthHandlerWrapper_Login_RequireTrustedDomainsFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	// A non-official handler with requireTrustedDomains set and no configured
+	// trusted domains must fail closed instead of allowing any HTTPS URL.
+	mock := &MockAuthHandlerPlugin{
+		loginFunc: func(_ context.Context, _ string, _ LoginRequest, cb func(DeviceCodePrompt)) (*LoginResponse, error) {
+			if cb != nil {
+				cb(DeviceCodePrompt{
+					UserCode:        "ABCD-9999",
+					VerificationURI: "https://any-provider.example.com/device",
+					Message:         "Enter code",
+				})
+			}
+			return &LoginResponse{
+				Claims:    &auth.Claims{Email: "user@any.com"},
+				ExpiresAt: time.Now().Add(time.Hour),
+			}, nil
+		},
+	}
+
+	w := &AuthHandlerWrapper{
+		client: &AuthHandlerClient{
+			plugin: mock,
+			name:   "test-plugin",
+		},
+		handlerName:           "openshift",
+		info:                  AuthHandlerInfo{Name: "openshift"},
+		trustedDomains:        nil, // empty
+		requireTrustedDomains: true,
+	}
+
+	called := false
+	_, err := w.Login(context.Background(), auth.LoginOptions{
+		Flow: auth.FlowDeviceCode,
+		DeviceCodeCallback: func(_, _, _ string) {
+			called = true
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no configured trusted domains")
+	assert.Contains(t, err.Error(), "openshift")
+	assert.False(t, called, "device code callback must not be invoked when blocked")
+}
+
+func TestAuthHandlerWrapper_Login_RequireTrustedDomainsWithConfig(t *testing.T) {
+	t.Parallel()
+
+	// A non-official handler with requireTrustedDomains set AND configured
+	// trusted domains validates against them normally.
+	mock := &MockAuthHandlerPlugin{
+		loginFunc: func(_ context.Context, _ string, _ LoginRequest, cb func(DeviceCodePrompt)) (*LoginResponse, error) {
+			if cb != nil {
+				cb(DeviceCodePrompt{
+					UserCode:        "ABCD-9999",
+					VerificationURI: "https://sso.openshift.example.com/device",
+					Message:         "Enter code",
+				})
+			}
+			return &LoginResponse{
+				Claims:    &auth.Claims{Email: "user@any.com"},
+				ExpiresAt: time.Now().Add(time.Hour),
+			}, nil
+		},
+	}
+
+	w := &AuthHandlerWrapper{
+		client: &AuthHandlerClient{
+			plugin: mock,
+			name:   "test-plugin",
+		},
+		handlerName:           "openshift",
+		info:                  AuthHandlerInfo{Name: "openshift"},
+		trustedDomains:        []string{"sso.openshift.example.com"},
+		requireTrustedDomains: true,
+	}
+
+	var gotURI string
+	result, err := w.Login(context.Background(), auth.LoginOptions{
+		Flow: auth.FlowDeviceCode,
+		DeviceCodeCallback: func(_, uri, _ string) {
+			gotURI = uri
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "user@any.com", result.Claims.Email)
+	assert.Equal(t, "https://sso.openshift.example.com/device", gotURI)
+}
+
 // ── RegisterAuthHandlerPlugins tests ─────────────────────────────────────────
 
 func TestRegisterAuthHandlerPlugins_EmptyDirs(t *testing.T) {

--- a/pkg/plugin/wrapper_auth.go
+++ b/pkg/plugin/wrapper_auth.go
@@ -41,9 +41,14 @@ type AuthHandlerWrapper struct {
 	handlerName    string
 	info           AuthHandlerInfo
 	trustedDomains []string
-	startupLatency time.Duration
-	hostCfg        hostConfig // host-level config (Quiet, NoColor, BinaryName)
-	mu             sync.RWMutex
+	// requireTrustedDomains, when true, makes device-code verification fail
+	// closed if no trusted domains are configured (instead of allowing any
+	// HTTPS URL). Set for non-official handlers, which do not carry hardcoded
+	// trust domains.
+	requireTrustedDomains bool
+	startupLatency        time.Duration
+	hostCfg               hostConfig // host-level config (Quiet, NoColor, BinaryName)
+	mu                    sync.RWMutex
 }
 
 // hostConfig stores host-level ProviderConfig fields so ApplyOverrides
@@ -76,6 +81,17 @@ func (w *AuthHandlerWrapper) SetTrustedDomains(domains []string) {
 	}
 	w.trustedDomains = make([]string, len(domains))
 	copy(w.trustedDomains, domains)
+}
+
+// SetRequireTrustedDomains controls whether device-code verification fails
+// closed when no trusted domains are configured. Set true for non-official
+// handlers so a catalog-resolved third-party handler cannot display arbitrary
+// verification URLs without explicitly configured
+// auth.handlers.<name>.trustedVerificationDomains.
+func (w *AuthHandlerWrapper) SetRequireTrustedDomains(require bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.requireTrustedDomains = require
 }
 
 // Name implements auth.Handler.
@@ -133,11 +149,23 @@ func (w *AuthHandlerWrapper) Login(ctx context.Context, opts auth.LoginOptions) 
 	w.mu.RLock()
 	trustedSnapshot := make([]string, len(w.trustedDomains))
 	copy(trustedSnapshot, w.trustedDomains)
+	requireTrust := w.requireTrustedDomains
 	w.mu.RUnlock()
 
 	var deviceCodeCb func(DeviceCodePrompt)
 	if opts.DeviceCodeCallback != nil {
 		deviceCodeCb = func(prompt DeviceCodePrompt) {
+			// Fail closed for non-official handlers with no configured trust:
+			// an empty trusted list would otherwise allow any HTTPS URL.
+			if requireTrust && len(trustedSnapshot) == 0 {
+				err := fmt.Errorf("device code verification blocked: handler %q has no configured trusted domains; set auth.handlers.%s.trustedVerificationDomains",
+					w.handlerName, w.handlerName)
+				lgr.Error(err, "device code prompt blocked -- terminating login",
+					"handler", w.handlerName,
+					"uri", prompt.VerificationURI)
+				cancelCause(err)
+				return
+			}
 			if err := ValidateVerificationURI(prompt.VerificationURI, trustedSnapshot); err != nil {
 				lgr.Error(err, "device code prompt blocked -- terminating login",
 					"handler", w.handlerName,
@@ -351,8 +379,10 @@ func configureAndRegisterAuthHandlers(ctx context.Context, registry *auth.Regist
 	// Resolve trusted verification domains from context sources.
 	officialReg := authofficial.RegistryFromContext(ctx)
 	var cfgDomains []string
+	var handlerCfgs map[string]config.HandlerConfig
 	if appCfg := config.FromContext(ctx); appCfg != nil {
 		cfgDomains = appCfg.Auth.TrustedVerificationDomains
+		handlerCfgs = appCfg.Auth.Handlers
 	}
 
 	var registered []string
@@ -368,10 +398,20 @@ func configureAndRegisterAuthHandlers(ctx context.Context, registry *auth.Regist
 
 		wrapper := NewAuthHandlerWrapper(client, info)
 
-		// Set trusted domains: merge per-handler official domains + global config domains.
-		trusted := buildTrustedDomains(info.Name, officialReg, cfgDomains)
+		// Set trusted domains: merge per-handler official domains + global config
+		// domains + per-handler config domains. Non-official handlers do not
+		// inherit the hardcoded official domains; their trust comes from config.
+		trusted := buildTrustedDomains(info.Name, officialReg, cfgDomains, handlerCfgs[info.Name].TrustedVerificationDomains)
 		if len(trusted) > 0 {
 			wrapper.SetTrustedDomains(trusted)
+		}
+
+		// Fail closed on device-code verification for non-official handlers: a
+		// catalog-resolved third-party handler must not display arbitrary
+		// verification URLs without configured trusted domains. Official
+		// handlers carry hardcoded trust domains and are exempt.
+		if officialReg == nil || !officialReg.Has(info.Name) {
+			wrapper.SetRequireTrustedDomains(true)
 		}
 
 		if err := registry.Register(wrapper); err != nil {
@@ -424,8 +464,11 @@ func propagateStartupLatency(ctx context.Context, registry *auth.Registry, clien
 	}
 }
 
-// buildTrustedDomains merges per-handler official domains with global config domains.
-func buildTrustedDomains(handlerName string, officialReg *authofficial.Registry, cfgDomains []string) []string {
+// buildTrustedDomains merges per-handler official domains with global config
+// domains and per-handler config domains. Non-official handlers match no
+// official entry, so their trust derives solely from config (global +
+// per-handler) — they never inherit the hardcoded official domains.
+func buildTrustedDomains(handlerName string, officialReg *authofficial.Registry, cfgDomains, handlerDomains []string) []string {
 	var domains []string
 
 	if officialReg != nil {
@@ -435,6 +478,7 @@ func buildTrustedDomains(handlerName string, officialReg *authofficial.Registry,
 	}
 
 	domains = append(domains, cfgDomains...)
+	domains = append(domains, handlerDomains...)
 	return domains
 }
 

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2358,10 +2358,15 @@ func TestIntegration_AuthHandlersRemoveHelp(t *testing.T) {
 
 func TestIntegration_AuthHandlersInstallUnknown(t *testing.T) {
 	t.Parallel()
-	_, stderr, exitCode := runScafctl(t, "auth", "handlers", "install", "nonexistent-handler-xyz")
+	// An unknown handler name is no longer rejected against the official
+	// allowlist; it is resolved by name against configured catalogs (issue
+	// #576). With only an empty local catalog configured, resolution fails
+	// cleanly with a not-found error and no network access.
+	env := isolatedCatalogEnv(t)
+	_, stderr, exitCode := runScafctlWithEnv(t, env, "auth", "handlers", "install", "nonexistent-handler-xyz")
 
 	assert.NotEqual(t, 0, exitCode)
-	assert.Contains(t, stderr, "unknown auth handler")
+	assert.Contains(t, stderr, "not found in any catalog")
 }
 
 func TestIntegration_AuthHandlersRemoveNotInstalled(t *testing.T) {
@@ -5102,6 +5107,89 @@ func TestIntegration_BuildPlugin_AuthHandler(t *testing.T) {
 	}
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "Built test-auth@1.0.0")
+}
+
+// TestIntegration_AuthHandlersInstall_ThirdPartyFromCatalog verifies the fix
+// for issue #576: a non-official auth handler published to a configured
+// catalog resolves by name instead of being rejected against the hardcoded
+// official allowlist (entra, gcp, github).
+func TestIntegration_AuthHandlersInstall_ThirdPartyFromCatalog(t *testing.T) {
+	t.Parallel()
+	env := isolatedCatalogEnv(t)
+
+	// Build a third-party auth handler into the local catalog for the current
+	// platform (so 'handlers install' can fetch it for this host).
+	binDir := t.TempDir()
+	binPath := filepath.Join(binDir, "scafctl-plugin-auth-openshift")
+	require.NoError(t, os.WriteFile(binPath, []byte("dummy-auth-handler"), 0o755))
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+
+	_, buildErr, buildExit := runScafctlWithEnv(t, env, "build", "plugin",
+		"--name", "openshift",
+		"--kind", "auth-handler",
+		"--version", "0.1.0",
+		"--platform", platform+"="+binPath)
+	require.Equal(t, 0, buildExit, "build plugin failed: %s", buildErr)
+
+	// It is listed as an auth-handler artifact in the local catalog.
+	listOut, _, listExit := runScafctlWithEnv(t, env, "catalog", "list", "--kind", "auth-handler", "-o", "json")
+	require.Equal(t, 0, listExit)
+	assert.Contains(t, listOut, "openshift")
+
+	// 'auth handlers install openshift' must get PAST the official allowlist and
+	// resolve the handler from the catalog, exiting 0. Previously this failed
+	// immediately with 'unknown auth handler "openshift"; available: entra, gcp,
+	// github'.
+	stdout, stderr, exitCode := runScafctlWithEnv(t, env, "auth", "handlers", "install", "openshift")
+	combined := stdout + stderr
+	require.Equal(t, 0, exitCode,
+		"third-party handler install should succeed; stdout=%s stderr=%s", stdout, stderr)
+	assert.Contains(t, combined, "openshift")
+	assert.NotContains(t, combined, "available: entra, gcp, github",
+		"handler should resolve from catalog, not be rejected by the allowlist")
+	assert.NotContains(t, combined, `unknown auth handler "openshift"`,
+		"handler should resolve from catalog, not be rejected by the allowlist")
+}
+
+// TestIntegration_AuthHandlersInstall_ThirdPartyDisabled verifies that the
+// disableThirdPartyAuthHandlers policy rejects a non-official handler even when
+// present in a configured catalog.
+func TestIntegration_AuthHandlersInstall_ThirdPartyDisabled(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "scafctl")
+	require.NoError(t, os.MkdirAll(configDir, 0o755))
+	configContent := `catalogs:
+  - name: local
+    type: filesystem
+settings:
+  disableOfficialCatalog: true
+  disableThirdPartyAuthHandlers: true
+`
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(configContent), 0o600))
+	env := map[string]string{
+		"XDG_DATA_HOME":   tmpDir,
+		"XDG_CACHE_HOME":  tmpDir,
+		"XDG_CONFIG_HOME": tmpDir,
+	}
+
+	binDir := t.TempDir()
+	binPath := filepath.Join(binDir, "scafctl-plugin-auth-openshift")
+	require.NoError(t, os.WriteFile(binPath, []byte("dummy-auth-handler"), 0o755))
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+
+	_, buildErr, buildExit := runScafctlWithEnv(t, env, "build", "plugin",
+		"--name", "openshift",
+		"--kind", "auth-handler",
+		"--version", "0.1.0",
+		"--platform", platform+"="+binPath)
+	require.Equal(t, 0, buildExit, "build plugin failed: %s", buildErr)
+
+	// Policy blocks resolution of the third-party handler.
+	_, stderr, exitCode := runScafctlWithEnv(t, env, "auth", "handlers", "install", "openshift")
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "openshift")
+	assert.Contains(t, stderr, "disabled")
 }
 
 func TestIntegration_BuildPlugin_ForceOverwrite(t *testing.T) {


### PR DESCRIPTION
Third-party (non-official) auth handlers published to a configured catalog now resolve by name across every entry point -- auth login, auth token, auth handlers install, kube login --handler, and the kubectl/oc exec-credential helper -- instead of being rejected against the hardcoded official allowlist (entra, github, gcp). The official list becomes a convenience and trust anchor rather than a hard gate, bringing auth handlers to parity with providers.

- Add pkg/auth/handlerdep resolver: name -> plugin dependency with precedence config-pin > official allowlist > bare catalog name, gated by the official/third-party disable switches
- Rework the auth registry fallback resolver to route through handlerdep, so all handler lookups (including kube login and exec-credential token minting) resolve catalog handlers in one place
- Propagate caller context in auth.GetHandler so catalog fetches during kube login / auth token honor timeout and cancellation
- Add settings.disableThirdPartyAuthHandlers for official-only lockdown
- Add auth.handlers.<name>.plugin catalog pin and per-handler trustedVerificationDomains; third-party handlers no longer inherit the hardcoded official verification domains
- Relax handlers install and CLI validators to defer unknown names to catalog resolution; include config-pinned names in completions
- Add unit + integration coverage (handlerdep 100%) and document the feature in auth design, config tutorial, migration guide, and auth examples

BREAKING CHANGE: unknown auth handler names are no longer rejected against the official allowlist; they attempt catalog resolution and fail with a not-found error instead. HandlerConfig gains host-consumed fields (plugin, trustedVerificationDomains) that were previously forwarded opaquely to the plugin via Settings.

Closes #576