### PR TITLE
feat(config): add config-driven kube cluster resolution

### DIFF
--- a/docs/design/kubernetes-auth.md
+++ b/docs/design/kubernetes-auth.md
@@ -41,8 +41,9 @@ See the [auth tutorial](../tutorials/auth-tutorial.md) for the kubeconfig wiring
 ## Phase 1b: ClusterResolver (Shipped)
 
 The `pkg/kube` package defines a dependency-free extension point that maps a
-cluster name to its connection details. scafctl ships **no** cluster data --
-embedders with a cluster registry provide the implementation.
+cluster name to its connection details. The stock binary can populate it from
+configuration (see Config-Driven Resolution below); embedders with their own
+cluster registry can supply an implementation instead.
 
 ### The Interface
 
@@ -124,6 +125,48 @@ When unset, `kube.ResolverFromContext` returns `nil` and cluster-aware commands
 fall back to an explicit `--server` and auto-detection. Setting a resolver lights
 up positional cluster names, shell completion (via `List`), and OIDC audience
 resolution.
+
+### Config-Driven Resolution (Shipped)
+
+The stock binary resolves clusters by name from the `kube.clusters` config
+section, so users get positional `kube login <cluster>` without an embedder
+resolver. `pkg/kube/clusterconfig` implements `kube.ClusterResolver` backed by
+config and is attached by `RootOptions` when no embedder resolver is supplied
+and `kube.clusters` declares any aliases or an inventory. An embedder-provided
+`ClusterResolver` always wins.
+
+Resolution precedence, highest to lowest:
+
+1. **Explicit flags** -- `--server` / `--handler` override everything.
+2. **Concrete URL argument** -- a `<cluster>` that is already an `http(s)://`
+   URL is used directly as the API server (no inventory required) and is not
+   used as the logical name.
+3. **Static alias** -- a `kube.clusters.aliases.<name>` entry carrying `server`
+   plus optional `defaultHandler`, `authType`, `oidcAudience`, `caData`.
+4. **Dynamic inventory** -- `kube.clusters.resolver` fetches and CEL-transforms
+   a cluster inventory. It reuses the auth hostname inventory engine
+   (`pkg/auth/hostname`: fetch + transform + TTL cache); the transform yields
+   `{name, url}` entries plus the same optional per-cluster fields. Static
+   aliases win over inventory entries of the same name.
+
+~~~yaml
+kube:
+  clusters:
+    aliases:
+      lab:
+        server: https://api.lab.example.com:6443
+        defaultHandler: openshift
+    resolver:
+      source:
+        url: https://clusters.example.com/
+      transform: '_.map(k, {"name": k, "url": _[k].apiServerURL, "defaultHandler": "openshift", "authType": "oauth"})'
+      ttl: 10m
+~~~
+
+Because a fleet transform can stamp the same `defaultHandler` and `authType` on
+every entry, `kube login <cluster>` then needs neither `--server` nor
+`--handler`. One-off users with only a URL or a handful of static aliases keep
+working unchanged.
 
 ### Runtime Model
 

--- a/examples/auth/kube-login.md
+++ b/examples/auth/kube-login.md
@@ -79,6 +79,48 @@ After login, `kubectl` reuses the scafctl-managed identity automatically:
 kubectl --context prod get pods
 ```
 
+## Configure Cluster Resolution
+
+The stock binary resolves clusters by name from the `kube.clusters` config
+section, so `kube login <cluster>` needs neither `--server` nor `--handler` for
+known clusters. Resolution precedence is: explicit `--server`/`--handler` flags,
+then a concrete URL argument, then a static alias, then the dynamic inventory.
+
+Static aliases for one-off clusters not in any inventory:
+
+```yaml
+kube:
+  clusters:
+    aliases:
+      lab:
+        server: https://api.lab.example.com:6443
+        defaultHandler: openshift
+```
+
+A fleet inventory that stamps the handler and auth type on every entry (reuses
+the hostname inventory contract -- source, CEL transform, ttl):
+
+```yaml
+kube:
+  clusters:
+    resolver:
+      source:
+        url: https://clusters.example.com/
+      transform: '_.map(k, {"name": k, "url": _[k].apiServerURL, "defaultHandler": "openshift", "authType": "oauth"})'
+      ttl: 10m
+```
+
+With either configured, all of these work:
+
+```bash
+scafctl kube login lab                      # static alias
+scafctl kube login pd1020                    # from inventory
+scafctl kube login https://api.x:6443 --handler oidc   # direct URL, no config
+```
+
+Embedders can still supply a `RootOptions.ClusterResolver` implementation, which
+takes precedence over the config-driven resolver.
+
 ## Log Out
 
 Remove the kubeconfig entry and revoke the handler's cached credentials:

--- a/pkg/auth/hostname/hostname.go
+++ b/pkg/auth/hostname/hostname.go
@@ -16,7 +16,8 @@
 //
 // Resolve returns just the endpoint URL. ResolveEntry returns the full Entry,
 // including optional per-cluster OIDC metadata (audience, authType, caData,
-// consoleUrl, insecureSkipTls) that a config-driven inventory can surface for
+// defaultHandler, consoleUrl, insecureSkipTls) that a config-driven inventory
+// can surface for
 // kube login.
 //
 // scafctl core stays shape-blind: all inventory normalization lives in the
@@ -52,6 +53,11 @@ type Entry struct {
 	// AuthType is the login method for this cluster: "" (auto), "oauth", or
 	// "oidc". It mirrors kube.AuthType.
 	AuthType string `json:"authType,omitempty"`
+
+	// DefaultHandler is the auth handler used to authenticate to this cluster
+	// when the caller does not pass an explicit --handler. It lets a fleet
+	// inventory drive `kube login <cluster>` without naming a handler.
+	DefaultHandler string `json:"defaultHandler,omitempty"`
 
 	// CAData is a PEM-encoded CA bundle for the endpoint (preferred over
 	// InsecureSkipTLS).
@@ -103,6 +109,15 @@ func (d Deps) withDefaults() Deps {
 		d.Transform = defaultTransform
 	}
 	return d
+}
+
+// DefaultDeps returns the production collaborators used by Resolve/ResolveEntry:
+// httpc fetch, tokenprovider token, celexp transform, and an on-disk inventory
+// cache. Callers that resolve an inventory outside the auth-handler config path
+// (for example kube cluster resolution) can reuse the same engine via
+// ResolveEntryWith with these deps.
+func DefaultDeps() Deps {
+	return Deps{Cache: newDiskCache()}.withDefaults()
 }
 
 // Resolve turns a hostname selector into a concrete endpoint URL for the given
@@ -179,6 +194,31 @@ func ResolveEntryWith(ctx context.Context, cfg *config.HostnameConfig, handler, 
 
 	// 5. Not found in aliases and no resolver configured.
 	return nil, fmt.Errorf("%w: %q (available: %s)", ErrSelectorNotFound, selector, availableNames(cfg, nil))
+}
+
+// ResolveInventory fetches, transforms, and caches the endpoint inventory for
+// the given resolver config and returns all entries. It is the list-all
+// counterpart to ResolveEntryWith's single-selector lookup, for callers that
+// enumerate entries (e.g. kube cluster-name shell completion). The handler
+// namespaces the cache key and guards against a resolver depending on the
+// handler it resolves; pass a stable non-auth-handler token (e.g. "kube") for
+// non-auth callers.
+func ResolveInventory(ctx context.Context, rc *config.HostnameResolverConfig, handler string, deps Deps) ([]Entry, error) {
+	return resolveInventory(ctx, rc, handler, deps.withDefaults())
+}
+
+// CachedInventory returns the inventory entries already cached for the resolver
+// config, without triggering a network fetch. ok is false when nothing is
+// cached (or caching is disabled). It lets latency-sensitive callers such as
+// shell completion enumerate previously-resolved entries without blocking on
+// I/O. The handler must match the one used at resolution time so the cache key
+// aligns.
+func CachedInventory(ctx context.Context, rc *config.HostnameResolverConfig, handler string, deps Deps) ([]Entry, bool) {
+	deps = deps.withDefaults()
+	if deps.Cache == nil {
+		return nil, false
+	}
+	return deps.Cache.Get(ctx, cacheKey(handler, rc))
 }
 
 // resolveInventory fetches, transforms, and caches the endpoint inventory.

--- a/pkg/auth/hostname/hostname_test.go
+++ b/pkg/auth/hostname/hostname_test.go
@@ -401,3 +401,66 @@ func TestResolveEntryWith_NotFound(t *testing.T) {
 	assert.ErrorIs(t, err, ErrSelectorNotFound)
 	assert.Nil(t, got)
 }
+
+func TestDefaultDeps(t *testing.T) {
+	t.Parallel()
+
+	d := DefaultDeps()
+	assert.NotNil(t, d.Fetch, "Fetch default must be set")
+	assert.NotNil(t, d.Token, "Token default must be set")
+	assert.NotNil(t, d.Transform, "Transform default must be set")
+	assert.NotNil(t, d.Cache, "on-disk inventory cache must be set")
+}
+
+func TestResolveInventory(t *testing.T) {
+	t.Parallel()
+
+	rc := &config.HostnameResolverConfig{
+		Source:    config.HostnameResolverSource{URL: "https://clusters.example.com"},
+		Transform: "_",
+		TTL:       "1h",
+	}
+	cache := &fakeCache{}
+	deps := Deps{
+		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) {
+			return []byte("{}"), nil
+		},
+		Transform: func(context.Context, string, []byte) ([]Entry, error) {
+			return []Entry{{Name: "pd1020", URL: "https://api.pd:6443"}}, nil
+		},
+		Cache: cache,
+	}
+
+	entries, err := ResolveInventory(context.Background(), rc, "kube", deps)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "pd1020", entries[0].Name)
+	assert.Equal(t, 1, cache.sets, "resolved inventory must be cached")
+}
+
+func TestCachedInventory(t *testing.T) {
+	t.Parallel()
+
+	rc := &config.HostnameResolverConfig{
+		Source:    config.HostnameResolverSource{URL: "https://clusters.example.com"},
+		Transform: "_",
+	}
+
+	t.Run("miss when no cache", func(t *testing.T) {
+		t.Parallel()
+		_, ok := CachedInventory(context.Background(), rc, "kube", Deps{})
+		assert.False(t, ok)
+	})
+
+	t.Run("hit returns cached entries without fetching", func(t *testing.T) {
+		t.Parallel()
+		cache := &fakeCache{store: map[string][]Entry{
+			cacheKey("kube", rc): {{Name: "pd1020", URL: "https://api.pd:6443"}},
+		}}
+		// No Fetch provided: CachedInventory must never call it.
+		entries, ok := CachedInventory(context.Background(), rc, "kube", Deps{Cache: cache})
+		require.True(t, ok)
+		require.Len(t, entries, 1)
+		assert.Equal(t, "pd1020", entries[0].Name)
+	})
+}

--- a/pkg/cmd/scafctl/kube/completion.go
+++ b/pkg/cmd/scafctl/kube/completion.go
@@ -1,0 +1,76 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	kubeapi "github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/kube/clusterconfig"
+)
+
+// clusterArgCompletion is the ValidArgsFunction for commands that take a single
+// optional <cluster> positional argument (kube login / kube logout).
+func clusterArgCompletion(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return completeClusterNames(cmd), cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeClusterNames returns cluster names for shell completion of the
+// <cluster> argument. It never blocks on network I/O: the stock config-driven
+// resolver (whether built here or supplied in context) lists static aliases
+// plus already-cached inventory only via ListCached, so a cold dynamic
+// inventory is skipped and the shell never stalls on a fetch. Any other
+// embedder-supplied context resolver is used via its List (the embedder owns
+// its latency). It is best-effort -- any error yields no completions.
+func completeClusterNames(cmd *cobra.Command) []string {
+	ctx := cmd.Context()
+
+	// Embedder/context resolver wins (present when an embedder wired one). The
+	// stock config-driven resolver uses ListCached so a slow or unreachable
+	// dynamic inventory can never hang the shell on <TAB>, even if it was wired
+	// into the context.
+	if r := kubeapi.ResolverFromContext(ctx); r != nil {
+		if cr, ok := r.(*clusterconfig.Resolver); ok {
+			return clusterNames(cr.ListCached(ctx))
+		}
+		infos, _ := r.List(ctx)
+		return clusterNames(infos)
+	}
+
+	// Shell completion runs without the root PersistentPreRun, so the
+	// config-driven resolver is built directly from the --config file. Use the
+	// non-blocking ListCached so a slow or unreachable dynamic inventory can
+	// never hang the shell on <TAB>.
+	cfg, err := config.NewManager(configPathFromCmd(cmd)).Load()
+	if err != nil {
+		return nil
+	}
+	cr := clusterconfig.New(cfg.Kube.Clusters)
+	if !cr.Enabled() {
+		return nil
+	}
+	return clusterNames(cr.ListCached(ctx))
+}
+
+// clusterNames extracts the Name field from a slice of ClusterInfos.
+func clusterNames(infos []kubeapi.ClusterInfo) []string {
+	names := make([]string, 0, len(infos))
+	for i := range infos {
+		names = append(names, infos[i].Name)
+	}
+	return names
+}
+
+// configPathFromCmd returns the value of the root --config flag, or "" when the
+// flag is absent (config then resolves via the default XDG path).
+func configPathFromCmd(cmd *cobra.Command) string {
+	if f := cmd.Root().Flag("config"); f != nil {
+		return f.Value.String()
+	}
+	return ""
+}

--- a/pkg/cmd/scafctl/kube/completion_test.go
+++ b/pkg/cmd/scafctl/kube/completion_test.go
@@ -1,0 +1,125 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth/hostname"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	kubeapi "github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/kube/clusterconfig"
+)
+
+// cmdWithContext returns a child command under a root that carries a --config
+// flag, with the given context set, mirroring the real command tree.
+func cmdWithContext(t *testing.T, ctx context.Context, configPath string) *cobra.Command {
+	t.Helper()
+	root := &cobra.Command{Use: "scafctl"}
+	root.PersistentFlags().String("config", configPath, "")
+	child := &cobra.Command{Use: "login"}
+	root.AddCommand(child)
+	child.SetContext(ctx)
+	return child
+}
+
+func TestCompleteClusterNames_ContextResolverWins(t *testing.T) {
+	t.Parallel()
+
+	resolver := &kubeapi.MockResolver{
+		ListResult: []kubeapi.ClusterInfo{{Name: "lab"}, {Name: "prod"}},
+	}
+	ctx := kubeapi.WithResolver(context.Background(), resolver)
+	cmd := cmdWithContext(t, ctx, "")
+
+	assert.Equal(t, []string{"lab", "prod"}, completeClusterNames(cmd))
+}
+
+func TestCompleteClusterNames_ConfigResolverInContextUsesCache(t *testing.T) {
+	t.Parallel()
+
+	// A stock config-driven resolver wired into the context must be completed
+	// via ListCached (aliases + already-cached inventory only), never List, so
+	// <TAB> can never stall on a dynamic-inventory fetch.
+	fetched := false
+	deps := hostname.Deps{
+		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) {
+			fetched = true
+			return nil, nil
+		},
+	}
+	cr := clusterconfig.New(config.ClusterResolutionConfig{
+		Aliases: map[string]config.ClusterAlias{"lab": {Server: "https://api.lab.example.com:6443"}},
+		Resolver: &config.HostnameResolverConfig{
+			Source:    config.HostnameResolverSource{URL: "https://clusters.example.com"},
+			Transform: "_",
+		},
+	}, clusterconfig.WithDeps(deps))
+	ctx := kubeapi.WithResolver(context.Background(), cr)
+	cmd := cmdWithContext(t, ctx, "")
+
+	assert.Equal(t, []string{"lab"}, completeClusterNames(cmd))
+	assert.False(t, fetched, "completion of a config resolver must not trigger a network fetch")
+}
+
+func TestCompleteClusterNames_ConfigFallback(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	seed := `kube:
+  clusters:
+    aliases:
+      lab:
+        server: https://api.lab.example.com:6443
+      prod:
+        server: https://api.prod.example.com:6443
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(seed), 0o600))
+
+	// No resolver in context: completion must load the config directly.
+	cmd := cmdWithContext(t, context.Background(), configPath)
+
+	names := completeClusterNames(cmd)
+	assert.ElementsMatch(t, []string{"lab", "prod"}, names)
+}
+
+func TestCompleteClusterNames_NoResolverNoConfig(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	cmd := cmdWithContext(t, context.Background(), filepath.Join(dir, "missing.yaml"))
+
+	assert.Empty(t, completeClusterNames(cmd),
+		"no context resolver and no kube.clusters config must yield no completions")
+}
+
+func TestClusterArgCompletion(t *testing.T) {
+	t.Parallel()
+
+	resolver := &kubeapi.MockResolver{ListResult: []kubeapi.ClusterInfo{{Name: "lab"}}}
+	ctx := kubeapi.WithResolver(context.Background(), resolver)
+	cmd := cmdWithContext(t, ctx, "")
+
+	t.Run("no arg yet completes cluster names", func(t *testing.T) {
+		t.Parallel()
+		names, directive := clusterArgCompletion(cmd, nil, "")
+		assert.Equal(t, []string{"lab"}, names)
+		assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	})
+
+	t.Run("second arg gets no completion", func(t *testing.T) {
+		t.Parallel()
+		names, directive := clusterArgCompletion(cmd, []string{"lab"}, "")
+		assert.Nil(t, names)
+		assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, directive)
+	})
+}

--- a/pkg/cmd/scafctl/kube/login.go
+++ b/pkg/cmd/scafctl/kube/login.go
@@ -76,8 +76,9 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			  # Login, make the new context current, and verify the identity
 			  scafctl kube login prod --current --verify
 		`), settings.CliBinaryName, cliParams.BinaryName),
-		SilenceUsage: true,
-		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage:      true,
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: clusterArgCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := writer.FromContext(ctx)

--- a/pkg/cmd/scafctl/kube/logout.go
+++ b/pkg/cmd/scafctl/kube/logout.go
@@ -59,8 +59,9 @@ func CommandLogout(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 			  # Remove the kubeconfig entry but keep cached credentials
 			  scafctl kube logout prod --keep-credentials
 		`), settings.CliBinaryName, cliParams.BinaryName),
-		SilenceUsage: true,
-		Args:         cobra.MaximumNArgs(1),
+		SilenceUsage:      true,
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: clusterArgCompletion,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			w := writer.FromContext(ctx)

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -48,6 +48,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/credentialhelper"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/kube/clusterconfig"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/metrics"
 	"github.com/oakwood-commons/scafctl/pkg/paths"
@@ -561,10 +562,17 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 
 			ctx = auth.WithRegistry(ctx, authRegistry)
 
-			// Attach the embedder-provided cluster resolver, if any, so
-			// cluster-aware commands can resolve names to connection details.
-			if opts.ClusterResolver != nil {
+			// Attach a cluster resolver so cluster-aware commands can resolve
+			// names to connection details. An embedder-provided resolver wins;
+			// otherwise a config-driven resolver is built from the kube.clusters
+			// config section when it declares any aliases or an inventory.
+			switch {
+			case opts.ClusterResolver != nil:
 				ctx = kube.WithResolver(ctx, opts.ClusterResolver)
+			default:
+				if cr := clusterconfig.New(cfg.Kube.Clusters); cr.Enabled() {
+					ctx = kube.WithResolver(ctx, cr)
+				}
 			}
 
 			// ── Resolve global auth profile ──

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -32,6 +32,7 @@ type Config struct {
 	Discovery  DiscoveryConfig  `json:"discovery,omitempty" yaml:"discovery,omitempty" mapstructure:"discovery" doc:"Auto-discovery configuration"`
 	Plugins    PluginsConfig    `json:"plugins,omitempty" yaml:"plugins,omitempty" mapstructure:"plugins" doc:"Plugin management configuration"`
 	MCP        MCPConfig        `json:"mcp,omitempty" yaml:"mcp,omitempty" mapstructure:"mcp" doc:"MCP server configuration"`
+	Kube       KubeConfig       `json:"kube,omitempty" yaml:"kube,omitempty" mapstructure:"kube" doc:"Kubernetes/OpenShift cluster resolution for kube login"`
 }
 
 // DiscoveryStrategy controls how a remote catalog discovers available artifacts.
@@ -524,6 +525,63 @@ type HostnameResolverSource struct {
 
 	// Headers are additional static request headers.
 	Headers map[string]string `json:"headers,omitempty" yaml:"headers,omitempty" mapstructure:"headers" doc:"Additional static request headers"`
+}
+
+// KubeConfig configures Kubernetes / OpenShift cluster resolution for the
+// `kube login` command so a cluster can be resolved by name in the stock
+// binary (no embedder-provided resolver required).
+type KubeConfig struct {
+	// Clusters resolves a cluster selector into connection details (server,
+	// default handler, auth type, audience) via static aliases and/or a
+	// dynamic inventory resolver.
+	Clusters ClusterResolutionConfig `json:"clusters,omitempty" yaml:"clusters,omitempty" mapstructure:"clusters" doc:"Cluster name resolution (static aliases and dynamic inventory)"`
+}
+
+// ClusterResolutionConfig declares how `kube login <cluster>` resolves a
+// cluster selector into connection details. Resolution precedence is: explicit
+// --server/--handler flags, then a concrete URL argument, then a static alias,
+// then the dynamic inventory resolver. Static aliases win over inventory
+// entries of the same name.
+type ClusterResolutionConfig struct {
+	// Aliases maps a short cluster selector (e.g. "lab") to concrete connection
+	// details for one-off clusters that are not part of any inventory. Static
+	// aliases win over the dynamic resolver.
+	Aliases map[string]ClusterAlias `json:"aliases,omitempty" yaml:"aliases,omitempty" mapstructure:"aliases" doc:"Static map of cluster selector to connection details"`
+
+	// Resolver dynamically fetches and normalizes a cluster inventory at login
+	// time. It reuses the hostname inventory contract (source + CEL transform +
+	// ttl); the transform yields entries with name, url, and optional
+	// defaultHandler/authType/audience/caData fields.
+	Resolver *HostnameResolverConfig `json:"resolver,omitempty" yaml:"resolver,omitempty" mapstructure:"resolver" doc:"Dynamic cluster inventory resolver (reuses the hostname inventory contract)"`
+}
+
+// ClusterAlias is a static per-cluster entry for kube login. Only Server is
+// required; the remaining fields populate the corresponding ClusterInfo so a
+// user can run `kube login <alias>` without --server or --handler.
+type ClusterAlias struct {
+	// Server is the cluster API server URL (https://...).
+	Server string `json:"server" yaml:"server" mapstructure:"server" doc:"Cluster API server URL" maxLength:"2048" example:"https://api.lab.example.com:6443"`
+
+	// DefaultHandler is the auth handler used when no explicit --handler is
+	// passed.
+	DefaultHandler string `json:"defaultHandler,omitempty" yaml:"defaultHandler,omitempty" mapstructure:"defaultHandler" doc:"Auth handler used when no explicit --handler is supplied" maxLength:"253" example:"openshift"`
+
+	// AuthType selects the authentication method: "" (auto), "oauth", or "oidc".
+	AuthType string `json:"authType,omitempty" yaml:"authType,omitempty" mapstructure:"authType" doc:"Authentication method: empty (auto), oauth, or oidc" maxLength:"16" example:"oauth"`
+
+	// OIDCAudience is the client ID / audience the minted token must target for
+	// OIDC clusters.
+	OIDCAudience string `json:"oidcAudience,omitempty" yaml:"oidcAudience,omitempty" mapstructure:"oidcAudience" doc:"Client ID/audience for OIDC clusters" maxLength:"512"`
+
+	// CAData is a PEM-encoded CA bundle for the API server (preferred over
+	// InsecureSkipTLS).
+	CAData string `json:"caData,omitempty" yaml:"caData,omitempty" mapstructure:"caData" doc:"PEM-encoded cluster CA bundle; preferred over insecureSkipTls" maxLength:"1048576"`
+
+	// ConsoleURL is an optional web console URL (informational).
+	ConsoleURL string `json:"consoleUrl,omitempty" yaml:"consoleUrl,omitempty" mapstructure:"consoleUrl" doc:"Optional web console URL (informational)" maxLength:"2048"`
+
+	// InsecureSkipTLS disables API server TLS verification (development only).
+	InsecureSkipTLS bool `json:"insecureSkipTls,omitempty" yaml:"insecureSkipTls,omitempty" mapstructure:"insecureSkipTls" doc:"Disable API server TLS verification (development only)"`
 }
 
 // EntraAuthConfig contains Entra-specific configuration.

--- a/pkg/kube/clusterconfig/resolver.go
+++ b/pkg/kube/clusterconfig/resolver.go
@@ -1,0 +1,197 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package clusterconfig implements a config-driven kube.ClusterResolver so the
+// stock scafctl binary can resolve a cluster by name for `kube login` without
+// an embedder-provided resolver.
+//
+// Resolution reuses the auth hostname inventory engine (fetch + CEL transform +
+// TTL cache) for the dynamic tier, and adds a richer static-alias tier that
+// carries per-cluster connection details (server, default handler, auth type,
+// audience). Precedence, highest to lowest:
+//
+//  1. Static alias (kube.clusters.aliases) -- wins over inventory.
+//  2. Dynamic inventory (kube.clusters.resolver).
+//
+// Concrete-URL passthrough and explicit --server/--handler flags are handled by
+// the caller (pkg/kube/login), which layers them above this resolver.
+package clusterconfig
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth/hostname"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/kube"
+)
+
+// resolverHandler namespaces the inventory cache key and satisfies the hostname
+// engine's loop guard. Cluster resolution has no auth handler of its own, so a
+// stable non-auth-handler token is used.
+const resolverHandler = "kube"
+
+// ErrClusterNotFound is returned when a selector matches neither a static alias
+// nor a dynamic inventory entry.
+var ErrClusterNotFound = fmt.Errorf("cluster not found")
+
+// Resolver resolves cluster selectors from configuration. It implements
+// kube.ClusterResolver.
+type Resolver struct {
+	cfg  config.ClusterResolutionConfig
+	deps hostname.Deps
+}
+
+// Option customizes a Resolver.
+type Option func(*Resolver)
+
+// WithDeps overrides the inventory engine collaborators (fetch/token/transform/
+// cache). Primarily for tests; production uses hostname.DefaultDeps.
+func WithDeps(deps hostname.Deps) Option {
+	return func(r *Resolver) { r.deps = deps }
+}
+
+// New builds a config-driven cluster resolver. When no options are supplied it
+// uses the production hostname engine collaborators (HTTP fetch, cached token,
+// CEL transform, on-disk inventory cache).
+func New(cfg config.ClusterResolutionConfig, opts ...Option) *Resolver {
+	r := &Resolver{cfg: cfg, deps: hostname.DefaultDeps()}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// Enabled reports whether any resolution source is configured. Callers use it
+// to decide whether to attach the resolver at all.
+func (r *Resolver) Enabled() bool {
+	return len(r.cfg.Aliases) > 0 || r.cfg.Resolver != nil
+}
+
+// Resolve returns the ClusterInfo for the named cluster. Static aliases win
+// over the dynamic inventory.
+func (r *Resolver) Resolve(ctx context.Context, name string) (*kube.ClusterInfo, error) {
+	if name == "" {
+		return nil, fmt.Errorf("cluster name is required")
+	}
+
+	if alias, ok := r.cfg.Aliases[name]; ok {
+		if alias.Server == "" {
+			return nil, fmt.Errorf("cluster alias %q is missing a server", name)
+		}
+		return aliasToInfo(name, alias), nil
+	}
+
+	if r.cfg.Resolver != nil {
+		hc := &config.HostnameConfig{Resolver: r.cfg.Resolver}
+		entry, err := hostname.ResolveEntryWith(ctx, hc, resolverHandler, name, r.deps)
+		if err != nil {
+			// Normalize an inventory miss to ErrClusterNotFound so callers can
+			// detect "no such cluster" uniformly, regardless of whether the
+			// miss came from the alias tier or the inventory tier.
+			if errors.Is(err, hostname.ErrSelectorNotFound) {
+				return nil, fmt.Errorf("%w: %q", ErrClusterNotFound, name)
+			}
+			return nil, fmt.Errorf("resolve cluster %q from inventory: %w", name, err)
+		}
+		return entryToInfo(entry), nil
+	}
+
+	return nil, fmt.Errorf("%w: %q", ErrClusterNotFound, name)
+}
+
+// List returns all known clusters (static aliases plus dynamic inventory
+// entries) for shell completion. Static aliases take precedence over inventory
+// entries of the same name. When the inventory cannot be fetched, the static
+// aliases gathered so far are returned along with the error so completion can
+// degrade gracefully.
+func (r *Resolver) List(ctx context.Context) ([]kube.ClusterInfo, error) {
+	out, seen := r.aliasInfos()
+
+	if r.cfg.Resolver != nil {
+		entries, err := hostname.ResolveInventory(ctx, r.cfg.Resolver, resolverHandler, r.deps)
+		if err != nil {
+			return out, fmt.Errorf("list clusters from inventory: %w", err)
+		}
+		out = appendEntries(out, seen, entries)
+	}
+
+	return out, nil
+}
+
+// ListCached returns known clusters without any network I/O: static aliases
+// always, plus dynamic inventory entries only when they were already cached by
+// a prior resolution. It is intended for shell completion, where blocking on a
+// network fetch would stall the shell.
+func (r *Resolver) ListCached(ctx context.Context) []kube.ClusterInfo {
+	out, seen := r.aliasInfos()
+
+	if r.cfg.Resolver != nil {
+		if entries, ok := hostname.CachedInventory(ctx, r.cfg.Resolver, resolverHandler, r.deps); ok {
+			out = appendEntries(out, seen, entries)
+		}
+	}
+
+	return out
+}
+
+// aliasInfos returns the static aliases as ClusterInfos (sorted by name) plus a
+// set of the names already included, for inventory de-duplication.
+func (r *Resolver) aliasInfos() ([]kube.ClusterInfo, map[string]bool) {
+	seen := make(map[string]bool, len(r.cfg.Aliases))
+	out := make([]kube.ClusterInfo, 0, len(r.cfg.Aliases))
+
+	aliasNames := make([]string, 0, len(r.cfg.Aliases))
+	for name := range r.cfg.Aliases {
+		aliasNames = append(aliasNames, name)
+	}
+	sort.Strings(aliasNames)
+	for _, name := range aliasNames {
+		out = append(out, *aliasToInfo(name, r.cfg.Aliases[name]))
+		seen[name] = true
+	}
+	return out, seen
+}
+
+// appendEntries appends inventory entries not already present (static aliases
+// win over inventory entries of the same name).
+func appendEntries(out []kube.ClusterInfo, seen map[string]bool, entries []hostname.Entry) []kube.ClusterInfo {
+	for i := range entries {
+		if seen[entries[i].Name] {
+			continue
+		}
+		out = append(out, *entryToInfo(&entries[i]))
+		seen[entries[i].Name] = true
+	}
+	return out
+}
+
+// aliasToInfo maps a static ClusterAlias to a ClusterInfo.
+func aliasToInfo(name string, a config.ClusterAlias) *kube.ClusterInfo {
+	return &kube.ClusterInfo{
+		Name:            name,
+		APIServerURL:    a.Server,
+		ConsoleURL:      a.ConsoleURL,
+		AuthType:        kube.AuthType(a.AuthType),
+		OIDCAudience:    a.OIDCAudience,
+		DefaultHandler:  a.DefaultHandler,
+		CAData:          a.CAData,
+		InsecureSkipTLS: a.InsecureSkipTLS,
+	}
+}
+
+// entryToInfo maps a resolved inventory Entry to a ClusterInfo.
+func entryToInfo(e *hostname.Entry) *kube.ClusterInfo {
+	return &kube.ClusterInfo{
+		Name:            e.Name,
+		APIServerURL:    e.URL,
+		ConsoleURL:      e.ConsoleURL,
+		AuthType:        kube.AuthType(e.AuthType),
+		OIDCAudience:    e.Audience,
+		DefaultHandler:  e.DefaultHandler,
+		CAData:          e.CAData,
+		InsecureSkipTLS: e.InsecureSkipTLS,
+	}
+}

--- a/pkg/kube/clusterconfig/resolver_test.go
+++ b/pkg/kube/clusterconfig/resolver_test.go
@@ -1,0 +1,303 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package clusterconfig
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth/hostname"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/kube"
+)
+
+// inventoryDeps returns hostname.Deps that yield the given entries without any
+// network access.
+func inventoryDeps(entries []hostname.Entry) hostname.Deps {
+	return hostname.Deps{
+		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) {
+			return []byte("{}"), nil
+		},
+		Transform: func(context.Context, string, []byte) ([]hostname.Entry, error) {
+			return entries, nil
+		},
+	}
+}
+
+func resolverConfig() *config.HostnameResolverConfig {
+	return &config.HostnameResolverConfig{
+		Source:    config.HostnameResolverSource{URL: "https://clusters.example.com"},
+		Transform: "_",
+	}
+}
+
+// fakeCache is an in-memory hostname.InventoryCache for exercising the cached
+// (non-fetching) completion path.
+type fakeCache struct {
+	entries []hostname.Entry
+	hit     bool
+}
+
+func (f *fakeCache) Get(context.Context, string) ([]hostname.Entry, bool) {
+	return f.entries, f.hit
+}
+
+func (f *fakeCache) Set(context.Context, string, []hostname.Entry, time.Duration) {}
+
+func TestResolver_ListCached_AliasesOnlyNoFetch(t *testing.T) {
+	t.Parallel()
+
+	fetched := false
+	deps := hostname.Deps{
+		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) {
+			fetched = true
+			return nil, errors.New("network must not be touched during completion")
+		},
+		// No cache: CachedInventory returns (nil,false) so inventory is skipped.
+	}
+	r := New(config.ClusterResolutionConfig{
+		Aliases:  map[string]config.ClusterAlias{"lab": {Server: "https://api.lab:6443"}},
+		Resolver: resolverConfig(),
+	}, WithDeps(deps))
+
+	list := r.ListCached(context.Background())
+	require.Len(t, list, 1)
+	assert.Equal(t, "lab", list[0].Name)
+	assert.False(t, fetched, "ListCached must not trigger a network fetch")
+}
+
+func TestResolver_ListCached_UsesCachedInventory(t *testing.T) {
+	t.Parallel()
+
+	deps := hostname.Deps{
+		Cache: &fakeCache{
+			hit:     true,
+			entries: []hostname.Entry{{Name: "pd1020", URL: "https://api.pd:6443"}},
+		},
+		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) {
+			t.Fatal("Fetch must not be called when the inventory is cached")
+			return nil, nil
+		},
+	}
+	r := New(config.ClusterResolutionConfig{
+		Aliases:  map[string]config.ClusterAlias{"lab": {Server: "https://api.lab:6443"}},
+		Resolver: resolverConfig(),
+	}, WithDeps(deps))
+
+	list := r.ListCached(context.Background())
+	names := make([]string, len(list))
+	for i, c := range list {
+		names[i] = c.Name
+	}
+	assert.ElementsMatch(t, []string{"lab", "pd1020"}, names)
+}
+
+func TestResolver_Enabled(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, New(config.ClusterResolutionConfig{}).Enabled())
+	assert.True(t, New(config.ClusterResolutionConfig{
+		Aliases: map[string]config.ClusterAlias{"lab": {Server: "https://api.lab:6443"}},
+	}).Enabled())
+	assert.True(t, New(config.ClusterResolutionConfig{Resolver: resolverConfig()}).Enabled())
+}
+
+func TestResolver_Resolve_Alias(t *testing.T) {
+	t.Parallel()
+
+	r := New(config.ClusterResolutionConfig{
+		Aliases: map[string]config.ClusterAlias{
+			"lab": {
+				Server:          "https://api.lab.example.com:6443",
+				DefaultHandler:  "openshift",
+				AuthType:        "oauth",
+				OIDCAudience:    "lab-aud",
+				CAData:          "ca-bytes",
+				ConsoleURL:      "https://console.lab.example.com",
+				InsecureSkipTLS: true,
+			},
+		},
+	})
+
+	info, err := r.Resolve(context.Background(), "lab")
+	require.NoError(t, err)
+	assert.Equal(t, "lab", info.Name)
+	assert.Equal(t, "https://api.lab.example.com:6443", info.APIServerURL)
+	assert.Equal(t, "openshift", info.DefaultHandler)
+	assert.Equal(t, kube.AuthTypeOAuth, info.AuthType)
+	assert.Equal(t, "lab-aud", info.OIDCAudience)
+	assert.Equal(t, "ca-bytes", info.CAData)
+	assert.Equal(t, "https://console.lab.example.com", info.ConsoleURL)
+	assert.True(t, info.InsecureSkipTLS)
+}
+
+func TestResolver_Resolve_Inventory(t *testing.T) {
+	t.Parallel()
+
+	deps := inventoryDeps([]hostname.Entry{
+		{Name: "pd1020", URL: "https://api.pd.example.com:6443", DefaultHandler: "openshift", AuthType: "oauth", Audience: "pd-aud"},
+	})
+	r := New(config.ClusterResolutionConfig{Resolver: resolverConfig()}, WithDeps(deps))
+
+	info, err := r.Resolve(context.Background(), "pd1020")
+	require.NoError(t, err)
+	assert.Equal(t, "pd1020", info.Name)
+	assert.Equal(t, "https://api.pd.example.com:6443", info.APIServerURL)
+	assert.Equal(t, "openshift", info.DefaultHandler)
+	assert.Equal(t, kube.AuthTypeOAuth, info.AuthType)
+	assert.Equal(t, "pd-aud", info.OIDCAudience)
+}
+
+func TestResolver_Resolve_AliasWinsOverInventory(t *testing.T) {
+	t.Parallel()
+
+	deps := inventoryDeps([]hostname.Entry{
+		{Name: "prod", URL: "https://inventory.example.com:6443", DefaultHandler: "entra"},
+	})
+	r := New(config.ClusterResolutionConfig{
+		Aliases:  map[string]config.ClusterAlias{"prod": {Server: "https://alias.example.com:6443", DefaultHandler: "openshift"}},
+		Resolver: resolverConfig(),
+	}, WithDeps(deps))
+
+	info, err := r.Resolve(context.Background(), "prod")
+	require.NoError(t, err)
+	assert.Equal(t, "https://alias.example.com:6443", info.APIServerURL,
+		"static alias must win over an inventory entry of the same name")
+	assert.Equal(t, "openshift", info.DefaultHandler)
+}
+
+func TestResolver_Resolve_NotFound(t *testing.T) {
+	t.Parallel()
+
+	r := New(config.ClusterResolutionConfig{
+		Aliases: map[string]config.ClusterAlias{"lab": {Server: "https://api.lab:6443"}},
+	})
+
+	_, err := r.Resolve(context.Background(), "missing")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrClusterNotFound)
+}
+
+func TestResolver_Resolve_InventoryMiss(t *testing.T) {
+	t.Parallel()
+
+	deps := inventoryDeps([]hostname.Entry{
+		{Name: "pd1020", URL: "https://api.pd.example.com:6443"},
+	})
+	r := New(config.ClusterResolutionConfig{Resolver: resolverConfig()}, WithDeps(deps))
+
+	_, err := r.Resolve(context.Background(), "nope")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrClusterNotFound,
+		"an inventory miss must normalize to ErrClusterNotFound like an alias miss")
+}
+
+func TestResolver_Resolve_AliasMissingServer(t *testing.T) {
+	t.Parallel()
+
+	// A static alias with no server is a config mistake; resolving it must fail
+	// with a targeted message rather than flowing through as an empty server.
+	r := New(config.ClusterResolutionConfig{
+		Aliases: map[string]config.ClusterAlias{"lab": {DefaultHandler: "openshift"}},
+	})
+
+	_, err := r.Resolve(context.Background(), "lab")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cluster alias \"lab\" is missing a server")
+}
+
+func TestResolver_Resolve_InventoryFetchError(t *testing.T) {
+	t.Parallel()
+
+	// A non-not-found inventory failure (e.g. network down) is surfaced as-is,
+	// not normalized to ErrClusterNotFound.
+	failDeps := hostname.Deps{
+		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) {
+			return nil, errors.New("network down")
+		},
+	}
+	r := New(config.ClusterResolutionConfig{Resolver: resolverConfig()}, WithDeps(failDeps))
+
+	_, err := r.Resolve(context.Background(), "prod")
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrClusterNotFound)
+	assert.Contains(t, err.Error(), "resolve cluster \"prod\" from inventory")
+}
+
+func TestResolver_Resolve_EmptyName(t *testing.T) {
+	t.Parallel()
+
+	_, err := New(config.ClusterResolutionConfig{}).Resolve(context.Background(), "")
+	require.Error(t, err)
+}
+
+func TestResolver_List(t *testing.T) {
+	t.Parallel()
+
+	deps := inventoryDeps([]hostname.Entry{
+		{Name: "prod", URL: "https://inventory-prod:6443"}, // shadowed by alias
+		{Name: "stage", URL: "https://inventory-stage:6443", DefaultHandler: "openshift"},
+	})
+	r := New(config.ClusterResolutionConfig{
+		Aliases: map[string]config.ClusterAlias{
+			"lab":  {Server: "https://api.lab:6443"},
+			"prod": {Server: "https://alias-prod:6443"},
+		},
+		Resolver: resolverConfig(),
+	}, WithDeps(deps))
+
+	list, err := r.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, list, 3)
+
+	byName := map[string]kube.ClusterInfo{}
+	for _, c := range list {
+		byName[c.Name] = c
+	}
+	// Aliases come first, sorted; alias "prod" shadows the inventory entry.
+	assert.Equal(t, "lab", list[0].Name)
+	assert.Equal(t, "prod", list[1].Name)
+	assert.Equal(t, "https://alias-prod:6443", byName["prod"].APIServerURL)
+	assert.Equal(t, "https://inventory-stage:6443", byName["stage"].APIServerURL)
+}
+
+func TestResolver_List_AliasesOnly(t *testing.T) {
+	t.Parallel()
+
+	r := New(config.ClusterResolutionConfig{
+		Aliases: map[string]config.ClusterAlias{
+			"b": {Server: "https://b:6443"},
+			"a": {Server: "https://a:6443"},
+		},
+	})
+	list, err := r.List(context.Background())
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+	assert.Equal(t, "a", list[0].Name, "aliases must be sorted")
+	assert.Equal(t, "b", list[1].Name)
+}
+
+func TestResolver_List_InventoryErrorReturnsAliases(t *testing.T) {
+	t.Parallel()
+
+	failDeps := hostname.Deps{
+		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) {
+			return nil, errors.New("network down")
+		},
+	}
+	r := New(config.ClusterResolutionConfig{
+		Aliases:  map[string]config.ClusterAlias{"lab": {Server: "https://api.lab:6443"}},
+		Resolver: resolverConfig(),
+	}, WithDeps(failDeps))
+
+	list, err := r.List(context.Background())
+	require.Error(t, err)
+	require.Len(t, list, 1, "static aliases must still be returned when inventory fetch fails")
+	assert.Equal(t, "lab", list[0].Name)
+}

--- a/pkg/kube/login/login.go
+++ b/pkg/kube/login/login.go
@@ -240,8 +240,15 @@ func Login(ctx context.Context, deps Deps, req Request) (*Result, error) {
 	// Name the kubeconfig entries. Unlike resolveCluster (which derives the
 	// logical identity used to look the cluster up, so req.Cluster wins), the
 	// explicit --cluster-name flag takes precedence here because its sole
-	// purpose is to override the written kubeconfig entry name.
-	clusterName := firstNonEmpty(req.ClusterName, req.Cluster, info.Name)
+	// purpose is to override the written kubeconfig entry name. A positional
+	// that is a concrete API server URL is not a usable entry name (and can
+	// exceed the provider's cluster_name limit), so it is ignored in favor of
+	// the host-derived info.Name.
+	positional := req.Cluster
+	if isConcreteClusterURL(positional) {
+		positional = ""
+	}
+	clusterName := firstNonEmpty(req.ClusterName, positional, info.Name)
 	contextName := firstNonEmpty(req.ContextName, clusterName)
 	userName := firstNonEmpty(req.UserName, clusterName)
 
@@ -257,9 +264,12 @@ func Login(ctx context.Context, deps Deps, req Request) (*Result, error) {
 		InteractiveMode: interactiveModeFor(info.AuthType),
 		InstallHint:     buildInstallHint(binaryName),
 		// Ask kubectl/oc to pass the target cluster's details (API server URL)
-		// via KUBERNETES_EXEC_INFO so the exec helper can route per-cluster
-		// tokens. Handlers that do not advertise CapTokenHostname simply ignore
-		// the extra info.
+		// to the exec plugin via KUBERNETES_EXEC_INFO. The exec helper
+		// (auth token --exec-credential) reads that server and forwards it as
+		// TokenOptions.Hostname only for handlers advertising CapTokenHostname;
+		// for handlers without the capability the host withholds it, so they
+		// behave exactly as before. Handlers never read KUBERNETES_EXEC_INFO
+		// directly.
 		ProvideClusterInfo: true,
 		CAData:             info.CAData,
 		InsecureSkipTLS:    info.InsecureSkipTLS,

--- a/pkg/kube/login/login_test.go
+++ b/pkg/kube/login/login_test.go
@@ -299,6 +299,43 @@ func TestLogin_ProvideClusterInfoAlwaysSet(t *testing.T) {
 		"kube login must set provideClusterInfo so kubectl passes cluster details via KUBERNETES_EXEC_INFO")
 }
 
+func TestLogin_DirectURLDerivesEntryNames(t *testing.T) {
+	t.Parallel()
+
+	// `kube login https://api.example.com:6443` (positional is a concrete URL):
+	// the kubeconfig entries must be named with the derived host, not the raw
+	// URL, which is not a usable entry name and can exceed cluster_name limits.
+	handler := &stubAuth{name: "oidc"}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+	deps := Deps{Handler: handler, Kubeconfig: kc}
+
+	_, err := Login(context.Background(), deps, Request{
+		Cluster: "https://api.example.com:6443",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "api.example.com", kc.writeIn.ClusterName)
+	assert.Equal(t, "api.example.com", kc.writeIn.ContextName)
+	assert.Equal(t, "api.example.com", kc.writeIn.UserName)
+	assert.Equal(t, "https://api.example.com:6443", kc.writeIn.Server)
+}
+
+func TestLogin_ClusterNameFlagOverridesDerivedURLName(t *testing.T) {
+	t.Parallel()
+
+	// An explicit --cluster-name still wins over the host-derived name for the
+	// direct URL form.
+	handler := &stubAuth{name: "oidc"}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+	deps := Deps{Handler: handler, Kubeconfig: kc}
+
+	_, err := Login(context.Background(), deps, Request{
+		Cluster:     "https://api.example.com:6443",
+		ClusterName: "prod",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "prod", kc.writeIn.ClusterName)
+}
+
 func TestLogin_SupportsPerClusterTokens(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/kube/login/resolve.go
+++ b/pkg/kube/login/resolve.go
@@ -20,17 +20,29 @@ import (
 func resolveCluster(ctx context.Context, deps Deps, req Request) (kube.ClusterInfo, error) {
 	var info kube.ClusterInfo
 
-	if req.Cluster != "" && deps.Resolver != nil {
-		resolved, err := deps.Resolver.Resolve(ctx, req.Cluster)
-		if err != nil {
-			return kube.ClusterInfo{}, fmt.Errorf("resolve cluster %q: %w", req.Cluster, err)
-		}
-		if resolved != nil {
+	// A concrete http(s) URL argument is used directly as the API server (no
+	// resolver required), and is not treated as the logical cluster name.
+	clusterArg := req.Cluster
+	switch {
+	case clusterArg != "" && isConcreteClusterURL(clusterArg):
+		info.APIServerURL = clusterArg
+		clusterArg = ""
+	case clusterArg != "" && deps.Resolver != nil:
+		resolved, err := deps.Resolver.Resolve(ctx, clusterArg)
+		switch {
+		case err != nil && req.Server != "":
+			// An explicit --server supplies the connection details, so a
+			// resolver miss (an unlisted name or an unavailable dynamic
+			// inventory) is non-fatal here: fall back to treating the
+			// positional as a plain cluster name.
+		case err != nil:
+			return kube.ClusterInfo{}, fmt.Errorf("resolve cluster %q: %w", clusterArg, err)
+		case resolved != nil:
 			info = *resolved
 		}
 	}
 	if info.Name == "" {
-		info.Name = firstNonEmpty(req.Cluster, req.ClusterName)
+		info.Name = firstNonEmpty(clusterArg, req.ClusterName)
 	}
 
 	if req.Server != "" {
@@ -76,6 +88,14 @@ func resolveCluster(ctx context.Context, deps Deps, req Request) (kube.ClusterIn
 		return kube.ClusterInfo{}, err
 	}
 	return info, nil
+}
+
+// isConcreteClusterURL reports whether the cluster argument is already an
+// absolute http(s) URL, in which case it is used directly as the API server
+// endpoint rather than resolved by name.
+func isConcreteClusterURL(s string) bool {
+	u, err := url.Parse(s)
+	return err == nil && (u.Scheme == "https" || u.Scheme == "http") && u.Host != ""
 }
 
 // clusterNameFromServer derives a kubeconfig entry name from an API server URL,

--- a/pkg/kube/login/resolve_test.go
+++ b/pkg/kube/login/resolve_test.go
@@ -54,6 +54,24 @@ func TestResolveCluster_NoResolverUsesFlags(t *testing.T) {
 	assert.Equal(t, "https://api.example.com:6443", info.APIServerURL)
 }
 
+func TestResolveCluster_ConcreteURLArgumentPassthrough(t *testing.T) {
+	t.Parallel()
+
+	// A cluster argument that is already an http(s) URL is used directly as the
+	// API server without consulting the resolver, and is not used as the name.
+	resolver := &kube.MockResolver{ResolveResult: &kube.ClusterInfo{Name: "should-not-run"}}
+	deps := Deps{Resolver: resolver, Kubeconfig: &stubKube{}}
+
+	info, err := resolveCluster(context.Background(), deps, Request{
+		Cluster: "https://api.direct.example.com:6443",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.direct.example.com:6443", info.APIServerURL)
+	assert.Equal(t, "api.direct.example.com", info.Name,
+		"a URL argument must derive the name from the host, not use the raw URL")
+	assert.Empty(t, resolver.ResolveCalls, "a concrete URL argument must bypass the resolver")
+}
+
 func TestResolveCluster_MissingServer(t *testing.T) {
 	t.Parallel()
 
@@ -144,4 +162,37 @@ func TestResolveCluster_InsecureSkipTLSClearsResolverCAData(t *testing.T) {
 	// explicit insecure flag is honored.
 	assert.True(t, info.InsecureSkipTLS)
 	assert.Empty(t, info.CAData)
+}
+
+func TestResolveCluster_ServerOverrideMakesResolverMissNonFatal(t *testing.T) {
+	t.Parallel()
+
+	// `kube login scratch --server https://... --handler oidc`: the positional
+	// is not a known alias, but the explicit --server supplies the connection,
+	// so the resolver miss must be non-fatal and the positional is used as the
+	// plain cluster name.
+	resolver := &kube.MockResolver{ResolveErr: errors.New("cluster not found")}
+	deps := Deps{Resolver: resolver, Kubeconfig: &stubKube{}}
+
+	info, err := resolveCluster(context.Background(), deps, Request{
+		Cluster: "scratch",
+		Server:  "https://api.scratch.example.com:6443",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "scratch", info.Name)
+	assert.Equal(t, "https://api.scratch.example.com:6443", info.APIServerURL)
+	assert.Equal(t, []string{"scratch"}, resolver.ResolveCalls)
+}
+
+func TestResolveCluster_ResolverMissFatalWithoutServer(t *testing.T) {
+	t.Parallel()
+
+	// Without an explicit --server, a resolver miss stays fatal so the user is
+	// told the name could not be resolved.
+	resolver := &kube.MockResolver{ResolveErr: errors.New("cluster not found")}
+	deps := Deps{Resolver: resolver, Kubeconfig: &stubKube{}}
+
+	_, err := resolveCluster(context.Background(), deps, Request{Cluster: "scratch"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolve cluster \"scratch\"")
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2183,6 +2183,35 @@ func TestIntegration_LoginMissingHandler(t *testing.T) {
 	assert.Contains(t, stderr, "auth handler is required")
 }
 
+func TestIntegration_LoginResolvesClusterFromConfigAlias(t *testing.T) {
+	t.Parallel()
+	// A kube.clusters static alias supplies the server and default handler, so
+	// `kube login <alias>` resolves without --server or --handler. Login still
+	// fails later (the openshift handler plugin is not installed), but it must
+	// get PAST cluster resolution -- i.e. never hit the "no cluster server
+	// resolved" error.
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	seed := `kube:
+  clusters:
+    aliases:
+      lab:
+        server: https://api.lab.example.com:6443
+        defaultHandler: openshift
+`
+	require.NoError(t, os.WriteFile(configPath, []byte(seed), 0o600))
+
+	_, stderr, exitCode := runScafctl(t, "--config", configPath, "kube", "login", "lab")
+
+	// Do not assert on the exit code: the goal is only that cluster resolution
+	// succeeds. Login may fail later (the openshift handler plugin is not
+	// installed) or, in some environments, get further -- either way it must
+	// never hit the "no cluster server resolved" error.
+	_ = exitCode
+	assert.NotContains(t, stderr, "no cluster server resolved",
+		"the config alias must supply the server so resolution succeeds")
+}
+
 func TestIntegration_LogoutHelp(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "kube", "logout", "--help")


### PR DESCRIPTION
Resolve kube clusters by name from config -- map short aliases to API server URLs, handlers, and auth settings, with dynamic hostname inventory as a fallback and a concrete-URL escape hatch.

- Add Kube.Clusters config: static aliases (server, handler, authType, OIDC audience, CA data, console URL, TLS skip) plus an optional hostname resolver for dynamic inventory
- Add clusterconfig.Resolver implementing kube.ClusterResolver; alias matches take precedence over inventory, with a concrete API-server URL passed through directly (no lookup)
- Wire the config resolver into the root command, preferring an embedder-supplied resolver when present
- Add shell completion of cluster names for `kube login`/`kube logout`, using cached inventory only so <TAB> never blocks on a network fetch
- Add hostname.DefaultDeps, ResolveInventory, and cache-only CachedInventory to back list/completion without forcing a fetch
- Document config-driven resolution in the kube auth design doc, tutorial, and login example

Closes #582
Relates to #560
