### PR TITLE
feat(resolver): context-aware go-template dependency inference

### DIFF
--- a/.github/skills/cel-patterns/SKILL.md
+++ b/.github/skills/cel-patterns/SKILL.md
@@ -267,11 +267,26 @@ has(_.config) && has(_.config.database) && has(_.config.database.host)
 | Missing field | `_.missing.field` (runtime error) | `has(_.missing) ? _.missing.field : default` |
 | List on non-list | `_.value.filter(...)` (if scalar) | Check type first or ensure resolver type is `array` |
 
+## Reference Extraction
+
+`pkg/celexp/refs.go` provides static analysis of an expression's AST:
+
+- `RequiredVariables(ctx)` / `GetUnderscoreVariables(ctx)` -- extract variable
+  and `_.` resolver references (used for dependency inference).
+- `MapLiteralKeys(ctx) ([]string, bool)` -- when the expression's top-level node
+  is a **map literal** with constant string keys (e.g.
+  `{"appName": _.appName}`), returns those keys and `true`. Returns `nil, false`
+  for anything else (function calls like `map.merge(...)`, identifiers, lists,
+  or non-string/non-constant keys). This lets a go-template `data:` input's key
+  set be determined statically so bare `{{ .field }}` template accessors are not
+  mis-inferred as resolver dependencies (see the go-template-patterns skill).
+
 ## Key Packages
 
 - `pkg/celexp/`: Expression type, Compile/Eval, EvaluateExpression convenience
 - `pkg/celexp/env/`: CEL environment setup, extension loading, caching
 - `pkg/celexp/ext/`: Custom function registration (regex, arrays, map, guid, time, sort, out)
+- `pkg/celexp/refs.go`: static reference extraction (RequiredVariables, MapLiteralKeys)
 - `pkg/provider/builtin/celprovider/`: CEL provider for transform phase
 
 ## Cost Limits

--- a/.github/skills/go-template-patterns/SKILL.md
+++ b/.github/skills/go-template-patterns/SKILL.md
@@ -48,6 +48,64 @@ When used with the directory provider for file generation:
 | `.__fileDir` | Directory containing the file |
 | `.__fileExt` | File extension |
 
+## Dependency Inference (resolver ref vs data context)
+
+A go-template render step's template root namespace is the **union** of three
+sources:
+
+1. **Resolver values** -- every resolved value (`{{ .resolverName }}`).
+2. **`data` input keys** -- top-level keys of the step's `data` input.
+3. **`forEach` aliases** -- the `item` and `index` names bound by a `forEach`
+   clause.
+
+scafctl auto-infers a step's resolver dependencies by scanning the template for
+root accessors. It disambiguates them as follows:
+
+| Accessor | Treated as a resolver dependency? |
+|----------|-----------------------------------|
+| `{{ ._.name }}` | Always -- explicit resolver reference. |
+| `{{ .field }}`, **no** `data` input | Yes, unless `field` is a `forEach` alias. |
+| `{{ .field }}` where `field` is a statically-known `data` key | No -- it is local data context. |
+| `{{ .field }}` with a **dynamic** `data` input (keys not statically known) | No -- assumed to come from `data`. |
+| `{{ .__self }}`, `{{ .__item }}`, `{{ .__fan.* }}` and other `.__` vars | No -- internal/special variables. |
+
+A `data` input's keys are statically known when it is a literal map or a CEL
+**map literal** expression (e.g. `expr: '{"appName": _.appName}'`). A `data`
+input that is a resolver reference (`rslvr`), a template (`tmpl`), or a
+non-map-literal CEL expression (e.g. `map.merge(...)`) is *dynamic* -- its key
+set cannot be determined ahead of time, so bare `{{ .field }}` accessors are
+assumed to be satisfied by `data` and are not inferred as resolver deps.
+
+**Consequence:** when a `data` input is present, a resolver referenced *only*
+via a bare `{{ .field }}` accessor is **not** auto-inferred as a dependency.
+Reference it inside the `data` expression with `_.name`, use `{{ ._.name }}` in
+the template, or add an explicit `dependsOn` entry.
+
+```yaml
+# The forEach alias `proj` and the data keys (projects, appName) are NOT
+# resolver dependencies. `platformAppName`/`appName` become dependencies only
+# because the data expression references them via `_.`.
+resolve:
+  with:
+    - provider: go-template
+      forEach:
+        item: proj
+        in:
+          expr: "_.gcpProjects"
+      inputs:
+        operation: render
+        template: |
+          bucket = "{{ .projects.tfstate_bucket_name }}"
+          app    = "{{ .appName }}"
+        data:
+          expr: '{"projects": proj, "appName": _.appName}'
+```
+
+The `template-unknown-accessor` lint rule warns when a bare `{{ .field }}` or
+`{{ ._.name }}` accessor cannot resolve to any known resolver, data key, or
+forEach alias -- a likely typo, since such accessors render empty at runtime
+rather than failing.
+
 ## Functions
 
 ### Sprig v3 (100+ functions)

--- a/docs/design/resolvers.md
+++ b/docs/design/resolvers.md
@@ -1550,6 +1550,33 @@ Rules:
 - Independent resolvers (no dependencies on each other) execute concurrently
 - Cycles in the dependency graph are rejected
 
+### Go-Template Dependency Inference
+
+A go-template render step's template root namespace is the **union** of resolver
+values, the step's `data`-input keys, and any `forEach` item/index aliases.
+Auto-inference disambiguates root accessors accordingly:
+
+| Accessor | Inferred as a resolver dependency? |
+|----------|------------------------------------|
+| `{{ ._.name }}` | Always (explicit resolver reference). |
+| `{{ .field }}`, no `data` input | Yes, unless `field` is a `forEach` alias. |
+| `{{ .field }}` matching a statically-known `data` key | No (local data context). |
+| `{{ .field }}` with a dynamic `data` input | No (keys not statically known). |
+| `{{ .__self }}`, `{{ .__item }}`, `{{ .__fan.* }}`, ... | No (internal variables). |
+
+A `data` input's key set is statically known when it is a literal map or a CEL
+**map-literal** expression (`expr: '{"appName": _.appName}'`). Resolver
+references (`rslvr`), templates (`tmpl`), and non-map-literal CEL expressions
+(e.g. `map.merge(...)`) are dynamic, so bare `{{ .field }}` accessors under them
+are treated as data context rather than resolver dependencies.
+
+Because unknown inferred edges are dropped as best-effort ordering hints (rather
+than causing a hard "depends on X but X wasn't present" failure), a bare
+`{{ .field }}` typo renders empty at runtime instead of failing the build. The
+`template-unknown-accessor` lint rule surfaces such accessors as warnings. To
+force a resolver dependency, reference it via `_.name` in the `data` expression,
+use `{{ ._.name }}` in the template, or add an explicit `dependsOn` entry.
+
 ### Explicit Dependencies (dependsOn)
 
 When dependencies cannot be auto-extracted (e.g., templates loaded from files), use `dependsOn`:

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -2292,6 +2292,16 @@ Hints: The 'range' action received a non-iterable value. Ensure the variable
 - Use `{{ printf "%T" .myField }}` to inspect the type of a value at runtime
 - Check `dependsOn` to ensure all upstream resolvers are resolved before the template runs
 
+> **Dependency inference note:** In a resolver's go-template step, a bare
+> `{{ .field }}` accessor is inferred as a resolver dependency only when the step
+> has no `data` input and `field` is not a `forEach` alias. When a `data` input
+> is present, accessors satisfied by its keys (or by a `forEach` item/index
+> alias) are treated as local context, not resolver dependencies. Use
+> `{{ ._.name }}` to force a resolver reference, reference it via `_.name` in the
+> `data` expression, or add an explicit `dependsOn`. The `template-unknown-accessor`
+> lint rule warns about bare accessors that match no resolver, data key, or
+> alias (likely typos, since they render empty rather than failing).
+
 ---
 
 ## Discovering Available Functions

--- a/examples/resolvers/README.md
+++ b/examples/resolvers/README.md
@@ -49,6 +49,7 @@ This directory contains practical examples demonstrating various resolver patter
 | [go-template-extensions.yaml](go-template-extensions.yaml) | Custom extension functions: toHcl, toHclValue, toYaml, fromYaml |
 | [go-template-sprig.yaml](go-template-sprig.yaml) | Sprig template functions (strings, type conversion, etc.) |
 | [go-template-ignored-blocks.yaml](go-template-ignored-blocks.yaml) | Using scafctl:ignore blocks to skip template rendering |
+| [template-dependency-inference.yaml](template-dependency-inference.yaml) | How go-template deps are inferred; data keys and forEach aliases vs `_.` refs |
 
 ### Integration
 

--- a/examples/resolvers/template-dependency-inference.yaml
+++ b/examples/resolvers/template-dependency-inference.yaml
@@ -1,0 +1,129 @@
+# Run: scafctl run resolver -f template-dependency-inference.yaml -o json
+#
+# Demonstrates how scafctl auto-infers a go-template step's resolver
+# dependencies from the template body, and how a `data` input or a `forEach`
+# alias changes whether a bare "{{ .field }}" accessor is treated as a resolver
+# reference or as local template context.
+#
+# A go-template render step's template root namespace is the UNION of:
+#   1. resolver values      -> {{ .resolverName }}
+#   2. the step's data keys -> top-level keys of the `data` input
+#   3. forEach aliases      -> the `item` / `index` names bound by `forEach`
+#
+# Disambiguation rules:
+#   | Accessor                                   | Resolver dependency?          |
+#   |--------------------------------------------|-------------------------------|
+#   | {{ ._.name }}                              | Always (explicit reference).  |
+#   | {{ .field }}, no data input                | Yes (unless a forEach alias). |
+#   | {{ .field }} matching a static data key    | No (local data context).      |
+#   | {{ .field }} with a dynamic data input     | No (keys not statically known)|
+#
+# Inspect the inferred edges with:
+#   scafctl run resolver -f template-dependency-inference.yaml --graph
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-dependency-inference
+  displayName: Template Dependency Inference
+  category: resolvers
+  tags:
+    - resolver-example
+  description: |
+    Shows go-template resolver-dependency inference and how data inputs and
+    forEach aliases disambiguate bare "{{ .field }}" accessors.
+
+spec:
+  resolvers:
+    # Phase 1: plain source values (no dependencies).
+    appName:
+      description: Application name
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: billing
+
+    region:
+      description: Deployment region
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: us-west-2
+
+    projects:
+      description: Projects to render one manifest per entry
+      type: array
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - name: dev
+                  bucket: billing-dev
+                - name: prod
+                  bucket: billing-prod
+
+    # Case A: bare accessor, no data input.
+    # "{{ .appName }}" is auto-inferred as a dependency on the appName resolver,
+    # so this step runs in a later phase than appName.
+    greeting:
+      description: Bare accessor becomes a resolver dependency
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              operation: render
+              template: "Deploying {{ .appName }}"
+
+    # Case B: data input + explicit resolver reference.
+    # "{{ .app }}" resolves against the data key `app` (NOT a resolver dep).
+    # "{{ ._.region }}" is an explicit resolver reference, so `region` IS a dep.
+    # The data expression also references _.appName, making `appName` a dep too.
+    manifest:
+      description: Data keys are local context; _. forces a resolver reference
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              operation: render
+              template: |
+                app    = "{{ .app }}"
+                region = "{{ ._.region }}"
+              data:
+                expr: '{"app": _.appName}'
+
+    # Case C: forEach alias + data keys (in a transform step).
+    # The loop alias `proj` and the data key `appName` are local context, so
+    # neither "{{ .proj.name }}" nor "{{ .appName }}" is inferred as a resolver
+    # dependency. The dependencies come from the CEL references: the resolve
+    # step reads _.projects and the data expression reads _.appName.
+    # (forEach works on both resolve and transform steps; it is shown on a
+    # transform step here.)
+    perProject:
+      description: forEach aliases and data keys are not resolver dependencies
+      type: array
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                expr: _.projects
+      transform:
+        with:
+          - provider: go-template
+            forEach:
+              item: proj
+            inputs:
+              operation: render
+              template: |
+                app    = "{{ .appName }}"
+                name   = "{{ .proj.name }}"
+                bucket = "{{ .proj.bucket }}"
+              data:
+                expr: '{"proj": proj, "appName": _.appName}'

--- a/examples/solutions/lint-stress-test/solution.yaml
+++ b/examples/solutions/lint-stress-test/solution.yaml
@@ -180,6 +180,19 @@ spec:
             inputs:
               expression: '__self.body.items'
 
+    # template-unknown-accessor — bare "{{ .projcts }}" is a typo (no resolver,
+    # data key, or forEach alias named "projcts"); it renders empty at runtime
+    # instead of failing, so it is surfaced as a warning.
+    typo_template:
+      type: string
+      description: Go template references an unknown root accessor
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              operation: render
+              template: "Deploying {{ .projcts }}"
+
     # used resolver so not everything is unused
     main_output:
       type: string
@@ -194,6 +207,7 @@ spec:
         - loose_schema
         - no_desc
         - bad_orvalue
+        - typo_template
       resolve:
         with:
           - provider: static

--- a/go.mod
+++ b/go.mod
@@ -254,7 +254,7 @@ require (
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
-	github.com/quic-go/quic-go v0.59.0 // indirect
+	github.com/quic-go/quic-go v0.59.1 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/sanity-io/litter v1.5.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -678,8 +678,8 @@ github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEy
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
 github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
-github.com/quic-go/quic-go v0.59.0 h1:OLJkp1Mlm/aS7dpKgTc6cnpynnD2Xg7C1pwL6vy/SAw=
-github.com/quic-go/quic-go v0.59.0/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
+github.com/quic-go/quic-go v0.59.1 h1:0Gmua0HW1Tv7ANR7hUYwRyD0MG5OJfgvYSZasGZzBic=
+github.com/quic-go/quic-go v0.59.1/go.mod h1:upnsH4Ju1YkqpLXC305eW3yDZ4NfnNbmQRCMWS58IKU=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=

--- a/pkg/celexp/refs.go
+++ b/pkg/celexp/refs.go
@@ -92,6 +92,77 @@ func (e Expression) GetUnderscoreVariables(ctx context.Context) ([]string, error
 	return e.GetVariablesWithPrefix(ctx, "_.")
 }
 
+// MapLiteralKeys parses the CEL expression and, if its top-level node is a map
+// literal with constant string keys (e.g. {"a": _.x, "b": proj}), returns the
+// list of those keys and true. For any other expression shape -- a function
+// call such as map.merge(...), an identifier, a map with non-constant or
+// non-string keys, etc. -- it returns nil and false, signalling that the set of
+// keys the expression produces cannot be determined statically.
+//
+// This is used by resolver dependency inference to decide whether a go-template
+// step's `data: {expr: ...}` input has a statically-known key set. When the keys
+// are known, template `{{ .field }}` accessors that match a key are recognised
+// as data-context references rather than resolver dependencies.
+//
+// Example:
+//
+//	keys, ok := celexp.Expression(`{"projects": proj, "app": _.appName}`).MapLiteralKeys(ctx)
+//	// keys == []string{"app", "projects"}, ok == true
+//
+//	keys, ok := celexp.Expression(`map.merge(_.a, _.b)`).MapLiteralKeys(ctx)
+//	// keys == nil, ok == false
+func (e Expression) MapLiteralKeys(ctx context.Context) ([]string, bool) {
+	var env *cel.Env
+	var err error
+	factory := getEnvFactory()
+	if factory != nil {
+		env, err = factory(ctx)
+	} else {
+		env, err = cel.NewEnv(cel.OptionalTypes())
+	}
+	if err != nil {
+		return nil, false
+	}
+
+	parsed, issues := env.Parse(string(e))
+	if issues != nil && issues.Err() != nil {
+		return nil, false
+	}
+
+	parsedExpr, err := cel.AstToParsedExpr(parsed)
+	if err != nil {
+		return nil, false
+	}
+
+	structExpr := parsedExpr.GetExpr().GetStructExpr()
+	if structExpr == nil {
+		// Not a map/struct literal (e.g. a function call or identifier).
+		return nil, false
+	}
+	// A message-construction expression (e.g. Foo{...}) is not a plain map.
+	if structExpr.GetMessageName() != "" {
+		return nil, false
+	}
+
+	entries := structExpr.GetEntries()
+	keys := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		mapKey := entry.GetMapKey()
+		if mapKey == nil {
+			return nil, false
+		}
+		sv, ok := mapKey.GetConstExpr().GetConstantKind().(*exprpb.Constant_StringValue)
+		if !ok {
+			// Non-constant or non-string key -- keys are not statically known.
+			return nil, false
+		}
+		keys = append(keys, sv.StringValue)
+	}
+
+	sort.Strings(keys)
+	return keys, true
+}
+
 // RequiredVariables parses the CEL expression and returns all variable references
 // found in the expression, regardless of prefix. This extracts ALL top-level identifiers
 // that are not function names or comprehension variables.

--- a/pkg/celexp/refs_test.go
+++ b/pkg/celexp/refs_test.go
@@ -657,6 +657,77 @@ func TestRequiredVariables(t *testing.T) {
 	}
 }
 
+func TestMapLiteralKeys(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		wantKeys   []string
+		wantOK     bool
+	}{
+		{
+			name:       "simple map literal",
+			expression: `{"appName": _.appName}`,
+			wantKeys:   []string{"appName"},
+			wantOK:     true,
+		},
+		{
+			name:       "multi-key map literal",
+			expression: `{"proj": proj, "appName": _.appName}`,
+			wantKeys:   []string{"appName", "proj"},
+			wantOK:     true,
+		},
+		{
+			name:       "trailing newline tolerated",
+			expression: "{\"appName\": _.appName}\n",
+			wantKeys:   []string{"appName"},
+			wantOK:     true,
+		},
+		{
+			name:       "empty map literal",
+			expression: "{}",
+			wantKeys:   []string{},
+			wantOK:     true,
+		},
+		{
+			name:       "function call is not a map literal",
+			expression: `map.merge({"a": 1}, other)`,
+			wantOK:     false,
+		},
+		{
+			name:       "identifier is not a map literal",
+			expression: "someResolver",
+			wantOK:     false,
+		},
+		{
+			name:       "list is not a map literal",
+			expression: `["a", "b"]`,
+			wantOK:     false,
+		},
+		{
+			name:       "non-string keys not statically known",
+			expression: `{key: "value"}`,
+			wantOK:     false,
+		},
+		{
+			name:       "parse error yields not-ok",
+			expression: `{"a":`,
+			wantOK:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keys, ok := Expression(tt.expression).MapLiteralKeys(context.Background())
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				sort.Strings(keys)
+				want := tt.wantKeys
+				sort.Strings(want)
+				assert.Equal(t, want, keys)
+			}
+		})
+	}
+}
+
 func BenchmarkRequiredVariables_Simple(b *testing.B) {
 	expr := Expression("x + y + z")
 	b.ResetTimer()

--- a/pkg/gotmpl/resolverdeps.go
+++ b/pkg/gotmpl/resolverdeps.go
@@ -1,0 +1,178 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gotmpl
+
+import "strings"
+
+// DepScanContextKey is the reserved input-map key under which resolver dependency
+// extraction context is passed to a template-based provider's ExtractDependencies
+// function. A provider that resolves inline templates should read this key,
+// falling back to best-effort local computation when it is absent.
+const DepScanContextKey = "__scafctl_dep_scan_context"
+
+// DepScanContext carries the pre-computed template scan context (data-input key
+// set and forEach aliases) from the dependency-graph builder into a provider's
+// ExtractDependencies function. It exists because that function receives only the
+// provider input map and cannot otherwise see sibling constructs such as a
+// forEach clause or statically analyse CEL data expressions.
+type DepScanContext struct {
+	// HasDataInput indicates the step supplies an explicit data input.
+	HasDataInput bool
+	// DataKeys is the set of top-level keys the data input provides. Only
+	// meaningful when DataKeysComplete is true.
+	DataKeys map[string]bool
+	// DataKeysComplete indicates DataKeys is an authoritative, complete key set.
+	DataKeysComplete bool
+	// Aliases is the set of forEach item/index alias names bound locally.
+	Aliases map[string]bool
+}
+
+// ResolverDepsInput configures resolver-dependency extraction from a Go template
+// string. It captures everything the extractor needs to correctly disambiguate a
+// {{ .field }} accessor between a resolver reference and a local template-context
+// binding (a data-input key or a forEach loop alias).
+type ResolverDepsInput struct {
+	// Template is the raw Go template text to scan. Callers should strip any
+	// ignored/raw pass-through regions before passing the text.
+	Template string
+
+	// LeftDelim and RightDelim are the template delimiters. Empty values fall
+	// back to the standard "{{" and "}}".
+	LeftDelim  string
+	RightDelim string
+
+	// HasDataInput indicates the step supplies an explicit `data` input. When
+	// true, the template's root namespace is dominated by the data context, so
+	// bare {{ .field }} accessors are resolved against the data rather than the
+	// resolver graph.
+	HasDataInput bool
+
+	// DataKeys is the set of top-level keys the `data` input provides. It is
+	// only meaningful when DataKeysComplete is true.
+	DataKeys map[string]bool
+
+	// DataKeysComplete indicates DataKeys is an authoritative, complete list of
+	// the keys the data input provides. It is false when the data input is
+	// dynamic (e.g. a rslvr reference or a non-map-literal expression) and the
+	// key set cannot be determined statically.
+	DataKeysComplete bool
+
+	// Aliases is the set of forEach item/index alias names bound locally for the
+	// step. They are never resolver dependencies.
+	Aliases map[string]bool
+}
+
+// pathKind classifies a template reference path.
+type pathKind int
+
+const (
+	// pathSpecial is a special/internal variable (e.g. .__self, .__item) that is
+	// never a resolver dependency.
+	pathSpecial pathKind = iota
+	// pathExplicitResolver is an explicit resolver-context reference
+	// ({{ ._.name }}) that is always a resolver dependency.
+	pathExplicitResolver
+	// pathField is a bare data-context accessor ({{ .field }}) that may or may
+	// not be a resolver dependency depending on the surrounding context.
+	pathField
+)
+
+// ExtractResolverDeps returns the resolver dependency names referenced by
+// root-level accessors in a Go template, applying context-aware disambiguation:
+//
+//   - {{ ._.name }} is always treated as a resolver dependency.
+//   - {{ .field }} is treated as a resolver dependency only when there is no
+//     data input and the field is not a forEach alias. When a data input is
+//     present, a field matching a statically-known data key (or any field when
+//     the data key set is not statically known) is treated as local context.
+//   - Special variables ({{ .__item }}, {{ .__self }}, ...) and scoped
+//     references (inside {{ with }}/{{ range }} bodies) are ignored.
+//
+// The returned names are de-duplicated and preserve first-seen order. Template
+// parse errors yield a nil slice (extraction is best-effort).
+func ExtractResolverDeps(in ResolverDepsInput) []string {
+	refs, err := GetGoTemplateReferences(in.Template, in.LeftDelim, in.RightDelim)
+	if err != nil {
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var deps []string
+	add := func(name string) {
+		if name != "" && !seen[name] {
+			seen[name] = true
+			deps = append(deps, name)
+		}
+	}
+
+	for _, ref := range refs {
+		// Scoped references point at fields of a {{ with }}/{{ range }} narrowed
+		// context, not the root data, so they are never resolver dependencies.
+		if ref.Scoped {
+			continue
+		}
+
+		name, kind := classifyTemplatePath(ref.Path)
+		switch kind {
+		case pathSpecial:
+			continue
+		case pathExplicitResolver:
+			add(name)
+		case pathField:
+			if in.Aliases[name] {
+				continue
+			}
+			if !in.HasDataInput {
+				// No data input: the template root is resolver data.
+				add(name)
+				continue
+			}
+			if !in.DataKeysComplete {
+				// Data input present but its keys are not statically known:
+				// treat the whole template root as data context.
+				continue
+			}
+			if in.DataKeys[name] {
+				continue
+			}
+			// A field not provided by the known data keys still resolves against
+			// resolver data (buildTemplateData copies resolver data first).
+			add(name)
+		}
+	}
+
+	return deps
+}
+
+// classifyTemplatePath maps a dot-notation template reference path to the
+// dependency name of its root segment and a classification. The recognised
+// prefixes are:
+//
+//	"._.name"  -> explicit resolver reference (ValueRef tmpl form)
+//	".__x"     -> special/internal variable (skipped)
+//	"._name"   -> explicit resolver reference (_.name form)
+//	".name"    -> bare data-context accessor
+func classifyTemplatePath(path string) (string, pathKind) {
+	switch {
+	case strings.HasPrefix(path, "._."):
+		return firstSegment(strings.TrimPrefix(path, "._.")), pathExplicitResolver
+	case strings.HasPrefix(path, ".__"):
+		return "", pathSpecial
+	case strings.HasPrefix(path, "._"):
+		return firstSegment(strings.TrimPrefix(path, "._")), pathExplicitResolver
+	case strings.HasPrefix(path, "."):
+		return firstSegment(strings.TrimPrefix(path, ".")), pathField
+	default:
+		return "", pathSpecial
+	}
+}
+
+// firstSegment returns the portion of a dotted path before the first ".",
+// e.g. "config.host" -> "config".
+func firstSegment(path string) string {
+	if idx := strings.Index(path, "."); idx >= 0 {
+		return path[:idx]
+	}
+	return path
+}

--- a/pkg/gotmpl/resolverdeps_test.go
+++ b/pkg/gotmpl/resolverdeps_test.go
@@ -1,0 +1,140 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gotmpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyTemplatePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		wantName string
+		wantKind pathKind
+	}{
+		{"explicit resolver dotted", "._.config.host", "config", pathExplicitResolver},
+		{"explicit resolver root", "._.name", "name", pathExplicitResolver},
+		{"underscore alias form", "._name", "name", pathExplicitResolver},
+		{"special self", ".__self", "", pathSpecial},
+		{"special item", ".__item", "", pathSpecial},
+		{"special actions", ".__actions.write", "", pathSpecial},
+		{"bare field root", ".appName", "appName", pathField},
+		{"bare field nested", ".config.host", "config", pathField},
+		{"no leading dot", "appName", "", pathSpecial},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			name, kind := classifyTemplatePath(tt.path)
+			assert.Equal(t, tt.wantName, name)
+			assert.Equal(t, tt.wantKind, kind)
+		})
+	}
+}
+
+func TestFirstSegment(t *testing.T) {
+	assert.Equal(t, "config", firstSegment("config.host.port"))
+	assert.Equal(t, "name", firstSegment("name"))
+	assert.Equal(t, "", firstSegment(""))
+}
+
+func TestExtractResolverDeps(t *testing.T) {
+	tests := []struct {
+		name string
+		in   ResolverDepsInput
+		want []string
+	}{
+		{
+			name: "no data input scans bare fields",
+			in: ResolverDepsInput{
+				Template: `{{ .foo }} and {{ .bar.baz }}`,
+			},
+			want: []string{"foo", "bar"},
+		},
+		{
+			name: "explicit resolver ref always a dep",
+			in: ResolverDepsInput{
+				Template: `{{ ._.token }}`,
+			},
+			want: []string{"token"},
+		},
+		{
+			name: "explicit resolver ref a dep even with data input",
+			in: ResolverDepsInput{
+				Template:         `{{ ._.token }} {{ .local }}`,
+				HasDataInput:     true,
+				DataKeys:         map[string]bool{"local": true},
+				DataKeysComplete: true,
+			},
+			want: []string{"token"},
+		},
+		{
+			name: "data input with known keys excludes those keys",
+			in: ResolverDepsInput{
+				Template:         `{{ .appName }} {{ .other }}`,
+				HasDataInput:     true,
+				DataKeys:         map[string]bool{"appName": true},
+				DataKeysComplete: true,
+			},
+			// appName is a data key (excluded); other is not, so it still
+			// resolves against resolver data.
+			want: []string{"other"},
+		},
+		{
+			name: "data input with dynamic keys skips bare fields",
+			in: ResolverDepsInput{
+				Template:         `{{ .appName }} {{ ._.token }}`,
+				HasDataInput:     true,
+				DataKeysComplete: false,
+			},
+			want: []string{"token"},
+		},
+		{
+			name: "forEach alias excluded",
+			in: ResolverDepsInput{
+				Template: `{{ .proj.name }} {{ .env }}`,
+				Aliases:  map[string]bool{"proj": true},
+			},
+			want: []string{"env"},
+		},
+		{
+			name: "special variables skipped",
+			in: ResolverDepsInput{
+				Template: `{{ .__self }} {{ .__item }} {{ .real }}`,
+			},
+			want: []string{"real"},
+		},
+		{
+			name: "de-dup preserves first-seen order",
+			in: ResolverDepsInput{
+				Template: `{{ .a }} {{ .b }} {{ .a }}`,
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "custom delimiters",
+			in: ResolverDepsInput{
+				Template:   `<< .foo >>`,
+				LeftDelim:  "<<",
+				RightDelim: ">>",
+			},
+			want: []string{"foo"},
+		},
+		{
+			name: "parse error yields nil",
+			in: ResolverDepsInput{
+				Template: `{{ .foo `,
+			},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ExtractResolverDeps(tt.in)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -110,6 +110,7 @@ func Solution(sol *solution.Solution, filePath string, registry *provider.Regist
 	lintResolvers(sol, result, registry, referencedResolvers)
 	lintTemplateFileDependencies(sol, solutionDir, result, registry)
 	lintResolverCycles(sol, result, registry)
+	lintTemplateAccessors(sol, result)
 	lintWorkflow(sol, result, registry)
 	lintState(sol, result, registry)
 	lintImmutableResolvers(sol, result)
@@ -669,6 +670,27 @@ func lintResolverCycles(sol *solution.Solution, result *Result, registry *provid
 			fmt.Sprintf("circular dependency detected: %s", cycleStr),
 			suggestion,
 			"resolver-cycle")
+	}
+}
+
+// lintTemplateAccessors reports root-level Go template accessors ({{ .field }}
+// or {{ ._.name }}) in resolve or transform steps that cannot resolve to any
+// known resolver, data-input key, or forEach alias. Such accessors render empty
+// at runtime (missingkey default) rather than failing, so they are surfaced here
+// as likely typos. Steps whose data input has a dynamic (non-statically-known)
+// key set are not flagged for bare {{ .field }} accessors, avoiding false
+// positives when the root is populated at runtime.
+func lintTemplateAccessors(sol *solution.Solution, result *Result) {
+	if sol.Spec.Resolvers == nil {
+		return
+	}
+	resolvers := sol.Spec.ResolversToSlice()
+	for _, acc := range resolver.UnresolvedTemplateAccessors(resolvers) {
+		location := fmt.Sprintf("resolvers.%s.%s", acc.Resolver, acc.Step)
+		result.addFinding(SeverityWarning, "template", location,
+			fmt.Sprintf("Go template references root accessor %q but no resolver, data key, or forEach alias with that name is in scope — it renders empty at runtime", acc.Name),
+			fmt.Sprintf("Fix the typo, add a resolver or dependsOn named %q, or provide it via a data input", acc.Name),
+			"template-unknown-accessor")
 	}
 }
 

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -1263,6 +1264,71 @@ func TestLintTemplateUnderscorePrefix(t *testing.T) {
 				}
 			} else {
 				assert.Empty(t, findings)
+			}
+		})
+	}
+}
+
+func TestLintTemplateAccessors(t *testing.T) {
+	dataExpr := celexp.Expression(`{"appName": _.appName}`)
+
+	tests := []struct {
+		name      string
+		resolvers map[string]*resolver.Resolver
+		wantNames []string
+	}{
+		{
+			name: "typo accessor with known data keys is flagged",
+			resolvers: map[string]*resolver.Resolver{
+				"appName": {Name: "appName"},
+				"rendered": {
+					Name: "rendered",
+					Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{
+						Provider: "go-template",
+						Inputs: map[string]*spec.ValueRef{
+							"template": {Literal: `app = "{{ .appNam }}"`},
+							"data":     {Expr: &dataExpr},
+						},
+					}}},
+				},
+			},
+			wantNames: []string{"appNam"},
+		},
+		{
+			name: "valid resolver ref is not flagged",
+			resolvers: map[string]*resolver.Resolver{
+				"appName": {Name: "appName"},
+				"rendered": {
+					Name: "rendered",
+					Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{
+						Provider: "go-template",
+						Inputs: map[string]*spec.ValueRef{
+							"template": {Literal: `{{ .appName }}`},
+						},
+					}}},
+				},
+			},
+			wantNames: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sol := &solution.Solution{Spec: solution.Spec{Resolvers: tt.resolvers}}
+			result := &Result{Findings: make([]*Finding, 0)}
+			lintTemplateAccessors(sol, result)
+
+			findings := filterFindingsByRule(result, "template-unknown-accessor")
+			assert.Len(t, findings, len(tt.wantNames))
+			for _, name := range tt.wantNames {
+				found := false
+				for _, f := range findings {
+					assert.Equal(t, SeverityWarning, f.Severity)
+					if strings.Contains(f.Message, name) {
+						found = true
+					}
+				}
+				assert.True(t, found, "expected a finding mentioning %q", name)
 			}
 		})
 	}

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -390,6 +390,17 @@ var KnownRules = map[string]RuleMeta{
 			"# Preferred:\ntmpl: \"Deploying {{ .config.appName }}\"\n\n# Also works (via underscore alias):\ntmpl: \"Deploying {{ ._.config.appName }}\"",
 		},
 	},
+	"template-unknown-accessor": {
+		Rule:        "template-unknown-accessor",
+		Severity:    string(SeverityWarning),
+		Category:    "template",
+		Description: "A resolve/transform Go template references a root-level accessor ('{{ .field }}' or '{{ ._.name }}') that is not a known resolver, data-input key, or forEach alias.",
+		Why:         "Go templates render an unknown root accessor as empty (missingkey default) instead of failing, so a typo silently produces blank output. The template root namespace is the union of resolver values, the step's data-input keys, and any forEach item/index aliases.",
+		Fix:         "Fix the typo, add a resolver (or dependsOn) with that name, or provide the value via a data input. Use '{{ ._.name }}' to force a resolver reference.",
+		Examples: []string{
+			"# Wrong — 'projcts' is a typo (no such resolver/data key):\nprovider: go-template\ninputs:\n  template:\n    tmpl: \"{{ range .projcts }}{{ .name }}{{ end }}\"\n\n# Correct — reference the real resolver 'projects':\nprovider: go-template\ninputs:\n  template:\n    tmpl: \"{{ range .projects }}{{ .name }}{{ end }}\"",
+		},
+	},
 	"missing-state-backend": {
 		Rule:        "missing-state-backend",
 		Severity:    string(SeverityError),

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 53 rules — update this when new rules are added
-	assert.Equal(t, 53, len(KnownRules), "expected 53 known lint rules")
+	// We expect exactly 54 rules — update this when new rules are added
+	assert.Equal(t, 54, len(KnownRules), "expected 54 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/provider/builtin/gotmplprovider/gotmpl.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl.go
@@ -907,54 +907,73 @@ func extractDependencies(inputs map[string]any) []string {
 		templateContent = strings.ReplaceAll(templateContent, repl.Find, "")
 	}
 
-	// Use gotmpl package to extract references with the specified delimiters
-	refs, err := gotmpl.GetGoTemplateReferences(templateContent, leftDelim, rightDelim)
-	if err != nil {
-		// On parse error, fall back to no dependencies - the error will be caught during execution
-		return deps
-	}
+	// Determine the template scan context (data keys + forEach aliases). Prefer
+	// the context injected by the dependency-graph builder (which can see the
+	// forEach clause and statically analyse CEL data expressions); otherwise
+	// fall back to best-effort local computation from a literal data map.
+	scan := resolveDepScanContext(inputs)
+	scan.Template = templateContent
+	scan.LeftDelim = leftDelim
+	scan.RightDelim = rightDelim
 
-	// Build set of keys provided by the data input so we can exclude them
-	// from resolver dependencies. The data map's keys become top-level
-	// template context variables (e.g., data: {config: ...} provides .config)
-	// and should not be treated as resolver references.
-	dataKeys := make(map[string]bool)
-	if dataMap, ok := inputs["data"].(map[string]any); ok {
-		for k := range dataMap {
-			dataKeys[k] = true
-		}
-	}
-
-	// Extract the first segment of each reference path as the dependency name
-	// e.g., ".config.host" -> "config", "._.name" -> "name"
-	for _, ref := range refs {
-		// Skip scoped references — they refer to fields inside {{ with }}/{{ range }}
-		// bodies where dot has been rebound, not to top-level resolvers.
-		if ref.Scoped {
-			continue
-		}
-
-		path := ref.Path
-		// Strip leading dot if present
-		path = strings.TrimPrefix(path, ".")
-		// Handle underscore prefix for resolver context (e.g., "_.name" -> "name")
-		path = strings.TrimPrefix(path, "_.")
-		path = strings.TrimPrefix(path, "_")
-
-		// Get first segment (before any dots)
-		if idx := strings.Index(path, "."); idx > 0 {
-			path = path[:idx]
-		}
-
-		// Skip references satisfied by the data input
-		if dataKeys[path] {
-			continue
-		}
-
-		addDep(path)
+	for _, name := range gotmpl.ExtractResolverDeps(scan) {
+		addDep(name)
 	}
 
 	return deps
+}
+
+// resolveDepScanContext builds the resolver-dependency scan context for the
+// inline template. It prefers a DepScanContext injected under
+// gotmpl.DepScanContextKey; when absent, it derives a best-effort context from a
+// literal data map in the inputs.
+func resolveDepScanContext(inputs map[string]any) gotmpl.ResolverDepsInput {
+	if injected, ok := inputs[gotmpl.DepScanContextKey].(gotmpl.DepScanContext); ok {
+		return gotmpl.ResolverDepsInput{
+			HasDataInput:     injected.HasDataInput,
+			DataKeys:         injected.DataKeys,
+			DataKeysComplete: injected.DataKeysComplete,
+			Aliases:          injected.Aliases,
+		}
+	}
+
+	dataMap, hasData := inputs["data"].(map[string]any)
+	if !hasData {
+		return gotmpl.ResolverDepsInput{}
+	}
+	// A ValueRef-shaped data map (e.g. {expr: "..."}, {rslvr: "vars"},
+	// {tmpl: "..."}) does not expose its runtime keys statically, so treat the
+	// key set as dynamic/incomplete rather than mistaking the control key
+	// (expr/rslvr/tmpl) for a data key.
+	if isValueRefShapedData(dataMap) {
+		return gotmpl.ResolverDepsInput{HasDataInput: true, DataKeysComplete: false}
+	}
+	dataKeys := make(map[string]bool, len(dataMap))
+	for k := range dataMap {
+		dataKeys[k] = true
+	}
+	return gotmpl.ResolverDepsInput{
+		HasDataInput:     true,
+		DataKeys:         dataKeys,
+		DataKeysComplete: true,
+	}
+}
+
+// isValueRefShapedData reports whether a raw data map is a ValueRef wrapper
+// (expr/rslvr/tmpl) rather than a literal map of template context keys. Such
+// wrappers resolve to their value at runtime, so their control key must not be
+// treated as a data-context key.
+func isValueRefShapedData(dataMap map[string]any) bool {
+	if _, ok := dataMap["expr"]; ok {
+		return true
+	}
+	if _, ok := dataMap["rslvr"]; ok {
+		return true
+	}
+	if _, ok := dataMap["tmpl"]; ok {
+		return true
+	}
+	return false
 }
 
 // extractCELDeps extracts resolver references from a CEL expression string.

--- a/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1561,6 +1562,79 @@ func TestExtractDependencies_DataKeyExclusion(t *testing.T) {
 		for _, d := range deps {
 			assert.NotEqual(t, "config", d)
 			assert.NotEqual(t, "labels", d)
+		}
+	})
+}
+
+func TestExtractDependencies_DepScanContext(t *testing.T) {
+	t.Run("injected context with known data keys excludes them", func(t *testing.T) {
+		deps := extractDependencies(map[string]any{
+			"template": "{{ .appName }} {{ .other }} {{ ._.token }}",
+			gotmpl.DepScanContextKey: gotmpl.DepScanContext{
+				HasDataInput:     true,
+				DataKeys:         map[string]bool{"appName": true},
+				DataKeysComplete: true,
+			},
+		})
+		assert.Contains(t, deps, "token", "explicit resolver ref is always a dep")
+		assert.Contains(t, deps, "other", "non-data-key field resolves against resolver data")
+		for _, d := range deps {
+			assert.NotEqual(t, "appName", d, "known data key should be excluded")
+		}
+	})
+
+	t.Run("injected context with forEach aliases excludes them", func(t *testing.T) {
+		deps := extractDependencies(map[string]any{
+			"template": "{{ .proj.name }} {{ .env }}",
+			gotmpl.DepScanContextKey: gotmpl.DepScanContext{
+				Aliases: map[string]bool{"proj": true},
+			},
+		})
+		assert.Contains(t, deps, "env")
+		for _, d := range deps {
+			assert.NotEqual(t, "proj", d, "forEach alias should be excluded")
+		}
+	})
+
+	t.Run("injected context with dynamic data keys skips bare fields", func(t *testing.T) {
+		deps := extractDependencies(map[string]any{
+			"template": "{{ .anything }} {{ ._.token }}",
+			gotmpl.DepScanContextKey: gotmpl.DepScanContext{
+				HasDataInput:     true,
+				DataKeysComplete: false,
+			},
+		})
+		assert.Contains(t, deps, "token")
+		for _, d := range deps {
+			assert.NotEqual(t, "anything", d, "bare field skipped when data keys are dynamic")
+		}
+	})
+
+	t.Run("falls back to literal data map when context absent", func(t *testing.T) {
+		deps := extractDependencies(map[string]any{
+			"template": "{{ .config }} {{ .other }}",
+			"data": map[string]any{
+				"config": map[string]any{"port": 8080},
+			},
+		})
+		assert.Contains(t, deps, "other")
+		for _, d := range deps {
+			assert.NotEqual(t, "config", d, "literal data key should be excluded via fallback")
+		}
+	})
+
+	t.Run("valueref-shaped data map is treated as dynamic in fallback", func(t *testing.T) {
+		for _, controlKey := range []string{"expr", "rslvr", "tmpl"} {
+			deps := extractDependencies(map[string]any{
+				"template":               "{{ .appName }} {{ ._.token }}",
+				"data":                   map[string]any{controlKey: "someValue"},
+				gotmpl.DepScanContextKey: nil,
+			})
+			assert.Contains(t, deps, "token", "explicit resolver ref is always a dep (%s)", controlKey)
+			for _, d := range deps {
+				assert.NotEqual(t, controlKey, d, "%s control key must not be a data key", controlKey)
+				assert.NotEqual(t, "appName", d, "bare field skipped for dynamic valueref data (%s)", controlKey)
+			}
 		}
 	})
 }

--- a/pkg/resolver/graph.go
+++ b/pkg/resolver/graph.go
@@ -167,6 +167,173 @@ func extractDependencies(r *Resolver, lookup DescriptorLookup) []string {
 	return result
 }
 
+// extractStrictDependencies extracts only the "strict" resolver references from a
+// resolver -- those a user stated directly and expects to fail fast on a typo:
+// explicit dependsOn entries, CEL `_.name` references, and direct rslvr: ValueRefs
+// (including rslvr/expr forms nested inside literal maps and arrays).
+//
+// Go-template forms are deliberately excluded: a bare {{ .field }} accessor, a
+// tmpl: ValueRef, or the go-template "template" input are inferred on a
+// best-effort basis and may legitimately reference local template context (a
+// data-input key or a forEach alias) rather than a resolver. BuildPhases uses this
+// set to keep unknown strict references (so genuine typos fail during graph
+// construction) while dropping unknown template-inferred edges.
+//
+// The result is always a subset of ExtractDependencies for the same resolver.
+func extractStrictDependencies(r *Resolver) map[string]bool {
+	deps := make(map[string]bool)
+
+	for _, dep := range r.DependsOn {
+		if dep != "" {
+			deps[dep] = true
+		}
+	}
+
+	if r.When != nil && r.When.Expr != nil {
+		extractDepsFromExpression(string(*r.When.Expr), deps)
+	}
+
+	extractStrictFromResolvePhase(r.Resolve, deps)
+	extractStrictFromTransformPhase(r.Transform, deps)
+	extractStrictFromValidatePhase(r.Validate, deps)
+
+	// A resolver is never a strict dependency of itself.
+	delete(deps, r.Name)
+	return deps
+}
+
+// extractStrictFromResolvePhase collects strict references from a resolve phase.
+func extractStrictFromResolvePhase(phase *ResolvePhase, deps map[string]bool) {
+	if phase == nil {
+		return
+	}
+	if phase.When != nil && phase.When.Expr != nil {
+		extractDepsFromExpression(string(*phase.When.Expr), deps)
+	}
+	if phase.Until != nil && phase.Until.Expr != nil {
+		extractDepsFromExpression(string(*phase.Until.Expr), deps)
+	}
+	for _, source := range phase.With {
+		if source.When != nil && source.When.Expr != nil {
+			extractDepsFromExpression(string(*source.When.Expr), deps)
+		}
+		if source.ContinueOnError != nil && source.ContinueOnError.Expr != nil {
+			extractDepsFromExpression(string(*source.ContinueOnError.Expr), deps)
+		}
+		if source.ForEach != nil && source.ForEach.In != nil {
+			extractStrictFromValueRef(source.ForEach.In, deps)
+		}
+		extractStrictFromInputs(source.Inputs, deps)
+	}
+}
+
+// extractStrictFromTransformPhase collects strict references from a transform phase.
+func extractStrictFromTransformPhase(phase *TransformPhase, deps map[string]bool) {
+	if phase == nil {
+		return
+	}
+	if phase.When != nil && phase.When.Expr != nil {
+		extractDepsFromExpression(string(*phase.When.Expr), deps)
+	}
+	for _, transform := range phase.With {
+		if transform.When != nil && transform.When.Expr != nil {
+			extractDepsFromExpression(string(*transform.When.Expr), deps)
+		}
+		if transform.ContinueOnError != nil && transform.ContinueOnError.Expr != nil {
+			extractDepsFromExpression(string(*transform.ContinueOnError.Expr), deps)
+		}
+		if transform.ForEach != nil && transform.ForEach.In != nil {
+			extractStrictFromValueRef(transform.ForEach.In, deps)
+		}
+		extractStrictFromInputs(transform.Inputs, deps)
+	}
+}
+
+// extractStrictFromValidatePhase collects strict references from a validate phase.
+func extractStrictFromValidatePhase(phase *ValidatePhase, deps map[string]bool) {
+	if phase == nil {
+		return
+	}
+	if phase.When != nil && phase.When.Expr != nil {
+		extractDepsFromExpression(string(*phase.When.Expr), deps)
+	}
+	for _, validation := range phase.With {
+		if validation.When != nil && validation.When.Expr != nil {
+			extractDepsFromExpression(string(*validation.When.Expr), deps)
+		}
+		extractStrictFromInputs(validation.Inputs, deps)
+		extractStrictFromValueRef(validation.Message, deps)
+	}
+}
+
+// extractStrictFromInputs collects strict references from a step's inputs map.
+// The go-template "template" input is skipped because its {{ .field }} accessors
+// are inferred best-effort, not strict references.
+func extractStrictFromInputs(inputs map[string]*ValueRef, deps map[string]bool) {
+	for key, input := range inputs {
+		if key == "template" {
+			continue
+		}
+		extractStrictFromValueRef(input, deps)
+	}
+}
+
+// extractStrictFromValueRef collects only strict references from a ValueRef:
+// direct rslvr references, CEL expressions, and rslvr/expr forms nested inside
+// literal values. tmpl: ValueRefs and {{ .field }} accessors in literal strings
+// are intentionally skipped.
+func extractStrictFromValueRef(ref *ValueRef, deps map[string]bool) {
+	if ref == nil {
+		return
+	}
+	switch {
+	case ref.Resolver != nil:
+		deps[*ref.Resolver] = true
+	case ref.Expr != nil:
+		extractDepsFromExpression(string(*ref.Expr), deps)
+	case ref.Tmpl != nil:
+		// Template ValueRef: inferred best-effort, not a strict reference.
+	case ref.Literal != nil:
+		extractStrictFromLiteral(ref.Literal, deps)
+	}
+}
+
+// extractStrictFromLiteral recursively collects strict references from a literal
+// value: rslvr keys, expr (CEL) keys, and CEL patterns in strings. tmpl keys and
+// {{ .field }} template accessors are skipped.
+func extractStrictFromLiteral(literal any, deps map[string]bool) {
+	switch v := literal.(type) {
+	case string:
+		if strings.Contains(v, "_.") || strings.Contains(v, "_[") {
+			extractDepsFromExpression(v, deps)
+		}
+	case map[string]any:
+		isValueRef := false
+		if rslvr, ok := v["rslvr"].(string); ok {
+			deps[rslvr] = true
+			isValueRef = true
+		}
+		if expr, ok := v["expr"].(string); ok {
+			extractDepsFromExpression(expr, deps)
+			isValueRef = true
+		}
+		if _, ok := v["tmpl"].(string); ok {
+			// Template ValueRef: inferred best-effort, not strict.
+			isValueRef = true
+		}
+		if isValueRef {
+			return
+		}
+		for _, mapVal := range v {
+			extractStrictFromLiteral(mapVal, deps)
+		}
+	case []any:
+		for _, arrVal := range v {
+			extractStrictFromLiteral(arrVal, deps)
+		}
+	}
+}
+
 // extractDepsFromExpression extracts resolver references from CEL expressions
 // Uses the existing GetUnderscoreVariables() method from pkg/celexp/refs.go
 func extractDepsFromExpression(expr string, deps map[string]bool) {
@@ -266,11 +433,7 @@ func extractDepsFromLiteralWithExclusions(literal any, deps, exclude map[string]
 		// Check if the string contains Go template syntax ({{ and }})
 		// This handles cases like go-template provider inputs with {{.resolverName}} patterns
 		if strings.Contains(v, "{{") && strings.Contains(v, "}}") {
-			if len(exclude) > 0 {
-				extractDepsFromTemplateWithExclusions(v, deps, exclude)
-			} else {
-				extractDepsFromTemplate(v, deps)
-			}
+			extractDepsFromTemplateCtx(v, deps, scanCtxFromExclude(exclude))
 		}
 	case map[string]any:
 		// Check if this map represents a nested ValueRef ({rslvr: x}, {expr: "..."}, {tmpl: "..."}).
@@ -289,11 +452,7 @@ func extractDepsFromLiteralWithExclusions(literal any, deps, exclude map[string]
 			isValueRef = true
 		}
 		if tmpl, ok := v["tmpl"].(string); ok {
-			if len(exclude) > 0 {
-				extractDepsFromTemplateWithExclusions(tmpl, deps, exclude)
-			} else {
-				extractDepsFromTemplate(tmpl, deps)
-			}
+			extractDepsFromTemplateCtx(tmpl, deps, scanCtxFromExclude(exclude))
 			isValueRef = true
 		}
 		if isValueRef {
@@ -305,11 +464,8 @@ func extractDepsFromLiteralWithExclusions(literal any, deps, exclude map[string]
 		// This prevents false-positive resolver dependencies when the template
 		// accesses variables provided by the data input (e.g., {{.config}}).
 		var dataKeys map[string]bool
-		if dataMap, ok := v["data"].(map[string]any); ok {
-			dataKeys = make(map[string]bool, len(dataMap))
-			for k := range dataMap {
-				dataKeys[k] = true
-			}
+		if dataVal, ok := v["data"]; ok {
+			dataKeys = literalDataKeys(dataVal)
 		}
 		// Recursively check map values, passing data keys as exclusions
 		// for template strings in the same map
@@ -328,76 +484,160 @@ func extractDepsFromLiteralWithExclusions(literal any, deps, exclude map[string]
 	}
 }
 
-// extractDepsFromTemplate extracts resolver references from Go templates.
-// Uses the gotmpl package's GetReferences function for proper template parsing.
-func extractDepsFromTemplate(tmplContent string, deps map[string]bool) {
-	extractDepsFromTemplateWithExclusions(tmplContent, deps, nil)
+// tmplScanCtx carries the context needed to correctly disambiguate a
+// {{ .field }} template accessor between a resolver reference and a local
+// template-context binding (a data-input key or a forEach loop alias).
+type tmplScanCtx struct {
+	// hasData indicates the step supplies an explicit "data" input.
+	hasData bool
+	// dataKeys is the set of top-level keys the data input provides. Only
+	// meaningful when dataKeysComplete is true.
+	dataKeys map[string]bool
+	// dataKeysComplete indicates dataKeys is an authoritative, complete key set.
+	dataKeysComplete bool
+	// aliases is the set of forEach item/index alias names bound locally.
+	aliases map[string]bool
 }
 
-// extractDepsFromTemplateWithExclusions extracts resolver references from Go templates,
-// skipping any variable names present in the exclude set. This is used when template
-// variables are provided by a sibling data input rather than resolvers.
-func extractDepsFromTemplateWithExclusions(tmplContent string, deps, exclude map[string]bool) {
-	// Use the gotmpl package to properly parse template references
-	refs, err := gotmpl.GetGoTemplateReferences(tmplContent, "", "")
-	if err != nil {
-		// If parsing fails, this is a non-fatal error - the resolver may still be valid
-		return
+// depsInput converts the scan context into the input for the shared
+// gotmpl.ExtractResolverDeps helper.
+func (c tmplScanCtx) depsInput(tmplContent string) gotmpl.ResolverDepsInput {
+	return gotmpl.ResolverDepsInput{
+		Template:         tmplContent,
+		HasDataInput:     c.hasData,
+		DataKeys:         c.dataKeys,
+		DataKeysComplete: c.dataKeysComplete,
+		Aliases:          c.aliases,
 	}
+}
 
-	// Extract resolver names from paths that reference data
-	for _, ref := range refs {
-		// Skip scoped references — they refer to fields inside {{ with }}/{{ range }}
-		// bodies where dot has been rebound, not to top-level resolvers.
-		if ref.Scoped {
-			continue
+// scanCtxFromExclude bridges the legacy exclude-set model used by the literal
+// extraction path into the richer scan context. A non-empty exclude set implies
+// a known, complete data-key set.
+func scanCtxFromExclude(exclude map[string]bool) tmplScanCtx {
+	if len(exclude) == 0 {
+		return tmplScanCtx{}
+	}
+	return tmplScanCtx{hasData: true, dataKeys: exclude, dataKeysComplete: true}
+}
+
+// extractDepsFromTemplate extracts resolver references from Go templates with no
+// surrounding data context (bare {{ .field }} accessors are resolver deps).
+func extractDepsFromTemplate(tmplContent string, deps map[string]bool) {
+	extractDepsFromTemplateCtx(tmplContent, deps, tmplScanCtx{})
+}
+
+// extractDepsFromTemplateCtx extracts resolver references from a Go template,
+// applying the context-aware disambiguation rules in gotmpl.ExtractResolverDeps.
+func extractDepsFromTemplateCtx(tmplContent string, deps map[string]bool, scan tmplScanCtx) {
+	for _, name := range gotmpl.ExtractResolverDeps(scan.depsInput(tmplContent)) {
+		deps[name] = true
+	}
+}
+
+// buildTmplScanCtx computes the template scan context for a set of provider
+// inputs and an optional forEach clause. The data input's key set is derived
+// from a literal map or a statically analysable CEL map-literal expression;
+// dynamic data inputs (rslvr/tmpl or non-map-literal expressions) yield an
+// incomplete key set, which causes bare {{ .field }} accessors to be treated as
+// local data context rather than resolver dependencies.
+func buildTmplScanCtx(inputs map[string]*ValueRef, forEach *ForEachClause) tmplScanCtx {
+	var scan tmplScanCtx
+	if forEach != nil {
+		aliases := make(map[string]bool, 2)
+		if forEach.Item != "" {
+			aliases[forEach.Item] = true
 		}
-
-		path := ref.Path
-		var varName string
-		// Handle different path patterns from template parsing
-		// The parser returns paths like:
-		// - "._.resolverName" for {{ ._.resolverName }} (ValueRef tmpl pattern)
-		// - ".__self" for {{ .__self }} (special variable)
-		// - ".resolverName" for {{ .resolverName }} (go-template provider pattern)
-		switch {
-		case strings.HasPrefix(path, "._."):
-			// Extract "resolverName" from "._.resolverName"
-			varName = strings.TrimPrefix(path, "._.")
-			// Only take the first segment if there are nested accesses
-			if idx := strings.Index(varName, "."); idx != -1 {
-				varName = varName[:idx]
-			}
-		case strings.HasPrefix(path, ".__"):
-			// Skip special variables like __self, __item, __index - they are not dependencies
-			continue
-		case strings.HasPrefix(path, "._"):
-			// Handle _.resolverName pattern (without leading dot after _.)
-			varName = strings.TrimPrefix(path, "._")
-			// Only take the first segment if there are nested accesses
-			if idx := strings.Index(varName, "."); idx != -1 {
-				varName = varName[:idx]
-			}
-		case strings.HasPrefix(path, "."):
-			// Handle direct root-level access like ".resolverName" used by go-template provider
-			// This pattern is used when resolver data is at the root level of template data
-			varName = strings.TrimPrefix(path, ".")
-			// Only take the first segment if there are nested accesses (e.g., ".config.host" -> "config")
-			if idx := strings.Index(varName, "."); idx != -1 {
-				varName = varName[:idx]
-			}
+		if forEach.Index != "" {
+			aliases[forEach.Index] = true
 		}
-
-		if varName != "" && !exclude[varName] {
-			deps[varName] = true
+		if len(aliases) > 0 {
+			scan.aliases = aliases
 		}
 	}
+	if dataRef, ok := inputs["data"]; ok && dataRef != nil {
+		scan.hasData = true
+		scan.dataKeys, scan.dataKeysComplete = valueRefDataScanKeys(dataRef)
+	}
+	return scan
+}
+
+// valueRefDataScanKeys returns the statically-known top-level key set of a data
+// ValueRef and whether that set is complete. Literal maps and CEL map-literal
+// expressions yield a complete key set; all other forms are dynamic (complete is
+// false, keys nil).
+func valueRefDataScanKeys(dataRef *ValueRef) (map[string]bool, bool) {
+	switch {
+	case dataRef.Literal != nil:
+		m, ok := dataRef.Literal.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		keys := make(map[string]bool, len(m))
+		for k := range m {
+			keys[k] = true
+		}
+		return keys, true
+	case dataRef.Expr != nil:
+		keys, known := celexp.Expression(string(*dataRef.Expr)).MapLiteralKeys(context.TODO())
+		if !known {
+			return nil, false
+		}
+		set := make(map[string]bool, len(keys))
+		for _, k := range keys {
+			set[k] = true
+		}
+		return set, true
+	default:
+		// rslvr / tmpl -> dynamic, keys not statically known.
+		return nil, false
+	}
+}
+
+// literalDataKeys returns the statically-known top-level key set of a data value
+// encountered on the raw-literal extraction path, or nil when the keys cannot be
+// determined. It recognises nested ValueRef shapes ({expr: ...}, {rslvr: ...},
+// {tmpl: ...}) so their control keys are not mistaken for data keys.
+func literalDataKeys(data any) map[string]bool {
+	m, ok := data.(map[string]any)
+	if !ok {
+		return nil
+	}
+	if expr, ok := m["expr"].(string); ok && len(m) == 1 {
+		keys, known := celexp.Expression(expr).MapLiteralKeys(context.TODO())
+		if !known {
+			return nil
+		}
+		set := make(map[string]bool, len(keys))
+		for _, k := range keys {
+			set[k] = true
+		}
+		return set
+	}
+	if _, ok := m["rslvr"]; ok {
+		return nil
+	}
+	if _, ok := m["tmpl"]; ok {
+		return nil
+	}
+	keys := make(map[string]bool, len(m))
+	for k := range m {
+		keys[k] = true
+	}
+	return keys
 }
 
 // extractDepsFromProviderInputs attempts to use a provider's ExtractDependencies function
 // to extract dependencies from inputs. Returns true if the provider handled the extraction,
 // false if generic extraction should be used instead.
-func extractDepsFromProviderInputs(providerName string, inputs map[string]*ValueRef, deps map[string]bool, lookup DescriptorLookup) bool {
+//
+// The forEach clause (when present) contributes item/index alias names that must
+// not be treated as resolver dependencies. Because a provider's
+// ExtractDependencies function receives only the input map, the computed scan
+// context (data keys + forEach aliases) is injected under the reserved
+// gotmpl.DepScanContextKey so template-based providers can disambiguate
+// {{ .field }} accessors.
+func extractDepsFromProviderInputs(providerName string, inputs map[string]*ValueRef, forEach *ForEachClause, deps map[string]bool, lookup DescriptorLookup) bool {
 	if lookup == nil {
 		return false
 	}
@@ -424,6 +664,16 @@ func extractDepsFromProviderInputs(providerName string, inputs map[string]*Value
 		case ref.Tmpl != nil:
 			rawInputs[key] = map[string]any{"tmpl": string(*ref.Tmpl)}
 		}
+	}
+
+	// Inject the template scan context so template-based providers can
+	// disambiguate {{ .field }} accessors from resolver references.
+	scan := buildTmplScanCtx(inputs, forEach)
+	rawInputs[gotmpl.DepScanContextKey] = gotmpl.DepScanContext{
+		HasDataInput:     scan.hasData,
+		DataKeys:         scan.dataKeys,
+		DataKeysComplete: scan.dataKeysComplete,
+		Aliases:          scan.aliases,
 	}
 
 	// Call the provider's ExtractDependencies function.
@@ -474,18 +724,18 @@ func extractDepsFromResolvePhase(phase *ResolvePhase, deps map[string]bool, look
 		}
 
 		// Try provider-specific extraction first
-		if extractDepsFromProviderInputs(source.Provider, source.Inputs, deps, lookup) {
+		if extractDepsFromProviderInputs(source.Provider, source.Inputs, source.ForEach, deps, lookup) {
 			continue
 		}
 
 		// Fall back to generic extraction from inputs.
-		// Collect data keys to exclude from template reference extraction.
-		// When a provider has both a "data" map and a "template" string,
-		// template references matching data keys are local context, not resolver deps.
-		dataKeys := extractDataKeys(source.Inputs)
+		// Compute the template scan context (data keys + forEach aliases) so that
+		// template {{ .field }} accessors are correctly disambiguated from resolver
+		// references.
+		scan := buildTmplScanCtx(source.Inputs, source.ForEach)
 		for key, input := range source.Inputs {
-			if len(dataKeys) > 0 && key == "template" {
-				extractDepsFromValueRefWithExclusions(input, deps, dataKeys)
+			if key == "template" {
+				extractDepsFromValueRefTmpl(input, deps, scan)
 			} else {
 				extractDepsFromValueRef(input, deps)
 			}
@@ -493,58 +743,41 @@ func extractDepsFromResolvePhase(phase *ResolvePhase, deps map[string]bool, look
 	}
 }
 
-// extractDataKeys returns a set of top-level keys from the "data" input if it
-// is a literal map. This allows template references like {{.config}} to be
-// recognized as local context rather than resolver dependencies.
-func extractDataKeys(inputs map[string]*ValueRef) map[string]bool {
-	dataRef, ok := inputs["data"]
-	if !ok || dataRef == nil || dataRef.Literal == nil {
-		return nil
-	}
-	dataMap, ok := dataRef.Literal.(map[string]any)
-	if !ok {
-		return nil
-	}
-	keys := make(map[string]bool, len(dataMap))
-	for k := range dataMap {
-		keys[k] = true
-	}
-	return keys
-}
-
-// extractDepsFromValueRefWithExclusions works like extractDepsFromValueRef but
-// excludes names in the exclude set from being treated as resolver dependencies.
-func extractDepsFromValueRefWithExclusions(ref *ValueRef, deps, exclude map[string]bool) {
+// extractDepsFromValueRefTmpl works like extractDepsFromValueRef but applies the
+// template scan context (data keys + forEach aliases) when the ValueRef resolves
+// to a Go template, so that {{ .field }} accessors are correctly disambiguated
+// from resolver references.
+func extractDepsFromValueRefTmpl(ref *ValueRef, deps map[string]bool, scan tmplScanCtx) {
 	if ref == nil {
 		return
 	}
 
-	// Direct resolver reference - never excluded
+	// Direct resolver reference - always a dependency.
 	if ref.Resolver != nil {
 		deps[*ref.Resolver] = true
 		return
 	}
 
-	// Expression - never excluded (CEL uses _.resolverName, not data keys)
+	// Expression - CEL uses _.resolverName, never data keys.
 	if ref.Expr != nil {
 		extractDepsFromExpression(string(*ref.Expr), deps)
 		return
 	}
 
-	// Template - apply exclusions
+	// Template - apply the scan context.
 	if ref.Tmpl != nil {
-		extractDepsFromTemplateWithExclusions(string(*ref.Tmpl), deps, exclude)
+		extractDepsFromTemplateCtx(string(*ref.Tmpl), deps, scan)
 		return
 	}
 
-	// Literal string with template syntax
+	// Literal string with CEL or template syntax.
 	if ref.Literal != nil {
 		if s, ok := ref.Literal.(string); ok {
 			if strings.Contains(s, "_.") || strings.Contains(s, "_[") {
 				extractDepsFromExpression(s, deps)
 			}
 			if strings.Contains(s, "{{") && strings.Contains(s, "}}") {
-				extractDepsFromTemplateWithExclusions(s, deps, exclude)
+				extractDepsFromTemplateCtx(s, deps, scan)
 			}
 		}
 	}
@@ -579,15 +812,15 @@ func extractDepsFromTransformPhase(phase *TransformPhase, deps map[string]bool, 
 		}
 
 		// Try provider-specific extraction first
-		if extractDepsFromProviderInputs(transform.Provider, transform.Inputs, deps, lookup) {
+		if extractDepsFromProviderInputs(transform.Provider, transform.Inputs, transform.ForEach, deps, lookup) {
 			continue
 		}
 
 		// Fall back to generic extraction from inputs
-		dataKeys := extractDataKeys(transform.Inputs)
+		scan := buildTmplScanCtx(transform.Inputs, transform.ForEach)
 		for key, input := range transform.Inputs {
-			if len(dataKeys) > 0 && key == "template" {
-				extractDepsFromValueRefWithExclusions(input, deps, dataKeys)
+			if key == "template" {
+				extractDepsFromValueRefTmpl(input, deps, scan)
 			} else {
 				extractDepsFromValueRef(input, deps)
 			}
@@ -614,7 +847,7 @@ func extractDepsFromValidatePhase(phase *ValidatePhase, deps map[string]bool, lo
 		}
 
 		// Try provider-specific extraction first
-		if extractDepsFromProviderInputs(validation.Provider, validation.Inputs, deps, lookup) {
+		if extractDepsFromProviderInputs(validation.Provider, validation.Inputs, nil, deps, lookup) {
 			// Still extract from message even if provider handled inputs
 			extractDepsFromValueRef(validation.Message, deps)
 			continue
@@ -628,6 +861,110 @@ func extractDepsFromValidatePhase(phase *ValidatePhase, deps map[string]bool, lo
 		// Extract from message
 		extractDepsFromValueRef(validation.Message, deps)
 	}
+}
+
+// TemplateAccessor identifies a root-level Go template accessor in a resolver's
+// resolve or transform step that does not resolve to any known resolver after
+// accounting for data-input keys and forEach aliases. These are likely typos:
+// at runtime a bare {{ .field }} accessor to an unknown root renders empty
+// rather than failing, so they are surfaced as advisory findings rather than
+// hard errors.
+type TemplateAccessor struct {
+	// Resolver is the name of the resolver containing the accessor.
+	Resolver string
+	// Step identifies where the accessor was found ("resolve" or "transform").
+	Step string
+	// Name is the unresolved accessor root name.
+	Name string
+}
+
+// UnresolvedTemplateAccessors scans the go-template "template" input of every
+// resolve and transform step for root-level accessors that cannot resolve to any
+// known resolver, data-input key, or forEach alias. A step whose data input has
+// a dynamically-determined key set is skipped for bare {{ .field }} accessors
+// (its root may be populated at runtime); {{ ._.name }} explicit resolver
+// references are always checked. The returned accessors are likely typos and are
+// intended to be surfaced as lint findings.
+func UnresolvedTemplateAccessors(resolvers []*Resolver) []TemplateAccessor {
+	known := make(map[string]bool, len(resolvers))
+	for _, r := range resolvers {
+		if r != nil {
+			known[r.Name] = true
+		}
+	}
+
+	var out []TemplateAccessor
+	for _, r := range resolvers {
+		if r == nil {
+			continue
+		}
+		if r.Resolve != nil {
+			for _, src := range r.Resolve.With {
+				collectUnresolvedAccessors(r.Name, "resolve", src.Inputs, src.ForEach, known, &out)
+			}
+		}
+		if r.Transform != nil {
+			for _, step := range r.Transform.With {
+				collectUnresolvedAccessors(r.Name, "transform", step.Inputs, step.ForEach, known, &out)
+			}
+		}
+	}
+	return out
+}
+
+// collectUnresolvedAccessors appends unresolved template accessors found in a
+// single step's "template" input to out.
+func collectUnresolvedAccessors(resolverName, step string, inputs map[string]*ValueRef, forEach *ForEachClause, known map[string]bool, out *[]TemplateAccessor) {
+	tmpl := templateInputString(inputs)
+	if tmpl == "" {
+		return
+	}
+
+	scan := buildTmplScanCtx(inputs, forEach)
+	in := scan.depsInput(tmpl)
+	in.LeftDelim = literalStringInput(inputs, "leftDelim")
+	in.RightDelim = literalStringInput(inputs, "rightDelim")
+
+	seen := make(map[string]bool)
+	for _, name := range gotmpl.ExtractResolverDeps(in) {
+		if known[name] || seen[name] {
+			continue
+		}
+		seen[name] = true
+		*out = append(*out, TemplateAccessor{Resolver: resolverName, Step: step, Name: name})
+	}
+}
+
+// templateInputString returns the inline template string from a step's
+// "template" input (whether provided as a tmpl ValueRef or a literal string), or
+// "" when the step has no inline template.
+func templateInputString(inputs map[string]*ValueRef) string {
+	ref, ok := inputs["template"]
+	if !ok || ref == nil {
+		return ""
+	}
+	if ref.Tmpl != nil {
+		return string(*ref.Tmpl)
+	}
+	if ref.Literal != nil {
+		if s, ok := ref.Literal.(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
+// literalStringInput returns the literal string value of the named input, or ""
+// when the input is absent or not a literal string.
+func literalStringInput(inputs map[string]*ValueRef, key string) string {
+	ref, ok := inputs[key]
+	if !ok || ref == nil || ref.Literal == nil {
+		return ""
+	}
+	if s, ok := ref.Literal.(string); ok {
+		return s
+	}
+	return ""
 }
 
 // GraphNode represents a resolver node in the dependency graph

--- a/pkg/resolver/graph_test.go
+++ b/pkg/resolver/graph_test.go
@@ -1329,7 +1329,7 @@ func TestExtractDepsFromProviderInputs_NilFallback(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			deps := make(map[string]bool)
-			used := extractDepsFromProviderInputs("test-provider", inputs, deps, tt.lookup)
+			used := extractDepsFromProviderInputs("test-provider", inputs, nil, deps, tt.lookup)
 			assert.Equal(t, tt.wantUsed, used)
 
 			if tt.wantDeps != nil {
@@ -1343,7 +1343,7 @@ func TestExtractDepsFromProviderInputs_NilFallback(t *testing.T) {
 	}
 }
 
-func TestExtractDepsFromTemplateWithExclusions(t *testing.T) {
+func TestExtractDepsFromTemplateCtx(t *testing.T) {
 	tests := []struct {
 		name    string
 		tmpl    string
@@ -1379,7 +1379,7 @@ func TestExtractDepsFromTemplateWithExclusions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			deps := make(map[string]bool)
-			extractDepsFromTemplateWithExclusions(tt.tmpl, deps, tt.exclude)
+			extractDepsFromTemplateCtx(tt.tmpl, deps, scanCtxFromExclude(tt.exclude))
 
 			wantMap := make(map[string]bool)
 			for _, dep := range tt.want {
@@ -1391,7 +1391,7 @@ func TestExtractDepsFromTemplateWithExclusions(t *testing.T) {
 	}
 }
 
-func TestExtractDataKeys(t *testing.T) {
+func TestBuildTmplScanCtx_DataKeys(t *testing.T) {
 	tests := []struct {
 		name   string
 		inputs map[string]*ValueRef
@@ -1428,7 +1428,201 @@ func TestExtractDataKeys(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractDataKeys(tt.inputs)
+			got := buildTmplScanCtx(tt.inputs, nil).dataKeys
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestValueRefDataScanKeys(t *testing.T) {
+	tests := []struct {
+		name         string
+		ref          *ValueRef
+		wantKeys     map[string]bool
+		wantComplete bool
+	}{
+		{
+			name:         "literal map",
+			ref:          &ValueRef{Literal: map[string]any{"a": 1, "b": 2}},
+			wantKeys:     map[string]bool{"a": true, "b": true},
+			wantComplete: true,
+		},
+		{
+			name:         "literal non-map is dynamic",
+			ref:          &ValueRef{Literal: "scalar"},
+			wantKeys:     nil,
+			wantComplete: false,
+		},
+		{
+			name:         "expr map literal is complete",
+			ref:          &ValueRef{Expr: celExpPtr(`{"appName": _.appName, "env": _.env}`)},
+			wantKeys:     map[string]bool{"appName": true, "env": true},
+			wantComplete: true,
+		},
+		{
+			name:         "expr non-map literal is dynamic",
+			ref:          &ValueRef{Expr: celExpPtr(`map.merge(_.base, _.extra)`)},
+			wantKeys:     nil,
+			wantComplete: false,
+		},
+		{
+			name:         "resolver ref is dynamic",
+			ref:          &ValueRef{Resolver: stringPtr("vars")},
+			wantKeys:     nil,
+			wantComplete: false,
+		},
+		{
+			name:         "tmpl ref is dynamic",
+			ref:          &ValueRef{Tmpl: tmplPtr("{{ .x }}")},
+			wantKeys:     nil,
+			wantComplete: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keys, complete := valueRefDataScanKeys(tt.ref)
+			assert.Equal(t, tt.wantComplete, complete)
+			assert.Equal(t, tt.wantKeys, keys)
+		})
+	}
+}
+
+func TestLiteralDataKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		data any
+		want map[string]bool
+	}{
+		{
+			name: "plain literal map",
+			data: map[string]any{"a": 1, "b": 2},
+			want: map[string]bool{"a": true, "b": true},
+		},
+		{
+			name: "expr map literal",
+			data: map[string]any{"expr": `{"appName": _.appName}`},
+			want: map[string]bool{"appName": true},
+		},
+		{
+			name: "expr non-map literal is unknown",
+			data: map[string]any{"expr": `map.merge(a, b)`},
+			want: nil,
+		},
+		{
+			name: "rslvr ref is unknown",
+			data: map[string]any{"rslvr": "vars"},
+			want: nil,
+		},
+		{
+			name: "tmpl ref is unknown",
+			data: map[string]any{"tmpl": "{{ .x }}"},
+			want: nil,
+		},
+		{
+			name: "non-map is unknown",
+			data: "scalar",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, literalDataKeys(tt.data))
+		})
+	}
+}
+
+func TestUnresolvedTemplateAccessors(t *testing.T) {
+	tests := []struct {
+		name      string
+		resolvers []*Resolver
+		want      []TemplateAccessor
+	}{
+		{
+			name: "typo accessor with known data keys is flagged",
+			resolvers: []*Resolver{
+				{Name: "appName"},
+				{
+					Name: "rendered",
+					Resolve: &ResolvePhase{With: []ProviderSource{{
+						Provider: "go-template",
+						Inputs: map[string]*ValueRef{
+							"template": {Literal: `app = "{{ .appNam }}"`},
+							"data":     {Expr: celExpPtr(`{"appName": _.appName}`)},
+						},
+					}}},
+				},
+			},
+			want: []TemplateAccessor{{Resolver: "rendered", Step: "resolve", Name: "appNam"}},
+		},
+		{
+			name: "known resolver reference is not flagged",
+			resolvers: []*Resolver{
+				{Name: "appName"},
+				{
+					Name: "rendered",
+					Resolve: &ResolvePhase{With: []ProviderSource{{
+						Provider: "go-template",
+						Inputs: map[string]*ValueRef{
+							"template": {Literal: `{{ .appName }}`},
+						},
+					}}},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "forEach alias is not flagged",
+			resolvers: []*Resolver{
+				{
+					Name: "rendered",
+					Resolve: &ResolvePhase{With: []ProviderSource{{
+						Provider: "go-template",
+						ForEach:  &ForEachClause{Item: "proj", In: &ValueRef{Resolver: stringPtr("projects")}},
+						Inputs: map[string]*ValueRef{
+							"template": {Literal: `{{ .proj.name }}`},
+						},
+					}}},
+				},
+				{Name: "projects"},
+			},
+			want: nil,
+		},
+		{
+			name: "dynamic data input suppresses bare field flagging",
+			resolvers: []*Resolver{
+				{
+					Name: "rendered",
+					Resolve: &ResolvePhase{With: []ProviderSource{{
+						Provider: "go-template",
+						Inputs: map[string]*ValueRef{
+							"template": {Literal: `{{ .anything }}`},
+							"data":     {Resolver: stringPtr("vars")},
+						},
+					}}},
+				},
+				{Name: "vars"},
+			},
+			want: nil,
+		},
+		{
+			name: "transform step accessor is flagged",
+			resolvers: []*Resolver{
+				{
+					Name: "rendered",
+					Transform: &TransformPhase{With: []ProviderTransform{{
+						Provider: "go-template",
+						Inputs: map[string]*ValueRef{
+							"template": {Literal: `{{ .missing }}`},
+						},
+					}}},
+				},
+			},
+			want: []TemplateAccessor{{Resolver: "rendered", Step: "transform", Name: "missing"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := UnresolvedTemplateAccessors(tt.resolvers)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/resolver/phase.go
+++ b/pkg/resolver/phase.go
@@ -112,7 +112,31 @@ func BuildPhases(resolvers []*Resolver, lookup DescriptorLookup) (*BuildResult, 
 
 	for _, r := range resolvers {
 		resolverMap[r.Name] = r
-		deps[r.Name] = extractDependencies(r, lookup)
+	}
+
+	for _, r := range resolvers {
+		// Partition dependencies by how they were derived. Strict references --
+		// explicit dependsOn entries, CEL `_.name` references, and rslvr: ValueRefs
+		// -- reflect intent a user stated directly, so an unknown target is almost
+		// always a typo and must fail fast during graph construction. Best-effort
+		// template-inferred edges (a go-template {{ .field }} accessor or a forEach
+		// alias) may legitimately reference local template context rather than a
+		// resolver, so an unknown target is dropped rather than failing the build.
+		inferred := extractDependencies(r, lookup)
+		strict := extractStrictDependencies(r)
+		filtered := make([]string, 0, len(inferred))
+		for _, dep := range inferred {
+			if _, ok := resolverMap[dep]; ok {
+				filtered = append(filtered, dep)
+				continue
+			}
+			// Unknown target: keep it only when it came from a strict reference so
+			// dag.Build surfaces the typo. Drop purely template-inferred edges.
+			if strict[dep] {
+				filtered = append(filtered, dep)
+			}
+		}
+		deps[r.Name] = filtered
 	}
 
 	// Build DAG using existing package

--- a/pkg/resolver/phase_test.go
+++ b/pkg/resolver/phase_test.go
@@ -884,6 +884,253 @@ func TestBuildPhases_StandaloneResolver(t *testing.T) {
 	assert.Len(t, result.Phases[0].Resolvers, 1)
 }
 
+func TestBuildPhases_DropsUnknownInferredDeps(t *testing.T) {
+	// A go-template resolver whose inline template references a bare {{ .field }}
+	// accessor to an unknown root must NOT hard-fail phase building. Such an
+	// inferred edge points at a non-existent resolver and is dropped as a
+	// best-effort ordering hint rather than producing a "depends on X but X
+	// wasn't present" DAG error.
+	resolvers := []*Resolver{
+		{
+			Name: "rendered",
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "go-template",
+						Inputs: map[string]*ValueRef{
+							"template": {Literal: `{{ .doesNotExist }}`},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	result, err := BuildPhases(resolvers, nil)
+	require.NoError(t, err)
+	assert.Len(t, result.Phases, 1)
+	assert.Equal(t, 1, result.Phases[0].Phase)
+	assert.Len(t, result.Phases[0].Resolvers, 1)
+}
+
+func TestBuildPhases_KeepsKnownInferredDeps(t *testing.T) {
+	// An inferred edge to an existing resolver is retained and orders the phases.
+	resolvers := []*Resolver{
+		{
+			Name: "rendered",
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "go-template",
+						Inputs: map[string]*ValueRef{
+							"template": {Literal: `{{ ._.appName }}`},
+						},
+					},
+				},
+			},
+		},
+		{Name: "appName"},
+	}
+
+	result, err := BuildPhases(resolvers, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Phases, 2)
+	// appName has no deps -> phase 1; rendered depends on appName -> phase 2.
+	assert.Equal(t, "appName", result.Phases[0].Resolvers[0].Name)
+	assert.Equal(t, "rendered", result.Phases[1].Resolvers[0].Name)
+}
+
+func TestBuildPhases_KeepsUnknownStrictDeps(t *testing.T) {
+	// Unknown targets reached via a *strict* reference -- dependsOn, a CEL
+	// `_.name` reference, or an rslvr: ValueRef -- are almost always typos and
+	// must fail fast during graph construction rather than being silently
+	// dropped. Each subtest wires a single strict reference to a non-existent
+	// resolver and expects BuildPhases to error.
+	tests := []struct {
+		name     string
+		resolver *Resolver
+	}{
+		{
+			name: "dependsOn typo",
+			resolver: &Resolver{
+				Name:      "app",
+				DependsOn: []string{"missing"},
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{{Provider: "parameter"}},
+				},
+			},
+		},
+		{
+			name: "cel reference typo",
+			resolver: &Resolver{
+				Name: "app",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{{
+						Provider: "cel",
+						Inputs: map[string]*ValueRef{
+							"expression": {Expr: exprPtr("_.missing")},
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "rslvr reference typo",
+			resolver: &Resolver{
+				Name: "app",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{{
+						Provider: "cel",
+						Inputs: map[string]*ValueRef{
+							"value": {Resolver: stringPtr("missing")},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := BuildPhases([]*Resolver{tt.resolver}, nil)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "missing")
+		})
+	}
+}
+
+func TestExtractStrictDependencies(t *testing.T) {
+	tests := []struct {
+		name     string
+		resolver *Resolver
+		want     []string
+	}{
+		{
+			name: "dependsOn is strict",
+			resolver: &Resolver{
+				Name:      "app",
+				DependsOn: []string{"env", "region"},
+			},
+			want: []string{"env", "region"},
+		},
+		{
+			name: "cel and rslvr refs are strict",
+			resolver: &Resolver{
+				Name: "app",
+				When: &Condition{Expr: exprPtr("_.gate")},
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{{
+						Provider: "cel",
+						Inputs: map[string]*ValueRef{
+							"value": {Resolver: stringPtr("env")},
+							"expr":  {Expr: exprPtr("_.region")},
+						},
+					}},
+				},
+			},
+			want: []string{"gate", "env", "region"},
+		},
+		{
+			name: "bare template accessor is not strict",
+			resolver: &Resolver{
+				Name: "app",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{{
+						Provider: "go-template",
+						Inputs: map[string]*ValueRef{
+							"template": {Literal: `{{ .notStrict }}`},
+						},
+					}},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "tmpl ValueRef is not strict",
+			resolver: &Resolver{
+				Name: "app",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{{
+						Provider: "go-template",
+						Inputs: map[string]*ValueRef{
+							"value": {Tmpl: tmplPtr(`{{ .notStrict }}`)},
+						},
+					}},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "rslvr and expr nested in literal map are strict",
+			resolver: &Resolver{
+				Name: "app",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{{
+						Provider: "cel",
+						Inputs: map[string]*ValueRef{
+							"value": {Literal: map[string]any{
+								"env":  map[string]any{"rslvr": "region"},
+								"zone": map[string]any{"expr": "_.zone"},
+							}},
+						},
+					}},
+				},
+			},
+			want: []string{"region", "zone"},
+		},
+		{
+			name: "cel string in literal array is strict",
+			resolver: &Resolver{
+				Name: "app",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{{
+						Provider: "cel",
+						Inputs: map[string]*ValueRef{
+							"value": {Literal: []any{"_.alpha", "plain-string"}},
+						},
+					}},
+				},
+			},
+			want: []string{"alpha"},
+		},
+		{
+			name: "tmpl nested in literal map is not strict",
+			resolver: &Resolver{
+				Name: "app",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{{
+						Provider: "go-template",
+						Inputs: map[string]*ValueRef{
+							"value": {Literal: map[string]any{
+								"t": map[string]any{"tmpl": "{{ .beta }}"},
+							}},
+						},
+					}},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "self reference is excluded",
+			resolver: &Resolver{
+				Name:      "app",
+				DependsOn: []string{"app", "env"},
+			},
+			want: []string{"env"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractStrictDependencies(tt.resolver)
+			assert.Len(t, got, len(tt.want))
+			for _, dep := range tt.want {
+				assert.True(t, got[dep], "expected strict dep %q", dep)
+			}
+		})
+	}
+}
+
 func TestResolverDagObject_GetDependencyKeys(t *testing.T) {
 	resolver := &Resolver{
 		Name: "test",

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2740,6 +2740,25 @@ func TestIntegration_Lint_WarningSeverityFilter(t *testing.T) {
 	assert.Contains(t, stdout, `"infoCount": 0`)
 }
 
+func TestIntegration_Lint_TemplateUnknownAccessor(t *testing.T) {
+	t.Parallel()
+	// The lint-stress-test solution intentionally contains a go-template
+	// resolver with a bare "{{ .projcts }}" accessor that matches no resolver,
+	// data key, or forEach alias. Lint must surface it via the
+	// template-unknown-accessor rule.
+	stdout, _, _ := runScafctl(t, "lint",
+		"-f", "examples/solutions/lint-stress-test/solution.yaml",
+		"-o", "json",
+	)
+
+	assert.Contains(t, stdout, "template-unknown-accessor",
+		"lint should report the unknown template accessor rule")
+	assert.Contains(t, stdout, "projcts",
+		"finding should name the unresolved accessor")
+	assert.Contains(t, stdout, "resolvers.typo_template.resolve",
+		"finding should point at the offending resolver step")
+}
+
 func TestIntegration_Lint_ActionSolution(t *testing.T) {
 	t.Parallel()
 	// Test linting a solution with actions

--- a/tests/integration/solutions/resolvers/template-dep-inference/solution.yaml
+++ b/tests/integration/solutions/resolvers/template-dep-inference/solution.yaml
@@ -1,0 +1,198 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-template-dep-inference
+  version: 1.0.0
+  description: |
+    Regression tests for go-template auto-dependency inference. A go-template
+    render step's template root namespace is the union of resolver values, the
+    step's data-input keys, and any forEach item/index aliases. Bare
+    "{{ .field }}" accessors that are satisfied by a data key or a forEach alias
+    must NOT be inferred as resolver dependencies — inferring them previously
+    produced a hard "depends on X but X wasn't present" build failure.
+
+    This exercises three scenarios that all must build (exit 0) and render:
+      - renderedFile:   forEach over a file-based template (template.expr) whose
+                        data.expr provides __fan/platformAppName/appName keys.
+      - renderedInline: forEach over an inline literal template whose data.expr
+                        provides projects/platformAppName/appName keys.
+      - renderedAlias:  forEach whose inline template references the loop alias
+                        directly as "{{ .proj.field }}" via a data key.
+
+spec:
+  resolvers:
+    debug:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "false"
+
+    appName:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: my-app
+
+    platformAppName:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: my-platform-app
+
+    gcpProjects:
+      type: array
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - app_environment: dev
+                  tfstate_bucket_name: bucket-dev
+                - app_environment: prod
+                  tfstate_bucket_name: bucket-prod
+
+    # Holds a go-template as a string under `.content`, mirroring a file-read
+    # result. Scenario A references it via template.expr: _.backendTemplate.content.
+    backendTemplate:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                content: |
+                  # The following determines where Terraform's state file is stored.
+
+                  #{{ if .debug | eq "false" }}
+                  terraform {
+                    backend "gcs" {
+                      bucket = "{{ .__fan.projects.tfstate_bucket_name }}"
+                      prefix = "terraform/{{ .platformAppName }}/{{ .__fan.projects.app_environment }}/{{ .appName }}"
+                    }
+                  }
+                  # {{else}}
+                  # Removed for testing purposes
+                  # {{ end}}
+
+    # Scenario A: forEach rendering a template stored in another resolver. The
+    # template references {{ .platformAppName }}, {{ .__fan.projects.* }},
+    # {{ .appName }}. No explicit dependsOn — the data keys and forEach alias are
+    # supplied via data.expr and the forEach clause, so none of them are deps.
+    renderedFile:
+      type: array
+      resolve:
+        with:
+          - provider: go-template
+            forEach:
+              item: proj
+              in:
+                expr: "_.gcpProjects"
+            inputs:
+              operation: render
+              template:
+                expr: "_.backendTemplate.content"
+              data:
+                expr: |
+                  {"__fan": {"projects": proj}, "debug": _.debug,
+                   "platformAppName": _.platformAppName, "appName": _.appName}
+
+    # Scenario B: forEach rendering an INLINE literal template. The template text
+    # contains {{ .projects.* }}, {{ .platformAppName }}, {{ .appName }}, all of
+    # which are provided via data.expr rather than resolvers.
+    renderedInline:
+      type: array
+      resolve:
+        with:
+          - provider: go-template
+            forEach:
+              item: proj
+              in:
+                expr: "_.gcpProjects"
+            inputs:
+              operation: render
+              template: |
+                terraform {
+                  backend "gcs" {
+                    bucket = "{{ .projects.tfstate_bucket_name }}"
+                    prefix = "terraform/{{ .platformAppName }}/{{ .projects.app_environment }}/{{ .appName }}"
+                  }
+                }
+              data:
+                expr: |
+                  {"projects": proj,
+                   "platformAppName": _.platformAppName, "appName": _.appName}
+
+    # Scenario C: forEach whose inline template references the loop alias `proj`
+    # directly through a data key. `proj` must not be inferred as a resolver dep.
+    renderedAlias:
+      type: array
+      resolve:
+        with:
+          - provider: go-template
+            forEach:
+              item: proj
+              in:
+                expr: "_.gcpProjects"
+            inputs:
+              operation: render
+              template: |
+                bucket = "{{ .proj.tfstate_bucket_name }}"
+                env    = "{{ .proj.app_environment }}"
+                app    = "{{ .appName }}"
+              data:
+                expr: |
+                  {"proj": proj, "appName": _.appName}
+
+  testing:
+    cases:
+      _base:
+        description: Base template — run all resolvers as JSON
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [resolver, template-dep-inference]
+        assertions:
+          - expression: __exitCode == 0
+            message: "Solution must build and render without a dependency error"
+
+      builds-without-dependency-error:
+        description: All three go-template scenarios build (no phantom deps)
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: size(__output.renderedFile) == 2
+            message: "renderedFile should produce one rendering per project"
+          - expression: size(__output.renderedInline) == 2
+          - expression: size(__output.renderedAlias) == 2
+
+      file-template-renders-per-project:
+        description: File-based template forEach renders both projects
+        extends: [_base]
+        assertions:
+          - expression: __output.renderedFile[0].contains("bucket-dev")
+            message: "First rendering should use the dev bucket"
+          - expression: __output.renderedFile[0].contains("terraform/my-platform-app/dev/my-app")
+            message: "Prefix should interpolate platformAppName, env, and appName"
+          - expression: __output.renderedFile[1].contains("bucket-prod")
+            message: "Second rendering should use the prod bucket"
+
+      inline-template-renders:
+        description: Inline template forEach renders using data keys
+        extends: [_base]
+        assertions:
+          - expression: __output.renderedInline[0].contains("bucket-dev")
+          - expression: __output.renderedInline[0].contains("terraform/my-platform-app/dev/my-app")
+
+      alias-template-renders:
+        description: forEach alias accessed via data key renders correctly
+        extends: [_base]
+        assertions:
+          - expression: __output.renderedAlias[0].contains("bucket-dev")
+          - expression: __output.renderedAlias[0].contains("env    = \"dev\"")
+          - expression: __output.renderedAlias[0].contains("app    = \"my-app\"")


### PR DESCRIPTION
Disambiguate bare {{ .field }} template accessors between resolver references and local template context (data-input keys or forEach aliases), and warn on accessors that resolve to nothing.

- Add gotmpl.ExtractResolverDeps with a scan context (data keys, forEach aliases, explicit ._. references) shared by the graph builder and the go-template provider
- Infer data-input key sets statically from literal maps and CEL map-literal expressions via new celexp.MapLiteralKeys; dynamic data inputs suppress bare-accessor resolver deps
- Inject DepScanContext into template providers so ExtractDependencies can see forEach aliases and analysed data expressions
- Add template-unknown-accessor lint rule flagging root accessors that match no resolver, data key, or forEach alias (silent empty renders at runtime)
- Drop inferred deps to unknown resolvers during phase build instead of failing; genuine dependsOn typos still reported by validation
- Add docs, resolver example, and integration coverage

Relates to #552