### PR TITLE
fix(provider): permit provider writes outside read-only resolver modes

### DIFF
--- a/docs/design/kubeconfig-provider-implementation-plan.md
+++ b/docs/design/kubeconfig-provider-implementation-plan.md
@@ -84,6 +84,21 @@ Trade-off: `CapabilityAction` would avoid touching `ValidateDescriptor`, but at
 the cost of weaker typing and discovery. The state precedent settles this in
 favor of a dedicated capability.
 
+### Write-operation guard exemption (issue #579)
+
+The host-side write-operation guard (`provider.ValidateWriteOperation`) rejects
+declared write operations only in the **read-only resolver phases**
+(`CapabilityFrom`, `CapabilityTransform`, `CapabilityValidation`). Write-capable
+capabilities -- `CapabilityKubeconfig`, `CapabilityState`, `CapabilityAction`,
+and `CapabilityAuthentication` -- are exempt, so a provider may classify
+`kubeconfig_write`/`kubeconfig_remove` as write operations without those calls
+being blocked when the manager runs them under `CapabilityKubeconfig`.
+
+Regression note: an earlier guard whitelisted only `CapabilityAction`, which
+blocked `kubeconfig_write` under `CapabilityKubeconfig` and broke `kube login`.
+When adding a new write-capable capability, ensure it is *not* treated as a
+read-only resolver phase by the guard.
+
 ## 3. The host invocation path and the registry/auto-fetch resolution
 
 ### Finding (the flagged risk, resolved)

--- a/pkg/kubeconfig/manager_test.go
+++ b/pkg/kubeconfig/manager_test.go
@@ -54,6 +54,14 @@ func registryWith(t *testing.T, p provider.Provider) *provider.Registry {
 func TestManager_WriteKubeconfig(t *testing.T) {
 	t.Parallel()
 	mock := NewMockProvider()
+	// Confirm the mock mirrors the real provider by declaring kubeconfig_write
+	// as a write op, so this test exercises the host-side write-operation guard
+	// under CapabilityKubeconfig rather than skipping it. Regression cover for
+	// #579: before the fix the guard only exempted CapabilityAction, so
+	// WriteKubeconfig failed with a read-only mode error even after a
+	// successful login.
+	require.True(t, mock.Descriptor().IsWriteOperation(OperationWrite))
+
 	m := NewManager("scafctl", WithRegistry(registryWith(t, mock)))
 
 	res, err := m.WriteKubeconfig(context.Background(), WriteInput{

--- a/pkg/kubeconfig/mock.go
+++ b/pkg/kubeconfig/mock.go
@@ -66,6 +66,10 @@ func (m *MockProvider) Descriptor() *provider.Descriptor {
 		Capabilities: []provider.Capability{
 			provider.CapabilityKubeconfig,
 		},
+		// WriteOperations mirrors the real kubeconfig provider so tests exercise
+		// the host-side write-operation guard (regression coverage for #579:
+		// kubeconfig writes must be permitted under CapabilityKubeconfig).
+		WriteOperations: []string{OperationWrite, OperationRemove},
 		OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 			provider.CapabilityKubeconfig: schemahelper.ObjectSchema([]string{"success"}, map[string]*jsonschema.Schema{
 				"success": schemahelper.BoolProp("Whether the operation succeeded"),

--- a/pkg/provider/executor.go
+++ b/pkg/provider/executor.go
@@ -77,15 +77,30 @@ func validateExecutionMode(ctx context.Context, desc *Descriptor) error {
 	return fmt.Errorf("provider %q does not support capability %q; supported: %v", desc.Name, execMode, desc.Capabilities)
 }
 
-// ValidateWriteOperation checks whether a write operation is being used in a read-only
-// context. Providers with Descriptor.WriteOperations populated declare which operations
-// mutate state; these are only allowed in action (CapabilityAction) context and rejected
-// in resolver resolve (CapabilityFrom) and transform (CapabilityTransform) contexts.
+// isReadOnlyResolverMode reports whether the execution mode is a read-only
+// resolver context in which write operations must be blocked. All other modes
+// (action, state, kubeconfig, authentication) legitimately perform writes and
+// are exempt from the write-operation guard.
+func isReadOnlyResolverMode(mode Capability) bool {
+	switch mode {
+	case CapabilityFrom, CapabilityTransform, CapabilityValidation:
+		return true
+	default:
+		return false
+	}
+}
+
+// ValidateWriteOperation checks whether a write operation is being used in a
+// read-only resolver context. Providers with Descriptor.WriteOperations
+// populated declare which operations mutate state; these are rejected only in
+// the read-only resolver phases (CapabilityFrom, CapabilityTransform,
+// CapabilityValidation) and permitted in every other mode (CapabilityAction,
+// CapabilityState, CapabilityKubeconfig, CapabilityAuthentication).
 //
 // Semantics follow the SDK convention:
 //   - nil WriteOperations: provider cannot classify (no enforcement)
 //   - empty []string{}: all operations are reads (everything allowed)
-//   - populated: listed operations are blocked outside action context
+//   - populated: listed operations are blocked only in read-only resolver modes
 func ValidateWriteOperation(ctx context.Context, p Provider, resolvedInputs map[string]any) error {
 	desc := p.Descriptor()
 	if desc == nil || desc.WriteOperations == nil {
@@ -93,8 +108,8 @@ func ValidateWriteOperation(ctx context.Context, p Provider, resolvedInputs map[
 	}
 
 	execMode, ok := ExecutionModeFromContext(ctx)
-	if !ok || execMode == CapabilityAction {
-		return nil // writes are allowed in action context
+	if !ok || !isReadOnlyResolverMode(execMode) {
+		return nil // writes are only blocked in read-only resolver modes
 	}
 
 	operation, _ := resolvedInputs["operation"].(string)

--- a/pkg/provider/executor_test.go
+++ b/pkg/provider/executor_test.go
@@ -704,11 +704,18 @@ func newMockWriteClassifierProvider(writeOps []string) *mockExecutableProvider {
 	version, _ := semver.NewVersion("1.0.0")
 	return &mockExecutableProvider{
 		descriptor: &Descriptor{
-			Name:            "test-provider",
-			APIVersion:      "v1",
-			Version:         version,
-			Description:     "Mock provider for testing",
-			Capabilities:    []Capability{CapabilityFrom, CapabilityAction, CapabilityTransform},
+			Name:        "test-provider",
+			APIVersion:  "v1",
+			Version:     version,
+			Description: "Mock provider for testing",
+			Capabilities: []Capability{
+				CapabilityFrom,
+				CapabilityAction,
+				CapabilityTransform,
+				CapabilityValidation,
+				CapabilityState,
+				CapabilityKubeconfig,
+			},
 			WriteOperations: writeOps,
 			Schema: schemahelper.ObjectSchema([]string{"operation"}, map[string]*jsonschema.Schema{
 				"operation": schemahelper.StringProp("Operation to perform"),
@@ -805,6 +812,60 @@ func TestValidateWriteOperation_SkipsNonClassifier(t *testing.T) {
 	result, err := executor.Execute(ctx, p, map[string]any{
 		"input1":    "value",
 		"operation": "create_label",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestValidateWriteOperation_BlocksWriteInValidation(t *testing.T) {
+	t.Parallel()
+
+	p := newMockWriteClassifierProvider([]string{"create_label", "delete_label"})
+
+	executor := NewExecutor()
+	ctx := WithExecutionMode(context.Background(), CapabilityValidation)
+
+	_, err := executor.Execute(ctx, p, map[string]any{
+		"operation": "create_label",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write operation")
+	assert.Contains(t, err.Error(), "create_label")
+	assert.Contains(t, err.Error(), "workflow action")
+}
+
+func TestValidateWriteOperation_AllowsWriteInKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	// Regression test for #579: kubeconfig writes run under CapabilityKubeconfig
+	// and must not be rejected by the read-only resolver write guard.
+	p := newMockWriteClassifierProvider([]string{"kubeconfig_write", "kubeconfig_remove"})
+
+	executor := NewExecutor()
+	ctx := WithExecutionMode(context.Background(), CapabilityKubeconfig)
+
+	result, err := executor.Execute(ctx, p, map[string]any{
+		"operation": "kubeconfig_write",
+	})
+
+	require.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+func TestValidateWriteOperation_AllowsWriteInState(t *testing.T) {
+	t.Parallel()
+
+	// Regression test for #579: state backends run save/delete under
+	// CapabilityState and must not be rejected by the write guard.
+	p := newMockWriteClassifierProvider([]string{"state_save", "state_delete"})
+
+	executor := NewExecutor()
+	ctx := WithExecutionMode(context.Background(), CapabilityState)
+
+	result, err := executor.Execute(ctx, p, map[string]any{
+		"operation": "state_save",
 	})
 
 	require.NoError(t, err)


### PR DESCRIPTION
The write-operation guard rejected declared write operations in every execution mode except CapabilityAction. This blocked kubeconfig and state backends, which legitimately run writes under CapabilityKubeconfig and CapabilityState, causing `kube login` to fail after a successful login without writing the kubeconfig entry.

- Invert the guard to a blocklist: writes are rejected only in the read-only resolver phases (from, transform, validation) and permitted in all other modes (action, state, kubeconfig, authentication)
- Add isReadOnlyResolverMode helper and update guard documentation
- Make the kubeconfig mock declare its write operations so tests exercise the host-side guard instead of skipping it
- Add regression tests for kubeconfig, state, and validation modes
- Document the guard exemption in the kubeconfig design plan

Closes #579