### PR TITLE
feat(auth): route per-cluster tokens on the exec-credential path

### DIFF
--- a/docs/design/kubernetes-auth.md
+++ b/docs/design/kubernetes-auth.md
@@ -22,6 +22,7 @@ The design is layered by dependency weight so each phase ships independently:
 | 2b | Kubeconfig provider plugin implementation (`client-go`/`clientcmd`) | plugin | Planned |
 | 3 | Thin `kube login` / `kube logout` commands | core (`pkg/kube/login`, `pkg/cmd/scafctl/kube`) | Shipped |
 | 4 | OpenShift OAuth auth-handler plugin | plugin | Planned |
+| 5 | Multi-cluster per-cluster token routing on the exec-credential path | core (`pkg/auth/execcredential`, `pkg/cmd/scafctl/auth`, `pkg/kube/login`) + SDK `CapTokenHostname` | Shipped |
 
 Phases 1-3 add no OpenShift- or vendor-specific code and already deliver
 credential-helper support for any OIDC cluster.
@@ -161,6 +162,46 @@ with no resolver involved.
 - **Phase 4 -- OpenShift OAuth handler plugin.** The one genuinely
   OpenShift-specific credential source: localhost-callback implicit-grant flow,
   plus `ListProjects` / MOTD behind graceful degradation.
+
+## Phase 5: Multi-Cluster Token Routing (Shipped)
+
+A single auth handler can back several clusters. Because the exec-credential
+kubeconfig entry `kube login` writes is otherwise identical for every cluster,
+the exec helper needs a per-invocation discriminator so `kubectl`/`oc` receive
+the correct cluster's token rather than the handler's most-recent one.
+
+The mechanism uses the client-go-idiomatic cluster hint, gated on a dedicated
+capability so mixed-version handlers never misroute silently (see issue #581 and
+the gating decision in #583):
+
+1. **`kube login` sets `provideClusterInfo: true`** on the kubeconfig exec
+   block (`pkg/kube/login`). `kubectl`/`oc` then pass the target cluster's
+   details -- including `spec.cluster.server` -- to the plugin via the
+   `KUBERNETES_EXEC_INFO` environment variable on every credential call. The
+   exec args stay cluster-agnostic (identical for all clusters); the cluster is
+   supplied at call time.
+2. **`auth token --exec-credential` extracts the server** from
+   `KUBERNETES_EXEC_INFO` (`execcredential.ClusterServerFromExecInfo`) and
+   forwards it as `TokenOptions.Hostname`, **only when the handler advertises
+   `auth.CapTokenHostname`**. Handlers that advertise `CapHostname` for login
+   but predate token-path hostname support never receive the field (proto3
+   would silently drop it), so they cannot misroute.
+3. **The host threads `Hostname`** through the in-process handler call and, for
+   plugin handlers, across the gRPC boundary
+   (`plugin.TokenRequest.Hostname` -> `proto.GetTokenRequest.hostname`) on both
+   the client and server mappings.
+4. **The routing key is the raw API server URL.** `kube login` sends
+   `LoginRequest.Hostname = info.APIServerURL`, writes that same value as the
+   kubeconfig `cluster.server`, and client-go echoes it back verbatim in
+   `KUBERNETES_EXEC_INFO`. So the token-time hostname matches the login-time
+   key by construction -- no normalization is required, and the handler stores
+   and retrieves per-cluster tokens under one stable key.
+
+When the resolved handler lacks `CapTokenHostname`, `kube login` emits a warning
+at login time (not token time, where the message would be swallowed inside the
+`kubectl` subprocess) noting that multi-cluster logins with that handler may
+return the wrong token. Single-cluster usage and handlers without the capability
+behave exactly as before.
 
 ## Design Decisions
 

--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -960,6 +960,37 @@ endpoints, and troubleshooting, see the
 [hostname resolution example](../../examples/auth/hostname-resolution.md) and the
 [hostname resolution design doc](../design/hostname-resolution.md).
 
+### Multi-Cluster Token Routing
+
+`kube login` can wire up several clusters that share one auth handler. Each
+`kube login` writes a kubeconfig exec entry with `provideClusterInfo: true`, so
+`kubectl`/`oc` pass the target cluster's API server URL to the exec helper on
+every credential call. The helper (`auth token --exec-credential`) forwards that
+URL to the handler, which returns the token for that specific cluster -- so two
+contexts backed by the same handler each mint the correct token with no
+re-login.
+
+This routing is active only for handlers that advertise the `token_hostname`
+capability (`auth.CapTokenHostname`). If a handler does not -- for example an
+older handler built before SDK v0.14.0, or one that only advertises the login
+`hostname` capability -- `kube login` prints a warning that logging into
+multiple clusters with it may return the wrong token; rebuild the handler
+against SDK v0.14.0 and advertise `token_hostname` to enable per-cluster
+routing.
+
+To request a specific cluster's token directly (for scripting or debugging,
+without `kubectl` setting `KUBERNETES_EXEC_INFO`), pass the cluster's API server
+URL to `auth token --server`:
+
+```console
+scafctl auth token openshift --server https://api.a.example.com:6443 --raw
+```
+
+`--server` takes precedence over `KUBERNETES_EXEC_INFO` and is honored only for
+handlers that advertise `token_hostname`. The structured `kube login` output
+(`-o json`) also reports a `perClusterTokens` boolean so scripts can detect
+whether the resolved handler supports this routing.
+
 ---
 
 ## GitHub Interactive Flow (Browser OAuth + PKCE)

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/oakwood-commons/httpc v0.1.0
 	github.com/oakwood-commons/kvx v0.14.0
 	github.com/oakwood-commons/oauth-helpers v0.2.0
-	github.com/oakwood-commons/scafctl-plugin-sdk v0.12.0
+	github.com/oakwood-commons/scafctl-plugin-sdk v0.14.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pelletier/go-toml/v2 v2.4.2

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,8 @@ github.com/oakwood-commons/kvx v0.14.0 h1:P09NTQPf1ZDDcB25ZUtzL6KWqVVepav2BZRw3N
 github.com/oakwood-commons/kvx v0.14.0/go.mod h1:PJktDsEq9PS88UDCkoIT+fgiSXs7dXWcq76Lhk5BmZY=
 github.com/oakwood-commons/oauth-helpers v0.2.0 h1:IIu8AitRWCNp51oRvfBU0D7JGM3Tt3QXUejLwEFZk+Q=
 github.com/oakwood-commons/oauth-helpers v0.2.0/go.mod h1:+VhuszKORoPc9H0HwvS92I/U0828up8XejsUpXS7FvE=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.12.0 h1:MzpmrsYuqNHEvC1X+yuHm2qFqMiBZHOfjwJKt5g9Fi0=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.12.0/go.mod h1:oC2LqrVwXEQBgR2rIp+PbSF0mLfkC1a2G5KJb6CzdgE=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.14.0 h1:BJkKwyh0zGG8i3jEiT9zIYfEsQt3BelwxNlahslIbeE=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.14.0/go.mod h1:oC2LqrVwXEQBgR2rIp+PbSF0mLfkC1a2G5KJb6CzdgE=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=

--- a/pkg/auth/capability.go
+++ b/pkg/auth/capability.go
@@ -13,6 +13,7 @@ const (
 	CapScopesOnTokenRequest = sdkauth.CapScopesOnTokenRequest
 	CapTenantID             = sdkauth.CapTenantID
 	CapHostname             = sdkauth.CapHostname
+	CapTokenHostname        = sdkauth.CapTokenHostname
 	CapFederatedToken       = sdkauth.CapFederatedToken
 	CapCallbackPort         = sdkauth.CapCallbackPort
 	CapFlowOverride         = sdkauth.CapFlowOverride

--- a/pkg/auth/execcredential/execcredential.go
+++ b/pkg/auth/execcredential/execcredential.go
@@ -91,3 +91,27 @@ func APIVersionFromExecInfo(execInfo string) string {
 	}
 	return parsed.APIVersion
 }
+
+// ClusterServerFromExecInfo extracts spec.cluster.server (the target API server
+// URL) from a KUBERNETES_EXEC_INFO payload. kubectl/oc only populate the cluster
+// block when the kubeconfig exec entry sets provideClusterInfo: true. The
+// returned value is the exact server string from the kubeconfig cluster entry,
+// so it matches the hostname a cluster-aware handler stored at login time and
+// can be used verbatim as a per-cluster token selector. It returns "" when the
+// payload is empty, unparseable, or carries no cluster server.
+func ClusterServerFromExecInfo(execInfo string) string {
+	if execInfo == "" {
+		return ""
+	}
+	var parsed struct {
+		Spec struct {
+			Cluster struct {
+				Server string `json:"server"`
+			} `json:"cluster"`
+		} `json:"spec"`
+	}
+	if err := json.Unmarshal([]byte(execInfo), &parsed); err != nil {
+		return ""
+	}
+	return parsed.Spec.Cluster.Server
+}

--- a/pkg/auth/execcredential/execcredential_test.go
+++ b/pkg/auth/execcredential/execcredential_test.go
@@ -132,3 +132,43 @@ func TestAPIVersionFromExecInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestClusterServerFromExecInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		execInfo string
+		want     string
+	}{
+		{name: "empty", execInfo: "", want: ""},
+		{name: "invalid json", execInfo: "{not json", want: ""},
+		{
+			name:     "server present",
+			execInfo: `{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential","spec":{"cluster":{"server":"https://api.a.example.com:6443"}}}`,
+			want:     "https://api.a.example.com:6443",
+		},
+		{
+			name:     "no cluster block",
+			execInfo: `{"apiVersion":"client.authentication.k8s.io/v1","spec":{"interactive":true}}`,
+			want:     "",
+		},
+		{
+			name:     "cluster without server",
+			execInfo: `{"spec":{"cluster":{"certificate-authority-data":"abc"}}}`,
+			want:     "",
+		},
+		{
+			name:     "no spec",
+			execInfo: `{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential"}`,
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, ClusterServerFromExecInfo(tt.execInfo))
+		})
+	}
+}

--- a/pkg/cmd/scafctl/auth/token.go
+++ b/pkg/cmd/scafctl/auth/token.go
@@ -41,6 +41,7 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 		exportToken  bool
 		execCred     bool
 		profile      string
+		serverURL    string
 	)
 
 	cmd := &cobra.Command{
@@ -189,10 +190,29 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				scope = strings.Join(sorted, " ")
 			}
 
+			// When kubectl/oc invoke this binary as an exec credential plugin
+			// with provideClusterInfo: true, KUBERNETES_EXEC_INFO carries the
+			// target cluster's API server URL. Forward it as the token hostname
+			// so cluster-aware handlers mint the correct per-cluster token.
+			// Gated on CapTokenHostname: older handlers that only advertise
+			// CapHostname (login) would silently ignore the field and return
+			// their default/most-recent token, so we must not rely on it.
+			// An explicit --server overrides the exec-info value so callers can
+			// request a specific cluster's token without kubectl.
+			execInfo := os.Getenv(execcredential.ExecInfoEnv)
+			var tokenHostname string
+			if auth.HasCapability(caps, auth.CapTokenHostname) {
+				tokenHostname = serverURL
+				if tokenHostname == "" {
+					tokenHostname = execcredential.ClusterServerFromExecInfo(execInfo)
+				}
+			}
+
 			token, err := handler.GetToken(ctx, auth.TokenOptions{
 				Scope:        scope,
 				MinValidFor:  minValidFor,
 				ForceRefresh: forceRefresh,
+				Hostname:     tokenHostname,
 			})
 			if err != nil {
 				err = fmt.Errorf("failed to get token: %w", err)
@@ -204,7 +224,6 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			// via --exec-credential, or auto-detected when kubectl invokes this binary
 			// as an exec plugin (KUBERNETES_EXEC_INFO set) and no other render mode or
 			// explicit output format was requested.
-			execInfo := os.Getenv(execcredential.ExecInfoEnv)
 			wantExecCred := execCred
 			if !wantExecCred && execInfo != "" &&
 				!rawToken && !clip && !exportToken && !curl && !decode &&
@@ -351,6 +370,7 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 	cmd.Flags().BoolVar(&exportToken, "export", false, fmt.Sprintf("Output a shell export statement: eval $(%s auth token ... --export)", cliParams.BinaryName))
 	cmd.Flags().BoolVar(&execCred, "exec-credential", false, "Emit a Kubernetes client-go ExecCredential JSON (for kubectl/oc exec credential plugins; auto-detected when KUBERNETES_EXEC_INFO is set)")
 	cmd.Flags().StringVar(&profile, "profile", "", "Named profile for isolated credential storage (e.g. work, personal)")
+	cmd.Flags().StringVar(&serverURL, "server", "", "Cluster API server URL selecting which per-cluster token to mint (handlers advertising token_hostname); overrides KUBERNETES_EXEC_INFO")
 	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
 
 	return cmd

--- a/pkg/cmd/scafctl/auth/token_test.go
+++ b/pkg/cmd/scafctl/auth/token_test.go
@@ -399,6 +399,107 @@ func TestCommandToken_ExecCredentialAutoDetect(t *testing.T) {
 	assert.Equal(t, "auto-detected-token", status["token"])
 }
 
+func TestCommandToken_ExecCredentialForwardsClusterHostname(t *testing.T) {
+	// Regression test for #581: with provideClusterInfo the exec info carries
+	// the target cluster's server, which must be forwarded as the token
+	// hostname so cluster-aware handlers mint the correct per-cluster token.
+	t.Setenv("KUBERNETES_EXEC_INFO", `{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential","spec":{"cluster":{"server":"https://api.a.example.com:6443"}}}`)
+
+	ctx, buf := newTestContext(t)
+
+	mock := newGitHubMock()
+	mock.CapabilitiesValue = append(mock.CapabilitiesValue, auth.CapTokenHostname)
+	mock.SetToken(&auth.Token{AccessToken: "cluster-a-token", TokenType: "Bearer", ExpiresAt: time.Now().Add(time.Hour)})
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandToken(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"github"})
+
+	require.NoError(t, cmd.Execute())
+
+	require.Len(t, mock.GetTokenCalls, 1)
+	assert.Equal(t, "https://api.a.example.com:6443", mock.GetTokenCalls[0].Hostname,
+		"cluster server must be forwarded as the token hostname for CapTokenHostname handlers")
+}
+
+func TestCommandToken_ExecCredentialHostnameGatedByCapability(t *testing.T) {
+	// A handler that advertises only CapHostname (login) but not
+	// CapTokenHostname must not receive the token hostname: it would silently
+	// ignore it (older SDK) and return its default token, so the host must not
+	// rely on it. See #583.
+	t.Setenv("KUBERNETES_EXEC_INFO", `{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential","spec":{"cluster":{"server":"https://api.a.example.com:6443"}}}`)
+
+	ctx, buf := newTestContext(t)
+
+	mock := newGitHubMock() // caps: CapScopesOnLogin, CapHostname (no CapTokenHostname)
+	mock.SetToken(&auth.Token{AccessToken: "default-token", TokenType: "Bearer", ExpiresAt: time.Now().Add(time.Hour)})
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandToken(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"github"})
+
+	require.NoError(t, cmd.Execute())
+
+	require.Len(t, mock.GetTokenCalls, 1)
+	assert.Empty(t, mock.GetTokenCalls[0].Hostname,
+		"token hostname must not be forwarded to handlers lacking CapTokenHostname")
+}
+
+func TestCommandToken_ServerFlagSelectsClusterHostname(t *testing.T) {
+	// #581: --server lets callers request a specific cluster's token without
+	// kubectl, and takes precedence over KUBERNETES_EXEC_INFO.
+	t.Setenv("KUBERNETES_EXEC_INFO", `{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential","spec":{"cluster":{"server":"https://api.b.example.com:6443"}}}`)
+
+	ctx, buf := newTestContext(t)
+
+	mock := newGitHubMock()
+	mock.CapabilitiesValue = append(mock.CapabilitiesValue, auth.CapTokenHostname)
+	mock.SetToken(&auth.Token{AccessToken: "cluster-a-token", TokenType: "Bearer", ExpiresAt: time.Now().Add(time.Hour)})
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandToken(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"github", "--server", "https://api.a.example.com:6443", "--raw"})
+
+	require.NoError(t, cmd.Execute())
+
+	require.Len(t, mock.GetTokenCalls, 1)
+	assert.Equal(t, "https://api.a.example.com:6443", mock.GetTokenCalls[0].Hostname,
+		"--server must override the exec-info cluster server")
+}
+
+func TestCommandToken_ServerFlagGatedByCapability(t *testing.T) {
+	// --server is ignored for handlers that do not advertise CapTokenHostname.
+	ctx, buf := newTestContext(t)
+
+	mock := newGitHubMock() // no CapTokenHostname
+	mock.SetToken(&auth.Token{AccessToken: "default-token", TokenType: "Bearer", ExpiresAt: time.Now().Add(time.Hour)})
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandToken(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"github", "--server", "https://api.a.example.com:6443", "--raw"})
+
+	require.NoError(t, cmd.Execute())
+
+	require.Len(t, mock.GetTokenCalls, 1)
+	assert.Empty(t, mock.GetTokenCalls[0].Hostname)
+}
+
 func TestCommandToken_ExecCredentialEchoesAPIVersion(t *testing.T) {
 	t.Setenv("KUBERNETES_EXEC_INFO", `{"apiVersion":"client.authentication.k8s.io/v1beta1","kind":"ExecCredential","spec":{}}`)
 

--- a/pkg/cmd/scafctl/kube/login.go
+++ b/pkg/cmd/scafctl/kube/login.go
@@ -126,6 +126,14 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				return exitcode.WithCode(err, exitcode.GeneralError)
 			}
 
+			if !res.SupportsPerClusterTokens {
+				w.WarnStderrf(
+					"handler %q does not support per-cluster token routing; logging into "+
+						"multiple clusters with it may return the wrong token. Upgrade the handler to enable multi-cluster.",
+					res.Handler,
+				)
+			}
+
 			return renderLoginResult(ioStreams, &outputFlags, w, res)
 		},
 	}
@@ -151,17 +159,18 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 // summary.
 func renderLoginResult(ioStreams *terminal.IOStreams, outputFlags *flags.KvxOutputFlags, w *writer.Writer, res *kubelogin.Result) error {
 	row := map[string]any{
-		"context":    res.ContextName,
-		"server":     res.Server,
-		"kubeconfig": res.KubeconfigPath,
-		"authType":   string(res.AuthType),
-		"handler":    res.Handler,
-		"user":       res.Username,
-		"fallback":   res.UsedFallback,
+		"context":          res.ContextName,
+		"server":           res.Server,
+		"kubeconfig":       res.KubeconfigPath,
+		"authType":         string(res.AuthType),
+		"handler":          res.Handler,
+		"user":             res.Username,
+		"fallback":         res.UsedFallback,
+		"perClusterTokens": res.SupportsPerClusterTokens,
 	}
 	opts := flags.ToKvxOutputOptions(outputFlags,
 		skvx.WithIOStreams(ioStreams),
-		skvx.WithOutputColumnOrder([]string{"context", "server", "kubeconfig", "authType", "handler", "user", "fallback"}),
+		skvx.WithOutputColumnOrder([]string{"context", "server", "kubeconfig", "authType", "handler", "user", "fallback", "perClusterTokens"}),
 	)
 	if skvx.IsStructuredFormat(opts.Format) {
 		return opts.Write([]map[string]any{row})

--- a/pkg/cmd/scafctl/kube/login_test.go
+++ b/pkg/cmd/scafctl/kube/login_test.go
@@ -136,6 +136,29 @@ func TestCommandLogin_JSONOutput(t *testing.T) {
 	assert.Contains(t, buf.String(), "prod")
 }
 
+func TestCommandLogin_JSONReportsPerClusterTokens(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx, mock := withMockHandler(t, ctx)
+	mock.CapabilitiesValue = []auth.Capability{auth.CapTokenHostname}
+	mock.GetTokenResult = &auth.Token{AccessToken: "tok"}
+
+	path := filepath.Join(t.TempDir(), "config")
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(embedderParams(), ioStreams, "mycli")
+	err := runCmd(t, cmd, ctx, "prod",
+		"--handler", mockHandlerName,
+		"--server", "https://api.example.com:6443",
+		"--kubeconfig", path,
+		"--output", "json",
+	)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "\"perClusterTokens\"")
+	assert.Contains(t, buf.String(), "true",
+		"a CapTokenHostname handler must report perClusterTokens:true")
+}
+
 func TestCommandLogin_HandlerFromResolverDefault(t *testing.T) {
 	t.Parallel()
 	ctx, buf := newTestContext(t)

--- a/pkg/kube/login/login.go
+++ b/pkg/kube/login/login.go
@@ -178,6 +178,12 @@ type Result struct {
 	// UsedFallback reports that the static kubeconfig writer was used because
 	// the kubeconfig provider was unavailable.
 	UsedFallback bool
+
+	// SupportsPerClusterTokens reports whether the auth handler advertises
+	// CapTokenHostname, i.e. it honors a per-cluster hostname on the token path.
+	// When false, logging into multiple clusters with this handler may return
+	// the wrong cluster's token (see issue #581).
+	SupportsPerClusterTokens bool
 }
 
 // Login resolves the cluster, runs the handler login, and writes a kubeconfig
@@ -240,26 +246,31 @@ func Login(ctx context.Context, deps Deps, req Request) (*Result, error) {
 	userName := firstNonEmpty(req.UserName, clusterName)
 
 	writeIn := kubeconfig.WriteInput{
-		Server:             info.APIServerURL,
-		Audience:           info.OIDCAudience,
-		ClusterName:        clusterName,
-		ContextName:        contextName,
-		UserName:           userName,
-		KubeconfigPath:     req.KubeconfigPath,
-		ExecCommand:        binaryName,
-		ExecArgs:           buildExecArgs(handler, info, req.Profile),
-		InteractiveMode:    interactiveModeFor(info.AuthType),
-		InstallHint:        buildInstallHint(binaryName),
-		ProvideClusterInfo: false,
+		Server:          info.APIServerURL,
+		Audience:        info.OIDCAudience,
+		ClusterName:     clusterName,
+		ContextName:     contextName,
+		UserName:        userName,
+		KubeconfigPath:  req.KubeconfigPath,
+		ExecCommand:     binaryName,
+		ExecArgs:        buildExecArgs(handler, info, req.Profile),
+		InteractiveMode: interactiveModeFor(info.AuthType),
+		InstallHint:     buildInstallHint(binaryName),
+		// Ask kubectl/oc to pass the target cluster's details (API server URL)
+		// via KUBERNETES_EXEC_INFO so the exec helper can route per-cluster
+		// tokens. Handlers that do not advertise CapTokenHostname simply ignore
+		// the extra info.
+		ProvideClusterInfo: true,
 		CAData:             info.CAData,
 		InsecureSkipTLS:    info.InsecureSkipTLS,
 		SetCurrentContext:  req.SetCurrentContext,
 	}
 
 	result := &Result{
-		Handler:  handler.Name(),
-		Server:   info.APIServerURL,
-		AuthType: info.AuthType,
+		Handler:                  handler.Name(),
+		Server:                   info.APIServerURL,
+		AuthType:                 info.AuthType,
+		SupportsPerClusterTokens: auth.HasCapability(handler.Capabilities(), auth.CapTokenHostname),
 	}
 
 	writeRes, err := deps.Kubeconfig.WriteKubeconfig(ctx, writeIn)
@@ -338,6 +349,13 @@ func tokenOptionsFor(h Authenticator, info kube.ClusterInfo) auth.TokenOptions {
 	opts := auth.TokenOptions{}
 	if info.OIDCAudience != "" && auth.HasCapability(h.Capabilities(), auth.CapScopesOnTokenRequest) {
 		opts.Scope = info.OIDCAudience
+	}
+	// Route the post-login whoami to the just-authenticated cluster so
+	// cluster-aware handlers return that cluster's token rather than relying on
+	// an implicit "most-recent" default. Mirrors the login-time Hostname and is
+	// gated on CapTokenHostname (see issue #581).
+	if info.APIServerURL != "" && auth.HasCapability(h.Capabilities(), auth.CapTokenHostname) {
+		opts.Hostname = info.APIServerURL
 	}
 	return opts
 }

--- a/pkg/kube/login/login_test.go
+++ b/pkg/kube/login/login_test.go
@@ -283,6 +283,93 @@ func TestLogin_HostnameNotForwardedWithoutCapability(t *testing.T) {
 		"handlers without CapHostname must not receive the API server URL")
 }
 
+func TestLogin_ProvideClusterInfoAlwaysSet(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{name: "openshift"}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+	deps := Deps{Handler: handler, Kubeconfig: kc}
+
+	_, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+	})
+	require.NoError(t, err)
+	assert.True(t, kc.writeIn.ProvideClusterInfo,
+		"kube login must set provideClusterInfo so kubectl passes cluster details via KUBERNETES_EXEC_INFO")
+}
+
+func TestLogin_SupportsPerClusterTokens(t *testing.T) {
+	t.Parallel()
+
+	t.Run("handler with CapTokenHostname", func(t *testing.T) {
+		t.Parallel()
+		handler := &stubAuth{name: "openshift", caps: []auth.Capability{auth.CapTokenHostname}}
+		kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+		res, err := Login(context.Background(), Deps{Handler: handler, Kubeconfig: kc}, Request{
+			Server:      "https://api.example.com:6443",
+			ClusterName: "prod",
+		})
+		require.NoError(t, err)
+		assert.True(t, res.SupportsPerClusterTokens)
+	})
+
+	t.Run("handler without CapTokenHostname", func(t *testing.T) {
+		t.Parallel()
+		handler := &stubAuth{name: "plain", caps: []auth.Capability{auth.CapHostname}}
+		kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+		res, err := Login(context.Background(), Deps{Handler: handler, Kubeconfig: kc}, Request{
+			Server:      "https://api.example.com:6443",
+			ClusterName: "prod",
+		})
+		require.NoError(t, err)
+		assert.False(t, res.SupportsPerClusterTokens,
+			"a handler that advertises only CapHostname (login) must not be reported as per-cluster token capable")
+	})
+}
+
+func TestLogin_WhoamiTokenRoutedByHostname(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CapTokenHostname handler gets the cluster hostname", func(t *testing.T) {
+		t.Parallel()
+		handler := &stubAuth{
+			name:  "openshift",
+			caps:  []auth.Capability{auth.CapTokenHostname},
+			token: &auth.Token{AccessToken: "tok"},
+		}
+		kc := &stubKube{
+			writeRes:  kubeconfig.WriteResult{Success: true},
+			whoamiRes: kubeconfig.WhoamiResult{Success: true},
+		}
+		_, err := Login(context.Background(), Deps{Handler: handler, Kubeconfig: kc}, Request{
+			Server:      "https://api.example.com:6443",
+			ClusterName: "prod",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "https://api.example.com:6443", handler.tokenOpts.Hostname,
+			"post-login whoami must route to the just-authenticated cluster")
+	})
+
+	t.Run("non-capable handler gets no hostname", func(t *testing.T) {
+		t.Parallel()
+		handler := &stubAuth{
+			name:  "plain",
+			token: &auth.Token{AccessToken: "tok"},
+		}
+		kc := &stubKube{
+			writeRes:  kubeconfig.WriteResult{Success: true},
+			whoamiRes: kubeconfig.WhoamiResult{Success: true},
+		}
+		_, err := Login(context.Background(), Deps{Handler: handler, Kubeconfig: kc}, Request{
+			Server:      "https://api.example.com:6443",
+			ClusterName: "prod",
+		})
+		require.NoError(t, err)
+		assert.Empty(t, handler.tokenOpts.Hostname)
+	})
+}
+
 func TestLogin_WriteError(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/plugin/auth_grpc_client_test.go
+++ b/pkg/plugin/auth_grpc_client_test.go
@@ -28,6 +28,8 @@ import (
 type mockAuthHandlerServiceClient struct {
 	proto.AuthHandlerServiceClient
 
+	capturedGetTokenReq *proto.GetTokenRequest
+
 	getAuthHandlersResp      *proto.GetAuthHandlersResponse
 	getAuthHandlersErr       error
 	configureAuthHandlerResp *proto.ConfigureAuthHandlerResponse
@@ -74,7 +76,8 @@ func (m *mockAuthHandlerServiceClient) GetStatus(_ context.Context, _ *proto.Get
 	return m.getStatusResp, m.getStatusErr
 }
 
-func (m *mockAuthHandlerServiceClient) GetToken(_ context.Context, _ *proto.GetTokenRequest, _ ...grpc.CallOption) (*proto.GetTokenResponse, error) {
+func (m *mockAuthHandlerServiceClient) GetToken(_ context.Context, req *proto.GetTokenRequest, _ ...grpc.CallOption) (*proto.GetTokenResponse, error) {
+	m.capturedGetTokenReq = req
 	return m.getTokenResp, m.getTokenErr
 }
 
@@ -468,6 +471,24 @@ func TestAuthHandlerGRPCClient_GetToken_Error(t *testing.T) {
 
 	_, err := client.GetToken(context.Background(), "azure", TokenRequest{})
 	require.Error(t, err)
+}
+
+func TestAuthHandlerGRPCClient_GetToken_ForwardsHostname(t *testing.T) {
+	t.Parallel()
+
+	// #581: the per-cluster hostname must cross the gRPC boundary so the remote
+	// handler can select the correct cluster's token.
+	mock := &mockAuthHandlerServiceClient{
+		getTokenResp: &proto.GetTokenResponse{AccessToken: "tok", TokenType: "Bearer"},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	_, err := client.GetToken(context.Background(), "openshift", TokenRequest{
+		Hostname: "https://api.a.example.com:6443",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, mock.capturedGetTokenReq)
+	assert.Equal(t, "https://api.a.example.com:6443", mock.capturedGetTokenReq.Hostname)
 }
 
 func TestAuthHandlerGRPCClient_ListCachedTokens_Success(t *testing.T) {

--- a/pkg/plugin/grpc_auth.go
+++ b/pkg/plugin/grpc_auth.go
@@ -211,6 +211,7 @@ func (s *AuthHandlerGRPCServer) GetToken(ctx context.Context, req *proto.GetToke
 		Scope:        req.Scope,
 		MinValidFor:  time.Duration(req.MinValidForSeconds) * time.Second,
 		ForceRefresh: req.ForceRefresh,
+		Hostname:     req.Hostname,
 	}
 	token, err := s.Impl.GetToken(ctx, req.HandlerName, tokenReq)
 	if err != nil {
@@ -412,6 +413,7 @@ func (c *AuthHandlerGRPCClient) GetToken(ctx context.Context, handlerName string
 		MinValidForSeconds: int64(req.MinValidFor / time.Second),
 		ForceRefresh:       req.ForceRefresh,
 		Profile:            auth.ProfileFromContext(ctx),
+		Hostname:           req.Hostname,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/plugin/grpc_auth_coverage_test.go
+++ b/pkg/plugin/grpc_auth_coverage_test.go
@@ -323,6 +323,29 @@ func TestAuthHandlerGRPCServer_GetToken(t *testing.T) {
 	assert.Equal(t, "openid", resp.Scope)
 }
 
+func TestAuthHandlerGRPCServer_GetToken_ForwardsHostname(t *testing.T) {
+	t.Parallel()
+
+	// #581: the server must map the proto hostname into the TokenRequest so a
+	// cluster-aware handler served over gRPC selects the correct cluster token.
+	var capturedReq TokenRequest
+	server := &AuthHandlerGRPCServer{
+		Impl: &MockAuthHandlerPlugin{
+			tokenFunc: func(_ context.Context, _ string, req TokenRequest) (*TokenResponse, error) {
+				capturedReq = req
+				return &TokenResponse{AccessToken: "tok", TokenType: "Bearer"}, nil
+			},
+		},
+	}
+
+	_, err := server.GetToken(t.Context(), &proto.GetTokenRequest{
+		HandlerName: "openshift",
+		Hostname:    "https://api.a.example.com:6443",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.a.example.com:6443", capturedReq.Hostname)
+}
+
 func TestAuthHandlerGRPCServer_ListCachedTokens(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/plugin/wrapper_auth.go
+++ b/pkg/plugin/wrapper_auth.go
@@ -238,6 +238,7 @@ func (w *AuthHandlerWrapper) GetToken(ctx context.Context, opts auth.TokenOption
 		Scope:        opts.Scope,
 		MinValidFor:  opts.MinValidFor,
 		ForceRefresh: opts.ForceRefresh,
+		Hostname:     opts.Hostname,
 	}
 
 	resp, err := w.client.plugin.GetToken(ctx, w.handlerName, req)

--- a/pkg/plugin/wrapper_auth_test.go
+++ b/pkg/plugin/wrapper_auth_test.go
@@ -519,6 +519,27 @@ func TestAuthHandlerWrapper_GetToken_ResolvesActiveProfile(t *testing.T) {
 	assert.Equal(t, "work", capturedProfile, "should resolve active profile from config")
 }
 
+func TestAuthHandlerWrapper_GetToken_ForwardsHostname(t *testing.T) {
+	t.Parallel()
+	var capturedReq TokenRequest
+	mock := &MockAuthHandlerPlugin{
+		tokenFunc: func(_ context.Context, _ string, req TokenRequest) (*TokenResponse, error) {
+			capturedReq = req
+			return &TokenResponse{AccessToken: "tok"}, nil
+		},
+	}
+	client := &AuthHandlerClient{plugin: mock}
+	wrapper := NewAuthHandlerWrapper(client, AuthHandlerInfo{Name: "openshift"})
+
+	// #581: the per-cluster hostname on TokenOptions must reach the plugin
+	// TokenRequest so the handler can select the right cluster's token.
+	_, err := wrapper.GetToken(context.Background(), auth.TokenOptions{
+		Hostname: "https://api.a.example.com:6443",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.a.example.com:6443", capturedReq.Hostname)
+}
+
 func TestAuthHandlerWrapper_GetToken_ProfileResolvedSkipsReResolution(t *testing.T) {
 	t.Parallel()
 	var capturedProfile string


### PR DESCRIPTION
kube login writes a cluster-agnostic exec-credential entry, so logging into multiple clusters with one handler left every context sharing an identical exec block. The exec helper had no way to tell which cluster kubectl was calling for, so it returned a single token and all but the most-recent cluster failed with Unauthorized.

kube login now sets provideClusterInfo:true so kubectl passes the target cluster's API server URL via KUBERNETES_EXEC_INFO. auth token --exec-credential extracts that server and forwards it as the token hostname, gated on the handler advertising CapTokenHostname so login-only handlers are never sent a field they would silently drop.

- Add ClusterServerFromExecInfo to parse spec.cluster.server
- Thread Hostname through TokenOptions, the wrapper, and both gRPC client and server mappings (SDK v0.14.0)
- Route the post-login whoami to the just-authenticated cluster
- Warn at login when the handler lacks per-cluster token routing
- Document the mechanism in the kubernetes-auth design doc and the auth tutorial

Closes #581
