### PR TITLE
feat(auth)!: forward --callback-port to plugin auth handlers

### DIFF
--- a/.github/prompts/completeness-check.prompt.md
+++ b/.github/prompts/completeness-check.prompt.md
@@ -1,0 +1,18 @@
+---
+description: "Check if staged changes have corresponding tests, examples, and documentation."
+agent: "agent"
+argument-hint: "Optional: specific area to check"
+---
+Review staged changes and check if supporting artifacts exist:
+
+1. Run `git diff --cached --stat` to identify staged changes
+2. If nothing is staged, fall back to `git log origin/main..HEAD --stat` to check pushed commits on the branch
+3. For each feature, type, or interface change, verify:
+   - Tests in corresponding `*_test.go` files
+   - Benchmarks for performance-sensitive code
+   - Examples in `examples/` if user-facing
+   - Updated README or doc comments on exported types
+   - Integration tests (`TestIntegration_*`) if cross-package
+   - Mock updates in `testutil/` if interfaces changed
+4. Report present vs missing as a checklist
+5. Do not create anything, just report the gaps

--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -262,6 +262,10 @@ scafctl auth login entra --callback-port 8400
 This makes the redirect URI `http://localhost:8400`, which must be registered in
 the app registration's **Authentication** settings.
 
+> `--callback-port` must be an unprivileged, in-range TCP port (1024-65535); any
+> other value is rejected. It works for both built-in handlers and plugin auth
+> handlers that advertise the `callback_port` capability.
+
 ### Setting a Timeout
 
 The interactive login flow has a 5-minute default timeout. To extend it:

--- a/docs/tutorials/config-tutorial.md
+++ b/docs/tutorials/config-tutorial.md
@@ -363,7 +363,25 @@ Cache:       ~/.cache/scafctl
 HTTP Cache:  ~/.cache/scafctl/http-cache
 State:       ~/.local/state/scafctl
 Override paths with XDG environment variables or SCAFCTL_SECRETS_DIR.
+
+ 💡 Config sources (merge order)
+
+  1. built-in defaults
+  2. ~/.config/scafctl/config.d/10-telemetry.yaml
+  3. ~/.config/scafctl/config.d/50-clusters.yaml
+  4. ~/.config/scafctl/config.yaml
+  5. SCAFCTL_* environment variables
+
+Later sources override earlier ones.
 ```
+
+The **Config sources** section lists every layer that feeds the merged
+configuration, in the order they are applied. Later sources override earlier
+ones, so a value in `config.d/50-clusters.yaml` wins over one in
+`10-telemetry.yaml`, and your `config.yaml` wins over both. This makes the
+`config.d/` drop-in directory discoverable -- otherwise it is easy to miss where
+a value like `kube.clusters` is actually set. A missing user config file is
+shown as `(not present)`.
 
 ## Configuration Reference
 

--- a/examples/auth/README.md
+++ b/examples/auth/README.md
@@ -119,6 +119,17 @@ scafctl auth status --warn-within 10m
 scafctl auth status --exit-code --warn-within 15m
 ```
 
+### Per-cluster rows
+
+Handlers that advertise the `instance_hostname` capability keep one cached
+session per cluster, and `auth status` expands into one row per cluster. The
+`profile` column shows the cluster's short selector (from `hostname.aliases` or
+the resolver inventory), otherwise the trimmed host, with `(active)` marking the
+most recently used session. A non-default (named) auth profile is preserved as a
+prefix (`work / prod`); the built-in profile is omitted. See
+[hostname-resolution.md](hostname-resolution.md#per-cluster-status) for details.
+
+
 ---
 
 ## Listing and Sorting Cached Tokens

--- a/examples/auth/hostname-resolution.md
+++ b/examples/auth/hostname-resolution.md
@@ -132,6 +132,36 @@ transform: |
   _.filter(c, c.state == "ready").map(c, {"name": c.id, "url": c.endpoint})
 ```
 
+## Per-cluster status
+
+Handlers that advertise the `instance_hostname` capability keep a separate
+cached session per cluster. For those handlers, `auth status` expands into one
+row per cluster instead of a single handler row:
+
+```bash
+scafctl auth status openshift
+```
+
+```
+handler     profile           status         user               expires
+openshift   prod (active)     authenticated  user@example.com   58m
+openshift   api.stg.example.com  authenticated  user@example.com   3h
+```
+
+- The `profile` column shows the cluster label: the reverse-mapped
+  `hostname.aliases`/resolver selector when the cluster URL matches (e.g.
+  `prod`), otherwise the trimmed host (e.g. `api.stg.example.com`).
+- When a **named** auth profile is active (e.g. `work`), it is preserved as a
+  prefix (`work / prod`) so identity and endpoint stay distinguishable; the
+  built-in/default profile is omitted since the alias alone is unambiguous.
+- `(active)` marks the most recently used cluster session.
+- `status` and `expires` are per cluster; an expired session shows `expired`.
+- Output is one row per cluster: if a handler caches several tokens for the same
+  instance (a user login plus minted service-account tokens), they collapse to a
+  single row that reflects the login session.
+
+Non-instance handlers are unaffected and still render a single row.
+
 ## Caching
 
 Resolved inventories are cached on disk under the scafctl cache directory

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/oakwood-commons/httpc v0.1.0
 	github.com/oakwood-commons/kvx v0.15.0
 	github.com/oakwood-commons/oauth-helpers v0.2.0
-	github.com/oakwood-commons/scafctl-plugin-sdk v0.14.0
+	github.com/oakwood-commons/scafctl-plugin-sdk v0.15.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pelletier/go-toml/v2 v2.4.2

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/oakwood-commons/httpc v0.1.0
 	github.com/oakwood-commons/kvx v0.15.0
 	github.com/oakwood-commons/oauth-helpers v0.2.0
-	github.com/oakwood-commons/scafctl-plugin-sdk v0.15.0
+	github.com/oakwood-commons/scafctl-plugin-sdk v0.16.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pelletier/go-toml/v2 v2.4.2

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,8 @@ github.com/oakwood-commons/kvx v0.15.0 h1:0rC7Zlz+6ZjaisRD6eQfe+cji9u3dyBiAFmlos
 github.com/oakwood-commons/kvx v0.15.0/go.mod h1:PJktDsEq9PS88UDCkoIT+fgiSXs7dXWcq76Lhk5BmZY=
 github.com/oakwood-commons/oauth-helpers v0.2.0 h1:IIu8AitRWCNp51oRvfBU0D7JGM3Tt3QXUejLwEFZk+Q=
 github.com/oakwood-commons/oauth-helpers v0.2.0/go.mod h1:+VhuszKORoPc9H0HwvS92I/U0828up8XejsUpXS7FvE=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.15.0 h1:Qul4F4B8agl++l6XY47nFhrsF8qUcWGgq1xtL8wjdXk=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.15.0/go.mod h1:oC2LqrVwXEQBgR2rIp+PbSF0mLfkC1a2G5KJb6CzdgE=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.16.0 h1:qCpABo7SSpHmgZ0KX8UXwDLT8L9CE9Qg2vrCXJROXv0=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.16.0/go.mod h1:oC2LqrVwXEQBgR2rIp+PbSF0mLfkC1a2G5KJb6CzdgE=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,8 @@ github.com/oakwood-commons/kvx v0.15.0 h1:0rC7Zlz+6ZjaisRD6eQfe+cji9u3dyBiAFmlos
 github.com/oakwood-commons/kvx v0.15.0/go.mod h1:PJktDsEq9PS88UDCkoIT+fgiSXs7dXWcq76Lhk5BmZY=
 github.com/oakwood-commons/oauth-helpers v0.2.0 h1:IIu8AitRWCNp51oRvfBU0D7JGM3Tt3QXUejLwEFZk+Q=
 github.com/oakwood-commons/oauth-helpers v0.2.0/go.mod h1:+VhuszKORoPc9H0HwvS92I/U0828up8XejsUpXS7FvE=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.14.0 h1:BJkKwyh0zGG8i3jEiT9zIYfEsQt3BelwxNlahslIbeE=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.14.0/go.mod h1:oC2LqrVwXEQBgR2rIp+PbSF0mLfkC1a2G5KJb6CzdgE=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.15.0 h1:Qul4F4B8agl++l6XY47nFhrsF8qUcWGgq1xtL8wjdXk=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.15.0/go.mod h1:oC2LqrVwXEQBgR2rIp+PbSF0mLfkC1a2G5KJb6CzdgE=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=

--- a/pkg/auth/capability.go
+++ b/pkg/auth/capability.go
@@ -19,6 +19,16 @@ const (
 	CapFlowOverride         = sdkauth.CapFlowOverride
 )
 
+// Callback port bounds for the interactive OAuth loopback callback server.
+// Zero means "unset" (ephemeral/OS-assigned); any non-zero value must be an
+// unprivileged, in-range TCP port within [MinCallbackPort, MaxCallbackPort].
+// These are the single source of truth shared by CLI flag validation and the
+// host->plugin wire clamp so the two layers cannot drift.
+const (
+	MinCallbackPort = 1024
+	MaxCallbackPort = 65535
+)
+
 // HasCapability checks if a set of capabilities includes the specified capability.
 func HasCapability(capabilities []Capability, capability Capability) bool {
 	return sdkauth.HasCapability(capabilities, capability)

--- a/pkg/auth/capability.go
+++ b/pkg/auth/capability.go
@@ -14,6 +14,7 @@ const (
 	CapTenantID             = sdkauth.CapTenantID
 	CapHostname             = sdkauth.CapHostname
 	CapTokenHostname        = sdkauth.CapTokenHostname
+	CapInstanceHostname     = sdkauth.CapInstanceHostname
 	CapFederatedToken       = sdkauth.CapFederatedToken
 	CapCallbackPort         = sdkauth.CapCallbackPort
 	CapFlowOverride         = sdkauth.CapFlowOverride

--- a/pkg/auth/capability_test.go
+++ b/pkg/auth/capability_test.go
@@ -16,6 +16,7 @@ func TestHasCapability(t *testing.T) {
 	assert.True(t, HasCapability(caps, CapTenantID))
 	assert.False(t, HasCapability(caps, CapScopesOnTokenRequest))
 	assert.False(t, HasCapability(caps, CapHostname))
+	assert.False(t, HasCapability(caps, CapInstanceHostname))
 	assert.False(t, HasCapability(caps, CapFederatedToken))
 }
 
@@ -31,8 +32,11 @@ func TestCapabilityConstants(t *testing.T) {
 		CapScopesOnTokenRequest,
 		CapTenantID,
 		CapHostname,
+		CapTokenHostname,
+		CapInstanceHostname,
 		CapFederatedToken,
 		CapCallbackPort,
+		CapFlowOverride,
 	}
 
 	seen := make(map[Capability]bool)

--- a/pkg/auth/flow_test.go
+++ b/pkg/auth/flow_test.go
@@ -6,6 +6,7 @@ package auth
 import (
 	"testing"
 
+	sdkauth "github.com/oakwood-commons/scafctl-plugin-sdk/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -54,11 +55,27 @@ func TestParseFlow_KnownFlows(t *testing.T) {
 	}
 }
 
+// TestFlowAliases_MatchSDK verifies every scafctl Flow constant is a faithful
+// alias of the SDK flow, so callers can use auth.Flow* without importing the
+// SDK. OnBehalfOf in particular was previously missing from the re-export set.
+func TestFlowAliases_MatchSDK(t *testing.T) {
+	assert.Equal(t, sdkauth.FlowDeviceCode, FlowDeviceCode)
+	assert.Equal(t, sdkauth.FlowInteractive, FlowInteractive)
+	assert.Equal(t, sdkauth.FlowServicePrincipal, FlowServicePrincipal)
+	assert.Equal(t, sdkauth.FlowWorkloadIdentity, FlowWorkloadIdentity)
+	assert.Equal(t, sdkauth.FlowPAT, FlowPAT)
+	assert.Equal(t, sdkauth.FlowMetadata, FlowMetadata)
+	assert.Equal(t, sdkauth.FlowGcloudADC, FlowGcloudADC)
+	assert.Equal(t, sdkauth.FlowGitHubApp, FlowGitHubApp)
+	assert.Equal(t, sdkauth.FlowClientCredentials, FlowClientCredentials)
+	assert.Equal(t, sdkauth.FlowOnBehalfOf, FlowOnBehalfOf)
+	assert.NotEmpty(t, string(FlowOnBehalfOf), "OnBehalfOf alias must resolve to a non-empty flow value")
+}
+
 func TestParseFlow_CaseInsensitive(t *testing.T) {
 	flow, err := ParseFlow("Device-Code", "entra")
 	require.NoError(t, err)
 	assert.Equal(t, FlowDeviceCode, flow)
-
 	flow, err = ParseFlow("INTERACTIVE", "gcp")
 	require.NoError(t, err)
 	assert.Equal(t, FlowInteractive, flow)

--- a/pkg/auth/handler.go
+++ b/pkg/auth/handler.go
@@ -73,6 +73,7 @@ const (
 	FlowGcloudADC         = sdkauth.FlowGcloudADC
 	FlowGitHubApp         = sdkauth.FlowGitHubApp
 	FlowClientCredentials = sdkauth.FlowClientCredentials
+	FlowOnBehalfOf        = sdkauth.FlowOnBehalfOf
 )
 
 // DefaultMinValidFor is the default minimum validity duration for tokens.

--- a/pkg/auth/hostname/cache.go
+++ b/pkg/auth/hostname/cache.go
@@ -101,6 +101,32 @@ func (c *diskCache) Get(_ context.Context, key string) ([]Entry, bool) {
 	return cf.Entries, true
 }
 
+// peekAll returns the union of entries from every inventory cache file on disk,
+// ignoring TTL expiry and without evicting anything. It backs display-only
+// reverse-mapping (URL -> short selector) where the caller does not know which
+// resolver produced the cache -- e.g. `auth status` labeling a cluster that was
+// resolved via `kube login` under a different cache key. Missing dir or corrupt
+// files are skipped.
+func (c *diskCache) peekAll() []Entry {
+	matches, err := filepath.Glob(filepath.Join(c.baseDir, "*.json"))
+	if err != nil {
+		return nil
+	}
+	var all []Entry
+	for _, p := range matches {
+		data, err := os.ReadFile(p) //nolint:gosec // p is a glob match under the fixed cache dir
+		if err != nil {
+			continue
+		}
+		var cf cacheFile
+		if err := json.Unmarshal(data, &cf); err != nil {
+			continue
+		}
+		all = append(all, cf.Entries...)
+	}
+	return all
+}
+
 // Set writes the entries with an expiry of now+ttl. Write failures are silent:
 // caching is best-effort and must not break resolution.
 func (c *diskCache) Set(_ context.Context, key string, entries []Entry, ttl time.Duration) {

--- a/pkg/auth/hostname/cache_test.go
+++ b/pkg/auth/hostname/cache_test.go
@@ -81,6 +81,49 @@ func TestDiskCache_CorruptFileIsMiss(t *testing.T) {
 	assert.False(t, ok, "corrupt file must be treated as a miss")
 }
 
+func TestDiskCache_PeekAll(t *testing.T) {
+	t.Parallel()
+
+	base := time.Now()
+	current := base
+	c := newTestCache(t, func() time.Time { return current })
+
+	// Two inventories under different keys; one will expire.
+	c.Set(context.Background(), "auth-key", []Entry{{Name: "pd1010", URL: "https://api.pd1010.example.com:6443"}}, time.Minute)
+	c.Set(context.Background(), "kube-key", []Entry{{Name: "pd1020", URL: "https://api.pd1020.example.com:6443"}}, time.Minute)
+
+	// Advance past expiry: Get would miss + evict, but peekAll ignores TTL.
+	current = base.Add(2 * time.Minute)
+
+	all := c.peekAll()
+	names := make(map[string]string, len(all))
+	for _, e := range all {
+		names[e.Name] = e.URL
+	}
+	assert.Len(t, all, 2, "peekAll returns entries from all cache files, ignoring TTL")
+	assert.Equal(t, "https://api.pd1010.example.com:6443", names["pd1010"])
+	assert.Equal(t, "https://api.pd1020.example.com:6443", names["pd1020"])
+
+	// peekAll must not evict expired files.
+	_, statErr := os.Stat(c.path("auth-key"))
+	assert.NoError(t, statErr, "peekAll must not delete expired files")
+}
+
+func TestDiskCache_PeekAll_EmptyDir(t *testing.T) {
+	t.Parallel()
+
+	c := newTestCache(t, time.Now)
+	assert.Nil(t, c.peekAll(), "no cache dir yields nil")
+}
+
+func TestAllCachedInventoryEntries_NoPanic(t *testing.T) {
+	t.Parallel()
+
+	// Smoke test: reads the real on-disk cache dir. It must never panic and
+	// returns a slice (possibly nil when nothing is cached in the environment).
+	_ = AllCachedInventoryEntries()
+}
+
 func TestCacheKey_StableAndSensitive(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/auth/hostname/hostname.go
+++ b/pkg/auth/hostname/hostname.go
@@ -221,6 +221,17 @@ func CachedInventory(ctx context.Context, rc *config.HostnameResolverConfig, han
 	return deps.Cache.Get(ctx, cacheKey(handler, rc))
 }
 
+// AllCachedInventoryEntries returns the union of inventory entries from every
+// resolver cache on disk, ignoring TTL expiry and without evicting anything. It
+// is a display-only, network-free helper for reverse-mapping a cluster URL back
+// to its short selector when the caller does not know which resolver produced
+// the cache -- for example `auth status` labeling a cluster that was resolved
+// via `kube login` under a different cache key. Returns nil when nothing is
+// cached.
+func AllCachedInventoryEntries() []Entry {
+	return newDiskCache().peekAll()
+}
+
 // resolveInventory fetches, transforms, and caches the endpoint inventory.
 func resolveInventory(ctx context.Context, rc *config.HostnameResolverConfig, handler string, deps Deps) ([]Entry, error) {
 	// Loop guard: a resolver must not depend on the handler it resolves.

--- a/pkg/auth/hostname/label.go
+++ b/pkg/auth/hostname/label.go
@@ -1,0 +1,70 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hostname
+
+import (
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// AliasForURL reverse-maps a concrete endpoint URL back to its configured alias
+// selector. Aliases is the static selector->URL map from
+// auth.handlers.<name>.hostname.aliases. Matching is by normalized host (scheme,
+// port, and path are ignored). When several selectors map to the same host it
+// returns the lexicographically-first one for deterministic output. It returns
+// ("", false) when no alias matches.
+func AliasForURL(aliases map[string]string, rawURL string) (string, bool) {
+	if len(aliases) == 0 || strings.TrimSpace(rawURL) == "" {
+		return "", false
+	}
+	target := normalizeHost(rawURL)
+	if target == "" {
+		return "", false
+	}
+	var matches []string
+	for selector, u := range aliases {
+		if normalizeHost(u) == target {
+			matches = append(matches, selector)
+		}
+	}
+	if len(matches) == 0 {
+		return "", false
+	}
+	sort.Strings(matches)
+	return matches[0], true
+}
+
+// DisplayHostFromURL trims a URL down to a compact host label for display,
+// stripping the scheme, port, and any path. A bare hostname is returned
+// lower-cased; an unparseable value is returned trimmed but otherwise unchanged.
+func DisplayHostFromURL(rawURL string) string {
+	if h := normalizeHost(rawURL); h != "" {
+		return h
+	}
+	return strings.TrimSpace(rawURL)
+}
+
+// normalizeHost extracts the lower-cased host (without port) from a URL or bare
+// hostname. It returns "" when no host can be determined.
+func normalizeHost(rawURL string) string {
+	s := strings.TrimSpace(rawURL)
+	if s == "" {
+		return ""
+	}
+	if !strings.Contains(s, "://") {
+		s = "https://" + s
+	}
+	if u, err := url.Parse(s); err == nil && u.Hostname() != "" {
+		return strings.ToLower(u.Hostname())
+	}
+	// Fallback: strip scheme prefix, then trailing path/port manually.
+	s = strings.TrimSpace(rawURL)
+	s = strings.TrimPrefix(s, "https://")
+	s = strings.TrimPrefix(s, "http://")
+	if i := strings.IndexAny(s, "/:"); i >= 0 {
+		s = s[:i]
+	}
+	return strings.ToLower(s)
+}

--- a/pkg/auth/hostname/label_test.go
+++ b/pkg/auth/hostname/label_test.go
@@ -1,0 +1,105 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package hostname
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAliasForURL(t *testing.T) {
+	t.Parallel()
+
+	aliases := map[string]string{
+		"pd1020": "https://api.pd1020.caas.ford.com:6443",
+		"np0510": "https://api.np0510.caas.ford.com:6443",
+		"legacy": "api.pd1020.caas.ford.com", // bare host, same as pd1020
+	}
+
+	tests := []struct {
+		name      string
+		aliases   map[string]string
+		url       string
+		wantAlias string
+		wantOK    bool
+	}{
+		{
+			name:      "exact url match",
+			aliases:   aliases,
+			url:       "https://api.np0510.caas.ford.com:6443",
+			wantAlias: "np0510",
+			wantOK:    true,
+		},
+		{
+			name:      "match ignores scheme and port",
+			aliases:   aliases,
+			url:       "https://api.np0510.caas.ford.com",
+			wantAlias: "np0510",
+			wantOK:    true,
+		},
+		{
+			name:      "ambiguous match returns lexicographically first",
+			aliases:   aliases,
+			url:       "https://api.pd1020.caas.ford.com:6443",
+			wantAlias: "legacy",
+			wantOK:    true,
+		},
+		{
+			name:      "no match",
+			aliases:   aliases,
+			url:       "https://api.unknown.example.com",
+			wantAlias: "",
+			wantOK:    false,
+		},
+		{
+			name:      "empty aliases",
+			aliases:   nil,
+			url:       "https://api.pd1020.caas.ford.com",
+			wantAlias: "",
+			wantOK:    false,
+		},
+		{
+			name:      "empty url",
+			aliases:   aliases,
+			url:       "",
+			wantAlias: "",
+			wantOK:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := AliasForURL(tt.aliases, tt.url)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantAlias, got)
+		})
+	}
+}
+
+func TestDisplayHostFromURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"https url with port", "https://api.pd1020.caas.ford.com:6443", "api.pd1020.caas.ford.com"},
+		{"http url with path", "http://host.example.com/some/path", "host.example.com"},
+		{"bare host", "host.example.com", "host.example.com"},
+		{"bare host with port", "host.example.com:8443", "host.example.com"},
+		{"uppercase normalized", "HTTPS://API.EXAMPLE.COM", "api.example.com"},
+		{"unparseable falls back to trimmed original", "://bad", "://bad"},
+		{"empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, DisplayHostFromURL(tt.url))
+		})
+	}
+}

--- a/pkg/auth/loginui/loginui.go
+++ b/pkg/auth/loginui/loginui.go
@@ -1,0 +1,437 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package loginui renders the interactive login experience shared by the
+// 'auth login' and 'kube login' commands. It runs an auth handler's login while
+// presenting progress: the kvx status-screen TUI when stdout is a terminal
+// (device-code and browser flows), or plain-text instructions otherwise.
+//
+// RunLogin returns the login Result and never prints the final success line or
+// error text — callers render their own output. This lets both commands share
+// one interactive presentation while keeping their distinct result rendering.
+package loginui
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/oakwood-commons/kvx/pkg/tui"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	skvx "github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+)
+
+// browserCallbackWait bounds how long the browser TUI waits for a device-code
+// callback before assuming a pure browser (auth-code) flow.
+const browserCallbackWait = 500 * time.Millisecond
+
+// deviceCodeData carries the verification URL and user code surfaced by a
+// handler's DeviceCodeCallback.
+type deviceCodeData struct {
+	userCode        string
+	verificationURI string
+}
+
+// loginOutcome carries the result of a handler.Login call across goroutines.
+type loginOutcome struct {
+	result *auth.Result
+	err    error
+}
+
+// RunLogin executes an interactive login for the given handler, presenting
+// progress via the kvx status TUI when running on a terminal (device-code and
+// browser flows) and plain-text instructions otherwise. It installs a SIGINT
+// handler that cancels the login.
+//
+// It returns the login Result on success. Callers render their own success
+// output; RunLogin does not print the final "logged in" line. Errors are
+// returned wrapped with an exit code and are not printed, so callers control
+// error presentation. The opts.DeviceCodeCallback is managed internally and any
+// caller-supplied callback is ignored.
+func RunLogin(ctx context.Context, w *writer.Writer, binaryName string, handler auth.Handler, opts auth.LoginOptions) (*auth.Result, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt)
+	go func() {
+		// Watch for an interrupt, but also unblock when the login finishes so the
+		// goroutine never outlives the call. signal.Stop halts delivery but does
+		// not close sigChan, so without the ctx.Done() arm this would leak one
+		// goroutine per invocation (loginui is a reusable library).
+		select {
+		case <-sigChan:
+			// Diagnostics go to stderr: RunLogin is a reusable library and must
+			// not corrupt a caller's structured stdout output.
+			w.PlainStderr("")
+			w.WarnStderr("Authentication cancelled by user.")
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+	defer signal.Stop(sigChan)
+
+	ioStreams := w.IOStreams()
+
+	// Use the kvx status TUI for interactive flows when running on a terminal.
+	// Non-interactive flows (SP, WI, PAT, metadata, client-credentials) fall
+	// through to the plain-text login path below.
+	if skvx.IsTerminal(ioStreams.Out) {
+		switch opts.Flow {
+		case auth.FlowDeviceCode:
+			return runStatusTUI(ctx, w, binaryName, handler, opts, ioStreams)
+		case auth.FlowInteractive, auth.FlowGcloudADC, auth.FlowGitHubApp, "":
+			return runBrowserTUI(ctx, w, binaryName, handler, opts, ioStreams)
+		case auth.FlowServicePrincipal, auth.FlowWorkloadIdentity, auth.FlowPAT,
+			auth.FlowMetadata, auth.FlowClientCredentials, auth.FlowOnBehalfOf:
+			// Non-interactive flows fall through to the plain-text path below.
+		}
+	}
+
+	// Plain-text login path (non-terminal, or non-device-code flows).
+	opts.DeviceCodeCallback = func(userCode, verificationURI, _ string) {
+		w.Info("")
+		w.Info("To sign in, use a web browser to open the page:")
+		w.Infof("  %s", verificationURI)
+		w.Info("")
+		w.Infof("Enter the code: %s", userCode)
+		w.Info("")
+		w.Info("Waiting for authentication...")
+	}
+
+	result, err := handler.Login(ctx, opts)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
+		}
+		return nil, exitcode.WithCode(fmt.Errorf("authentication failed: %w", err), exitcode.GeneralError)
+	}
+	return result, nil
+}
+
+// runStatusTUI runs the device-code login flow using the kvx status-screen TUI.
+// It:
+//  1. Starts handler.Login in a goroutine with a DeviceCodeCallback that captures
+//     the verification URL and user code.
+//  2. Waits for the device code before launching the TUI (avoids empty-data start).
+//  3. Launches tui.Run with a DisplaySchema status view and a Done channel that
+//     receives the login outcome when the goroutine completes.
+func runStatusTUI(
+	ctx context.Context,
+	w *writer.Writer,
+	binaryName string,
+	handler auth.Handler,
+	opts auth.LoginOptions,
+	ioStreams *terminal.IOStreams,
+) (*auth.Result, error) {
+	deviceCodeChan := make(chan deviceCodeData, 1)
+	outcomeChan := make(chan loginOutcome, 1)
+	done := make(chan tui.StatusResult, 1)
+
+	opts.DeviceCodeCallback = func(userCode, verificationURI, _ string) {
+		select {
+		case deviceCodeChan <- deviceCodeData{userCode: userCode, verificationURI: verificationURI}:
+		default:
+		}
+	}
+
+	go func() {
+		result, err := handler.Login(ctx, opts)
+		outcomeChan <- loginOutcome{result: result, err: err}
+	}()
+
+	// Wait for the device code, an early completion, or cancellation.
+	w.Verbosef("Initiating authentication with %s...", handler.DisplayName())
+	var dci deviceCodeData
+	select {
+	case dci = <-deviceCodeChan:
+		// Device code ready - proceed to TUI.
+	case outcome := <-outcomeChan:
+		// Login completed before device code was shown (unusual).
+		if outcome.err != nil {
+			return nil, loginError(ctx, outcome.err)
+		}
+		return outcome.result, nil
+	case <-ctx.Done():
+		return nil, exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
+	}
+
+	// Forward the login outcome to the TUI done channel.
+	// capturedOutcome is safe to read after outcomeReady is closed because
+	// close(outcomeReady) happens-before the receive on that channel.
+	var capturedOutcome loginOutcome
+	outcomeReady := make(chan struct{})
+	go func() {
+		outcome := <-outcomeChan
+		capturedOutcome = outcome
+		if outcome.err != nil {
+			done <- tui.StatusResult{Err: outcome.err}
+		} else {
+			done <- tui.StatusResult{Message: "Authenticated as " + loginIdentity(outcome.result)}
+		}
+		close(outcomeReady)
+	}()
+
+	data := map[string]any{
+		"title": fmt.Sprintf("Sign in to %s", handler.DisplayName()),
+		"url":   dci.verificationURI,
+		"code":  dci.userCode,
+	}
+
+	schema := &tui.DisplaySchema{
+		Version: "v1",
+		Status: &tui.StatusDisplayConfig{
+			TitleField:     "title",
+			WaitMessage:    "Waiting for authentication...",
+			SuccessMessage: "Authenticated successfully!",
+			DoneBehavior:   tui.DoneBehaviorExitAfterDelay,
+			DoneDelay:      "2s",
+			DisplayFields: []tui.StatusFieldDisplay{
+				{Label: "URL", Field: "url"},
+				{Label: "Code", Field: "code"},
+			},
+			Actions: []tui.StatusActionConfig{
+				{
+					Label: "Copy code",
+					Type:  "copy-value",
+					Field: "code",
+					Keys:  tui.StatusKeyBindings{Vim: "c", Emacs: "alt+c", Function: "f2"},
+				},
+				{
+					Label: "Open URL",
+					Type:  "open-url",
+					Field: "url",
+					Keys:  tui.StatusKeyBindings{Vim: "o", Emacs: "alt+o", Function: "f3"},
+				},
+			},
+		},
+	}
+
+	cfg := tui.DefaultConfig()
+	cfg.AppName = binaryName
+	cfg.DisplaySchema = schema
+	cfg.Done = done
+
+	teaOpts := tui.WithIO(ioStreams.In, ioStreams.Out)
+	if runErr := tui.Run(data, cfg, teaOpts...); runErr != nil {
+		if ctx.Err() != nil {
+			return nil, exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
+		}
+		return nil, fmt.Errorf("authentication display failed: %w", runErr)
+	}
+
+	// TUI exited normally (done channel received, DoneDelay elapsed).
+	// The outcomeReady channel should already be closed at this point.
+	select {
+	case <-outcomeReady:
+		// Outcome is captured - continue to post-display.
+	default:
+		// TUI exited before login completed (user quit early) - treat as cancelled.
+		return nil, exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
+	}
+
+	if capturedOutcome.err != nil {
+		return nil, loginError(ctx, capturedOutcome.err)
+	}
+	return capturedOutcome.result, nil
+}
+
+// runBrowserTUI runs the auth-code (browser) login flow using the kvx status
+// screen TUI. It also sets a DeviceCodeCallback so that handlers which
+// internally use device code within a FlowInteractive (e.g., GitHub without
+// client_secret) get the rich device-code TUI instead.
+func runBrowserTUI(
+	ctx context.Context,
+	w *writer.Writer,
+	binaryName string,
+	handler auth.Handler,
+	opts auth.LoginOptions,
+	ioStreams *terminal.IOStreams,
+) (*auth.Result, error) {
+	deviceCodeChan := make(chan deviceCodeData, 1)
+	outcomeChan := make(chan loginOutcome, 1)
+	done := make(chan tui.StatusResult, 1)
+
+	opts.DeviceCodeCallback = func(userCode, verificationURI, _ string) {
+		select {
+		case deviceCodeChan <- deviceCodeData{userCode: userCode, verificationURI: verificationURI}:
+		default:
+		}
+	}
+
+	go func() {
+		result, err := handler.Login(ctx, opts)
+		outcomeChan <- loginOutcome{result: result, err: err}
+	}()
+
+	// Wait briefly for a device code callback. If the handler internally
+	// uses device code (e.g., GitHub FlowInteractive without client_secret),
+	// we want to show the device-code TUI instead of the browser TUI.
+	w.Verbosef("Initiating authentication with %s...", handler.DisplayName())
+
+	var useDeviceCodeTUI bool
+	var dci deviceCodeData
+	select {
+	case dci = <-deviceCodeChan:
+		useDeviceCodeTUI = true
+	case outcome := <-outcomeChan:
+		// Login completed before any TUI was shown.
+		if outcome.err != nil {
+			return nil, loginError(ctx, outcome.err)
+		}
+		return outcome.result, nil
+	case <-time.After(browserCallbackWait):
+		// No device code within the wait window — assume browser flow.
+		useDeviceCodeTUI = false
+	case <-ctx.Done():
+		return nil, exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
+	}
+
+	// Forward the login outcome to the TUI done channel.
+	var capturedOutcome loginOutcome
+	outcomeReady := make(chan struct{})
+	go func() {
+		outcome := <-outcomeChan
+		capturedOutcome = outcome
+		if outcome.err != nil {
+			done <- tui.StatusResult{Err: outcome.err}
+		} else {
+			done <- tui.StatusResult{Message: "Authenticated as " + loginIdentity(outcome.result)}
+		}
+		close(outcomeReady)
+	}()
+
+	data, schema := browserTUISchema(handler.DisplayName(), useDeviceCodeTUI, dci)
+
+	cfg := tui.DefaultConfig()
+	cfg.AppName = binaryName
+	cfg.DisplaySchema = schema
+	cfg.Done = done
+
+	teaOpts := tui.WithIO(ioStreams.In, ioStreams.Out)
+	if runErr := tui.Run(data, cfg, teaOpts...); runErr != nil {
+		if ctx.Err() != nil {
+			return nil, exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
+		}
+		return nil, fmt.Errorf("authentication display failed: %w", runErr)
+	}
+
+	// TUI exited normally.
+	select {
+	case <-outcomeReady:
+		// Outcome is captured.
+	default:
+		return nil, exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
+	}
+
+	if capturedOutcome.err != nil {
+		return nil, loginError(ctx, capturedOutcome.err)
+	}
+	return capturedOutcome.result, nil
+}
+
+// browserTUISchema builds the TUI data and display schema for the browser login
+// flow, adapting to whether a device code, a browser auth URL, or neither was
+// surfaced by the handler.
+func browserTUISchema(displayName string, useDeviceCodeTUI bool, dci deviceCodeData) (map[string]any, *tui.DisplaySchema) {
+	switch {
+	case useDeviceCodeTUI && dci.userCode != "":
+		// Real device code flow (e.g., GitHub without client_secret).
+		return map[string]any{
+				"title": fmt.Sprintf("Sign in to %s", displayName),
+				"url":   dci.verificationURI,
+				"code":  dci.userCode,
+			}, &tui.DisplaySchema{
+				Version: "v1",
+				Status: &tui.StatusDisplayConfig{
+					TitleField:     "title",
+					WaitMessage:    "Waiting for authentication...",
+					SuccessMessage: "Authenticated successfully!",
+					DoneBehavior:   tui.DoneBehaviorExitAfterDelay,
+					DoneDelay:      "2s",
+					DisplayFields: []tui.StatusFieldDisplay{
+						{Label: "URL", Field: "url"},
+						{Label: "Code", Field: "code"},
+					},
+					Actions: []tui.StatusActionConfig{
+						{
+							Label: "Copy code",
+							Type:  "copy-value",
+							Field: "code",
+							Keys:  tui.StatusKeyBindings{Vim: "c", Emacs: "alt+c", Function: "f2"},
+						},
+						{
+							Label: "Open URL",
+							Type:  "open-url",
+							Field: "url",
+							Keys:  tui.StatusKeyBindings{Vim: "o", Emacs: "alt+o", Function: "f3"},
+						},
+					},
+				},
+			}
+	case useDeviceCodeTUI && dci.userCode == "" && dci.verificationURI != "":
+		// Browser auth code flow — handler reported the auth URL via callback.
+		return map[string]any{
+				"title": fmt.Sprintf("Sign in to %s", displayName),
+				"url":   dci.verificationURI,
+			}, &tui.DisplaySchema{
+				Version: "v1",
+				Status: &tui.StatusDisplayConfig{
+					TitleField:     "title",
+					WaitMessage:    "Waiting for browser authentication...",
+					SuccessMessage: "Authenticated successfully!",
+					DoneBehavior:   tui.DoneBehaviorExitAfterDelay,
+					DoneDelay:      "2s",
+					DisplayFields: []tui.StatusFieldDisplay{
+						{Label: "URL", Field: "url"},
+					},
+					Actions: []tui.StatusActionConfig{
+						{
+							Label: "Re-open in browser",
+							Type:  "open-url",
+							Field: "url",
+							Keys:  tui.StatusKeyBindings{Vim: "o", Emacs: "alt+o", Function: "f3"},
+						},
+					},
+				},
+			}
+	default:
+		// No callback fired — show minimal browser waiting TUI.
+		return map[string]any{
+				"title": fmt.Sprintf("Sign in to %s", displayName),
+			}, &tui.DisplaySchema{
+				Version: "v1",
+				Status: &tui.StatusDisplayConfig{
+					TitleField:     "title",
+					WaitMessage:    "Waiting for browser authentication...",
+					SuccessMessage: "Authenticated successfully!",
+					DoneBehavior:   tui.DoneBehaviorExitAfterDelay,
+					DoneDelay:      "2s",
+				},
+			}
+	}
+}
+
+// loginError maps a handler.Login error to an exit-coded error, translating a
+// cancelled context into ErrUserCancelled.
+func loginError(ctx context.Context, err error) error {
+	if ctx.Err() != nil {
+		return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
+	}
+	return exitcode.WithCode(fmt.Errorf("authentication failed: %w", err), exitcode.GeneralError)
+}
+
+// loginIdentity returns a display identity for a login result, falling back to
+// a placeholder when the claims carry no identity.
+func loginIdentity(result *auth.Result) string {
+	identity := result.Claims.DisplayIdentity()
+	if identity == "" {
+		identity = "unknown user"
+	}
+	return identity
+}

--- a/pkg/auth/loginui/loginui_test.go
+++ b/pkg/auth/loginui/loginui_test.go
@@ -1,0 +1,243 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package loginui
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+)
+
+// mockHandler is a minimal auth.Handler for exercising the plain-text login
+// path. Only Login, Name, and DisplayName carry behaviour; the rest return
+// zero values.
+type mockHandler struct {
+	name      string
+	loginFunc func(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error)
+}
+
+func (m *mockHandler) Name() string        { return m.name }
+func (m *mockHandler) DisplayName() string { return m.name }
+
+func (m *mockHandler) Login(ctx context.Context, opts auth.LoginOptions) (*auth.Result, error) {
+	return m.loginFunc(ctx, opts)
+}
+
+func (m *mockHandler) Logout(_ context.Context) error                 { return nil }
+func (m *mockHandler) Status(_ context.Context) (*auth.Status, error) { return &auth.Status{}, nil }
+
+func (m *mockHandler) GetToken(_ context.Context, _ auth.TokenOptions) (*auth.Token, error) {
+	return &auth.Token{}, nil
+}
+
+func (m *mockHandler) InjectAuth(_ context.Context, _ *http.Request, _ auth.TokenOptions) error {
+	return nil
+}
+
+func (m *mockHandler) SupportedFlows() []auth.Flow     { return nil }
+func (m *mockHandler) Capabilities() []auth.Capability { return nil }
+
+func newTestWriter(t *testing.T) *writer.Writer {
+	t.Helper()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	return writer.New(ioStreams, settings.NewCliParams())
+}
+
+func TestRunLogin_PlainSuccess(t *testing.T) {
+	t.Parallel()
+
+	callbackFired := false
+	handler := &mockHandler{
+		name: "gcp",
+		loginFunc: func(_ context.Context, opts auth.LoginOptions) (*auth.Result, error) {
+			// The plain path installs a device-code callback that prints
+			// instructions; exercise it.
+			if opts.DeviceCodeCallback != nil {
+				callbackFired = true
+				opts.DeviceCodeCallback("CODE123", "https://verify.example", "")
+			}
+			return &auth.Result{Claims: &auth.Claims{Username: "alice"}}, nil
+		},
+	}
+
+	w := newTestWriter(t)
+	result, err := RunLogin(context.Background(), w, "scafctl", handler, auth.LoginOptions{Flow: auth.FlowDeviceCode})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "alice", result.Claims.DisplayIdentity())
+	assert.True(t, callbackFired, "plain path should invoke the device-code callback")
+}
+
+func TestRunLogin_PlainError(t *testing.T) {
+	t.Parallel()
+
+	loginErr := errors.New("boom")
+	handler := &mockHandler{
+		name: "gcp",
+		loginFunc: func(_ context.Context, _ auth.LoginOptions) (*auth.Result, error) {
+			return nil, loginErr
+		},
+	}
+
+	w := newTestWriter(t)
+	result, err := RunLogin(context.Background(), w, "scafctl", handler, auth.LoginOptions{Flow: auth.FlowServicePrincipal})
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, loginErr)
+	assert.NotErrorIs(t, err, auth.ErrUserCancelled)
+}
+
+func TestRunLogin_PlainCancelled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	handler := &mockHandler{
+		name: "gcp",
+		loginFunc: func(ctx context.Context, _ auth.LoginOptions) (*auth.Result, error) {
+			return nil, ctx.Err()
+		},
+	}
+
+	w := newTestWriter(t)
+	_, err := RunLogin(ctx, w, "scafctl", handler, auth.LoginOptions{Flow: auth.FlowServicePrincipal})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, auth.ErrUserCancelled)
+}
+
+// TestRunStatusTUI_EarlyCompletion exercises the device-code TUI path when the
+// login finishes before a device code is surfaced, which returns without ever
+// launching the interactive TUI (untestable without a PTY).
+func TestRunStatusTUI_EarlyCompletion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		handler := &mockHandler{
+			name: "gcp",
+			loginFunc: func(_ context.Context, _ auth.LoginOptions) (*auth.Result, error) {
+				return &auth.Result{Claims: &auth.Claims{Username: "alice"}}, nil
+			},
+		}
+		w := newTestWriter(t)
+		result, err := runStatusTUI(context.Background(), w, "scafctl", handler, auth.LoginOptions{}, w.IOStreams())
+		require.NoError(t, err)
+		assert.Equal(t, "alice", result.Claims.DisplayIdentity())
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+		loginErr := errors.New("boom")
+		handler := &mockHandler{
+			name: "gcp",
+			loginFunc: func(_ context.Context, _ auth.LoginOptions) (*auth.Result, error) {
+				return nil, loginErr
+			},
+		}
+		w := newTestWriter(t)
+		_, err := runStatusTUI(context.Background(), w, "scafctl", handler, auth.LoginOptions{}, w.IOStreams())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, loginErr)
+	})
+}
+
+// TestRunBrowserTUI_EarlyCompletion exercises the browser TUI path when the
+// login finishes before any TUI is shown.
+func TestRunBrowserTUI_EarlyCompletion(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		handler := &mockHandler{
+			name: "gcp",
+			loginFunc: func(_ context.Context, _ auth.LoginOptions) (*auth.Result, error) {
+				return &auth.Result{Claims: &auth.Claims{Username: "bob"}}, nil
+			},
+		}
+		w := newTestWriter(t)
+		result, err := runBrowserTUI(context.Background(), w, "scafctl", handler, auth.LoginOptions{}, w.IOStreams())
+		require.NoError(t, err)
+		assert.Equal(t, "bob", result.Claims.DisplayIdentity())
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+		loginErr := errors.New("boom")
+		handler := &mockHandler{
+			name: "gcp",
+			loginFunc: func(_ context.Context, _ auth.LoginOptions) (*auth.Result, error) {
+				return nil, loginErr
+			},
+		}
+		w := newTestWriter(t)
+		_, err := runBrowserTUI(context.Background(), w, "scafctl", handler, auth.LoginOptions{}, w.IOStreams())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, loginErr)
+	})
+}
+
+func TestLoginIdentity(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "alice", loginIdentity(&auth.Result{Claims: &auth.Claims{Username: "alice"}}))
+	assert.Equal(t, "unknown user", loginIdentity(&auth.Result{}))
+}
+
+func TestLoginError(t *testing.T) {
+	t.Parallel()
+
+	// Cancelled context maps to ErrUserCancelled regardless of the wrapped error.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.ErrorIs(t, loginError(ctx, errors.New("ignored")), auth.ErrUserCancelled)
+
+	// Live context wraps the underlying error as an authentication failure.
+	underlying := errors.New("bad token")
+	err := loginError(context.Background(), underlying)
+	assert.ErrorIs(t, err, underlying)
+	assert.NotErrorIs(t, err, auth.ErrUserCancelled)
+}
+
+func TestBrowserTUISchema(t *testing.T) {
+	t.Parallel()
+
+	t.Run("device code", func(t *testing.T) {
+		t.Parallel()
+		data, schema := browserTUISchema("GitHub", true, deviceCodeData{userCode: "ABC", verificationURI: "https://verify"})
+		assert.Equal(t, "ABC", data["code"])
+		assert.Equal(t, "https://verify", data["url"])
+		assert.Equal(t, "Waiting for authentication...", schema.Status.WaitMessage)
+		assert.Len(t, schema.Status.Actions, 2)
+	})
+
+	t.Run("browser auth url", func(t *testing.T) {
+		t.Parallel()
+		data, schema := browserTUISchema("GitHub", true, deviceCodeData{verificationURI: "https://auth"})
+		_, hasCode := data["code"]
+		assert.False(t, hasCode)
+		assert.Equal(t, "https://auth", data["url"])
+		assert.Equal(t, "Waiting for browser authentication...", schema.Status.WaitMessage)
+		assert.Len(t, schema.Status.Actions, 1)
+	})
+
+	t.Run("minimal browser", func(t *testing.T) {
+		t.Parallel()
+		data, schema := browserTUISchema("GitHub", false, deviceCodeData{})
+		assert.Equal(t, "Sign in to GitHub", data["title"])
+		_, hasURL := data["url"]
+		assert.False(t, hasURL)
+		assert.Empty(t, schema.Status.Actions)
+		assert.Empty(t, schema.Status.DisplayFields)
+	})
+}

--- a/pkg/auth/statusrows/statusrows.go
+++ b/pkg/auth/statusrows/statusrows.go
@@ -1,0 +1,197 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package statusrows contains the domain logic for expanding an auth handler's
+// status into per-cluster (per-instance) sessions. It is consumed by the CLI
+// auth status/list commands (and reusable by embedders) so the command layer
+// stays thin: the command builds display rows, this package decides which
+// clusters, which representative token per cluster, which session is active,
+// and how each cluster is labeled.
+package statusrows
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/auth/hostname"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+)
+
+// InstanceSession is one per-cluster cached session selected for display.
+type InstanceSession struct {
+	// ClusterLabel is the display label for the cluster: the reverse-mapped
+	// alias when the token hostname matches a configured/resolved alias, else
+	// the trimmed host.
+	ClusterLabel string
+	// Active marks the most recently used session (newest CachedAt).
+	Active bool
+	// Token is the representative cached token for the cluster.
+	Token *auth.CachedTokenInfo
+}
+
+// Expand returns one session per cached cluster when the handler advertises
+// CapInstanceHostname and exposes per-instance cached tokens (each carrying a
+// Hostname). It returns nil when the handler is not an instance handler, is
+// unauthenticated, does not implement TokenLister, or has no hostname-bearing
+// cached tokens -- callers then render the handler's single base row unchanged.
+//
+// Sessions are one per cluster (deduplicated by Hostname): when a handler
+// returns several tokens for the same instance -- e.g. a user login plus minted
+// service-account tokens -- a single representative token is chosen (a
+// user/login flow wins over a machine flow; ties break by most-recent CachedAt)
+// so a service token is never rendered as if it were the login session. Sessions
+// are ordered deterministically by hostname, with Active marking the
+// most-recently-used cluster.
+func Expand(ctx context.Context, handlerName string, handler auth.Handler, status *auth.Status) []InstanceSession {
+	if status == nil || !status.Authenticated {
+		return nil
+	}
+	if !auth.HasCapability(handler.Capabilities(), auth.CapInstanceHostname) {
+		return nil
+	}
+	lister, ok := handler.(auth.TokenLister)
+	if !ok {
+		return nil
+	}
+	tokens, err := lister.ListCachedTokens(ctx)
+	if err != nil || len(tokens) == 0 {
+		return nil
+	}
+
+	// One representative token per instance (deduplicated by hostname).
+	instanceTokens := dedupInstanceTokens(tokens)
+	if len(instanceTokens) == 0 {
+		return nil
+	}
+
+	// Deterministic order by hostname.
+	sort.Slice(instanceTokens, func(i, j int) bool {
+		return instanceTokens[i].Hostname < instanceTokens[j].Hostname
+	})
+
+	aliases := InstanceAliases(ctx, handlerName)
+	activeIdx := mostRecentTokenIndex(instanceTokens)
+
+	sessions := make([]InstanceSession, 0, len(instanceTokens))
+	for i, tk := range instanceTokens {
+		sessions = append(sessions, InstanceSession{
+			ClusterLabel: ClusterLabel(aliases, tk.Hostname),
+			Active:       i == activeIdx,
+			Token:        tk,
+		})
+	}
+	return sessions
+}
+
+// ClusterLabel returns the display label for a cluster URL: the reverse-mapped
+// alias selector when rawURL matches a configured/resolved alias, else the
+// trimmed display host.
+func ClusterLabel(aliases map[string]string, rawURL string) string {
+	if label, ok := hostname.AliasForURL(aliases, rawURL); ok {
+		return label
+	}
+	return hostname.DisplayHostFromURL(rawURL)
+}
+
+// dedupInstanceTokens returns one representative cached token per hostname. When
+// a handler returns several tokens for the same instance (e.g. a user login plus
+// minted service-account tokens), a user/login flow is preferred over a machine
+// flow, with ties broken by the most-recent CachedAt, so each cluster renders as
+// a single session reflecting the login. Tokens without a hostname are skipped.
+func dedupInstanceTokens(tokens []*auth.CachedTokenInfo) []*auth.CachedTokenInfo {
+	byHost := make(map[string]*auth.CachedTokenInfo)
+	for _, tk := range tokens {
+		if tk == nil || tk.Hostname == "" {
+			continue
+		}
+		if current, ok := byHost[tk.Hostname]; !ok || preferInstanceToken(tk, current) {
+			byHost[tk.Hostname] = tk
+		}
+	}
+	out := make([]*auth.CachedTokenInfo, 0, len(byHost))
+	for _, tk := range byHost {
+		out = append(out, tk)
+	}
+	return out
+}
+
+// preferInstanceToken reports whether candidate is a better per-cluster
+// representative than current: a user/login flow beats a machine flow, otherwise
+// the newer CachedAt wins.
+func preferInstanceToken(candidate, current *auth.CachedTokenInfo) bool {
+	cu, ru := isUserFlow(candidate.Flow), isUserFlow(current.Flow)
+	if cu != ru {
+		return cu
+	}
+	return candidate.CachedAt.After(current.CachedAt)
+}
+
+// isUserFlow reports whether a flow represents an interactive user/login session
+// (as opposed to a machine/service credential).
+func isUserFlow(f auth.Flow) bool {
+	switch f {
+	case auth.FlowInteractive, auth.FlowDeviceCode, auth.FlowPAT:
+		return true
+	default:
+		return false
+	}
+}
+
+// mostRecentTokenIndex returns the index of the cached token with the newest
+// CachedAt timestamp, used to mark the "(active)" cluster session. It returns
+// -1 when no token carries a usable timestamp (no marker is applied).
+func mostRecentTokenIndex(tokens []*auth.CachedTokenInfo) int {
+	idx := -1
+	var latest time.Time
+	for i, tk := range tokens {
+		if tk.CachedAt.IsZero() {
+			continue
+		}
+		if idx == -1 || tk.CachedAt.After(latest) {
+			latest = tk.CachedAt
+			idx = i
+		}
+	}
+	return idx
+}
+
+// InstanceAliases returns a selector->URL map for reverse-mapping a cluster URL
+// back to its short name. It merges static hostname aliases with the resolver's
+// already-cached inventory entries (no network fetch), so both statically
+// aliased and dynamically resolved fleets render the short selector. Static
+// aliases win over resolver entries on selector collisions. Returns nil when
+// nothing is configured.
+func InstanceAliases(ctx context.Context, handlerName string) map[string]string {
+	cfg := config.FromContext(ctx)
+	if cfg == nil {
+		return nil
+	}
+	hc, ok := cfg.Auth.Handlers[handlerName]
+	if !ok || hc.Hostname == nil {
+		return nil
+	}
+
+	merged := make(map[string]string, len(hc.Hostname.Aliases))
+	// Reverse-map from any cached resolver inventory (network-free, stale-OK): a
+	// cluster resolved via `kube login` is cached under a different key than the
+	// openshift-auth resolver, so union all cached inventories for labeling.
+	// Static aliases overwrite on selector collision.
+	if hc.Hostname.Resolver != nil || len(hc.Hostname.Aliases) > 0 {
+		for _, e := range hostname.AllCachedInventoryEntries() {
+			if e.Name != "" && e.URL != "" {
+				if _, ok := merged[e.Name]; !ok {
+					merged[e.Name] = e.URL
+				}
+			}
+		}
+	}
+	for sel, url := range hc.Hostname.Aliases {
+		merged[sel] = url
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
+}

--- a/pkg/auth/statusrows/statusrows_test.go
+++ b/pkg/auth/statusrows/statusrows_test.go
@@ -1,0 +1,211 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package statusrows
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+)
+
+func instanceConfigCtx(handler string, aliases map[string]string) context.Context {
+	return config.WithConfig(context.Background(), &config.Config{
+		Auth: config.GlobalAuthConfig{
+			Handlers: map[string]config.HandlerConfig{
+				handler: {
+					Hostname: &config.HostnameConfig{Aliases: aliases},
+				},
+			},
+		},
+	})
+}
+
+func TestMostRecentTokenIndex(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	assert.Equal(t, -1, mostRecentTokenIndex(nil))
+	assert.Equal(t, -1, mostRecentTokenIndex([]*auth.CachedTokenInfo{{}, {}}))
+
+	tokens := []*auth.CachedTokenInfo{
+		{CachedAt: now.Add(-time.Hour)},
+		{CachedAt: now},
+		{CachedAt: now.Add(-2 * time.Hour)},
+	}
+	assert.Equal(t, 1, mostRecentTokenIndex(tokens))
+}
+
+// TestPreferInstanceToken covers representative selection: a user/login flow
+// beats a machine flow regardless of age; same-class tokens break ties by the
+// most-recent CachedAt.
+func TestPreferInstanceToken(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	user := &auth.CachedTokenInfo{Flow: auth.FlowInteractive, CachedAt: now.Add(-time.Hour)}
+	machine := &auth.CachedTokenInfo{Flow: auth.FlowServicePrincipal, CachedAt: now}
+
+	// User/login flow wins even when the machine token is newer.
+	assert.True(t, preferInstanceToken(user, machine))
+	assert.False(t, preferInstanceToken(machine, user))
+
+	// Same class -> newer CachedAt wins.
+	older := &auth.CachedTokenInfo{Flow: auth.FlowInteractive, CachedAt: now.Add(-time.Hour)}
+	newer := &auth.CachedTokenInfo{Flow: auth.FlowInteractive, CachedAt: now}
+	assert.True(t, preferInstanceToken(newer, older))
+	assert.False(t, preferInstanceToken(older, newer))
+}
+
+func TestIsUserFlow(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isUserFlow(auth.FlowInteractive))
+	assert.True(t, isUserFlow(auth.FlowDeviceCode))
+	assert.True(t, isUserFlow(auth.FlowPAT))
+	assert.False(t, isUserFlow(auth.FlowServicePrincipal))
+	assert.False(t, isUserFlow(auth.FlowClientCredentials))
+	assert.False(t, isUserFlow(""))
+}
+
+func TestDedupInstanceTokens(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	tokens := []*auth.CachedTokenInfo{
+		nil,            // skipped
+		{Hostname: ""}, // skipped (no host)
+		{Hostname: "https://a.example.com", Flow: auth.FlowServicePrincipal, CachedAt: now},
+		{Hostname: "https://a.example.com", Flow: auth.FlowInteractive, CachedAt: now.Add(-time.Hour)},
+		{Hostname: "https://b.example.com", Flow: auth.FlowInteractive, CachedAt: now},
+	}
+
+	out := dedupInstanceTokens(tokens)
+	require.Len(t, out, 2, "one representative per hostname; nil/no-host skipped")
+
+	byHost := map[string]*auth.CachedTokenInfo{}
+	for _, tk := range out {
+		byHost[tk.Hostname] = tk
+	}
+	// The user/login flow represents host a even though the SA token is newer.
+	assert.Equal(t, auth.FlowInteractive, byHost["https://a.example.com"].Flow)
+	assert.Equal(t, auth.FlowInteractive, byHost["https://b.example.com"].Flow)
+}
+
+func TestClusterLabel(t *testing.T) {
+	t.Parallel()
+
+	aliases := map[string]string{"pd1020": "https://api.pd1020.example.com:6443"}
+
+	// Alias match -> short selector.
+	assert.Equal(t, "pd1020", ClusterLabel(aliases, "https://api.pd1020.example.com:6443"))
+	// No alias -> trimmed display host.
+	assert.Equal(t, "api.other.example.com", ClusterLabel(aliases, "https://api.other.example.com:6443"))
+	// No aliases at all -> display host.
+	assert.Equal(t, "api.x.example.com", ClusterLabel(nil, "https://api.x.example.com"))
+}
+
+func TestInstanceAliases(t *testing.T) {
+	t.Parallel()
+
+	// No config in context.
+	assert.Nil(t, InstanceAliases(context.Background(), "openshift"))
+
+	ctx := instanceConfigCtx("openshift", map[string]string{"pd1020": "https://api.pd1020.example.com"})
+	got := InstanceAliases(ctx, "openshift")
+	assert.Equal(t, "https://api.pd1020.example.com", got["pd1020"])
+
+	// Unknown handler -> nil.
+	assert.Nil(t, InstanceAliases(ctx, "other"))
+
+	// A resolver-configured handler with no cached inventory still returns the
+	// static aliases (the resolver branch is a no-op without a cache hit).
+	resolverCtx := config.WithConfig(context.Background(), &config.Config{
+		Auth: config.GlobalAuthConfig{
+			Handlers: map[string]config.HandlerConfig{
+				"openshift": {
+					Hostname: &config.HostnameConfig{
+						Aliases:  map[string]string{"pd1020": "https://api.pd1020.example.com"},
+						Resolver: &config.HostnameResolverConfig{Transform: "_"},
+					},
+				},
+			},
+		},
+	})
+	resolved := InstanceAliases(resolverCtx, "openshift")
+	assert.Equal(t, "https://api.pd1020.example.com", resolved["pd1020"])
+}
+
+func TestExpand_NonInstanceHandler(t *testing.T) {
+	t.Parallel()
+
+	h := auth.NewMockHandler("entra")
+	h.CapabilitiesValue = []auth.Capability{auth.CapScopesOnLogin}
+	assert.Nil(t, Expand(context.Background(), "entra", h, &auth.Status{Authenticated: true}))
+}
+
+func TestExpand_NotAuthenticated(t *testing.T) {
+	t.Parallel()
+
+	h := auth.NewMockHandler("openshift")
+	h.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
+	assert.Nil(t, Expand(context.Background(), "openshift", h, &auth.Status{Authenticated: false}))
+	assert.Nil(t, Expand(context.Background(), "openshift", h, nil))
+}
+
+func TestExpand_NoHostnameTokens(t *testing.T) {
+	t.Parallel()
+
+	h := auth.NewMockHandler("openshift")
+	h.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
+	h.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{Handler: "openshift", TokenKind: "access_token"}, // no Hostname
+	}
+	assert.Nil(t, Expand(context.Background(), "openshift", h, &auth.Status{Authenticated: true}))
+}
+
+func TestExpand_TwoClusters(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	h := auth.NewMockHandler("openshift")
+	h.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
+	h.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{Handler: "openshift", Hostname: "https://api.np0510.example.com:6443", Flow: auth.FlowInteractive, CachedAt: now.Add(-2 * time.Hour)},
+		{Handler: "openshift", Hostname: "https://api.pd1020.example.com:6443", Flow: auth.FlowInteractive, CachedAt: now}, // most recent -> active
+	}
+	ctx := instanceConfigCtx("openshift", map[string]string{"pd1020": "https://api.pd1020.example.com:6443"})
+
+	sessions := Expand(ctx, "openshift", h, &auth.Status{Authenticated: true})
+	require.Len(t, sessions, 2)
+
+	// Sorted by hostname: np0510 < pd1020.
+	assert.Equal(t, "api.np0510.example.com", sessions[0].ClusterLabel)
+	assert.False(t, sessions[0].Active)
+	assert.Equal(t, "pd1020", sessions[1].ClusterLabel)
+	assert.True(t, sessions[1].Active, "most recent CachedAt is active")
+}
+
+// TestExpand_DedupesPerCluster asserts several tokens for the same instance
+// collapse to a single session that reflects the user/login flow.
+func TestExpand_DedupesPerCluster(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	h := auth.NewMockHandler("openshift")
+	h.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
+	h.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{Handler: "openshift", Hostname: "https://api.pd1020.example.com:6443", Flow: auth.FlowInteractive, CachedAt: now.Add(-time.Hour)},
+		{Handler: "openshift", Hostname: "https://api.pd1020.example.com:6443", Flow: auth.FlowServicePrincipal, CachedAt: now},
+	}
+
+	sessions := Expand(context.Background(), "openshift", h, &auth.Status{Authenticated: true})
+	require.Len(t, sessions, 1)
+	assert.Equal(t, auth.FlowInteractive, sessions[0].Token.Flow, "user/login flow wins over newer machine token")
+}

--- a/pkg/cmd/scafctl/auth/auth_status_schema.json
+++ b/pkg/cmd/scafctl/auth/auth_status_schema.json
@@ -61,7 +61,7 @@
       "flow":           { "type": "string", "title": "Flow" },
       "user":           { "type": "string", "title": "User", "maxLength": 30 },
       "expiresIn":      { "type": "string", "title": "Expires", "maxLength": 10 },
-      "profile":        { "type": "string", "title": "Profile", "maxLength": 20 },
+      "profile":        { "type": "string", "title": "Profile", "maxLength": 60 },
       "displayName":    { "type": "string", "title": "Display Name" },
       "email":          { "type": "string", "title": "Email" },
       "username":       { "type": "string", "title": "Username" },

--- a/pkg/cmd/scafctl/auth/diagnose.go
+++ b/pkg/cmd/scafctl/auth/diagnose.go
@@ -105,7 +105,7 @@ func CommandDiagnose(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ s
 			}
 
 			// ── 1. Auth registry ──────────────────────────────────────────────
-			handlerNames := listHandlers(ctx)
+			handlerNames := listActiveHandlers(ctx, cliParams.BinaryName)
 			if len(handlerNames) == 0 {
 				unconfigured := listUnconfiguredOfficialHandlers(ctx)
 				if len(unconfigured) > 0 {

--- a/pkg/cmd/scafctl/auth/diagnose_test.go
+++ b/pkg/cmd/scafctl/auth/diagnose_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adrg/xdg"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/auth/diagnose"
 	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
@@ -23,6 +24,17 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// Isolate the plugin cache so tests never pick up the developer's real
+	// installed auth-handler plugins -- listActiveHandlers/installedAuthHandlerNames
+	// scan xdg.CacheHome, and a populated cache would make "no handlers" tests
+	// non-deterministic. Set the env var (not just xdg.CacheHome) so it survives
+	// the xdg.Reload() calls other tests make when overriding XDG_CONFIG_HOME etc.
+	cacheDir, _ := os.MkdirTemp("", "scafctl-auth-test-cache")
+	if cacheDir != "" {
+		_ = os.Setenv("XDG_CACHE_HOME", cacheDir)
+		xdg.Reload()
+	}
+
 	// Replace the clock skew check with a fast, offline stub so tests
 	// don't make real HTTPS calls (~3 s each).
 	clockSkewCheckFunc = func() diagnose.Check {
@@ -33,7 +45,13 @@ func TestMain(m *testing.M) {
 			Message:  "stubbed — no network call",
 		}
 	}
-	os.Exit(m.Run())
+
+	code := m.Run()
+
+	if cacheDir != "" {
+		_ = os.RemoveAll(cacheDir)
+	}
+	os.Exit(code)
 }
 
 func TestCommandDiagnose_Structure(t *testing.T) {

--- a/pkg/cmd/scafctl/auth/handler.go
+++ b/pkg/cmd/scafctl/auth/handler.go
@@ -13,6 +13,9 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/auth/handlerdep"
 	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/plugin"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
 )
 
 // handlerContextKey is used for test injection of handlers.
@@ -63,6 +66,69 @@ func listHandlers(ctx context.Context) []string {
 		return nil
 	}
 	return registry.List()
+}
+
+// listActiveHandlers returns the handler names to enumerate for root ("no
+// handler") bulk operations (status, list, diagnose): the union of
+// eagerly-registered handlers and locally-installed auth-handler plugins.
+//
+// Unlike listHandlers it also surfaces third-party plugin handlers the user
+// actually uses (e.g. openshift) that are resolved lazily by name and so are not
+// eagerly registered. The installed-plugin cache is a host-owned, handler-
+// agnostic signal that requires no config pin, no fragile credential-file
+// parsing, and no network fetch (only already-cached plugins are included).
+//
+// Policy applies: installed third-party plugins are omitted when
+// settings.disableThirdPartyAuthHandlers is set (official handlers still surface
+// via the eager registry). Results are deduplicated and sorted.
+func listActiveHandlers(ctx context.Context, binaryName string) []string {
+	if h := handlerFromContext(ctx); h != nil {
+		return []string{h.Name()}
+	}
+
+	seen := make(map[string]struct{})
+	if registry := auth.RegistryFromContext(ctx); registry != nil {
+		for _, name := range registry.List() {
+			seen[name] = struct{}{}
+		}
+	}
+
+	for _, name := range installedAuthHandlerNames(ctx, binaryName) {
+		seen[name] = struct{}{}
+	}
+
+	if len(seen) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// installedAuthHandlerNames returns the names of auth-handler plugins present in
+// the local plugin cache (i.e. already fetched/used). This is a host-owned,
+// handler-agnostic, network-free signal for surfacing lazily-resolved
+// third-party handlers (e.g. openshift). It returns nil when third-party
+// resolution is disabled by policy or nothing is cached. Names are not sorted.
+func installedAuthHandlerNames(ctx context.Context, binaryName string) []string {
+	if cfg := config.FromContext(ctx); cfg != nil && cfg.Settings.DisableThirdPartyAuthHandlers {
+		return nil
+	}
+	cache := plugin.NewCache(settings.PluginCacheDirFor(binaryName))
+	cached, err := cache.List()
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, p := range cached {
+		if name, kind := plugin.PluginKindFromCacheKey(p.Name); kind == solution.PluginKindAuthHandler && name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 // listKnownHandlers returns the names of all registered and officially-known

--- a/pkg/cmd/scafctl/auth/handler_test.go
+++ b/pkg/cmd/scafctl/auth/handler_test.go
@@ -5,11 +5,15 @@ package auth
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -65,6 +69,59 @@ func TestListHandlers_WithRegistry(t *testing.T) {
 	assert.Contains(t, handlers, "entra")
 	assert.Contains(t, handlers, "github")
 	assert.Len(t, handlers, 2)
+}
+
+func TestListActiveHandlers_TestHandlerShortCircuit(t *testing.T) {
+	mock := auth.NewMockHandler("openshift")
+	ctx := withTestHandler(context.Background(), mock)
+	assert.Equal(t, []string{"openshift"}, listActiveHandlers(ctx, "scafctl"))
+}
+
+func TestListActiveHandlers_EagerOnlyWhenNoInstalledPlugins(t *testing.T) {
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(auth.NewMockHandler("entra")))
+	require.NoError(t, registry.Register(auth.NewMockHandler("gcp")))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	// A binary name whose plugin cache dir does not exist yields just the eager
+	// handlers (the installed-plugin scan is an empty/graceful miss).
+	got := listActiveHandlers(ctx, "scafctl-test-nonexistent-cache-xyz")
+	assert.Equal(t, []string{"entra", "gcp"}, got)
+}
+
+func TestListActiveHandlers_ThirdPartyDisabledSkipsInstalledScan(t *testing.T) {
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(auth.NewMockHandler("gcp")))
+	ctx := auth.WithRegistry(context.Background(), registry)
+	ctx = config.WithConfig(ctx, &config.Config{
+		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
+	})
+
+	// Even if the local machine has installed plugins under "scafctl", policy
+	// disables the scan, so only the eager handler surfaces.
+	got := listActiveHandlers(ctx, "scafctl")
+	assert.Equal(t, []string{"gcp"}, got)
+}
+
+func TestListActiveHandlers_SurfacesInstalledAuthPlugin(t *testing.T) {
+	t.Parallel()
+
+	// The package TestMain isolates xdg.CacheHome, so seeding under a unique
+	// binary-name subdir is hermetic without mutating any global.
+	// Layout: <cacheDir>/<key>/<ver>/<plat>/<key>.
+	const binaryName = "mycli-surfaces-test"
+	cacheDir := settings.PluginCacheDirFor(binaryName)
+	platformDir := runtime.GOOS + "-" + runtime.GOARCH
+	pluginDir := filepath.Join(cacheDir, "auth-handler-openshift", "0.1.0", platformDir)
+	require.NoError(t, os.MkdirAll(pluginDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "auth-handler-openshift"), []byte("binary"), 0o600))
+
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(auth.NewMockHandler("gcp")))
+	ctx := auth.WithRegistry(context.Background(), registry)
+
+	got := listActiveHandlers(ctx, binaryName)
+	assert.Equal(t, []string{"gcp", "openshift"}, got, "installed auth plugin surfaces alongside eager handlers, deduped and sorted")
 }
 
 func TestListHandlers_WithTestHandler(t *testing.T) {

--- a/pkg/cmd/scafctl/auth/handlers.go
+++ b/pkg/cmd/scafctl/auth/handlers.go
@@ -175,35 +175,44 @@ func CommandHandlers(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ s
 	return cmd
 }
 
+// authHandlerNameSet returns the sorted union of auth handler names to display:
+// eagerly-registered handlers, official (auto-fetchable) handlers, and
+// locally-installed third-party plugins (e.g. openshift) that resolve lazily by
+// name. Including the last group ensures installed third-party handlers surface
+// in 'auth handlers', completions, and detail lookups.
+func authHandlerNameSet(ctx context.Context) []string {
+	nameSet := make(map[string]struct{})
+	if authReg := authpkg.RegistryFromContext(ctx); authReg != nil {
+		for _, n := range authReg.List() {
+			nameSet[n] = struct{}{}
+		}
+	}
+	if officialReg := authofficial.RegistryFromContext(ctx); officialReg != nil {
+		for _, n := range officialReg.Names() {
+			nameSet[n] = struct{}{}
+		}
+	}
+	for _, n := range installedAuthHandlerNames(ctx, settings.BinaryNameFromContext(ctx)) {
+		nameSet[n] = struct{}{}
+	}
+	names := make([]string, 0, len(nameSet))
+	for n := range nameSet {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
 // collectHandlerInfo gathers information about all known auth handlers:
 // registered (installed) and official (available for auto-fetch).
 func collectHandlerInfo(ctx context.Context) []map[string]any {
 	authReg := authpkg.RegistryFromContext(ctx)
 	officialReg := authofficial.RegistryFromContext(ctx)
 
-	// Collect all unique handler names from both registries.
-	nameSet := make(map[string]struct{})
-	if authReg != nil {
-		for _, name := range authReg.List() {
-			nameSet[name] = struct{}{}
-		}
-	}
-	if officialReg != nil {
-		for _, name := range officialReg.Names() {
-			nameSet[name] = struct{}{}
-		}
-	}
-
-	names := make([]string, 0, len(nameSet))
-	for name := range nameSet {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
+	names := authHandlerNameSet(ctx)
 	results := make([]map[string]any, 0, len(names))
 	for _, name := range names {
-		result := buildHandlerInfoResult(ctx, name, authReg, officialReg)
-		results = append(results, result)
+		results = append(results, buildHandlerInfoResult(ctx, name, authReg, officialReg))
 	}
 
 	return results
@@ -216,24 +225,7 @@ func collectHandlerInfoInteractive(ctx context.Context) []any {
 	authReg := authpkg.RegistryFromContext(ctx)
 	officialReg := authofficial.RegistryFromContext(ctx)
 
-	nameSet := make(map[string]struct{})
-	if authReg != nil {
-		for _, name := range authReg.List() {
-			nameSet[name] = struct{}{}
-		}
-	}
-	if officialReg != nil {
-		for _, name := range officialReg.Names() {
-			nameSet[name] = struct{}{}
-		}
-	}
-
-	names := make([]string, 0, len(nameSet))
-	for name := range nameSet {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
+	names := authHandlerNameSet(ctx)
 	rows := make([]any, 0, len(names))
 	for _, name := range names {
 		rows = append(rows, buildHandlerInteractiveResult(ctx, name, authReg, officialReg))
@@ -247,14 +239,21 @@ func collectHandlerInfoInteractive(ctx context.Context) []any {
 // arrays; available handlers include an install hint; unknown handlers are
 // marked not-found.
 func buildHandlerInteractiveResult(ctx context.Context, name string, authReg *authpkg.Registry, officialReg *authofficial.Registry) map[string]any {
+	// Registered (built-in or eagerly-loaded plugin).
 	if authReg != nil && authReg.Has(name) {
 		if handler, err := authReg.Get(name); err == nil {
 			return buildHandlerDetailMap(ctx, handler)
 		}
 	}
 
+	// Official handler that is not yet installed: show the install hint.
 	if officialReg != nil && officialReg.Has(name) {
 		return buildAvailableHandlerCard(ctx, name)
+	}
+
+	// Locally-installed third-party handler resolved lazily by name.
+	if handler, err := getHandler(ctx, name); err == nil {
+		return buildHandlerDetailMap(ctx, handler)
 	}
 
 	return map[string]any{
@@ -295,63 +294,60 @@ func buildHandlerInfoResult(ctx context.Context, name string, authReg *authpkg.R
 		"loggedIn":    false,
 	}
 
-	// Check if handler is installed (registered in auth registry).
+	// Registered in the auth registry (built-in or eagerly-loaded plugin).
 	if authReg != nil && authReg.Has(name) {
-		handler, err := authReg.Get(name)
-		if err == nil {
-			result["status"] = "installed"
-			result["displayName"] = handler.DisplayName()
-			switch handler.(type) {
-			case *plugin.AuthHandlerWrapper, *plugin.LazyAuthHandlerWrapper:
-				result["source"] = "plugin"
-			default:
-				result["source"] = "built-in"
-			}
-
-			// Collect supported flows.
-			flows := handler.SupportedFlows()
-			flowNames := make([]string, 0, len(flows))
-			for _, f := range flows {
-				flowNames = append(flowNames, string(f))
-			}
-			result["flows"] = strings.Join(flowNames, ", ")
-
-			// Check authentication status.
-			if status, err := handler.Status(ctx); err == nil {
-				result["loggedIn"] = status.Authenticated
-			}
+		if handler, err := authReg.Get(name); err == nil {
+			populateInstalledHandlerInfo(ctx, result, handler)
 		}
-	} else if officialReg != nil && officialReg.Has(name) {
-		// Handler is in the official registry but not installed yet.
+		return result
+	}
+
+	// Official handler that is not yet installed: mark available without
+	// resolving it (avoids a network fetch just to list).
+	if officialReg != nil && officialReg.Has(name) {
 		result["status"] = "available"
 		result["source"] = "catalog"
 		binName := settings.BinaryNameFromContext(ctx)
 		result["flows"] = "run '" + binName + " auth handlers install " + name + "' to inspect"
+		return result
 	}
 
+	// Locally-installed third-party handler: resolve lazily by name so installed
+	// plugins (e.g. openshift) surface with real status/flows.
+	if handler, err := getHandler(ctx, name); err == nil {
+		populateInstalledHandlerInfo(ctx, result, handler)
+	}
 	return result
+}
+
+// populateInstalledHandlerInfo fills an installed handler's status, source,
+// flows, and loggedIn fields into result.
+func populateInstalledHandlerInfo(ctx context.Context, result map[string]any, handler authpkg.Handler) {
+	result["status"] = "installed"
+	result["displayName"] = handler.DisplayName()
+	switch handler.(type) {
+	case *plugin.AuthHandlerWrapper, *plugin.LazyAuthHandlerWrapper:
+		result["source"] = "plugin"
+	default:
+		result["source"] = "built-in"
+	}
+
+	flows := handler.SupportedFlows()
+	flowNames := make([]string, 0, len(flows))
+	for _, f := range flows {
+		flowNames = append(flowNames, string(f))
+	}
+	result["flows"] = strings.Join(flowNames, ", ")
+
+	if status, err := handler.Status(ctx); err == nil {
+		result["loggedIn"] = status.Authenticated
+	}
 }
 
 // handlerCompletionNames returns the sorted union of installed and available
 // auth handler names for shell completion.
 func handlerCompletionNames(ctx context.Context) []string {
-	nameSet := make(map[string]struct{})
-	if authReg := authpkg.RegistryFromContext(ctx); authReg != nil {
-		for _, n := range authReg.List() {
-			nameSet[n] = struct{}{}
-		}
-	}
-	if officialReg := authofficial.RegistryFromContext(ctx); officialReg != nil {
-		for _, n := range officialReg.Names() {
-			nameSet[n] = struct{}{}
-		}
-	}
-	names := make([]string, 0, len(nameSet))
-	for n := range nameSet {
-		names = append(names, n)
-	}
-	sort.Strings(names)
-	return names
+	return authHandlerNameSet(ctx)
 }
 
 // runHandlerDetail shows detailed information about a single auth handler.
@@ -362,36 +358,9 @@ func runHandlerDetail(ctx context.Context, name string, outputFlags *flags.KvxOu
 	authReg := authpkg.RegistryFromContext(ctx)
 	officialReg := authofficial.RegistryFromContext(ctx)
 
-	if authReg != nil && authReg.Has(name) {
-		handler, err := authReg.Get(name)
-		if err != nil {
-			return exitcode.WithCode(fmt.Errorf("failed to load auth handler %q: %w", name, err), exitcode.GeneralError)
-		}
-		detail := buildHandlerDetailMap(ctx, handler)
-
-		// Interactive mode: wrap in an array and reuse the list display schema
-		// so the TUI enters list view and the user can drill into the detail
-		// card. Structured formats fall through to the flat detail map below.
-		if outputFlags.Interactive {
-			interactiveOpts := flags.ToKvxOutputOptions(outputFlags,
-				kvx.WithIOStreams(ioStreams),
-				kvx.WithOutputAppName(cliParams.BinaryName+" auth handlers"),
-				kvx.WithOutputDisplaySchemaJSON(authHandlersDisplaySchema),
-			)
-			if !kvx.IsStructuredFormat(interactiveOpts.Format) {
-				return interactiveOpts.Write([]any{detail})
-			}
-		}
-
-		outputOpts := flags.ToKvxOutputOptions(outputFlags,
-			kvx.WithIOStreams(ioStreams),
-			kvx.WithOutputDisplaySchemaJSON(authHandlerDetailSchema),
-			kvx.WithOutputColumnOrder([]string{"name", "displayName", "source", "status", "loggedIn", "flows", "capabilities"}),
-		)
-		return outputOpts.Write(detail)
-	}
-
-	if officialReg != nil && officialReg.Has(name) {
+	// Official handler that is not yet installed: show the install hint without
+	// resolving it.
+	if officialReg != nil && officialReg.Has(name) && (authReg == nil || !authReg.Has(name)) {
 		// Interactive mode: render a minimal card showing the install hint.
 		if outputFlags.Interactive {
 			interactiveOpts := flags.ToKvxOutputOptions(outputFlags,
@@ -422,7 +391,34 @@ func runHandlerDetail(ctx context.Context, name string, outputFlags *flags.KvxOu
 		return nil
 	}
 
-	return exitcode.WithCode(fmt.Errorf("auth handler %q not found", name), exitcode.FileNotFound)
+	// Registered or locally-installed (third-party) handler: resolve lazily by
+	// name so installed plugins (e.g. openshift) can be inspected here.
+	handler, err := getHandler(ctx, name)
+	if err != nil {
+		return exitcode.WithCode(fmt.Errorf("auth handler %q not found", name), exitcode.FileNotFound)
+	}
+	detail := buildHandlerDetailMap(ctx, handler)
+
+	// Interactive mode: wrap in an array and reuse the list display schema so the
+	// TUI enters list view and the user can drill into the detail card.
+	// Structured formats fall through to the flat detail map below.
+	if outputFlags.Interactive {
+		interactiveOpts := flags.ToKvxOutputOptions(outputFlags,
+			kvx.WithIOStreams(ioStreams),
+			kvx.WithOutputAppName(cliParams.BinaryName+" auth handlers"),
+			kvx.WithOutputDisplaySchemaJSON(authHandlersDisplaySchema),
+		)
+		if !kvx.IsStructuredFormat(interactiveOpts.Format) {
+			return interactiveOpts.Write([]any{detail})
+		}
+	}
+
+	outputOpts := flags.ToKvxOutputOptions(outputFlags,
+		kvx.WithIOStreams(ioStreams),
+		kvx.WithOutputDisplaySchemaJSON(authHandlerDetailSchema),
+		kvx.WithOutputColumnOrder([]string{"name", "displayName", "source", "status", "loggedIn", "flows", "capabilities"}),
+	)
+	return outputOpts.Write(detail)
 }
 
 // buildHandlerDetailMap builds the structured detail representation of an

--- a/pkg/cmd/scafctl/auth/handlers_test.go
+++ b/pkg/cmd/scafctl/auth/handlers_test.go
@@ -4,7 +4,11 @@
 package auth
 
 import (
+	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/oakwood-commons/kvx/pkg/tui"
@@ -16,6 +20,36 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestAuthHandlerNameSet_EmbedderBinaryName is an embedder-scenario test: a
+// non-default binary name ("cldctl") must scope the installed-plugin scan to the
+// embedder's own plugin cache (so 'auth handlers', completions, and root
+// enumeration surface it), and installed handlers must not leak across binary
+// names.
+func TestAuthHandlerNameSet_EmbedderBinaryName(t *testing.T) {
+	t.Parallel()
+
+	// The package TestMain isolates xdg.CacheHome, so seeding under the embedder's
+	// binary-name subdir is hermetic. Layout: <cacheDir>/<key>/<ver>/<plat>/<key>.
+	const embedder = "cldctl"
+	cacheDir := settings.PluginCacheDirFor(embedder)
+	platformDir := runtime.GOOS + "-" + runtime.GOARCH
+	pluginDir := filepath.Join(cacheDir, "auth-handler-openshift", "0.1.0", platformDir)
+	require.NoError(t, os.MkdirAll(pluginDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "auth-handler-openshift"), []byte("binary"), 0o600))
+
+	// The embedder's binary name comes from the Run settings in context, exactly
+	// as the root command wires it for embedders like cldctl.
+	embedderCtx := settings.IntoContext(context.Background(), &settings.Run{BinaryName: embedder})
+	assert.Contains(t, authHandlerNameSet(embedderCtx), "openshift",
+		"installed third-party plugin under the embedder's cache must surface")
+
+	// Isolation: the same handler must NOT appear under the default binary name,
+	// since it lives only in the embedder's cache dir.
+	defaultCtx := settings.IntoContext(context.Background(), &settings.Run{BinaryName: "scafctl"})
+	assert.NotContains(t, authHandlerNameSet(defaultCtx), "openshift",
+		"handlers installed under an embedder's cache must not leak into the default binary")
+}
 
 func TestCollectHandlerInfo_EmptyRegistries(t *testing.T) {
 	ctx, _ := newTestContext(t)

--- a/pkg/cmd/scafctl/auth/list.go
+++ b/pkg/cmd/scafctl/auth/list.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/auth/hostname"
+	"github.com/oakwood-commons/scafctl/pkg/auth/statusrows"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -19,6 +21,31 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
 )
+
+// authListSchema controls table column display for 'auth list'. Columns in the
+// "required" array resist truncation; "deprecated" fields are hidden in table
+// view but still emitted in json/yaml. Property order sets priority tiebreakers.
+var authListSchema = []byte(`{
+	"type": "array",
+	"items": {
+		"type": "object",
+		"required": ["handler", "tokenKind"],
+		"properties": {
+			"handler":         { "type": "string", "title": "Handler", "maxLength": 16 },
+			"cluster":         { "type": "string", "title": "Cluster", "maxLength": 40 },
+			"tokenKind":       { "type": "string", "title": "Kind", "maxLength": 10 },
+			"scope":           { "type": "string", "title": "Scope", "maxLength": 40 },
+			"expiresIn":       { "type": "string", "title": "Expires", "maxLength": 10 },
+			"isExpired":       { "type": "boolean", "title": "Expired" },
+			"tokenType":       { "type": "string", "deprecated": true },
+			"flow":            { "type": "string", "deprecated": true },
+			"sessionId":       { "type": "string", "deprecated": true },
+			"expiresAt":       { "type": "string", "deprecated": true },
+			"cachedAt":        { "type": "string", "deprecated": true },
+			"getTokenCommand": { "type": "string", "deprecated": true }
+		}
+	}
+}`)
 
 // CommandList creates the 'auth list' command.
 // It shows metadata for all cached tokens (refresh and minted access) for the
@@ -130,7 +157,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
 
-			handlerNames := listHandlers(ctx)
+			handlerNames := listActiveHandlers(ctx, cliParams.BinaryName)
 
 			// When a specific handler is provided, allow lazy resolution (user
 			// explicitly asked for it). Otherwise only iterate eagerly-registered
@@ -228,6 +255,8 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 				kvx.WithOutputContext(ctx),
 				kvx.WithOutputNoColor(cliParams.NoColor),
 				kvx.WithOutputAppName(cliParams.BinaryName+" auth list"),
+				kvx.WithOutputColumnOrder([]string{"handler", "cluster", "tokenKind", "scope", "expiresIn", "isExpired"}),
+				kvx.WithOutputSchemaJSON(authListSchema),
 			)
 			outputOpts.IOStreams = ioStreams
 
@@ -259,8 +288,9 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 					continue
 				}
 
+				aliases := statusrows.InstanceAliases(handlerCtx, name)
 				for _, t := range tokens {
-					results = append(results, cachedTokenInfoToMap(t, cliParams.BinaryName))
+					results = append(results, cachedTokenInfoToMap(t, cliParams.BinaryName, aliases))
 				}
 			}
 
@@ -355,11 +385,22 @@ func sortTokenResults(results []map[string]any, field string) error {
 }
 
 // cachedTokenInfoToMap converts a CachedTokenInfo into a map suitable for kvx output.
-func cachedTokenInfoToMap(t *auth.CachedTokenInfo, binaryName string) map[string]any {
+func cachedTokenInfoToMap(t *auth.CachedTokenInfo, binaryName string, aliases map[string]string) map[string]any {
 	row := map[string]any{
 		"handler":   t.Handler,
 		"tokenKind": t.TokenKind,
 		"isExpired": t.IsExpired,
+	}
+
+	// Cluster label for per-instance handlers: reverse-mapped alias/selector when
+	// the token's hostname matches, else the trimmed host. Empty for handlers
+	// whose tokens carry no hostname.
+	if t.Hostname != "" {
+		if label, ok := hostname.AliasForURL(aliases, t.Hostname); ok {
+			row["cluster"] = label
+		} else {
+			row["cluster"] = hostname.DisplayHostFromURL(t.Hostname)
+		}
 	}
 
 	if t.Scope != "" {

--- a/pkg/cmd/scafctl/auth/list_test.go
+++ b/pkg/cmd/scafctl/auth/list_test.go
@@ -21,6 +21,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCachedTokenInfoToMap_ClusterLabel(t *testing.T) {
+	t.Parallel()
+
+	aliases := map[string]string{"pd1020": "https://api.pd1020.example.com:6443"}
+
+	// Hostname matches an alias -> short selector.
+	aliased := cachedTokenInfoToMap(&auth.CachedTokenInfo{
+		Handler:   "openshift",
+		TokenKind: "access",
+		Hostname:  "https://api.pd1020.example.com:6443",
+	}, "scafctl", aliases)
+	assert.Equal(t, "pd1020", aliased["cluster"])
+
+	// Hostname without an alias -> trimmed host.
+	unaliased := cachedTokenInfoToMap(&auth.CachedTokenInfo{
+		Handler:  "openshift",
+		Hostname: "https://api.stg.example.com:6443",
+	}, "scafctl", aliases)
+	assert.Equal(t, "api.stg.example.com", unaliased["cluster"])
+
+	// No hostname -> no cluster column.
+	noHost := cachedTokenInfoToMap(&auth.CachedTokenInfo{Handler: "entra", TokenKind: "refresh"}, "scafctl", nil)
+	_, ok := noHost["cluster"]
+	assert.False(t, ok, "handlers without a per-instance hostname have no cluster column")
+}
+
 func TestCommandList_NoTokens(t *testing.T) {
 	ctx, buf := newTestContext(t)
 

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -186,6 +186,14 @@ func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cob
 			}
 			handlerName := args[0]
 
+			// Validate the callback port range up front -- it is a static input
+			// constraint independent of the handler. Zero means ephemeral.
+			if callbackPort != 0 && (callbackPort < auth.MinCallbackPort || callbackPort > auth.MaxCallbackPort) {
+				err := fmt.Errorf("--callback-port must be between %d and %d, got %d", auth.MinCallbackPort, auth.MaxCallbackPort, callbackPort)
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+
 			// Resolve effective profile: per-command --profile > global --auth-profile > config activeProfile
 			// Track whether profile was explicitly set (even if normalized to empty/default).
 			profileExplicit := cmd.Flags().Changed("profile")

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -8,14 +8,13 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/signal"
 	"strings"
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
-	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	hostnameresolver "github.com/oakwood-commons/scafctl/pkg/auth/hostname"
+	"github.com/oakwood-commons/scafctl/pkg/auth/loginui"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/config"
@@ -23,7 +22,6 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
-	skvx "github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
 )
@@ -463,447 +461,29 @@ func loginWithFlowDetection(ctx context.Context, w *writer.Writer, binaryName st
 	return executeLogin(ctx, w, binaryName, handler, flow, tenantID, hostname, callbackPort, timeout, scopes)
 }
 
-// executeLogin runs the common login logic for any auth handler.
-// For device-code flows on a terminal, it uses the kvx status screen TUI.
-// All other flows (and non-terminal output) use plain text output.
+// executeLogin runs the common login logic for any auth handler. It delegates
+// the interactive presentation (kvx status TUI on a terminal, plain text
+// otherwise) to loginui.RunLogin, then renders the consolidated success line.
 func executeLogin(ctx context.Context, w *writer.Writer, binaryName string, handler auth.Handler, flow auth.Flow, tenantID, hostname string, callbackPort int, timeout time.Duration, scopes []string) error {
-	// Set up cancellation handling
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, os.Interrupt)
-	go func() {
-		<-sigChan
-		w.Info("")
-		w.Warning("Authentication cancelled by user.")
-		cancel()
-	}()
-	defer signal.Stop(sigChan)
-
-	ioStreams := w.IOStreams()
-
-	// Use kvx status TUI for interactive flows when running in a terminal.
-	// Non-interactive flows (SP, WI, PAT, metadata, client-credentials) fall
-	// through to the plain-text login path below.
-	if skvx.IsTerminal(ioStreams.Out) {
-		switch flow {
-		case auth.FlowDeviceCode:
-			return executeLoginWithStatusTUI(ctx, w, binaryName, handler, flow, tenantID, hostname, callbackPort, timeout, scopes, ioStreams)
-		case auth.FlowInteractive, auth.FlowGcloudADC, auth.FlowGitHubApp, "":
-			return executeLoginWithBrowserTUI(ctx, w, binaryName, handler, flow, tenantID, hostname, callbackPort, timeout, scopes, ioStreams)
-		}
-	}
-
-	// Plain-text login path (non-terminal, or non-device-code flows).
-	loginOpts := auth.LoginOptions{
+	opts := auth.LoginOptions{
 		TenantID:     tenantID,
 		Hostname:     hostname,
 		Scopes:       scopes,
 		Flow:         flow,
 		Timeout:      timeout,
 		CallbackPort: callbackPort,
-		DeviceCodeCallback: func(userCode, verificationURI, _ string) {
-			w.Info("")
-			w.Info("To sign in, use a web browser to open the page:")
-			w.Infof("  %s", verificationURI)
-			w.Info("")
-			w.Infof("Enter the code: %s", userCode)
-			w.Info("")
-			w.Info("Waiting for authentication...")
-		},
 	}
 
-	result, err := handler.Login(ctx, loginOpts)
+	result, err := loginui.RunLogin(ctx, w, binaryName, handler, opts)
 	if err != nil {
-		if ctx.Err() != nil {
-			return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
+		if !errors.Is(err, auth.ErrUserCancelled) {
+			w.Errorf("%v", err)
 		}
-		err = fmt.Errorf("authentication failed: %w", err)
-		w.Errorf("%v", err)
-		return exitcode.WithCode(err, exitcode.GeneralError)
+		return err
 	}
 
 	w.Info("")
 	return displayLoginResult(w, result, flow, handler.DisplayName(), auth.ProfileFromContext(ctx))
-}
-
-// executeLoginWithStatusTUI runs the device-code login flow using the kvx status
-// screen TUI. It:
-//  1. Starts handler.Login in a goroutine with a DeviceCodeCallback that captures
-//     the verification URL and user code.
-//  2. Waits for the device code before launching the TUI (avoids empty-data start).
-//  3. Launches tui.Run with a DisplaySchema status view and a Done channel that
-//     receives the login outcome when the goroutine completes.
-func executeLoginWithStatusTUI(
-	ctx context.Context,
-	w *writer.Writer,
-	binaryName string,
-	handler auth.Handler,
-	flow auth.Flow,
-	tenantID string,
-	hostname string,
-	callbackPort int,
-	timeout time.Duration,
-	scopes []string,
-	ioStreams *terminal.IOStreams,
-) error {
-	type deviceCodeData struct {
-		userCode        string
-		verificationURI string
-	}
-	type loginOutcome struct {
-		result *auth.Result
-		err    error
-	}
-
-	deviceCodeChan := make(chan deviceCodeData, 1)
-	outcomeChan := make(chan loginOutcome, 1)
-	done := make(chan tui.StatusResult, 1)
-
-	loginOpts := auth.LoginOptions{
-		TenantID:     tenantID,
-		Hostname:     hostname,
-		Scopes:       scopes,
-		Flow:         flow,
-		Timeout:      timeout,
-		CallbackPort: callbackPort,
-		DeviceCodeCallback: func(userCode, verificationURI, _ string) {
-			select {
-			case deviceCodeChan <- deviceCodeData{userCode: userCode, verificationURI: verificationURI}:
-			default:
-			}
-		},
-	}
-
-	go func() {
-		result, err := handler.Login(ctx, loginOpts)
-		outcomeChan <- loginOutcome{result: result, err: err}
-	}()
-
-	// Wait for the device code, an early completion, or cancellation.
-	w.Verbosef("Initiating authentication with %s...", handler.DisplayName())
-	var dci deviceCodeData
-	select {
-	case dci = <-deviceCodeChan:
-		// Device code ready - proceed to TUI.
-	case outcome := <-outcomeChan:
-		// Login completed before device code was shown (unusual).
-		if outcome.err != nil {
-			if ctx.Err() != nil {
-				return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
-			}
-			err := fmt.Errorf("authentication failed: %w", outcome.err)
-			w.Errorf("%v", err)
-			return exitcode.WithCode(err, exitcode.GeneralError)
-		}
-		w.Info("")
-		return displayLoginResult(w, outcome.result, flow, handler.DisplayName(), auth.ProfileFromContext(ctx))
-	case <-ctx.Done():
-		return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
-	}
-
-	// Forward the login outcome to the TUI done channel.
-	// capturedOutcome is safe to read after outcomeReady is closed because
-	// close(outcomeReady) happens-before the receive on that channel.
-	var capturedOutcome loginOutcome
-	outcomeReady := make(chan struct{})
-	go func() {
-		outcome := <-outcomeChan
-		capturedOutcome = outcome
-		if outcome.err != nil {
-			done <- tui.StatusResult{Err: outcome.err}
-		} else {
-			identity := outcome.result.Claims.DisplayIdentity()
-			if identity == "" {
-				identity = "unknown user"
-			}
-			done <- tui.StatusResult{Message: "Authenticated as " + identity}
-		}
-		close(outcomeReady)
-	}()
-
-	data := map[string]any{
-		"title": fmt.Sprintf("Sign in to %s", handler.DisplayName()),
-		"url":   dci.verificationURI,
-		"code":  dci.userCode,
-	}
-
-	schema := &tui.DisplaySchema{
-		Version: "v1",
-		Status: &tui.StatusDisplayConfig{
-			TitleField:     "title",
-			WaitMessage:    "Waiting for authentication...",
-			SuccessMessage: "Authenticated successfully!",
-			DoneBehavior:   tui.DoneBehaviorExitAfterDelay,
-			DoneDelay:      "2s",
-			DisplayFields: []tui.StatusFieldDisplay{
-				{Label: "URL", Field: "url"},
-				{Label: "Code", Field: "code"},
-			},
-			Actions: []tui.StatusActionConfig{
-				{
-					Label: "Copy code",
-					Type:  "copy-value",
-					Field: "code",
-					Keys:  tui.StatusKeyBindings{Vim: "c", Emacs: "alt+c", Function: "f2"},
-				},
-				{
-					Label: "Open URL",
-					Type:  "open-url",
-					Field: "url",
-					Keys:  tui.StatusKeyBindings{Vim: "o", Emacs: "alt+o", Function: "f3"},
-				},
-			},
-		},
-	}
-
-	cfg := tui.DefaultConfig()
-	cfg.AppName = binaryName
-	cfg.DisplaySchema = schema
-	cfg.Done = done
-
-	teaOpts := tui.WithIO(ioStreams.In, ioStreams.Out)
-	if runErr := tui.Run(data, cfg, teaOpts...); runErr != nil {
-		if ctx.Err() != nil {
-			return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
-		}
-		return fmt.Errorf("authentication display failed: %w", runErr)
-	}
-
-	// TUI exited normally (done channel received, DoneDelay elapsed).
-	// The outcomeReady channel should already be closed at this point.
-	select {
-	case <-outcomeReady:
-		// Outcome is captured - continue to post-display.
-	default:
-		// TUI exited before login completed (user quit early) - treat as cancelled.
-		return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
-	}
-
-	if capturedOutcome.err != nil {
-		if ctx.Err() != nil {
-			return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
-		}
-		err := fmt.Errorf("authentication failed: %w", capturedOutcome.err)
-		w.Errorf("%v", err)
-		return exitcode.WithCode(err, exitcode.GeneralError)
-	}
-
-	return displayLoginResult(w, capturedOutcome.result, flow, handler.DisplayName(), auth.ProfileFromContext(ctx))
-}
-
-// executeLoginWithBrowserTUI runs the auth code (browser) login flow using the
-// kvx status screen TUI. It also sets a DeviceCodeCallback so that handlers
-// which internally use device code within a FlowInteractive (e.g., GitHub
-// without client_secret) get the rich device-code TUI instead.
-func executeLoginWithBrowserTUI(
-	ctx context.Context,
-	w *writer.Writer,
-	binaryName string,
-	handler auth.Handler,
-	flow auth.Flow,
-	tenantID string,
-	hostname string,
-	callbackPort int,
-	timeout time.Duration,
-	scopes []string,
-	ioStreams *terminal.IOStreams,
-) error {
-	type deviceCodeData struct {
-		userCode        string
-		verificationURI string
-	}
-	type loginOutcome struct {
-		result *auth.Result
-		err    error
-	}
-
-	deviceCodeChan := make(chan deviceCodeData, 1)
-	outcomeChan := make(chan loginOutcome, 1)
-	done := make(chan tui.StatusResult, 1)
-
-	loginOpts := auth.LoginOptions{
-		TenantID:     tenantID,
-		Hostname:     hostname,
-		Scopes:       scopes,
-		Flow:         flow,
-		Timeout:      timeout,
-		CallbackPort: callbackPort,
-		DeviceCodeCallback: func(userCode, verificationURI, _ string) {
-			select {
-			case deviceCodeChan <- deviceCodeData{userCode: userCode, verificationURI: verificationURI}:
-			default:
-			}
-		},
-	}
-
-	go func() {
-		result, err := handler.Login(ctx, loginOpts)
-		outcomeChan <- loginOutcome{result: result, err: err}
-	}()
-
-	// Wait briefly for a device code callback. If the handler internally
-	// uses device code (e.g., GitHub FlowInteractive without client_secret),
-	// we want to show the device-code TUI instead of the browser TUI.
-	w.Verbosef("Initiating authentication with %s...", handler.DisplayName())
-
-	var useDeviceCodeTUI bool
-	var dci deviceCodeData
-	select {
-	case dci = <-deviceCodeChan:
-		useDeviceCodeTUI = true
-	case outcome := <-outcomeChan:
-		// Login completed before any TUI was shown.
-		if outcome.err != nil {
-			if ctx.Err() != nil {
-				return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
-			}
-			err := fmt.Errorf("authentication failed: %w", outcome.err)
-			w.Errorf("%v", err)
-			return exitcode.WithCode(err, exitcode.GeneralError)
-		}
-		w.Info("")
-		return displayLoginResult(w, outcome.result, flow, handler.DisplayName(), auth.ProfileFromContext(ctx))
-	case <-time.After(500 * time.Millisecond):
-		// No device code within 500ms — assume browser flow.
-		useDeviceCodeTUI = false
-	case <-ctx.Done():
-		return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
-	}
-
-	// Forward the login outcome to the TUI done channel.
-	var capturedOutcome loginOutcome
-	outcomeReady := make(chan struct{})
-	go func() {
-		outcome := <-outcomeChan
-		capturedOutcome = outcome
-		if outcome.err != nil {
-			done <- tui.StatusResult{Err: outcome.err}
-		} else {
-			identity := outcome.result.Claims.DisplayIdentity()
-			if identity == "" {
-				identity = "unknown user"
-			}
-			done <- tui.StatusResult{Message: "Authenticated as " + identity}
-		}
-		close(outcomeReady)
-	}()
-
-	var data map[string]any
-	var schema *tui.DisplaySchema
-
-	switch {
-	case useDeviceCodeTUI && dci.userCode != "":
-		// Real device code flow (e.g., GitHub without client_secret)
-		data = map[string]any{
-			"title": fmt.Sprintf("Sign in to %s", handler.DisplayName()),
-			"url":   dci.verificationURI,
-			"code":  dci.userCode,
-		}
-		schema = &tui.DisplaySchema{
-			Version: "v1",
-			Status: &tui.StatusDisplayConfig{
-				TitleField:     "title",
-				WaitMessage:    "Waiting for authentication...",
-				SuccessMessage: "Authenticated successfully!",
-				DoneBehavior:   tui.DoneBehaviorExitAfterDelay,
-				DoneDelay:      "2s",
-				DisplayFields: []tui.StatusFieldDisplay{
-					{Label: "URL", Field: "url"},
-					{Label: "Code", Field: "code"},
-				},
-				Actions: []tui.StatusActionConfig{
-					{
-						Label: "Copy code",
-						Type:  "copy-value",
-						Field: "code",
-						Keys:  tui.StatusKeyBindings{Vim: "c", Emacs: "alt+c", Function: "f2"},
-					},
-					{
-						Label: "Open URL",
-						Type:  "open-url",
-						Field: "url",
-						Keys:  tui.StatusKeyBindings{Vim: "o", Emacs: "alt+o", Function: "f3"},
-					},
-				},
-			},
-		}
-	case useDeviceCodeTUI && dci.userCode == "" && dci.verificationURI != "":
-		// Browser auth code flow — handler reported the auth URL via callback
-		data = map[string]any{
-			"title": fmt.Sprintf("Sign in to %s", handler.DisplayName()),
-			"url":   dci.verificationURI,
-		}
-		schema = &tui.DisplaySchema{
-			Version: "v1",
-			Status: &tui.StatusDisplayConfig{
-				TitleField:     "title",
-				WaitMessage:    "Waiting for browser authentication...",
-				SuccessMessage: "Authenticated successfully!",
-				DoneBehavior:   tui.DoneBehaviorExitAfterDelay,
-				DoneDelay:      "2s",
-				DisplayFields: []tui.StatusFieldDisplay{
-					{Label: "URL", Field: "url"},
-				},
-				Actions: []tui.StatusActionConfig{
-					{
-						Label: "Re-open in browser",
-						Type:  "open-url",
-						Field: "url",
-						Keys:  tui.StatusKeyBindings{Vim: "o", Emacs: "alt+o", Function: "f3"},
-					},
-				},
-			},
-		}
-	default:
-		// No callback fired — show minimal browser waiting TUI
-		data = map[string]any{
-			"title": fmt.Sprintf("Sign in to %s", handler.DisplayName()),
-		}
-		schema = &tui.DisplaySchema{
-			Version: "v1",
-			Status: &tui.StatusDisplayConfig{
-				TitleField:     "title",
-				WaitMessage:    "Waiting for browser authentication...",
-				SuccessMessage: "Authenticated successfully!",
-				DoneBehavior:   tui.DoneBehaviorExitAfterDelay,
-				DoneDelay:      "2s",
-			},
-		}
-	}
-
-	cfg := tui.DefaultConfig()
-	cfg.AppName = binaryName
-	cfg.DisplaySchema = schema
-	cfg.Done = done
-
-	teaOpts := tui.WithIO(ioStreams.In, ioStreams.Out)
-	if runErr := tui.Run(data, cfg, teaOpts...); runErr != nil {
-		if ctx.Err() != nil {
-			return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
-		}
-		return fmt.Errorf("authentication display failed: %w", runErr)
-	}
-
-	// TUI exited normally.
-	select {
-	case <-outcomeReady:
-		// Outcome is captured.
-	default:
-		return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
-	}
-
-	if capturedOutcome.err != nil {
-		if ctx.Err() != nil {
-			return exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
-		}
-		err := fmt.Errorf("authentication failed: %w", capturedOutcome.err)
-		w.Errorf("%v", err)
-		return exitcode.WithCode(err, exitcode.GeneralError)
-	}
-
-	return displayLoginResult(w, capturedOutcome.result, flow, handler.DisplayName(), auth.ProfileFromContext(ctx))
 }
 
 // displayLoginResult prints a consolidated authentication success message.

--- a/pkg/cmd/scafctl/auth/login_extra_test.go
+++ b/pkg/cmd/scafctl/auth/login_extra_test.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"bytes"
+	"strconv"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
@@ -130,6 +131,40 @@ func TestCommandLogin_CallbackPortNotSupported(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--callback-port is not supported")
+}
+
+// TestCommandLogin_CallbackPortOutOfRange verifies that --callback-port is
+// rejected when it is outside the valid 1024-65535 range, even when the handler
+// advertises CapCallbackPort.
+func TestCommandLogin_CallbackPortOutOfRange(t *testing.T) {
+	cases := []struct {
+		name string
+		port string
+	}{
+		{"privileged", "80"},
+		{"negative", "-1"},
+		{"above_max", "70000"},
+		{"just_above_max", strconv.Itoa(auth.MaxCallbackPort + 1)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, buf := newTestContext(t)
+
+			mock := auth.NewMockHandler("entra")
+			mock.CapabilitiesValue = []auth.Capability{auth.CapCallbackPort}
+			mock.SetNotAuthenticated()
+			ctx = withTestHandler(ctx, mock)
+
+			ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+			cmd := CommandLogin(settings.NewCliParams(), ioStreams, "scafctl/auth")
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"entra", "--callback-port", tc.port})
+
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "--callback-port must be between 1024 and 65535")
+		})
+	}
 }
 
 // TestCommandLogin_ImpersonateOnNonGCP verifies that --impersonate-service-account

--- a/pkg/cmd/scafctl/auth/login_hostname_test.go
+++ b/pkg/cmd/scafctl/auth/login_hostname_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/adrg/xdg"
 	"github.com/stretchr/testify/assert"
@@ -102,6 +103,93 @@ func TestCommandLogin_HostnameConcreteURLPassthrough(t *testing.T) {
 	require.NoError(t, cmd.Execute())
 	require.Len(t, mock.LoginCalls, 1)
 	assert.Equal(t, "https://api.custom.example.com:6443", mock.LoginCalls[0].Hostname)
+}
+
+// hostnameTokenFixture builds a CapTokenHostname mock handler that returns a
+// token, seeded with the given hostname config for that handler, for exercising
+// `auth token --server <selector>` resolution.
+func hostnameTokenFixture(t *testing.T, hn *config.HostnameConfig) (context.Context, *auth.MockHandler) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_STATE_HOME", tmp)
+	xdg.Reload()
+
+	ctx, _ := newTestContext(t)
+
+	const handlerName = "openshift"
+	mock := auth.NewMockHandler(handlerName)
+	mock.CapabilitiesValue = []auth.Capability{auth.CapTokenHostname}
+	mock.SetToken(&auth.Token{AccessToken: "cluster-token", TokenType: "Bearer", ExpiresAt: time.Now().Add(time.Hour)})
+	ctx = withTestHandler(ctx, mock)
+
+	cfg := &config.Config{
+		Auth: config.GlobalAuthConfig{
+			Handlers: map[string]config.HandlerConfig{
+				handlerName: {Hostname: hn},
+			},
+		},
+	}
+	ctx = config.WithConfig(ctx, cfg)
+	return ctx, mock
+}
+
+// TestCommandToken_HostnameAliasResolved verifies that `auth token --server
+// <alias>` resolves a static hostname alias to a concrete endpoint URL before
+// requesting the token, mirroring the login path.
+func TestCommandToken_HostnameAliasResolved(t *testing.T) {
+	ctx, mock := hostnameTokenFixture(t, &config.HostnameConfig{
+		Aliases: map[string]string{"pd1020": "https://api.pd1020.example.com:6443"},
+	})
+
+	buf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	cmd := CommandToken(settings.NewCliParams(), ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"openshift", "--server", "pd1020", "--raw"})
+
+	require.NoError(t, cmd.Execute())
+	require.Len(t, mock.GetTokenCalls, 1)
+	assert.Equal(t, "https://api.pd1020.example.com:6443", mock.GetTokenCalls[0].Hostname,
+		"a --server alias must be resolved to the concrete endpoint URL before GetToken")
+}
+
+// TestCommandToken_HostnameConcreteURLPassthrough verifies an already concrete
+// --server URL is forwarded unchanged even when aliases exist.
+func TestCommandToken_HostnameConcreteURLPassthrough(t *testing.T) {
+	ctx, mock := hostnameTokenFixture(t, &config.HostnameConfig{
+		Aliases: map[string]string{"pd1020": "https://api.pd1020.example.com:6443"},
+	})
+
+	buf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	cmd := CommandToken(settings.NewCliParams(), ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"openshift", "--server", "https://api.custom.example.com:6443", "--raw"})
+
+	require.NoError(t, cmd.Execute())
+	require.Len(t, mock.GetTokenCalls, 1)
+	assert.Equal(t, "https://api.custom.example.com:6443", mock.GetTokenCalls[0].Hostname)
+}
+
+// TestCommandToken_HostnameSelectorNotFound verifies that an unknown --server
+// selector fails with an invalid-input error and never calls the handler.
+func TestCommandToken_HostnameSelectorNotFound(t *testing.T) {
+	ctx, mock := hostnameTokenFixture(t, &config.HostnameConfig{
+		Aliases: map[string]string{"pd1020": "https://api.pd1020.example.com:6443"},
+	})
+
+	buf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	cmd := CommandToken(settings.NewCliParams(), ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"openshift", "--server", "nope", "--raw"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "selector not found")
+	assert.Empty(t, mock.GetTokenCalls, "handler must not be called when selector resolution fails")
 }
 
 // TestCommandLogin_HostnameResolvedForEmbedder verifies the hook works under a

--- a/pkg/cmd/scafctl/auth/logout.go
+++ b/pkg/cmd/scafctl/auth/logout.go
@@ -110,7 +110,7 @@ func CommandLogout(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 
 			var handlerNames []string
 			if all {
-				handlerNames = listHandlers(ctx)
+				handlerNames = listActiveHandlers(ctx, cliParams.BinaryName)
 				if len(handlerNames) == 0 {
 					unconfigured := listUnconfiguredOfficialHandlers(ctx)
 					if len(unconfigured) > 0 {
@@ -156,14 +156,30 @@ func CommandLogout(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 				}
 
 				if !force {
-					// Check if authenticated first; skip logout if not.
-					status, err := handler.Status(ctx)
-					if err != nil {
-						w.Errorf("Failed to check auth status for %s: %v", handlerName, err)
-						hadError = true
-						continue
+					// Decide whether there are credentials to clear. A multi-instance
+					// handler (e.g. one advertising CapInstanceHostname) reports an
+					// unauthenticated -- or even errored -- hostname-less base status
+					// even when individual clusters still hold live sessions, so the
+					// base status alone must not gate logout. When the base status is
+					// not clearly authenticated, consult the cached tokens and clear
+					// them if any exist instead of silently leaving them behind.
+					status, statusErr := handler.Status(ctx)
+					authenticated := statusErr == nil && status.Authenticated
+					if !authenticated {
+						if lister, ok := handler.(auth.TokenLister); ok {
+							if tokens, lerr := lister.ListCachedTokens(ctx); lerr == nil && len(tokens) > 0 {
+								authenticated = true
+							}
+						}
 					}
-					if !status.Authenticated {
+					if !authenticated {
+						// Nothing cached to clear: surface the status error if the
+						// check failed, otherwise report the handler as logged out.
+						if statusErr != nil {
+							w.Errorf("Failed to check auth status for %s: %v", handlerName, statusErr)
+							hadError = true
+							continue
+						}
 						w.Infof("Not currently authenticated with %s.", handler.DisplayName())
 						continue
 					}

--- a/pkg/cmd/scafctl/auth/logout_test.go
+++ b/pkg/cmd/scafctl/auth/logout_test.go
@@ -74,6 +74,65 @@ func TestCommandLogout_NotAuthenticated(t *testing.T) {
 	assert.Contains(t, output, "Not currently authenticated")
 }
 
+// TestCommandLogout_MultiClusterCachedSessions verifies that a handler whose
+// hostname-less base status is unauthenticated but which still holds cached
+// per-cluster sessions is logged out (its tokens are cleared) rather than
+// skipped.
+func TestCommandLogout_MultiClusterCachedSessions(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockHandler("openshift")
+	mock.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
+	mock.SetNotAuthenticated() // hostname-less base instance reports unauthenticated
+	mock.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{Handler: "openshift", Hostname: "https://api.pd1020.example.com:6443"},
+	}
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogout(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"openshift"})
+
+	require.NoError(t, cmd.Execute())
+
+	// Logout must be called because cached sessions exist, even though the base
+	// status is unauthenticated.
+	assert.Equal(t, 1, mock.LogoutCalls)
+	assert.Contains(t, buf.String(), "Successfully logged out")
+}
+
+// TestCommandLogout_BaseStatusErrorWithCachedSessions verifies that a
+// hostname-less base status that errors does not block logout when cached
+// per-cluster sessions still exist.
+func TestCommandLogout_BaseStatusErrorWithCachedSessions(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockHandler("openshift")
+	mock.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
+	mock.StatusErr = errors.New("no api server configured")
+	mock.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{Handler: "openshift", Hostname: "https://api.pd1020.example.com:6443"},
+	}
+
+	ctx = withTestHandler(ctx, mock)
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogout(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"openshift"})
+
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, 1, mock.LogoutCalls, "cached sessions must be cleared even when the base status check errors")
+	assert.Contains(t, buf.String(), "Successfully logged out")
+}
+
 func TestCommandLogout_Success(t *testing.T) {
 	ctx, buf := newTestContext(t)
 

--- a/pkg/cmd/scafctl/auth/status.go
+++ b/pkg/cmd/scafctl/auth/status.go
@@ -15,6 +15,7 @@ import (
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/auth/statusrows"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/config"
@@ -50,7 +51,7 @@ var authStatusSchema = []byte(`{
 			"flow":           { "type": "string", "title": "Flow", "enum": ["device_code", "interactive", "service_principal", "workload_identity", "pat", "gcloud_adc", "github_app", "client_credentials", "token"] },
 			"user":           { "type": "string", "title": "User", "maxLength": 30 },
 			"expiresIn":      { "type": "string", "title": "Expires", "maxLength": 10 },
-			"profile":        { "type": "string", "title": "Profile", "maxLength": 20 },
+			"profile":        { "type": "string", "title": "Profile", "maxLength": 60 },
 			"type":           { "type": "string", "deprecated": true },
 			"displayName":    { "type": "string", "deprecated": true },
 			"email":          { "type": "string", "deprecated": true },
@@ -148,7 +149,7 @@ func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 				ctx = auth.WithProfile(ctx, effectiveProfile)
 			}
 
-			handlers := listHandlers(ctx)
+			handlers := listActiveHandlers(ctx, cliParams.BinaryName)
 			var results []map[string]any
 			var warnings []string
 
@@ -363,8 +364,8 @@ func queryHandlerStatuses(ctx context.Context, cliParams *settings.Run, handlers
 	defer span.End()
 
 	type indexedResult struct {
-		index  int
-		result map[string]any
+		index   int
+		results []map[string]any
 	}
 
 	var (
@@ -407,9 +408,10 @@ func queryHandlerStatuses(ctx context.Context, cliParams *settings.Run, handlers
 
 			metrics.RecordAuthStatus(handlerCtx, handlerName, time.Since(statusStart).Seconds(), true)
 			result := buildStatusResult(handlerCtx, cliParams, handlerName, handler, st)
+			rows := expandInstanceRows(handlerCtx, handlerName, handler, st, result)
 
 			mu.Lock()
-			indexed = append(indexed, indexedResult{index: i, result: result})
+			indexed = append(indexed, indexedResult{index: i, results: rows})
 			mu.Unlock()
 			return nil
 		})
@@ -425,7 +427,7 @@ func queryHandlerStatuses(ctx context.Context, cliParams *settings.Run, handlers
 
 	results := make([]map[string]any, 0, len(indexed))
 	for _, ir := range indexed {
-		results = append(results, ir.result)
+		results = append(results, ir.results...)
 	}
 
 	return results, warnings
@@ -562,6 +564,77 @@ func buildStatusResult(ctx context.Context, cliParams *settings.Run, handlerName
 	}
 
 	return result
+}
+
+// expandInstanceRows expands a handler's base status row into one row per cached
+// cluster session. The per-cluster selection, dedup, active-session, and cluster
+// labeling decisions live in pkg/auth/statusrows; this adapter renders each
+// selected session as a kvx display row, overloading the "profile" column with
+// "<identity> / <cluster>" (identity omitted for the built-in profile) and
+// marking the active session. Handlers without per-cluster sessions return the
+// single base row unchanged.
+func expandInstanceRows(ctx context.Context, handlerName string, handler auth.Handler, status *auth.Status, base map[string]any) []map[string]any {
+	sessions := statusrows.Expand(ctx, handlerName, handler, status)
+	if len(sessions) == 0 {
+		return []map[string]any{base}
+	}
+
+	// Preserve a *named* auth profile (e.g. "work") alongside the cluster label so
+	// identity and endpoint stay distinguishable when multiple profiles exist.
+	// The built-in/default profile is omitted -- for a single-identity fleet the
+	// cluster alias alone is the meaningful value (no redundant "built-in /").
+	identity, _ := base["profile"].(string)
+	identity = strings.TrimSpace(strings.TrimSuffix(identity, " (active)"))
+	if identity == auth.BuiltinProfileName {
+		identity = ""
+	}
+
+	rows := make([]map[string]any, 0, len(sessions))
+	for _, s := range sessions {
+		row := cloneStatusRow(base)
+
+		clusterLabel := s.ClusterLabel
+		if s.Active {
+			clusterLabel += " (active)"
+		}
+		if identity != "" {
+			row["profile"] = identity + " / " + clusterLabel
+		} else {
+			row["profile"] = clusterLabel
+		}
+
+		tk := s.Token
+		if tk.IsExpired {
+			row["status"] = "expired"
+		} else {
+			row["status"] = "authenticated"
+		}
+		if tk.Flow != "" {
+			row["flow"] = string(tk.Flow)
+		}
+		if isValidExpiryTime(tk.ExpiresAt) {
+			row["expiresAt"] = tk.ExpiresAt.Format(time.RFC3339)
+			row["_expiresAtTime"] = tk.ExpiresAt
+			if timeUntil := time.Until(tk.ExpiresAt); timeUntil > 0 {
+				row["expiresIn"] = humanDuration(timeUntil)
+			} else {
+				row["expiresIn"] = ""
+			}
+		}
+
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+// cloneStatusRow makes a shallow copy of a status result row so per-cluster rows
+// do not alias the shared base map.
+func cloneStatusRow(base map[string]any) map[string]any {
+	row := make(map[string]any, len(base))
+	for k, v := range base {
+		row[k] = v
+	}
+	return row
 }
 
 // appendCatalogStatus adds a row for each remote (OCI) catalog from config,

--- a/pkg/cmd/scafctl/auth/status_instance_test.go
+++ b/pkg/cmd/scafctl/auth/status_instance_test.go
@@ -1,0 +1,356 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// baseStatusRow builds a minimal authenticated base row like buildStatusResult
+// would produce, sufficient for exercising expandInstanceRows.
+func baseStatusRow(handler string) map[string]any {
+	return map[string]any{
+		"handler":        handler,
+		"kind":           "auth",
+		"type":           "handler",
+		"status":         "authenticated",
+		"authenticated":  true,
+		"user":           "user@example.com",
+		"flow":           "device_code",
+		"profile":        "built-in",
+		"expiresIn":      "",
+		"expiresAt":      "",
+		"_expiresAtTime": nil,
+	}
+}
+
+func instanceConfigCtx(t *testing.T, handler string, aliases map[string]string) context.Context {
+	t.Helper()
+	return config.WithConfig(context.Background(), &config.Config{
+		Auth: config.GlobalAuthConfig{
+			Handlers: map[string]config.HandlerConfig{
+				handler: {
+					Hostname: &config.HostnameConfig{Aliases: aliases},
+				},
+			},
+		},
+	})
+}
+
+func TestExpandInstanceRows_NonInstanceHandler(t *testing.T) {
+	t.Parallel()
+
+	h := auth.NewMockHandler("entra")
+	h.CapabilitiesValue = []auth.Capability{auth.CapScopesOnLogin}
+	status := &auth.Status{Authenticated: true}
+
+	rows := expandInstanceRows(context.Background(), "entra", h, status, baseStatusRow("entra"))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "built-in", rows[0]["profile"])
+}
+
+func TestExpandInstanceRows_NotAuthenticated(t *testing.T) {
+	t.Parallel()
+
+	h := auth.NewMockHandler("openshift")
+	h.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
+	status := &auth.Status{Authenticated: false}
+
+	rows := expandInstanceRows(context.Background(), "openshift", h, status, baseStatusRow("openshift"))
+	require.Len(t, rows, 1)
+}
+
+func TestExpandInstanceRows_NoHostnameTokens(t *testing.T) {
+	t.Parallel()
+
+	h := auth.NewMockHandler("openshift")
+	h.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
+	h.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{Handler: "openshift", TokenKind: "access_token"}, // no Hostname
+	}
+	status := &auth.Status{Authenticated: true}
+
+	rows := expandInstanceRows(context.Background(), "openshift", h, status, baseStatusRow("openshift"))
+	require.Len(t, rows, 1)
+}
+
+func TestExpandInstanceRows_TwoClusters(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	h := auth.NewMockHandler("openshift")
+	h.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
+	h.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{
+			Handler:   "openshift",
+			Hostname:  "https://api.np0510.caas.ford.com:6443",
+			Flow:      auth.FlowInteractive,
+			ExpiresAt: now.Add(time.Hour),
+			CachedAt:  now.Add(-2 * time.Hour),
+		},
+		{
+			Handler:   "openshift",
+			Hostname:  "https://api.pd1020.caas.ford.com:6443",
+			Flow:      auth.FlowInteractive,
+			ExpiresAt: now.Add(30 * time.Minute),
+			CachedAt:  now, // most recent -> active
+		},
+	}
+	status := &auth.Status{Authenticated: true}
+
+	ctx := instanceConfigCtx(t, "openshift", map[string]string{
+		"pd1020": "https://api.pd1020.caas.ford.com:6443",
+	})
+
+	rows := expandInstanceRows(ctx, "openshift", h, status, baseStatusRow("openshift"))
+	require.Len(t, rows, 2)
+
+	// Deterministic order: sorted by hostname; np0510 < pd1020. For the built-in
+	// profile the cluster alias/label alone is shown (no redundant "built-in /").
+	assert.Equal(t, "api.np0510.caas.ford.com", rows[0]["profile"], "unaliased host trimmed")
+	assert.Equal(t, "pd1020 (active)", rows[1]["profile"], "aliased host + active marker (most recent CachedAt)")
+
+	// Shared identity fills the user column on every row.
+	assert.Equal(t, "user@example.com", rows[0]["user"])
+	assert.Equal(t, "user@example.com", rows[1]["user"])
+
+	// Per-cluster status.
+	assert.Equal(t, "authenticated", rows[0]["status"])
+	assert.Equal(t, "authenticated", rows[1]["status"])
+}
+
+// TestExpandInstanceRows_DedupesTokensPerCluster asserts that several cached
+// tokens for the same instance (e.g. a user login plus minted service-account
+// tokens) collapse to a single row per cluster, and that the representative row
+// reflects the user/login session rather than a machine token.
+func TestExpandInstanceRows_DedupesTokensPerCluster(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	h := auth.NewMockHandler("openshift")
+	h.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
+	h.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{
+			Handler:  "openshift",
+			Hostname: "https://api.pd1020.caas.ford.com:6443",
+			Flow:     auth.FlowInteractive, // user login (older)
+			CachedAt: now.Add(-time.Hour),
+		},
+		{
+			Handler:  "openshift",
+			Hostname: "https://api.pd1020.caas.ford.com:6443",
+			Flow:     auth.FlowServicePrincipal, // minted SA token (newer)
+			CachedAt: now,
+		},
+	}
+	status := &auth.Status{Authenticated: true}
+
+	rows := expandInstanceRows(context.Background(), "openshift", h, status, baseStatusRow("openshift"))
+	require.Len(t, rows, 1, "multiple tokens for one cluster must collapse to a single row")
+	// The user/login flow wins over the newer machine flow.
+	assert.Equal(t, string(auth.FlowInteractive), rows[0]["flow"])
+	assert.Equal(t, "api.pd1020.caas.ford.com (active)", rows[0]["profile"])
+}
+
+// TestExpandInstanceRows_NamedProfilePrefix asserts that a non-default (named)
+// auth profile is preserved as a prefix on each cluster label, so identity and
+// endpoint stay distinguishable when multiple profiles exist.
+func TestExpandInstanceRows_NamedProfilePrefix(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	h := auth.NewMockHandler("openshift")
+	h.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
+	h.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{
+			Handler:  "openshift",
+			Hostname: "https://api.pd1020.caas.ford.com:6443",
+			Flow:     auth.FlowInteractive,
+			CachedAt: now,
+		},
+	}
+	status := &auth.Status{Authenticated: true}
+
+	base := baseStatusRow("openshift")
+	base["profile"] = "work" // a named profile is active
+	rows := expandInstanceRows(context.Background(), "openshift", h, status, base)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "work / api.pd1020.caas.ford.com (active)", rows[0]["profile"])
+}
+
+func TestExpandInstanceRows_ExpiredCluster(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	h := auth.NewMockHandler("openshift")
+	h.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
+	h.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{
+			Handler:   "openshift",
+			Hostname:  "https://api.pd1020.caas.ford.com:6443",
+			IsExpired: true,
+			CachedAt:  now,
+		},
+	}
+	status := &auth.Status{Authenticated: true}
+
+	rows := expandInstanceRows(context.Background(), "openshift", h, status, baseStatusRow("openshift"))
+	require.Len(t, rows, 1)
+	assert.Equal(t, "expired", rows[0]["status"])
+}
+
+func TestExpandInstanceRows_NoActiveWithoutTimestamps(t *testing.T) {
+	t.Parallel()
+
+	h := auth.NewMockHandler("openshift")
+	h.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
+	h.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{Handler: "openshift", Hostname: "https://a.example.com"},
+		{Handler: "openshift", Hostname: "https://b.example.com"},
+	}
+	status := &auth.Status{Authenticated: true}
+
+	rows := expandInstanceRows(context.Background(), "openshift", h, status, baseStatusRow("openshift"))
+	require.Len(t, rows, 2)
+	for _, r := range rows {
+		assert.NotContains(t, r["profile"], "(active)", "no active marker when no CachedAt timestamps")
+	}
+}
+
+// TestQueryHandlerStatuses_PerClusterExpansion exercises the full status query
+// path (queryHandlerStatuses -> expandInstanceRows -> flatten) so the wiring
+// that turns one instance handler into multiple rows is covered end-to-end.
+func TestQueryHandlerStatuses_PerClusterExpansion(t *testing.T) {
+	ctx, _ := newTestContext(t)
+	ctx = config.WithConfig(ctx, &config.Config{
+		Auth: config.GlobalAuthConfig{
+			Handlers: map[string]config.HandlerConfig{
+				"openshift": {
+					Hostname: &config.HostnameConfig{Aliases: map[string]string{
+						"prod": "https://api.prod.example.com:6443",
+					}},
+				},
+			},
+		},
+	})
+
+	now := time.Now()
+	mock := auth.NewMockHandler("openshift")
+	mock.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
+	mock.StatusResult = &auth.Status{
+		Authenticated: true,
+		Claims:        &auth.Claims{Email: "user@example.com"},
+	}
+	mock.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{
+			Handler:  "openshift",
+			Hostname: "https://api.prod.example.com:6443",
+			Flow:     auth.FlowInteractive,
+			CachedAt: now, // most recent -> active
+		},
+		{
+			Handler:  "openshift",
+			Hostname: "https://api.stg.example.com:6443",
+			Flow:     auth.FlowInteractive,
+			CachedAt: now.Add(-time.Hour),
+		},
+	}
+
+	registry := auth.NewRegistry()
+	require.NoError(t, registry.Register(mock))
+	ctx = auth.WithRegistry(ctx, registry)
+
+	results, warnings := queryHandlerStatuses(ctx, settings.NewCliParams(), []string{"openshift"}, false)
+	assert.Empty(t, warnings)
+	require.Len(t, results, 2, "one instance handler with two cluster sessions should yield two rows")
+
+	// Sorted by hostname: prod < stg. For the built-in profile the cluster label
+	// alone is shown.
+	assert.Equal(t, "prod (active)", results[0]["profile"])
+	assert.Equal(t, "api.stg.example.com", results[1]["profile"])
+	for _, r := range results {
+		assert.Equal(t, "openshift", r["handler"])
+		assert.Equal(t, "user@example.com", r["user"])
+		assert.Equal(t, "authenticated", r["status"])
+	}
+}
+
+// TestAuthStatusSchema_PropertySetUnchanged guards the display shape: the set of
+// declared properties in both the inline and embedded schemas must stay in sync
+// with this expected list. Adding/removing a property (a shape change) fails the
+// test intentionally; only the profile maxLength was widened for cluster labels.
+func TestAuthStatusSchema_PropertySetUnchanged(t *testing.T) {
+	t.Parallel()
+
+	expected := []string{
+		"handler", "kind", "status", "flow", "user", "expiresIn", "profile",
+		"type", "displayName", "email", "username", "authenticated",
+		"identityType", "clientId", "tokenFile", "name", "tenantId",
+		"expiresAt", "lastRefresh", "scopes", "cachedTokens", "hint",
+		"_expiresAtTime",
+	}
+	sort.Strings(expected)
+
+	inline := schemaPropertyKeys(t, authStatusSchema)
+	assert.Equal(t, expected, inline, "inline authStatusSchema property set drifted")
+
+	// The embedded display schema mirrors the inline schema minus the two
+	// inline-only internal fields ("type" and "_expiresAtTime").
+	embedExpected := make([]string, 0, len(expected))
+	for _, k := range expected {
+		if k == "_expiresAtTime" || k == "type" {
+			continue
+		}
+		embedExpected = append(embedExpected, k)
+	}
+	embed := schemaPropertyKeys(t, authStatusDisplaySchema)
+	assert.Equal(t, embedExpected, embed, "embedded auth_status_schema.json property set drifted")
+
+	// The profile column must be wide enough for the "<identity> / <cluster>"
+	// label used by per-cluster rows.
+	assert.Equal(t, float64(60), schemaPropertyMaxLength(t, authStatusSchema, "profile"))
+	assert.Equal(t, float64(60), schemaPropertyMaxLength(t, authStatusDisplaySchema, "profile"))
+}
+
+func schemaPropertyKeys(t *testing.T, raw []byte) []string {
+	t.Helper()
+	props := schemaProperties(t, raw)
+	keys := make([]string, 0, len(props))
+	for k := range props {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func schemaPropertyMaxLength(t *testing.T, raw []byte, prop string) float64 {
+	t.Helper()
+	props := schemaProperties(t, raw)
+	entry, ok := props[prop].(map[string]any)
+	require.True(t, ok, "property %q not found", prop)
+	ml, ok := entry["maxLength"].(float64)
+	require.True(t, ok, "property %q has no maxLength", prop)
+	return ml
+}
+
+func schemaProperties(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var doc struct {
+		Items struct {
+			Properties map[string]any `json:"properties"`
+		} `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &doc))
+	return doc.Items.Properties
+}

--- a/pkg/cmd/scafctl/auth/token.go
+++ b/pkg/cmd/scafctl/auth/token.go
@@ -6,6 +6,7 @@ package auth
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -16,6 +17,7 @@ import (
 	"github.com/atotto/clipboard"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/auth/execcredential"
+	hostnameresolver "github.com/oakwood-commons/scafctl/pkg/auth/hostname"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -174,8 +176,13 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
 
-			// Scope is required only for handlers that support per-request scopes
-			if len(scopes) == 0 && auth.HasCapability(caps, auth.CapScopesOnTokenRequest) {
+			// Scope is required for handlers that support per-request scopes,
+			// EXCEPT in exec-credential mode. The kubeconfig exec block encodes
+			// the intended scope (or intentionally none, for handlers like
+			// openshift whose empty-scope token is the held user credential), so
+			// requiring one here would break kubectl/oc for those clusters.
+			execMode := execCred || os.Getenv("KUBERNETES_EXEC_INFO") != ""
+			if len(scopes) == 0 && auth.HasCapability(caps, auth.CapScopesOnTokenRequest) && !execMode {
 				err := fmt.Errorf("--scope is required for the %q auth handler", handlerName)
 				w.Errorf("%v", err)
 				return exitcode.WithCode(err, exitcode.InvalidInput)
@@ -206,6 +213,27 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				if tokenHostname == "" {
 					tokenHostname = execcredential.ClusterServerFromExecInfo(execInfo)
 				}
+			}
+
+			// Resolve a hostname selector (static alias or dynamic inventory) into
+			// a concrete endpoint URL before requesting the token, mirroring the
+			// login path. Returns the value unchanged when it is already a URL or
+			// when the handler has no hostname config, so plain-hostname handlers
+			// and exec-info URLs are unaffected. Without this, a bare cluster
+			// selector (e.g. "pd1020") would reach the plugin unresolved and fail.
+			if tokenHostname != "" {
+				resolved, rErr := hostnameresolver.Resolve(ctx, handlerName, tokenHostname)
+				if rErr != nil {
+					w.Errorf("%v", rErr)
+					code := exitcode.GeneralError
+					if errors.Is(rErr, hostnameresolver.ErrSelectorNotFound) ||
+						errors.Is(rErr, hostnameresolver.ErrResolverLoop) ||
+						errors.Is(rErr, hostnameresolver.ErrTransformShape) {
+						code = exitcode.InvalidInput
+					}
+					return exitcode.WithCode(rErr, code)
+				}
+				tokenHostname = resolved
 			}
 
 			token, err := handler.GetToken(ctx, auth.TokenOptions{

--- a/pkg/cmd/scafctl/auth/token_test.go
+++ b/pkg/cmd/scafctl/auth/token_test.go
@@ -399,6 +399,55 @@ func TestCommandToken_ExecCredentialAutoDetect(t *testing.T) {
 	assert.Equal(t, "auto-detected-token", status["token"])
 }
 
+// TestCommandToken_ExecCredentialNoScopeForScopeCapableHandler verifies that a
+// handler advertising CapScopesOnTokenRequest may be used in exec-credential
+// mode WITHOUT --scope: the kubeconfig exec block wants the held (empty-scope)
+// user token, so requiring a scope would break kubectl/oc. Regression for the
+// openshift credential-helper flow.
+func TestCommandToken_ExecCredentialNoScopeForScopeCapableHandler(t *testing.T) {
+	t.Setenv("KUBERNETES_EXEC_INFO", `{"apiVersion":"client.authentication.k8s.io/v1","kind":"ExecCredential","spec":{}}`)
+
+	ctx, buf := newTestContext(t)
+
+	mock := newEntraMock() // advertises CapScopesOnTokenRequest
+	mock.SetToken(&auth.Token{AccessToken: "held-user-token", TokenType: "Bearer", ExpiresAt: time.Now().Add(time.Hour)})
+	ctx = withTestHandler(ctx, mock)
+
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	cmd := CommandToken(settings.NewCliParams(), ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra", "--exec-credential"}) // no --scope
+
+	require.NoError(t, cmd.Execute())
+
+	ec := decodeExecCredential(t, buf.String())
+	status, ok := ec["status"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "held-user-token", status["token"])
+}
+
+// TestCommandToken_InteractiveNoScopeStillRequiredForScopeCapableHandler
+// verifies the scope-required check is relaxed ONLY in exec-credential mode: an
+// interactive `auth token <handler>` with no --scope for a scope-capable
+// handler still errors early.
+func TestCommandToken_InteractiveNoScopeStillRequiredForScopeCapableHandler(t *testing.T) {
+	t.Setenv("KUBERNETES_EXEC_INFO", "") // ensure exec mode is not auto-detected
+
+	ctx, buf := newTestContext(t)
+
+	mock := newEntraMock() // advertises CapScopesOnTokenRequest
+	ctx = withTestHandler(ctx, mock)
+
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	cmd := CommandToken(settings.NewCliParams(), ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra"}) // no --scope, no exec mode
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--scope is required")
+}
+
 func TestCommandToken_ExecCredentialForwardsClusterHostname(t *testing.T) {
 	// Regression test for #581: with provideClusterInfo the exec info carries
 	// the target cluster's server, which must be forwarded as the token

--- a/pkg/cmd/scafctl/config/paths.go
+++ b/pkg/cmd/scafctl/config/paths.go
@@ -6,6 +6,7 @@ package config
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	appconfig "github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/paths"
@@ -156,10 +158,21 @@ func (o *PathsOptions) Run(ctx context.Context) error {
 		pathInfos = o.getRealPaths()
 	}
 
+	// Config file sources (real platform only): the config.d fragments and the
+	// user config file that actually feed the merged configuration.
+	var sourceInfos []configSource
+	if !isIllustrative {
+		sourceInfos = o.configSourceInfos()
+	}
+
 	// Handle structured output formats
 	outputOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags, kvx.WithIOStreams(o.IOStreams))
 	if kvx.IsStructuredFormat(outputOpts.Format) {
-		return outputOpts.Write(pathInfos)
+		out := pathInfos
+		for _, s := range sourceInfos {
+			out = append(out, s.Info)
+		}
+		return outputOpts.Write(out)
 	}
 
 	// Table output
@@ -191,7 +204,83 @@ func (o *PathsOptions) Run(ctx context.Context) error {
 		w.Plainf("Override paths with XDG environment variables or %s_SECRETS_DIR.\n", settings.SafeEnvPrefix(o.BinaryName))
 	}
 
+	// Show the config sources in merge order so the config.d overlay (where most
+	// real values live) is discoverable, not just the base config file path.
+	if !isIllustrative && len(sourceInfos) > 0 {
+		w.Plain("")
+		w.Infof("Config sources (merge order)")
+		w.Plain("")
+		idx := 1
+		w.Plainf("  %d. %s\n", idx, "built-in defaults")
+		idx++
+		for _, s := range sourceInfos {
+			line := s.Info.Path
+			if !s.Exists {
+				line += "  (not present)"
+			}
+			w.Plainf("  %d. %s\n", idx, line)
+			idx++
+		}
+		w.Plainf("  %d. %s_* environment variables\n", idx, settings.SafeEnvPrefix(o.BinaryName))
+		w.Plain("")
+		w.Plain("Later sources override earlier ones.")
+	}
+
 	return nil
+}
+
+// configSource is a single on-disk config file layer feeding the merged
+// configuration, paired with whether the file currently exists on disk.
+type configSource struct {
+	Info   paths.PathInfo
+	Exists bool
+}
+
+// configSourceInfos returns the on-disk config file sources that feed the merged
+// configuration, in merge order: each config.d fragment (lexical), followed by
+// the user config file. Non-file layers (built-in defaults, any embedder base
+// config, and SCAFCTL_* environment overrides) are surfaced separately by the
+// table output. Returns nil when the config path cannot be resolved.
+func (o *PathsOptions) configSourceInfos() []configSource {
+	configPath, err := paths.ConfigFile()
+	if err != nil {
+		return nil
+	}
+
+	fragments, err := appconfig.DirFragments(filepath.Dir(configPath))
+	if err != nil {
+		return nil
+	}
+
+	sources := make([]configSource, 0, len(fragments)+1)
+	for _, frag := range fragments {
+		// Fragments come from a directory glob, so they exist by construction.
+		sources = append(sources, configSource{
+			Info: paths.PathInfo{
+				Name:        "config.d",
+				Path:        frag,
+				Description: "Drop-in fragment (loaded in merge order)",
+			},
+			Exists: true,
+		})
+	}
+
+	_, statErr := os.Stat(configPath)
+	exists := statErr == nil
+	desc := "User config file"
+	if !exists {
+		desc = "User config file (not present)"
+	}
+	sources = append(sources, configSource{
+		Info: paths.PathInfo{
+			Name:        "config.yaml",
+			Path:        configPath,
+			Description: desc,
+		},
+		Exists: exists,
+	})
+
+	return sources
 }
 
 // getRealPaths returns the actual paths for the current platform.

--- a/pkg/cmd/scafctl/config/paths_test.go
+++ b/pkg/cmd/scafctl/config/paths_test.go
@@ -1,0 +1,98 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/adrg/xdg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+)
+
+// setupConfigDir points XDG_CONFIG_HOME at a temp dir and returns the resolved
+// scafctl config directory (its parent is the temp dir). Uses t.Setenv, so the
+// caller must not be parallel.
+func setupConfigDir(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	xdg.Reload()
+	t.Cleanup(xdg.Reload)
+	cfgDir := filepath.Join(tmp, "scafctl")
+	require.NoError(t, os.MkdirAll(filepath.Join(cfgDir, "config.d"), 0o755))
+	return cfgDir
+}
+
+// TestPathsOptions_ConfigSources_JSON verifies the config.d fragments appear in
+// the structured output so nothing is hidden from tooling.
+func TestPathsOptions_ConfigSources_JSON(t *testing.T) {
+	cfgDir := setupConfigDir(t)
+	fragPath := filepath.Join(cfgDir, "config.d", "50-clusters.yaml")
+	require.NoError(t, os.WriteFile(fragPath, []byte("telemetry:\n  serviceName: x\n"), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &stderr, false)
+	cliParams := settings.NewCliParams()
+
+	opts := &PathsOptions{IOStreams: ioStreams, CliParams: cliParams, BinaryName: "scafctl"}
+	opts.KvxOutputFlags.Output = "json"
+	opts.KvxOutputFlags.AppName = "scafctl"
+
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+	require.NoError(t, opts.Run(ctx))
+
+	out := stdout.String()
+	assert.Contains(t, out, "50-clusters.yaml")
+	assert.Contains(t, out, "config.d")
+}
+
+// TestPathsOptions_ConfigSources_Table verifies the merge-order section is
+// rendered in human output, including the fragment and the built-in/env layers.
+func TestPathsOptions_ConfigSources_Table(t *testing.T) {
+	cfgDir := setupConfigDir(t)
+	fragPath := filepath.Join(cfgDir, "config.d", "50-clusters.yaml")
+	require.NoError(t, os.WriteFile(fragPath, []byte("telemetry:\n  serviceName: x\n"), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &stderr, false)
+	cliParams := settings.NewCliParams()
+
+	opts := &PathsOptions{IOStreams: ioStreams, CliParams: cliParams, BinaryName: "scafctl"}
+	opts.KvxOutputFlags.AppName = "scafctl"
+
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+	require.NoError(t, opts.Run(ctx))
+
+	out := stdout.String()
+	assert.Contains(t, out, "Config sources (merge order)")
+	assert.Contains(t, out, "built-in defaults")
+	assert.Contains(t, out, "50-clusters.yaml")
+	assert.Contains(t, out, "environment variables")
+}
+
+// TestConfigSourceInfos_MarksMissingConfigFile verifies the user config file is
+// reported as not present when it does not exist on disk.
+func TestConfigSourceInfos_MarksMissingConfigFile(t *testing.T) {
+	setupConfigDir(t)
+
+	opts := &PathsOptions{BinaryName: "scafctl"}
+	infos := opts.configSourceInfos()
+	require.NotEmpty(t, infos)
+
+	last := infos[len(infos)-1]
+	assert.Equal(t, "config.yaml", last.Info.Name)
+	assert.False(t, last.Exists)
+	assert.Contains(t, last.Info.Description, "not present")
+}

--- a/pkg/cmd/scafctl/kube/login.go
+++ b/pkg/cmd/scafctl/kube/login.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/auth/loginui"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	kubeapi "github.com/oakwood-commons/scafctl/pkg/kube"
@@ -98,6 +99,18 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				HandlerLookup: func(ctx context.Context, name string) (kubelogin.Authenticator, error) {
 					return auth.GetHandler(ctx, name)
 				},
+			}
+			// Present the shared interactive login TUI (used by 'auth login')
+			// when stdout is a terminal and the output is not structured or
+			// quiet. Piped, non-TTY, -o json/table, or -o quiet output keeps the
+			// plain line-based path.
+			if skvx.IsTerminal(ioStreams.Out) && loginTUIEligibleFormat(outputFlags.Output) {
+				deps.LoginRunner = func(ctx context.Context, h kubelogin.Authenticator, opts auth.LoginOptions) (*auth.Result, error) {
+					if handler, ok := h.(auth.Handler); ok {
+						return loginui.RunLogin(ctx, w, cliParams.BinaryName, handler, opts)
+					}
+					return h.Login(ctx, opts)
+				}
 			}
 			req := kubelogin.Request{
 				Cluster:           cluster,
@@ -186,4 +199,14 @@ func renderLoginResult(ioStreams *terminal.IOStreams, outputFlags *flags.KvxOutp
 		w.Warningf("kubeconfig provider unavailable; wrote a static kubeconfig entry")
 	}
 	return nil
+}
+
+// loginTUIEligibleFormat reports whether the requested output format permits the
+// interactive login TUI. Structured (json/yaml/csv/toml/mermaid) and quiet
+// formats keep the plain line-based path; auto/table/list are eligible. An
+// unrecognized format parses as auto and is treated as eligible. The caller
+// additionally gates on stdout being a terminal.
+func loginTUIEligibleFormat(output string) bool {
+	format, _ := skvx.ParseOutputFormat(output)
+	return !skvx.IsStructuredFormat(format) && !skvx.IsQuietFormat(format)
 }

--- a/pkg/cmd/scafctl/kube/login_test.go
+++ b/pkg/cmd/scafctl/kube/login_test.go
@@ -207,3 +207,32 @@ func TestCommandLogin_VerifyFailsWithoutProvider(t *testing.T) {
 	assert.FileExists(t, path, "kubeconfig entry is written even when verification fails")
 	assert.Contains(t, buf.String(), "was written", "user is told the entry was written despite the verify failure")
 }
+
+func TestLoginTUIEligibleFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		output string
+		want   bool
+	}{
+		{output: "", want: true},         // auto
+		{output: "auto", want: true},     // auto
+		{output: "table", want: true},    // human table
+		{output: "list", want: true},     // human list
+		{output: "json", want: false},    // structured
+		{output: "yaml", want: false},    // structured
+		{output: "csv", want: false},     // structured
+		{output: "toml", want: false},    // structured
+		{output: "mermaid", want: false}, // structured
+		{output: "quiet", want: false},   // suppressed
+		{output: "bogus", want: true},    // unrecognized parses as auto
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.output, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, loginTUIEligibleFormat(tt.output),
+				"format %q eligibility", tt.output)
+		})
+	}
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -177,13 +177,19 @@ func (m *Manager) Load() (*Config, error) {
 	return &cfg, nil
 }
 
-// mergeConfigDir merges every *.yaml/*.yml fragment in the config.d directory
-// located next to the main config file. Fragments are merged in lexical
-// filename order (later files override earlier ones). A missing config.d
-// directory is not an error; individual fragments that fail to parse are.
-func (m *Manager) mergeConfigDir(baseDir string) error {
+// DirFragments returns the config.d fragment file paths located next to
+// the main config file, in the same lexical order the loader merges them.
+// baseDir is the directory containing the config file (i.e. the parent of the
+// config.d directory). Both *.yaml and *.yml fragments are included. A missing
+// or empty config.d directory yields a nil slice and no error.
+//
+// This is the single source of truth for config.d discovery: mergeConfigDir
+// consumes it during load, and the `config paths` command uses it to list the
+// fragments that are actually read. Keeping one implementation prevents the
+// listing from drifting from the merge behavior.
+func DirFragments(baseDir string) ([]string, error) {
 	if baseDir == "" {
-		return nil
+		return nil, nil
 	}
 	dir := filepath.Join(baseDir, ConfigDirName)
 
@@ -191,14 +197,26 @@ func (m *Manager) mergeConfigDir(baseDir string) error {
 	for _, pattern := range []string{"*.yaml", "*.yml"} {
 		matches, err := filepath.Glob(filepath.Join(dir, pattern))
 		if err != nil {
-			return fmt.Errorf("failed to scan %s: %w", dir, err)
+			return nil, fmt.Errorf("failed to scan %s: %w", dir, err)
 		}
 		fragments = append(fragments, matches...)
+	}
+	sort.Strings(fragments)
+	return fragments, nil
+}
+
+// mergeConfigDir merges every *.yaml/*.yml fragment in the config.d directory
+// located next to the main config file. Fragments are merged in lexical
+// filename order (later files override earlier ones). A missing config.d
+// directory is not an error; individual fragments that fail to parse are.
+func (m *Manager) mergeConfigDir(baseDir string) error {
+	fragments, err := DirFragments(baseDir)
+	if err != nil {
+		return err
 	}
 	if len(fragments) == 0 {
 		return nil
 	}
-	sort.Strings(fragments)
 
 	// Track drop-in values (parsed with documented yaml-tag casing) so Save can
 	// identify and skip them, keeping config.d fragments out of the persisted

--- a/pkg/config/configdir_test.go
+++ b/pkg/config/configdir_test.go
@@ -176,3 +176,59 @@ func TestManager_Save_KeepsUserOverrideOfFragmentKey(t *testing.T) {
 	assert.Contains(t, string(data), "from-user",
 		"user-owned value that shadows a fragment key must be persisted")
 }
+
+// TestConfigDirFragments verifies the exported discovery helper returns both
+// *.yaml and *.yml fragments in lexical merge order.
+func TestConfigDirFragments(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Create fragments out of order to prove sorting.
+	writeFile(t, filepath.Join(dir, ConfigDirName, "20-b.yml"), "telemetry:\n  serviceName: b\n")
+	writeFile(t, filepath.Join(dir, ConfigDirName, "10-a.yaml"), "telemetry:\n  serviceName: a\n")
+	writeFile(t, filepath.Join(dir, ConfigDirName, "05-c.yaml"), "telemetry:\n  serviceName: c\n")
+	// A non-config extension must be ignored.
+	writeFile(t, filepath.Join(dir, ConfigDirName, "notes.txt"), "ignored\n")
+
+	fragments, err := DirFragments(dir)
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		filepath.Join(dir, ConfigDirName, "05-c.yaml"),
+		filepath.Join(dir, ConfigDirName, "10-a.yaml"),
+		filepath.Join(dir, ConfigDirName, "20-b.yml"),
+	}, fragments)
+}
+
+// TestConfigDirFragments_EmptyOrMissing verifies missing directories and an
+// empty baseDir yield no fragments and no error.
+func TestConfigDirFragments_EmptyOrMissing(t *testing.T) {
+	t.Parallel()
+
+	empty, err := DirFragments("")
+	require.NoError(t, err)
+	assert.Empty(t, empty)
+
+	missing, err := DirFragments(t.TempDir())
+	require.NoError(t, err)
+	assert.Empty(t, missing)
+}
+
+// TestConfigDirFragments_MatchesMergeOrder verifies the helper returns the same
+// ordering the loader relies on: the last fragment wins on conflicting keys.
+func TestConfigDirFragments_MatchesMergeOrder(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+	writeFile(t, configPath, "settings:\n  defaultCatalog: user-catalog\n")
+	writeFile(t, filepath.Join(dir, ConfigDirName, "10-a.yaml"), "telemetry:\n  serviceName: first\n")
+	writeFile(t, filepath.Join(dir, ConfigDirName, "20-b.yaml"), "telemetry:\n  serviceName: second\n")
+
+	fragments, err := DirFragments(dir)
+	require.NoError(t, err)
+	require.Len(t, fragments, 2)
+	// The last fragment in the returned order is the one that wins the merge.
+	cfg, err := NewManager(configPath).Load()
+	require.NoError(t, err)
+	assert.Contains(t, fragments[len(fragments)-1], "20-b.yaml")
+	assert.Equal(t, "second", cfg.Telemetry.ServiceName)
+}

--- a/pkg/kube/login/login.go
+++ b/pkg/kube/login/login.go
@@ -101,6 +101,14 @@ type Deps struct {
 	// Resolver resolves cluster names to connection details. Optional.
 	Resolver kube.ClusterResolver
 
+	// LoginRunner, when set, performs the interactive handler login. It lets the
+	// caller wrap the login with a progress UI (e.g. the shared kvx status TUI
+	// used by 'auth login'). When nil, handler.Login is called directly. The
+	// returned Result is currently unused by the orchestration; only the error
+	// matters. The CLI populates this with a TUI-capable runner when stdout is a
+	// terminal and the output is not structured.
+	LoginRunner func(ctx context.Context, handler Authenticator, opts auth.LoginOptions) (*auth.Result, error)
+
 	// BinaryName is the host binary baked into the kubeconfig exec command.
 	// Empty falls back to settings.CliBinaryName.
 	BinaryName string
@@ -233,7 +241,13 @@ func Login(ctx context.Context, deps Deps, req Request) (*Result, error) {
 	if info.APIServerURL != "" && auth.HasCapability(handler.Capabilities(), auth.CapHostname) {
 		loginOpts.Hostname = info.APIServerURL
 	}
-	if _, err := handler.Login(ctx, loginOpts); err != nil {
+	loginRun := deps.LoginRunner
+	if loginRun == nil {
+		loginRun = func(ctx context.Context, h Authenticator, opts auth.LoginOptions) (*auth.Result, error) {
+			return h.Login(ctx, opts)
+		}
+	}
+	if _, err := loginRun(ctx, handler, loginOpts); err != nil {
 		return nil, fmt.Errorf("login with handler %q: %w", handler.Name(), err)
 	}
 

--- a/pkg/kube/login/login_test.go
+++ b/pkg/kube/login/login_test.go
@@ -181,6 +181,60 @@ func TestLogin_LoginError(t *testing.T) {
 	assert.ErrorIs(t, err, loginErr)
 }
 
+func TestLogin_LoginRunnerUsed(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{name: "oidc", token: &auth.Token{AccessToken: "tok"}}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true, ContextName: "prod"}}
+
+	var (
+		runnerCalls   int
+		runnerHandler Authenticator
+		runnerOpts    auth.LoginOptions
+	)
+	deps := Deps{
+		Handler:    handler,
+		Kubeconfig: kc,
+		LoginRunner: func(_ context.Context, h Authenticator, opts auth.LoginOptions) (*auth.Result, error) {
+			runnerCalls++
+			runnerHandler = h
+			runnerOpts = opts
+			return &auth.Result{}, nil
+		},
+	}
+
+	_, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+		Timeout:     42 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// The runner is invoked in place of handler.Login and receives the resolved
+	// handler plus the built login options.
+	assert.Equal(t, 1, runnerCalls)
+	assert.Same(t, handler, runnerHandler)
+	assert.Equal(t, 42*time.Second, runnerOpts.Timeout)
+	// handler.Login must not be called directly when a runner is set.
+	assert.Equal(t, auth.LoginOptions{}, handler.loginOpts)
+}
+
+func TestLogin_LoginRunnerError(t *testing.T) {
+	t.Parallel()
+
+	runnerErr := errors.New("runner boom")
+	deps := Deps{
+		Handler:    &stubAuth{name: "oidc"},
+		Kubeconfig: &stubKube{},
+		LoginRunner: func(_ context.Context, _ Authenticator, _ auth.LoginOptions) (*auth.Result, error) {
+			return nil, runnerErr
+		},
+	}
+	_, err := Login(context.Background(), deps, Request{Server: "https://api.example.com:6443", ClusterName: "prod"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, runnerErr)
+}
+
 func TestLogin_ProviderSuccess(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/plugin/auth_grpc_client_test.go
+++ b/pkg/plugin/auth_grpc_client_test.go
@@ -235,6 +235,65 @@ func TestAuthHandlerGRPCClient_Login_ForwardsHostname(t *testing.T) {
 	assert.Equal(t, "pd1020", gotReq.Hostname, "hostname must be mapped onto the proto LoginRequest")
 }
 
+func TestAuthHandlerGRPCClient_Login_ForwardsCallbackPort(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().Truncate(time.Second)
+	var gotReq *proto.LoginRequest
+	mock := &mockAuthHandlerServiceClient{
+		loginFunc: func(_ context.Context, req *proto.LoginRequest) (grpc.ServerStreamingClient[proto.LoginStreamMessage], error) {
+			gotReq = req
+			return &mockLoginStreamClient{
+				messages: []*proto.LoginStreamMessage{
+					{
+						Payload: &proto.LoginStreamMessage_Result{
+							Result: &proto.LoginResult{
+								Claims:        &proto.Claims{Email: "user@example.com"},
+								ExpiresAtUnix: now.Add(time.Hour).Unix(),
+							},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+	client := &AuthHandlerGRPCClient{client: mock}
+
+	_, err := client.Login(context.Background(), "openshift", LoginRequest{
+		CallbackPort: 8400,
+		Flow:         auth.FlowInteractive,
+	}, nil)
+	require.NoError(t, err)
+	require.NotNil(t, gotReq)
+	assert.Equal(t, int32(8400), gotReq.CallbackPort, "callback port must be mapped onto the proto LoginRequest")
+}
+
+func TestCallbackPortToProto(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   int
+		want int32
+	}{
+		{"unset", 0, 0},
+		{"min_valid", 1024, 1024},
+		{"typical", 8400, 8400},
+		{"max_valid", 65535, 65535},
+		{"privileged_clamped", 80, 0},
+		{"negative_clamped", -1, 0},
+		{"above_max_clamped", 70000, 0},
+		{"just_above_max_clamped", auth.MaxCallbackPort + 1, 0},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, callbackPortToProto(tc.in))
+		})
+	}
+}
+
 func TestAuthHandlerGRPCClient_Login_WithDeviceCodePrompt(t *testing.T) {
 	t.Parallel()
 
@@ -372,7 +431,7 @@ func TestAuthHandlerGRPCClient_Logout_Success(t *testing.T) {
 	}
 	client := &AuthHandlerGRPCClient{client: mock}
 
-	err := client.Logout(context.Background(), "azure")
+	err := client.Logout(context.Background(), "azure", LogoutRequest{})
 	require.NoError(t, err)
 }
 
@@ -384,7 +443,7 @@ func TestAuthHandlerGRPCClient_Logout_Error(t *testing.T) {
 	}
 	client := &AuthHandlerGRPCClient{client: mock}
 
-	err := client.Logout(context.Background(), "azure")
+	err := client.Logout(context.Background(), "azure", LogoutRequest{})
 	require.Error(t, err)
 }
 
@@ -410,7 +469,7 @@ func TestAuthHandlerGRPCClient_GetStatus_Success(t *testing.T) {
 	}
 	client := &AuthHandlerGRPCClient{client: mock}
 
-	s, err := client.GetStatus(context.Background(), "azure")
+	s, err := client.GetStatus(context.Background(), "azure", StatusRequest{})
 	require.NoError(t, err)
 	assert.True(t, s.Authenticated)
 	assert.Equal(t, "user@example.com", s.Claims.Email)
@@ -427,7 +486,7 @@ func TestAuthHandlerGRPCClient_GetStatus_Error(t *testing.T) {
 	}
 	client := &AuthHandlerGRPCClient{client: mock}
 
-	_, err := client.GetStatus(context.Background(), "azure")
+	_, err := client.GetStatus(context.Background(), "azure", StatusRequest{})
 	require.Error(t, err)
 }
 
@@ -830,7 +889,7 @@ func TestAuthHandlerGRPCServer_Logout_Error(t *testing.T) {
 	t.Parallel()
 
 	mock := &MockAuthHandlerPlugin{
-		logoutFunc: func(_ context.Context, _ string) error {
+		logoutFunc: func(_ context.Context, _ string, _ LogoutRequest) error {
 			return fmt.Errorf("logout error")
 		},
 	}
@@ -844,7 +903,7 @@ func TestAuthHandlerGRPCServer_GetStatus_Error(t *testing.T) {
 	t.Parallel()
 
 	mock := &MockAuthHandlerPlugin{
-		statusFunc: func(_ context.Context, _ string) (*auth.Status, error) {
+		statusFunc: func(_ context.Context, _ string, _ StatusRequest) (*auth.Status, error) {
 			return nil, fmt.Errorf("status error")
 		},
 	}
@@ -1460,11 +1519,11 @@ func (e *errAuthPlugin) Login(_ context.Context, _ string, _ LoginRequest, _ fun
 	return nil, e.err
 }
 
-func (e *errAuthPlugin) Logout(_ context.Context, _ string) error {
+func (e *errAuthPlugin) Logout(_ context.Context, _ string, _ LogoutRequest) error {
 	return e.err
 }
 
-func (e *errAuthPlugin) GetStatus(_ context.Context, _ string) (*auth.Status, error) {
+func (e *errAuthPlugin) GetStatus(_ context.Context, _ string, _ StatusRequest) (*auth.Status, error) {
 	return nil, e.err
 }
 

--- a/pkg/plugin/client.go
+++ b/pkg/plugin/client.go
@@ -549,12 +549,12 @@ func (c *AuthHandlerClient) Login(ctx context.Context, handlerName string, req L
 
 // Logout delegates to the plugin's Logout.
 func (c *AuthHandlerClient) Logout(ctx context.Context, handlerName string) error {
-	return c.plugin.Logout(ctx, handlerName)
+	return c.plugin.Logout(ctx, handlerName, LogoutRequest{})
 }
 
 // GetStatus delegates to the plugin's GetStatus.
 func (c *AuthHandlerClient) GetStatus(ctx context.Context, handlerName string) (*auth.Status, error) {
-	return c.plugin.GetStatus(ctx, handlerName)
+	return c.plugin.GetStatus(ctx, handlerName, StatusRequest{})
 }
 
 // GetToken delegates to the plugin's GetToken.

--- a/pkg/plugin/grpc_auth.go
+++ b/pkg/plugin/grpc_auth.go
@@ -590,6 +590,7 @@ func statusToProto(s *auth.Status) *proto.GetStatusResponse {
 		TokenFile:       s.TokenFile,
 		Scopes:          s.Scopes,
 		Flow:            string(s.Flow),
+		Hostname:        s.Hostname,
 	}
 }
 
@@ -609,6 +610,7 @@ func protoToStatus(resp *proto.GetStatusResponse) *auth.Status {
 		TokenFile:     resp.TokenFile,
 		Scopes:        resp.Scopes,
 		Flow:          auth.Flow(resp.Flow),
+		Hostname:      resp.Hostname,
 	}
 }
 
@@ -654,6 +656,7 @@ func cachedTokenInfoToProto(t *auth.CachedTokenInfo) *proto.CachedTokenInfo {
 		Flow:      string(t.Flow),
 		IsExpired: t.IsExpired,
 		SessionId: t.SessionID,
+		Hostname:  t.Hostname,
 	}
 	if !t.ExpiresAt.IsZero() {
 		p.ExpiresAtUnix = t.ExpiresAt.Unix()
@@ -676,6 +679,7 @@ func protoToCachedTokenInfo(t *proto.CachedTokenInfo) *auth.CachedTokenInfo {
 		Flow:      auth.Flow(t.Flow),
 		IsExpired: t.IsExpired,
 		SessionID: t.SessionId,
+		Hostname:  t.Hostname,
 	}
 	if t.ExpiresAtUnix != 0 {
 		info.ExpiresAt = time.Unix(t.ExpiresAtUnix, 0)

--- a/pkg/plugin/grpc_auth.go
+++ b/pkg/plugin/grpc_auth.go
@@ -153,6 +153,8 @@ func (s *AuthHandlerGRPCServer) Login(req *proto.LoginRequest, stream grpc.Serve
 		Scopes:   req.Scopes,
 		Flow:     auth.Flow(req.Flow),
 		Timeout:  time.Duration(req.TimeoutSeconds) * time.Second,
+		// int32 -> int is a widening conversion and always safe.
+		CallbackPort: int(req.CallbackPort),
 	}
 	loginReq.TenantID = req.TenantId
 
@@ -182,7 +184,7 @@ func (s *AuthHandlerGRPCServer) Logout(ctx context.Context, req *proto.LogoutReq
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid profile: %v", err)
 	}
-	if err := s.Impl.Logout(ctx, req.HandlerName); err != nil {
+	if err := s.Impl.Logout(ctx, req.HandlerName, LogoutRequest{Hostname: req.Hostname}); err != nil {
 		return nil, err
 	}
 	return &proto.LogoutResponse{}, nil
@@ -194,7 +196,7 @@ func (s *AuthHandlerGRPCServer) GetStatus(ctx context.Context, req *proto.GetSta
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid profile: %v", err)
 	}
-	status, err := s.Impl.GetStatus(ctx, req.HandlerName)
+	status, err := s.Impl.GetStatus(ctx, req.HandlerName, StatusRequest{Hostname: req.Hostname})
 	if err != nil {
 		return nil, err
 	}
@@ -346,6 +348,19 @@ func (c *AuthHandlerGRPCClient) GetAuthHandlers(ctx context.Context) ([]AuthHand
 	return handlers, nil
 }
 
+// callbackPortToProto converts a host-side callback port to its wire (int32)
+// form. Out-of-range values (negative, privileged, above the max TCP port, or
+// beyond int32) are normalized to 0 (unset) so the narrowing conversion can
+// never truncate an untrusted value into a spurious port. The bounds are the
+// shared auth.MinCallbackPort/auth.MaxCallbackPort so this wire clamp cannot
+// drift from the CLI's --callback-port validation.
+func callbackPortToProto(port int) int32 {
+	if port < auth.MinCallbackPort || port > auth.MaxCallbackPort {
+		return 0
+	}
+	return int32(port)
+}
+
 // Login implements AuthHandlerPlugin.Login with streaming device code support.
 func (c *AuthHandlerGRPCClient) Login(ctx context.Context, handlerName string, req LoginRequest, deviceCodeCb func(DeviceCodePrompt)) (*LoginResponse, error) {
 	stream, err := c.client.Login(ctx, &proto.LoginRequest{
@@ -356,6 +371,7 @@ func (c *AuthHandlerGRPCClient) Login(ctx context.Context, handlerName string, r
 		Flow:           string(req.Flow),
 		TimeoutSeconds: int64(req.Timeout / time.Second),
 		Profile:        auth.ProfileFromContext(ctx),
+		CallbackPort:   callbackPortToProto(req.CallbackPort),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("login RPC failed: %w", err)
@@ -391,14 +407,14 @@ func (c *AuthHandlerGRPCClient) Login(ctx context.Context, handlerName string, r
 }
 
 // Logout implements AuthHandlerPlugin.Logout.
-func (c *AuthHandlerGRPCClient) Logout(ctx context.Context, handlerName string) error {
-	_, err := c.client.Logout(ctx, &proto.LogoutRequest{HandlerName: handlerName, Profile: auth.ProfileFromContext(ctx)})
+func (c *AuthHandlerGRPCClient) Logout(ctx context.Context, handlerName string, req LogoutRequest) error {
+	_, err := c.client.Logout(ctx, &proto.LogoutRequest{HandlerName: handlerName, Hostname: req.Hostname, Profile: auth.ProfileFromContext(ctx)})
 	return err
 }
 
 // GetStatus implements AuthHandlerPlugin.GetStatus.
-func (c *AuthHandlerGRPCClient) GetStatus(ctx context.Context, handlerName string) (*auth.Status, error) {
-	resp, err := c.client.GetStatus(ctx, &proto.GetStatusRequest{HandlerName: handlerName, Profile: auth.ProfileFromContext(ctx)})
+func (c *AuthHandlerGRPCClient) GetStatus(ctx context.Context, handlerName string, req StatusRequest) (*auth.Status, error) {
+	resp, err := c.client.GetStatus(ctx, &proto.GetStatusRequest{HandlerName: handlerName, Hostname: req.Hostname, Profile: auth.ProfileFromContext(ctx)})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/plugin/grpc_auth_coverage_test.go
+++ b/pkg/plugin/grpc_auth_coverage_test.go
@@ -265,7 +265,7 @@ func TestAuthHandlerGRPCServer_Logout(t *testing.T) {
 	var logoutCalled string
 	server := &AuthHandlerGRPCServer{
 		Impl: &MockAuthHandlerPlugin{
-			logoutFunc: func(_ context.Context, name string) error {
+			logoutFunc: func(_ context.Context, name string, _ LogoutRequest) error {
 				logoutCalled = name
 				return nil
 			},
@@ -283,7 +283,7 @@ func TestAuthHandlerGRPCServer_GetStatus(t *testing.T) {
 
 	server := &AuthHandlerGRPCServer{
 		Impl: &MockAuthHandlerPlugin{
-			statusFunc: func(_ context.Context, _ string) (*auth.Status, error) {
+			statusFunc: func(_ context.Context, _ string, _ StatusRequest) (*auth.Status, error) {
 				return &auth.Status{
 					Authenticated: true,
 					Claims:        &auth.Claims{Email: "user@test.com"},

--- a/pkg/plugin/grpc_auth_coverage_test.go
+++ b/pkg/plugin/grpc_auth_coverage_test.go
@@ -98,6 +98,7 @@ func TestStatusRoundTrip(t *testing.T) {
 		TokenFile:    "/tmp/token",
 		Scopes:       []string{"openid", "profile"},
 		Flow:         auth.FlowDeviceCode,
+		Hostname:     "cluster.example.com",
 	}
 
 	protoStatus := statusToProto(original)
@@ -117,6 +118,7 @@ func TestStatusRoundTrip(t *testing.T) {
 	assert.Equal(t, original.ExpiresAt.Unix(), roundTripped.ExpiresAt.Unix())
 	assert.Equal(t, original.LastRefresh.Unix(), roundTripped.LastRefresh.Unix())
 	assert.Equal(t, original.Flow, roundTripped.Flow)
+	assert.Equal(t, original.Hostname, roundTripped.Hostname)
 }
 
 // ── tokenResponseToProto / protoToTokenResponse round-trip tests ──────────────
@@ -190,6 +192,7 @@ func TestCachedTokenInfoRoundTrip(t *testing.T) {
 		CachedAt:  now,
 		IsExpired: false,
 		SessionID: "session-xyz",
+		Hostname:  "cluster.example.com",
 	}
 
 	protoInfo := cachedTokenInfoToProto(original)
@@ -207,6 +210,7 @@ func TestCachedTokenInfoRoundTrip(t *testing.T) {
 	assert.Equal(t, original.CachedAt.Unix(), roundTripped.CachedAt.Unix())
 	assert.Equal(t, original.IsExpired, roundTripped.IsExpired)
 	assert.Equal(t, original.SessionID, roundTripped.SessionID)
+	assert.Equal(t, original.Hostname, roundTripped.Hostname)
 }
 
 // ── AuthHandlerGRPCServer conversion tests ────────────────────────────────────

--- a/pkg/plugin/interface.go
+++ b/pkg/plugin/interface.go
@@ -38,6 +38,12 @@ type TokenRequest = sdkplugin.TokenRequest
 // TokenResponse contains the result of a plugin GetToken call.
 type TokenResponse = sdkplugin.TokenResponse
 
+// StatusRequest contains parameters for a plugin GetStatus call.
+type StatusRequest = sdkplugin.StatusRequest
+
+// LogoutRequest contains parameters for a plugin Logout call.
+type LogoutRequest = sdkplugin.LogoutRequest
+
 // FlowAvailability reports whether a specific auth flow is available based on
 // environment credentials or configuration.
 type FlowAvailability = sdkplugin.FlowAvailability

--- a/pkg/plugin/plugin_auth_test.go
+++ b/pkg/plugin/plugin_auth_test.go
@@ -20,8 +20,8 @@ import (
 type MockAuthHandlerPlugin struct {
 	handlers        []AuthHandlerInfo
 	loginFunc       func(ctx context.Context, name string, req LoginRequest, cb func(DeviceCodePrompt)) (*LoginResponse, error)
-	logoutFunc      func(ctx context.Context, name string) error
-	statusFunc      func(ctx context.Context, name string) (*auth.Status, error)
+	logoutFunc      func(ctx context.Context, name string, req LogoutRequest) error
+	statusFunc      func(ctx context.Context, name string, req StatusRequest) (*auth.Status, error)
 	tokenFunc       func(ctx context.Context, name string, req TokenRequest) (*TokenResponse, error)
 	listFunc        func(ctx context.Context, name string) ([]*auth.CachedTokenInfo, error)
 	purgeFunc       func(ctx context.Context, name string) (int, error)
@@ -66,16 +66,16 @@ func (m *MockAuthHandlerPlugin) Login(ctx context.Context, handlerName string, r
 	}, nil
 }
 
-func (m *MockAuthHandlerPlugin) Logout(ctx context.Context, handlerName string) error {
+func (m *MockAuthHandlerPlugin) Logout(ctx context.Context, handlerName string, req LogoutRequest) error {
 	if m.logoutFunc != nil {
-		return m.logoutFunc(ctx, handlerName)
+		return m.logoutFunc(ctx, handlerName, req)
 	}
 	return nil
 }
 
-func (m *MockAuthHandlerPlugin) GetStatus(ctx context.Context, handlerName string) (*auth.Status, error) {
+func (m *MockAuthHandlerPlugin) GetStatus(ctx context.Context, handlerName string, req StatusRequest) (*auth.Status, error) {
 	if m.statusFunc != nil {
-		return m.statusFunc(ctx, handlerName)
+		return m.statusFunc(ctx, handlerName, req)
 	}
 	return &auth.Status{
 		Authenticated: true,
@@ -215,7 +215,7 @@ func TestAuthHandlerGRPC_LoginWithDeviceCode(t *testing.T) {
 func TestAuthHandlerGRPC_GetStatus(t *testing.T) {
 	mock := &MockAuthHandlerPlugin{}
 
-	status, err := mock.GetStatus(context.Background(), "test-handler")
+	status, err := mock.GetStatus(context.Background(), "test-handler", StatusRequest{})
 	require.NoError(t, err)
 	assert.True(t, status.Authenticated)
 	assert.Equal(t, "test@example.com", status.Claims.Email)
@@ -882,6 +882,37 @@ func TestAuthHandlerWrapper_Login_ForwardsHostname(t *testing.T) {
 	assert.Equal(t, "pd1020", gotReq.Hostname, "hostname from LoginOptions must reach the plugin LoginRequest")
 }
 
+func TestAuthHandlerWrapper_Login_ForwardsCallbackPort(t *testing.T) {
+	t.Parallel()
+
+	var gotReq LoginRequest
+	mock := &MockAuthHandlerPlugin{
+		loginFunc: func(_ context.Context, _ string, req LoginRequest, _ func(DeviceCodePrompt)) (*LoginResponse, error) {
+			gotReq = req
+			return &LoginResponse{
+				Claims:    &auth.Claims{Email: "user@corp.com"},
+				ExpiresAt: time.Now().Add(time.Hour),
+			}, nil
+		},
+	}
+
+	w := &AuthHandlerWrapper{
+		client: &AuthHandlerClient{
+			plugin: mock,
+			name:   "test-plugin",
+		},
+		handlerName: "openshift",
+		info:        AuthHandlerInfo{Name: "openshift"},
+	}
+
+	_, err := w.Login(context.Background(), auth.LoginOptions{
+		Flow:         auth.FlowInteractive,
+		CallbackPort: 8400,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 8400, gotReq.CallbackPort, "callback port from LoginOptions must reach the plugin LoginRequest")
+}
+
 // mockLoginServerStream is a minimal grpc.ServerStreamingServer used to drive
 // AuthHandlerGRPCServer.Login in unit tests. It records sent messages.
 type mockLoginServerStream struct {
@@ -925,6 +956,32 @@ func TestAuthHandlerGRPCServer_Login_ForwardsHostname(t *testing.T) {
 	}, stream)
 	require.NoError(t, err)
 	assert.Equal(t, "pd1020", gotReq.Hostname, "hostname from proto LoginRequest must reach the handler")
+	require.NotEmpty(t, stream.messages, "server must send a result message")
+}
+
+func TestAuthHandlerGRPCServer_Login_ForwardsCallbackPort(t *testing.T) {
+	t.Parallel()
+
+	var gotReq LoginRequest
+	mock := &MockAuthHandlerPlugin{
+		loginFunc: func(_ context.Context, _ string, req LoginRequest, _ func(DeviceCodePrompt)) (*LoginResponse, error) {
+			gotReq = req
+			return &LoginResponse{
+				Claims:    &auth.Claims{Email: "user@corp.com"},
+				ExpiresAt: time.Now().Add(time.Hour),
+			}, nil
+		},
+	}
+	server := &AuthHandlerGRPCServer{Impl: mock}
+	stream := &mockLoginServerStream{}
+
+	err := server.Login(&proto.LoginRequest{
+		HandlerName:  "openshift",
+		CallbackPort: 8400,
+		Flow:         string(auth.FlowInteractive),
+	}, stream)
+	require.NoError(t, err)
+	assert.Equal(t, 8400, gotReq.CallbackPort, "callback port from proto LoginRequest must reach the handler")
 	require.NotEmpty(t, stream.messages, "server must send a result message")
 }
 

--- a/pkg/plugin/testdata/authhandler/main.go
+++ b/pkg/plugin/testdata/authhandler/main.go
@@ -39,9 +39,11 @@ func (h *testAuthHandler) Login(_ context.Context, _ string, _ sdkplugin.LoginRe
 	return &sdkplugin.LoginResponse{}, nil
 }
 
-func (h *testAuthHandler) Logout(_ context.Context, _ string) error { return nil }
+func (h *testAuthHandler) Logout(_ context.Context, _ string, _ sdkplugin.LogoutRequest) error {
+	return nil
+}
 
-func (h *testAuthHandler) GetStatus(_ context.Context, _ string) (*auth.Status, error) {
+func (h *testAuthHandler) GetStatus(_ context.Context, _ string, _ sdkplugin.StatusRequest) (*auth.Status, error) {
 	return &auth.Status{}, nil
 }
 

--- a/pkg/plugin/wrapper_auth.go
+++ b/pkg/plugin/wrapper_auth.go
@@ -132,11 +132,12 @@ func (w *AuthHandlerWrapper) Login(ctx context.Context, opts auth.LoginOptions) 
 	lgr.V(1).Info("login via plugin auth handler", "handler", w.handlerName)
 
 	req := LoginRequest{
-		TenantID: opts.TenantID,
-		Hostname: opts.Hostname,
-		Scopes:   opts.Scopes,
-		Flow:     opts.Flow,
-		Timeout:  opts.Timeout,
+		TenantID:     opts.TenantID,
+		Hostname:     opts.Hostname,
+		Scopes:       opts.Scopes,
+		Flow:         opts.Flow,
+		Timeout:      opts.Timeout,
+		CallbackPort: opts.CallbackPort,
 	}
 
 	// Bridge the LoginOptions.DeviceCodeCallback to the plugin's streaming callback.
@@ -197,11 +198,24 @@ func (w *AuthHandlerWrapper) Login(ctx context.Context, opts auth.LoginOptions) 
 }
 
 // Logout implements auth.Handler.
+//
+// The empty LogoutRequest{} sends no instance Hostname: the auth.Handler
+// interface's Logout(ctx) carries no selector, so scafctl's own commands clear
+// all of a handler's cached credentials. Per-instance status/logout selection
+// (LogoutRequest/StatusRequest.Hostname, backed by CapInstanceHostname) is
+// forwarded faithfully at the gRPC boundary but not yet wired into a
+// hostname-aware auth.Handler path -- that is tracked separately as part of
+// scafctl-plugin-sdk#58 and is intentionally out of scope for the
+// --callback-port work (#589).
 func (w *AuthHandlerWrapper) Logout(ctx context.Context) error {
-	return w.client.plugin.Logout(ctx, w.handlerName)
+	return w.client.plugin.Logout(ctx, w.handlerName, LogoutRequest{})
 }
 
 // Status implements auth.Handler.
+//
+// See Logout: StatusRequest{} carries no instance Hostname because the
+// auth.Handler interface has no selector; per-instance status is deferred to
+// the CapInstanceHostname follow-up (scafctl-plugin-sdk#58).
 func (w *AuthHandlerWrapper) Status(ctx context.Context) (*auth.Status, error) {
 	ctx, span := authTracer.Start(ctx, "auth.plugin.status",
 		trace.WithAttributes(attribute.String("auth.handler", w.handlerName)))
@@ -216,7 +230,7 @@ func (w *AuthHandlerWrapper) Status(ctx context.Context) (*auth.Status, error) {
 		}
 	}
 
-	return w.client.plugin.GetStatus(ctx, w.handlerName)
+	return w.client.plugin.GetStatus(ctx, w.handlerName, StatusRequest{})
 }
 
 // GetToken implements auth.Handler.

--- a/pkg/plugin/wrapper_auth_test.go
+++ b/pkg/plugin/wrapper_auth_test.go
@@ -456,7 +456,7 @@ func TestAuthHandlerWrapper_Status_ResolvesActiveProfile(t *testing.T) {
 	t.Parallel()
 	var capturedProfile string
 	mock := &MockAuthHandlerPlugin{
-		statusFunc: func(ctx context.Context, _ string) (*auth.Status, error) {
+		statusFunc: func(ctx context.Context, _ string, _ StatusRequest) (*auth.Status, error) {
 			capturedProfile = auth.ProfileFromContext(ctx)
 			return &auth.Status{Authenticated: true}, nil
 		},
@@ -479,7 +479,7 @@ func TestAuthHandlerWrapper_Status_ExplicitProfileTakesPrecedence(t *testing.T) 
 	t.Parallel()
 	var capturedProfile string
 	mock := &MockAuthHandlerPlugin{
-		statusFunc: func(ctx context.Context, _ string) (*auth.Status, error) {
+		statusFunc: func(ctx context.Context, _ string, _ StatusRequest) (*auth.Status, error) {
 			capturedProfile = auth.ProfileFromContext(ctx)
 			return &auth.Status{Authenticated: true}, nil
 		},

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2296,6 +2296,23 @@ func TestIntegration_AuthLoginCallbackPortSupported(t *testing.T) {
 	assert.Contains(t, stdout, "--callback-port")
 }
 
+func TestIntegration_AuthLoginCallbackPortOutOfRange(t *testing.T) {
+	t.Parallel()
+	// The callback-port range is validated as a static input constraint before
+	// any handler resolution, so out-of-range values are rejected regardless of
+	// whether the target handler/plugin is installed.
+	for _, port := range []string{"80", "-1", "70000"} {
+		port := port
+		t.Run(port, func(t *testing.T) {
+			t.Parallel()
+			_, stderr, exitCode := runScafctl(t, "auth", "login", "entra", "--callback-port", port)
+			assert.NotEqual(t, 0, exitCode)
+			assert.Contains(t, stderr, "--callback-port must be between 1024 and 65535",
+				"expected range validation error, got: %s", stderr)
+		})
+	}
+}
+
 func TestIntegration_AuthLoginGitHubInteractiveFlow(t *testing.T) {
 	t.Parallel()
 	// Verify that --flow is accepted for the login command


### PR DESCRIPTION
Deliver the login --callback-port value across the host->plugin boundary so plugin auth handlers advertising the callback_port capability actually receive it (previously it was honored only by built-in handlers and silently dropped for plugins).

- Bump scafctl-plugin-sdk to v0.16.0
- Thread LoginRequest.CallbackPort through the host->plugin login bridge (wrapper, gRPC client, and gRPC server) so capable plugin handlers get the requested loopback port
- Validate --callback-port range (1024-65535) as early, handler-independent input validation; normalize out-of-range values to unset at the plugin bridge so the int32 conversion can never truncate
- Update AuthHandlerPlugin Logout/GetStatus to the SDK's new LogoutRequest/StatusRequest signatures, forwarding hostname faithfully at the gRPC boundary
- Add unit + integration coverage for callback-port delivery, clamping, and out-of-range rejection; document the range in the auth tutorial

## Additional scope (epic #591, Phases 0 + 2b)

This branch also folds in the cluster-aware auth work that depends on the same SDK adoption:

- **Cluster-aware `auth token`**: `auth token --server <selector>` now runs the host-side hostname resolver before GetToken (mirroring `auth login --hostname`), so a bare cluster alias resolves to the API-server URL. It also no longer requires `--scope` in exec-credential mode for handlers advertising CapScopesOnTokenRequest (fixes the kubectl/oc credential-helper flow).
- **Per-cluster `auth status`** (SDK v0.16.0 `CachedTokenInfo.Hostname`): handlers advertising `instance_hostname` expand into one row per cluster (deduplicated by hostname), keeping the auth identity in the `profile` column with the cluster label appended (`<identity> / <cluster>`).
- Forwards the new `Hostname` field across the Status/CachedTokenInfo gRPC mappers.

BREAKING CHANGE: pkg/plugin AuthHandlerPlugin.Logout and .GetStatus now take LogoutRequest / StatusRequest parameters (via scafctl-plugin-sdk v0.16.0). Plugin auth handler implementations must update their method signatures.

Closes #589
Refs #591
