### PR TITLE
feat(provider): add built-in ignore markers and token mode to go-template

### DIFF
--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -1294,7 +1294,7 @@ resolve:
 - `missingKey`: Behavior when a map key is missing: `default`, `zero`, or `error`
 - `leftDelim`, `rightDelim`: Custom delimiters (default: `{{` and `}}`)
 - `data`: Additional data to merge with resolver context
-- `ignoredBlocks`: Blocks to pass through without template processing
+- `ignoredBlocks`: Extra literal pass-through markers (start/end, line, or token). Built-in zero-config markers (`{{/* scafctl:ignore:start */}}`...`{{/* scafctl:ignore:end */}}` and `# scafctl:ignore`) need no declaration
 
 **`render-tree` inputs:**
 - `entries` (required): Array of `{path, content}` objects (typically from the directory provider with `includeContent: true`)

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -2396,6 +2396,32 @@ The AI calls `list_go_template_functions` and returns a curated list of matching
 
 When templates contain syntax that conflicts with Go template delimiters (e.g., Terraform `${}`, Helm double braces, GitHub Actions `${{ }}`, or PromQL), you can preserve those sections literally using `ignoredBlocks`.
 
+### Built-in Markers (Zero Config)
+
+Two markers are recognized automatically -- you do **not** need to declare them in `ignoredBlocks`:
+
+- **Fence:** `{{/* scafctl:ignore:start */}}` ... `{{/* scafctl:ignore:end */}}` -- everything between the markers passes through unchanged, and the markers themselves are **stripped** from the output. Because the markers use Go template comment syntax, the template stays valid even if the feature is unused.
+- **Per-line:** `# scafctl:ignore` -- any line containing this substring is preserved verbatim (the marker stays as a trailing comment).
+
+```yaml
+transform:
+  with:
+    - provider: go-template
+      inputs:
+        name: builtin-markers
+        template: |
+          app: {{ .appName }}
+          {{/* scafctl:ignore:start */}}
+          raw = "${not.parsed.by.go}"
+          {{/* scafctl:ignore:end */}}
+          token: ${{ secrets.TOKEN }}  # scafctl:ignore
+        # No ignoredBlocks needed -- built-in markers are always on.
+```
+
+The rendered output drops the fence markers but keeps the `raw = ...` line and the `${{ secrets.TOKEN }}` line intact.
+
+Use the explicit `ignoredBlocks` modes below when you need **custom** markers or a literal **token**.
+
 ### Start/End Mode (Multi-line)
 
 Define pairs of start/end markers. Content between matched markers passes through without template processing:
@@ -2422,6 +2448,27 @@ transform:
 ```
 
 The markers themselves are preserved in the output. The content between them — including Go template-like syntax, interpolations, and special characters — passes through unchanged.
+
+> [!NOTE]
+> **Custom start/end markers are preserved** in the output (unlike the built-in fence, which strips its markers). Choose markers that are valid comments in the target file format.
+
+### Token Mode (Literal Substring)
+
+When a specific literal substring should always pass through -- wherever it appears -- use `token`. Every occurrence of the exact substring is preserved:
+
+```yaml
+transform:
+  with:
+    - provider: go-template
+      inputs:
+        name: literal-tokens
+        template: |
+          service: {{ .name }}
+          url: ${LITERAL}/api
+          fallback: ${LITERAL}/health
+        ignoredBlocks:
+          - token: "${LITERAL}"
+```
 
 ### Line Mode (Single-line)
 
@@ -2450,7 +2497,7 @@ transform:
 Append the marker as an inline comment on any line that should be ignored. Only those lines are protected — the rest of the template renders normally.
 
 > [!NOTE]
-> **Note:** `line` and `start`/`end` are mutually exclusive within a single entry. Different entries can use different modes.
+> **Note:** `line`, `start`/`end`, and `token` are mutually exclusive within a single entry. Different entries can use different modes.
 
 ### Multiple Ignored Blocks
 

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -1169,7 +1169,7 @@ Transform data using Go text/template syntax. Supports single-template rendering
 | `leftDelim` | string | ❌ | Left delimiter (default: `{{`) |
 | `rightDelim` | string | ❌ | Right delimiter (default: `}}`) |
 | `data` | any | ❌ | Additional data to merge with resolver context |
-| `ignoredBlocks` | array | ❌ | Blocks to pass through literally without template processing. Each entry uses EITHER `{ start, end }` markers (multi-line) OR `{ line }` marker (single-line). Content is preserved as-is. |
+| `ignoredBlocks` | array | ❌ | Extra literal pass-through markers (on top of the always-on built-ins). Each entry uses EXACTLY ONE mode: `{ start, end }` (multi-line, markers preserved), `{ line }` (single-line), or `{ token }` (every occurrence of a literal). Built-in zero-config markers `{{/* scafctl:ignore:start */}}`...`{{/* scafctl:ignore:end */}}` (markers stripped) and `# scafctl:ignore` (per-line) need no declaration. |
 
 ### Output
 

--- a/examples/resolvers/go-template-ignored-blocks.yaml
+++ b/examples/resolvers/go-template-ignored-blocks.yaml
@@ -11,8 +11,10 @@ metadata:
     - template
   description: |
     Preserve literal content that conflicts with Go template delimiters
-    using ignoredBlocks. Two modes: start/end for multi-line blocks,
-    or line for single-line markers.
+    using ignoredBlocks. Modes: start/end for multi-line blocks, line for
+    single-line markers, and token for a literal substring. The built-in
+    zero-config fence ({{/* scafctl:ignore:start */}} ... {{/* scafctl:ignore:end */}})
+    and per-line marker (# scafctl:ignore) need no declaration.
 
 spec:
   resolvers:
@@ -84,3 +86,45 @@ spec:
                       - run: echo ${{ github.sha }}  # scafctl:ignore
               ignoredBlocks:
                 - line: "# scafctl:ignore"
+
+    # --- built-in fence: zero-config, markers stripped from output ---
+    builtinFence:
+      description: Uses the always-on built-in fence -- no ignoredBlocks needed
+      dependsOn: [appName]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: builtin-fence
+              template: |
+                app: {{ .appName }}
+                {{/* scafctl:ignore:start */}}
+                raw_block = "${not.parsed.by.go}"
+                {{/* scafctl:ignore:end */}}
+                token: ${{ secrets.TOKEN }}  # scafctl:ignore
+
+    # --- token mode: preserve every occurrence of a literal substring ---
+    literalTokens:
+      description: Preserve a literal token wherever it appears
+      dependsOn: [appName]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: tokens
+              template: |
+                service: {{ .appName }}
+                url: ${LITERAL}/api
+                healthcheck: ${LITERAL}/health
+              ignoredBlocks:
+                - token: "${LITERAL}"

--- a/pkg/gotmpl/gotmpl.go
+++ b/pkg/gotmpl/gotmpl.go
@@ -109,6 +109,12 @@ type Replacement struct {
 	// Replace is the temporary replacement value
 	// If empty, a UUID will be generated automatically
 	Replace string `json:"replace,omitempty" yaml:"replace,omitempty" doc:"Temporary replacement value; if empty, a UUID is generated" maxLength:"4096"`
+
+	// RestoreAs is the value written back into the output after execution.
+	// If empty, Find is restored verbatim (the default). Set this to restore a
+	// different value than what was matched -- e.g. to strip fence markers while
+	// preserving only the inner content of a protected block.
+	RestoreAs string `json:"restoreAs,omitempty" yaml:"restoreAs,omitempty" doc:"Value restored into the output after execution; if empty, Find is restored verbatim" maxLength:"1048576"`
 }
 
 // ExecuteResult contains the result of template execution
@@ -344,10 +350,15 @@ func (s *Service) applyReplacements(ctx context.Context, content string, replace
 			continue
 		}
 
-		// Apply replacement
+		// Apply replacement. RestoreAs controls what is written back after
+		// execution; when empty the matched text (Find) is restored verbatim.
+		restoreValue := r.Find
+		if r.RestoreAs != "" {
+			restoreValue = r.RestoreAs
+		}
 		count := strings.Count(modified, r.Find)
 		modified = strings.ReplaceAll(modified, r.Find, placeholder)
-		reversalMap[placeholder] = r.Find
+		reversalMap[placeholder] = restoreValue
 
 		lgr.V(2).Info("applied replacement",
 			"index", i,

--- a/pkg/gotmpl/gotmpl_test.go
+++ b/pkg/gotmpl/gotmpl_test.go
@@ -301,6 +301,24 @@ func TestService_Execute_Replacements(t *testing.T) {
 			data: map[string]any{"Items": []string{"a", "b"}},
 			want: "a b KEEP_THIS",
 		},
+		{
+			name:    "restoreAs strips markers",
+			content: "before <RAW>{{ .notParsed }}</RAW> after",
+			replacements: []Replacement{
+				{Find: "<RAW>{{ .notParsed }}</RAW>", RestoreAs: "{{ .notParsed }}"},
+			},
+			data: map[string]any{},
+			want: "before {{ .notParsed }} after",
+		},
+		{
+			name:    "restoreAs empty falls back to find",
+			content: "keep VERBATIM here",
+			replacements: []Replacement{
+				{Find: "VERBATIM", RestoreAs: ""},
+			},
+			data: map[string]any{},
+			want: "keep VERBATIM here",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/provider/builtin/gotmplprovider/gotmpl.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl.go
@@ -28,6 +28,19 @@ const (
 	OperationRender = "render"
 	// OperationRenderTree is the batch render operation for directory trees.
 	OperationRenderTree = "render-tree"
+
+	// DefaultRawStart is the built-in, zero-config fence start marker. Content
+	// between DefaultRawStart and DefaultRawEnd is preserved verbatim (never
+	// parsed as a Go template) and the markers themselves are stripped from the
+	// output. It uses Go template comment syntax so the template remains valid
+	// even when the fence is unused. No ignoredBlocks declaration is required.
+	DefaultRawStart = "{{/* scafctl:ignore:start */}}"
+	// DefaultRawEnd is the built-in, zero-config fence end marker. See DefaultRawStart.
+	DefaultRawEnd = "{{/* scafctl:ignore:end */}}"
+	// DefaultRawLine is the built-in, zero-config per-line marker. Any line
+	// containing this substring is preserved verbatim (marker included, as a
+	// harmless trailing comment). No ignoredBlocks declaration is required.
+	DefaultRawLine = "# scafctl:ignore"
 )
 
 // GoTemplateProvider provides data transformation using Go templates
@@ -102,19 +115,22 @@ func NewGoTemplateProvider() *GoTemplateProvider {
 					schemahelper.WithMaxLength(*ptrs.IntPtr(10))),
 				"data": schemahelper.AnyProp("Additional data to merge with resolver context. These values are accessible alongside resolver data in the template."),
 				"ignoredBlocks": schemahelper.ArrayProp(
-					"List of literal blocks to preserve without template parsing. Each entry uses EITHER start/end markers (for multi-line blocks) OR a line marker (for single-line matches). Content is passed through unchanged. Useful for templates containing syntax like Terraform for_each or GitHub Actions expressions that conflict with Go template delimiters.",
+					"Additional literal blocks to preserve without template parsing, on top of the always-on built-in markers. Built-in (zero-config) markers are recognized without any declaration: fence '{{/* scafctl:ignore:start */}}' ... '{{/* scafctl:ignore:end */}}' (markers stripped from output) and per-line '# scafctl:ignore'. Use this list to declare EXTRA markers. Each entry uses EXACTLY ONE mode: start/end (multi-line, markers preserved), line (single-line matches), or token (every literal occurrence of a substring). Useful for templates containing syntax like Terraform for_each or GitHub Actions expressions that conflict with Go template delimiters.",
 					schemahelper.WithItems(schemahelper.ObjectProp(
-						"A block to exclude from template parsing. Use 'start'+'end' for multi-line ranges, or 'line' for single-line matches. These modes are mutually exclusive.",
+						"A block to exclude from template parsing. Use 'start'+'end' for multi-line ranges, 'line' for single-line matches, or 'token' for every occurrence of a literal substring. These modes are mutually exclusive.",
 						nil,
 						map[string]*jsonschema.Schema{
-							"start": schemahelper.StringProp("Start marker for a multi-line ignored block (e.g., '/*scafctl:ignore:start*/'). Must be paired with 'end'. Mutually exclusive with 'line'.",
+							"start": schemahelper.StringProp("Start marker for a multi-line ignored block (e.g., '/*scafctl:ignore:start*/'). Must be paired with 'end'. Mutually exclusive with 'line' and 'token'.",
 								schemahelper.WithExample("/*scafctl:ignore:start*/"),
 								schemahelper.WithMaxLength(*ptrs.IntPtr(255))),
-							"end": schemahelper.StringProp("End marker for a multi-line ignored block (e.g., '/*scafctl:ignore:end*/'). Must be paired with 'start'. Mutually exclusive with 'line'.",
+							"end": schemahelper.StringProp("End marker for a multi-line ignored block (e.g., '/*scafctl:ignore:end*/'). Must be paired with 'start'. Mutually exclusive with 'line' and 'token'.",
 								schemahelper.WithExample("/*scafctl:ignore:end*/"),
 								schemahelper.WithMaxLength(*ptrs.IntPtr(255))),
-							"line": schemahelper.StringProp("Marker that identifies lines to ignore individually. Every line containing this substring is preserved literally. Mutually exclusive with 'start'/'end'.",
+							"line": schemahelper.StringProp("Marker that identifies lines to ignore individually. Every line containing this substring is preserved literally. Mutually exclusive with 'start'/'end' and 'token'.",
 								schemahelper.WithExample("# scafctl:ignore"),
+								schemahelper.WithMaxLength(*ptrs.IntPtr(255))),
+							"token": schemahelper.StringProp("Literal token to preserve wherever it appears. Every occurrence of this exact substring is passed through unchanged. Mutually exclusive with 'start'/'end' and 'line'.",
+								schemahelper.WithExample("${LITERAL}"),
 								schemahelper.WithMaxLength(*ptrs.IntPtr(255))),
 						},
 					)),
@@ -253,6 +269,33 @@ inputs:
     - line: "# scafctl:ignore"`,
 				},
 				{
+					Name:        "Built-in fence (zero-config, markers stripped)",
+					Description: "Preserve a block literally using the always-on built-in fence. No ignoredBlocks declaration is needed, and the fence markers are stripped from the output.",
+					YAML: `name: builtin-fence
+provider: go-template
+inputs:
+  name: terraform-config
+  template: |
+    name = "{{.appName}}"
+    {{/* scafctl:ignore:start */}}
+    for_each = { for k, v in var.items : k => v }
+    {{/* scafctl:ignore:end */}}`,
+				},
+				{
+					Name:        "Token mode (literal substring pass-through)",
+					Description: "Preserve every occurrence of a literal substring without wrapping each in markers. Useful when a placeholder like ${LITERAL} must survive rendering wherever it appears.",
+					YAML: `name: literal-tokens
+provider: go-template
+inputs:
+  name: tokens
+  template: |
+    service: {{.appName}}
+    url: ${LITERAL}/api
+    healthcheck: ${LITERAL}/health
+  ignoredBlocks:
+    - token: "${LITERAL}"`,
+				},
+				{
 					Name:        "Render directory tree of templates",
 					Description: "Batch-render an array of file entries from the directory provider. Combine with the file provider's write-tree operation to write rendered files preserving directory structure.",
 					YAML: `name: rendered-templates
@@ -343,27 +386,14 @@ func (p *GoTemplateProvider) executeRender(ctx context.Context, inputs map[strin
 		"rightDelim", rightDelim)
 
 	// Extract ignored blocks for literal pass-through
-	ignoredBlocksCfg := p.parseIgnoredBlocksConfig(inputs)
+	ignoredBlocksCfg := parseIgnoredBlocksConfig(inputs)
 
 	// Validate mutual exclusion for ignored blocks
-	if blocks, ok := inputs["ignoredBlocks"].([]any); ok {
-		for i, block := range blocks {
-			blockMap, ok := block.(map[string]any)
-			if !ok {
-				continue
-			}
-			start, _ := blockMap["start"].(string)
-			end, _ := blockMap["end"].(string)
-			line, _ := blockMap["line"].(string)
-			hasStartEnd := start != "" || end != ""
-			hasLine := line != ""
-			if hasLine && hasStartEnd {
-				return nil, fmt.Errorf("%s: ignoredBlocks[%d]: 'line' and 'start'/'end' are mutually exclusive — use one mode per entry", ProviderName, i)
-			}
-		}
+	if err := validateIgnoredBlocks(inputs); err != nil {
+		return nil, err
 	}
 
-	replacements := p.buildIgnoredBlockReplacements(templateStr, ignoredBlocksCfg)
+	replacements := buildIgnoredBlockReplacements(templateStr, ignoredBlocksCfg)
 
 	// Execute the template
 	result, err := p.service.Execute(ctx, gotmpl.TemplateOptions{
@@ -457,8 +487,13 @@ func (p *GoTemplateProvider) executeRenderTree(ctx context.Context, inputs map[s
 		return nil, err
 	}
 
+	// Validate mutual exclusion for ignored blocks
+	if err := validateIgnoredBlocks(inputs); err != nil {
+		return nil, err
+	}
+
 	// Parse ignored blocks configuration (shared with render)
-	ignoredBlocksCfg := p.parseIgnoredBlocksConfig(inputs)
+	ignoredBlocksCfg := parseIgnoredBlocksConfig(inputs)
 
 	// Build base template data from resolver context + additional data
 	baseData := p.buildTemplateData(ctx, inputs)
@@ -507,7 +542,7 @@ func (p *GoTemplateProvider) executeRenderTree(ctx context.Context, inputs map[s
 		maps.Copy(templateData, baseData)
 
 		// Build ignored block replacements for this entry's content
-		replacements := p.buildIgnoredBlockReplacements(entryContent, ignoredBlocksCfg)
+		replacements := buildIgnoredBlockReplacements(entryContent, ignoredBlocksCfg)
 
 		// Render the entry content as a Go template
 		entryTemplateName := fmt.Sprintf("%s/%s", templateName, entryPath)
@@ -645,11 +680,71 @@ type ignoredBlockConfig struct {
 	start string
 	end   string
 	line  string
+	token string
+	// stripMarkers indicates the start/end markers should be removed from the
+	// output, restoring only the inner content. Used by the built-in fence.
+	stripMarkers bool
+}
+
+// builtinIgnoredBlockConfigs returns the always-on, zero-config ignored block
+// markers that are recognized without any ignoredBlocks declaration:
+//   - a fence ('{{/* scafctl:ignore:start */}}' ... '{{/* scafctl:ignore:end */}}')
+//     whose markers are stripped from the output, and
+//   - a per-line marker ('# scafctl:ignore') whose line is preserved verbatim.
+func builtinIgnoredBlockConfigs() []ignoredBlockConfig {
+	return []ignoredBlockConfig{
+		{start: DefaultRawStart, end: DefaultRawEnd, stripMarkers: true},
+		{line: DefaultRawLine},
+	}
+}
+
+// validateIgnoredBlocks enforces that each ignoredBlocks entry uses exactly one
+// mode: start/end, line, or token. The modes are mutually exclusive, at least
+// one mode must be set, and start/end must be declared as a pair.
+func validateIgnoredBlocks(inputs map[string]any) error {
+	blocks, ok := inputs["ignoredBlocks"].([]any)
+	if !ok {
+		return nil
+	}
+	for i, block := range blocks {
+		blockMap, ok := block.(map[string]any)
+		if !ok {
+			continue
+		}
+		start, _ := blockMap["start"].(string)
+		end, _ := blockMap["end"].(string)
+		line, _ := blockMap["line"].(string)
+		token, _ := blockMap["token"].(string)
+
+		hasStartEnd := start != "" || end != ""
+		hasLine := line != ""
+		hasToken := token != ""
+
+		modes := 0
+		if hasStartEnd {
+			modes++
+		}
+		if hasLine {
+			modes++
+		}
+		if hasToken {
+			modes++
+		}
+		switch {
+		case modes == 0:
+			return fmt.Errorf("%s: ignoredBlocks[%d]: no mode set -- use exactly one of 'start'/'end', 'line', or 'token'", ProviderName, i)
+		case modes > 1:
+			return fmt.Errorf("%s: ignoredBlocks[%d]: 'start'/'end', 'line', and 'token' are mutually exclusive -- use one mode per entry", ProviderName, i)
+		case hasStartEnd && (start == "" || end == ""):
+			return fmt.Errorf("%s: ignoredBlocks[%d]: 'start' and 'end' must both be set for start/end mode", ProviderName, i)
+		}
+	}
+	return nil
 }
 
 // parseIgnoredBlocksConfig parses the ignoredBlocks input into a config slice without
 // applying it to a specific template string. The actual replacements are built per-entry.
-func (p *GoTemplateProvider) parseIgnoredBlocksConfig(inputs map[string]any) []ignoredBlockConfig {
+func parseIgnoredBlocksConfig(inputs map[string]any) []ignoredBlockConfig {
 	blocks, ok := inputs["ignoredBlocks"].([]any)
 	if !ok {
 		return nil
@@ -665,11 +760,13 @@ func (p *GoTemplateProvider) parseIgnoredBlocksConfig(inputs map[string]any) []i
 		start, _ := blockMap["start"].(string)
 		end, _ := blockMap["end"].(string)
 		line, _ := blockMap["line"].(string)
+		token, _ := blockMap["token"].(string)
 
 		configs = append(configs, ignoredBlockConfig{
 			start: start,
 			end:   end,
 			line:  line,
+			token: token,
 		})
 	}
 
@@ -677,24 +774,31 @@ func (p *GoTemplateProvider) parseIgnoredBlocksConfig(inputs map[string]any) []i
 }
 
 // buildIgnoredBlockReplacements builds gotmpl.Replacement entries for a specific template
-// string based on the parsed ignored block config.
-func (p *GoTemplateProvider) buildIgnoredBlockReplacements(templateStr string, configs []ignoredBlockConfig) []gotmpl.Replacement {
+// string based on the parsed ignored block config. The always-on built-in markers are
+// applied in addition to the user-declared configs.
+//
+// Replacements are emitted in two passes: all start/end (fence) replacements first,
+// then all line/token replacements. Because applyReplacements consumes replacements in
+// order, this guarantees fenced regions are protected before any line/token scan runs,
+// so a token/line entry that overlaps a fence cannot mutate the fenced text and prevent
+// the fence from matching -- regardless of user entry order.
+//
+// Within each pass the always-on built-in markers are emitted before user-declared
+// configs. This preserves the "always-on" contract: a user cannot shadow or override
+// the built-in fence stripping (or the built-in per-line marker) by declaring the same
+// markers in ignoredBlocks, because the built-in replacement is consumed first.
+func buildIgnoredBlockReplacements(templateStr string, configs []ignoredBlockConfig) []gotmpl.Replacement {
 	var replacements []gotmpl.Replacement
 
-	for _, cfg := range configs {
-		hasStartEnd := cfg.start != "" || cfg.end != ""
-		hasLine := cfg.line != ""
+	// Always-on built-in markers first, then user-declared configs, so built-ins
+	// take priority and cannot be shadowed/mutated by user entries.
+	effective := make([]ignoredBlockConfig, 0, len(configs)+2)
+	effective = append(effective, builtinIgnoredBlockConfigs()...)
+	effective = append(effective, configs...)
 
-		if hasLine {
-			for _, templateLine := range strings.Split(templateStr, "\n") {
-				if strings.Contains(templateLine, cfg.line) {
-					replacements = append(replacements, gotmpl.Replacement{Find: templateLine})
-				}
-			}
-			continue
-		}
-
-		if !hasStartEnd || cfg.start == "" || cfg.end == "" {
+	// Pass 1: start/end fence replacements take precedence.
+	for _, cfg := range effective {
+		if cfg.start == "" || cfg.end == "" {
 			continue
 		}
 
@@ -709,9 +813,32 @@ func (p *GoTemplateProvider) buildIgnoredBlockReplacements(templateStr string, c
 			if endIdx < 0 {
 				break
 			}
+			inner := afterStart[:endIdx]
 			fullBlock := remaining[startIdx : startIdx+len(cfg.start)+endIdx+len(cfg.end)]
-			replacements = append(replacements, gotmpl.Replacement{Find: fullBlock})
+			repl := gotmpl.Replacement{Find: fullBlock}
+			if cfg.stripMarkers {
+				// Restore only the inner content, dropping the fence markers.
+				repl.RestoreAs = inner
+			}
+			replacements = append(replacements, repl)
 			remaining = remaining[startIdx+len(cfg.start)+endIdx+len(cfg.end):]
+		}
+	}
+
+	// Pass 2: line/token replacements, applied after fences are protected.
+	for _, cfg := range effective {
+		switch {
+		case cfg.token != "":
+			if strings.Contains(templateStr, cfg.token) {
+				replacements = append(replacements, gotmpl.Replacement{Find: cfg.token})
+			}
+
+		case cfg.line != "":
+			for _, templateLine := range strings.Split(templateStr, "\n") {
+				if strings.Contains(templateLine, cfg.line) {
+					replacements = append(replacements, gotmpl.Replacement{Find: templateLine})
+				}
+			}
 		}
 	}
 
@@ -770,6 +897,14 @@ func extractDependencies(inputs map[string]any) []string {
 	}
 	if rd, ok := inputs["rightDelim"].(string); ok && rd != "" {
 		rightDelim = rd
+	}
+
+	// Strip ignored/raw regions (built-in markers + declared ignoredBlocks)
+	// so that references inside literal pass-through blocks are not mistaken
+	// for resolver dependencies.
+	ignoredCfg := parseIgnoredBlocksConfig(inputs)
+	for _, repl := range buildIgnoredBlockReplacements(templateContent, ignoredCfg) {
+		templateContent = strings.ReplaceAll(templateContent, repl.Find, "")
 	}
 
 	// Use gotmpl package to extract references with the specified delimiters

--- a/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
@@ -571,19 +571,38 @@ func TestGoTemplateProvider_Execute_IgnoredBlocks_Empty(t *testing.T) {
 		"name": "test",
 	})
 
-	// Empty/invalid blocks should be silently skipped
-	inputs := map[string]any{
-		"name":     "empty-blocks-test",
-		"template": "Hello, {{.name}}!",
-		"ignoredBlocks": []any{
-			map[string]any{"start": "", "end": ""},
-			map[string]any{"start": "something", "end": ""},
+	// Empty/invalid blocks are rejected: an entry must declare exactly one mode,
+	// and start/end must be set as a pair.
+	tests := []struct {
+		name    string
+		block   map[string]any
+		wantErr string
+	}{
+		{
+			name:    "no mode set",
+			block:   map[string]any{"start": "", "end": ""},
+			wantErr: "no mode set",
+		},
+		{
+			name:    "start without end",
+			block:   map[string]any{"start": "something", "end": ""},
+			wantErr: "'start' and 'end' must both be set",
 		},
 	}
 
-	output, err := p.Execute(ctx, inputs)
-	require.NoError(t, err)
-	assert.Equal(t, "Hello, test!", output.Data)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputs := map[string]any{
+				"name":          "empty-blocks-test",
+				"template":      "Hello, {{.name}}!",
+				"ignoredBlocks": []any{tt.block},
+			}
+
+			_, err := p.Execute(ctx, inputs)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
 }
 
 func TestGoTemplateProvider_Execute_IgnoredBlocks_Line(t *testing.T) {
@@ -725,6 +744,266 @@ func TestGoTemplateProvider_Execute_IgnoredBlocks_Line_MixedEntries(t *testing.T
 	assert.Contains(t, result, "${{ secrets.KEY }}")
 	// Block-ignored content preserved
 	assert.Contains(t, result, "for k, v in var.x : k => v")
+}
+
+func TestGoTemplateProvider_Execute_BuiltinFence_StripsMarkers(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"name": "my-app",
+	})
+
+	// The built-in fence requires NO ignoredBlocks declaration and strips markers.
+	inputs := map[string]any{
+		"name": "builtin-fence-test",
+		"template": `name: {{.name}}
+{{/* scafctl:ignore:start */}}
+raw: {{ this.is.not.parsed }}
+{{/* scafctl:ignore:end */}}
+done: {{.name}}`,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	result, ok := output.Data.(string)
+	require.True(t, ok)
+
+	// Template variables rendered
+	assert.Contains(t, result, "name: my-app")
+	assert.Contains(t, result, "done: my-app")
+	// Inner content preserved verbatim
+	assert.Contains(t, result, "raw: {{ this.is.not.parsed }}")
+	// Fence markers stripped from output
+	assert.NotContains(t, result, "scafctl:ignore:start")
+	assert.NotContains(t, result, "scafctl:ignore:end")
+}
+
+func TestGoTemplateProvider_Execute_BuiltinFence_NotShadowedByUserConfig(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"name": "my-app",
+	})
+
+	// A user declares the SAME markers as the built-in fence. Because built-in
+	// configs take priority, the built-in marker stripping must still win -- the
+	// user's start/end entry (which preserves markers) cannot shadow it.
+	inputs := map[string]any{
+		"name": "builtin-fence-shadow-test",
+		"template": `name: {{.name}}
+{{/* scafctl:ignore:start */}}
+raw: {{ this.is.not.parsed }}
+{{/* scafctl:ignore:end */}}
+done: {{.name}}`,
+		"ignoredBlocks": []any{
+			map[string]any{
+				"start": "{{/* scafctl:ignore:start */}}",
+				"end":   "{{/* scafctl:ignore:end */}}",
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	result, ok := output.Data.(string)
+	require.True(t, ok)
+
+	// Template variables rendered
+	assert.Contains(t, result, "name: my-app")
+	assert.Contains(t, result, "done: my-app")
+	// Inner content preserved verbatim
+	assert.Contains(t, result, "raw: {{ this.is.not.parsed }}")
+	// Built-in stripping still wins: markers removed despite the user config.
+	assert.NotContains(t, result, "scafctl:ignore:start")
+	assert.NotContains(t, result, "scafctl:ignore:end")
+}
+
+func TestGoTemplateProvider_Execute_BuiltinLineMarker(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"appName": "my-app",
+	})
+
+	// The built-in '# scafctl:ignore' line marker works with no declaration.
+	inputs := map[string]any{
+		"name": "builtin-line-test",
+		"template": `name: {{.appName}}
+token: ${{ secrets.TOKEN }}  # scafctl:ignore
+tail: {{.appName}}`,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	result, ok := output.Data.(string)
+	require.True(t, ok)
+
+	assert.Contains(t, result, "name: my-app")
+	assert.Contains(t, result, "${{ secrets.TOKEN }}")
+	assert.Contains(t, result, "tail: my-app")
+}
+
+func TestGoTemplateProvider_Execute_IgnoredBlocks_Token(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"name": "svc",
+	})
+
+	inputs := map[string]any{
+		"name": "token-test",
+		"template": `service: {{.name}}
+a: ${LITERAL}
+b: ${LITERAL}`,
+		"ignoredBlocks": []any{
+			map[string]any{
+				"token": "${LITERAL}",
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	result, ok := output.Data.(string)
+	require.True(t, ok)
+
+	assert.Contains(t, result, "service: svc")
+	// Every occurrence of the token is preserved literally
+	assert.Equal(t, 2, strings.Count(result, "${LITERAL}"))
+}
+
+func TestGoTemplateProvider_Execute_IgnoredBlocks_Token_MutualExclusion(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"name": "test",
+	})
+
+	inputs := map[string]any{
+		"name":     "token-mutual-exclusion-test",
+		"template": "Hello, {{.name}}!",
+		"ignoredBlocks": []any{
+			map[string]any{
+				"token": "${LITERAL}",
+				"line":  "# scafctl:ignore",
+			},
+		},
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestGoTemplateProvider_Execute_IgnoredBlocks_EmptyEntry_Errors(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"name": "test",
+	})
+
+	inputs := map[string]any{
+		"name":     "empty-entry-test",
+		"template": "Hello, {{.name}}!",
+		"ignoredBlocks": []any{
+			map[string]any{},
+		},
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no mode set")
+}
+
+func TestGoTemplateProvider_Execute_IgnoredBlocks_StartWithoutEnd_Errors(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"name": "test",
+	})
+
+	inputs := map[string]any{
+		"name":     "start-without-end-test",
+		"template": "Hello, {{.name}}!",
+		"ignoredBlocks": []any{
+			map[string]any{
+				"start": "<<<",
+			},
+		},
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "'start' and 'end' must both be set")
+}
+
+func TestGoTemplateProvider_Execute_TokenInsideFence_FenceTakesPrecedence(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"name": "svc",
+	})
+
+	// A user-declared token overlaps a built-in fenced region. The fence must
+	// still be recognized (markers stripped, inner content preserved verbatim)
+	// regardless of the token entry's ordering.
+	inputs := map[string]any{
+		"name": "token-in-fence-test",
+		"template": `service: {{.name}}
+{{/* scafctl:ignore:start */}}
+url: ${LITERAL}/api
+{{/* scafctl:ignore:end */}}
+tail: ${LITERAL}`,
+		"ignoredBlocks": []any{
+			map[string]any{
+				"token": "${LITERAL}",
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	result, ok := output.Data.(string)
+	require.True(t, ok)
+
+	assert.Contains(t, result, "service: svc")
+	// Fence markers are stripped, inner content preserved.
+	assert.NotContains(t, result, "scafctl:ignore:start")
+	assert.NotContains(t, result, "scafctl:ignore:end")
+	// The literal token is preserved both inside the fence and outside it.
+	assert.Equal(t, 2, strings.Count(result, "${LITERAL}"))
+}
+
+func TestExtractDependencies_ExcludesIgnoredRegions(t *testing.T) {
+	// References inside built-in fenced regions must not be treated as deps.
+	inputs := map[string]any{
+		"template": `real: {{ .realDep }}
+{{/* scafctl:ignore:start */}}
+phantom: {{ .phantomDep }}
+{{/* scafctl:ignore:end */}}
+line: {{ .lineDep }}  # scafctl:ignore`,
+	}
+
+	deps := extractDependencies(inputs)
+
+	assert.Contains(t, deps, "realDep")
+	assert.NotContains(t, deps, "phantomDep")
+	assert.NotContains(t, deps, "lineDep")
 }
 
 // --- render-tree tests ---

--- a/tests/integration/solutions/providers/go-template/solution.yaml
+++ b/tests/integration/solutions/providers/go-template/solution.yaml
@@ -200,6 +200,47 @@ spec:
               ignoredBlocks:
                 - line: "# scafctl:ignore"
 
+    # Built-in zero-config fence: markers stripped, inner content preserved
+    builtinFenceTemplate:
+      description: Template using the always-on built-in fence (no ignoredBlocks)
+      dependsOn: [appName]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: builtin-fence
+              template: |
+                name = "{{ .appName }}"
+                {{/* scafctl:ignore:start */}}
+                raw = "${var.project}-${var.env}"
+                {{/* scafctl:ignore:end */}}
+
+    # Token mode: preserve every occurrence of a literal substring
+    ignoredBlocksTokenTemplate:
+      description: Template using token-based literal pass-through
+      dependsOn: [appName]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              name: ignored-blocks-token
+              template: |
+                service: {{ .appName }}
+                url: ${LITERAL}/api
+                health: ${LITERAL}/health
+              ignoredBlocks:
+                - token: "${LITERAL}"
+
     # Test: name input is optional (defaults to "template")
     optionalNameTemplate:
       description: Template without explicit name input
@@ -318,6 +359,32 @@ spec:
             message: "Line with ignore marker should be preserved literally"
           - expression: '__output.ignoredBlocksLineTemplate.contains("echo \"deployed\"")'
             message: "Non-ignored lines should render normally"
+
+      builtin-fence:
+        description: Verify the built-in fence strips markers and preserves inner content
+        extends: [_base]
+        tags: [ignoredBlocks]
+        assertions:
+          - expression: '__output.builtinFenceTemplate.contains("name = \"my-service\"")'
+            message: "Template variables outside the fence should be rendered"
+          - expression: '__output.builtinFenceTemplate.contains("raw = \"${var.project}-${var.env}\"")'
+            message: "Content inside the built-in fence should be preserved literally"
+          - expression: '!__output.builtinFenceTemplate.contains("scafctl:ignore:start")'
+            message: "Built-in fence start marker should be stripped from output"
+          - expression: '!__output.builtinFenceTemplate.contains("scafctl:ignore:end")'
+            message: "Built-in fence end marker should be stripped from output"
+
+      ignored-blocks-token:
+        description: Verify token-based ignoredBlocks preserves every occurrence
+        extends: [_base]
+        tags: [ignoredBlocks]
+        assertions:
+          - expression: '__output.ignoredBlocksTokenTemplate.contains("service: my-service")'
+            message: "Template variables should be rendered"
+          - expression: '__output.ignoredBlocksTokenTemplate.contains("${LITERAL}/api")'
+            message: "First token occurrence should be preserved literally"
+          - expression: '__output.ignoredBlocksTokenTemplate.contains("${LITERAL}/health")'
+            message: "Second token occurrence should be preserved literally"
 
       optional-name:
         description: Verify template works without explicit name input


### PR DESCRIPTION
- Add always-on, zero-config ignore markers that need no ignoredBlocks declaration: a fence ({{/* scafctl:ignore:start */}} ... {{/* scafctl:ignore:end */}}) whose markers are stripped from output, and a per-line marker (# scafctl:ignore) preserved verbatim
- Add token mode to ignoredBlocks to preserve every occurrence of a literal substring
- Make start/end, line, and token modes mutually exclusive per entry
- Exclude references inside ignored/raw regions from resolver dependency extraction so literal pass-through blocks are not treated as dependencies
- Add RestoreAs field to gotmpl.Replacement to restore a different value than what was matched (enables fence marker stripping)
- Refactor ignored-block helpers to package-level functions and share validation between render and render-tree
- Update docs, examples, and integration solution with new modes