### PR TITLE
feat(provider): serialize structured http request bodies to JSON

### DIFF
--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -1451,7 +1451,7 @@ HTTP client for API calls with built-in pagination support for fetching data acr
 | `url` | string | ✅ | URL to request |
 | `method` | string | ❌ | HTTP method (default: `GET`) |
 | `headers` | object | ❌ | HTTP headers |
-| `body` | string | ❌ | Request body |
+| `body` | any | ❌ | Request body. A string is sent verbatim; an object or array is serialized to compact JSON and `Content-Type` defaults to `application/json` when not otherwise set |
 | `timeout` | int | ❌ | Timeout in seconds (max 300) |
 | `retry` | object | ❌ | Retry configuration |
 | `auth` | string | ❌ | Auth provider (e.g., `entra`, `github`) |
@@ -1459,6 +1459,25 @@ HTTP client for API calls with built-in pagination support for fetching data acr
 | `pagination` | object | ❌ | Pagination configuration (see below) |
 | `autoParseJson` | bool | ❌ | Parse response body as JSON when Content-Type is `application/json`. Enables direct field access (e.g., `_.result.body.items`) |
 | `poll` | object | ❌ | Polling configuration — re-execute request until a condition is met (see below) |
+
+### Request body
+
+`body` accepts either a string or a structured value:
+
+- **String** -- sent verbatim. You control the exact bytes and the `Content-Type` header.
+- **Object or array** -- serialized to compact JSON. When you do not set a `Content-Type` header, the provider defaults it to `application/json`. An explicit `Content-Type` (matched case-insensitively) is always preserved.
+
+Passing a structured body lets you build the payload directly from resolver values with a CEL expression, avoiding a separate serializer resolver:
+
+```yaml
+# Object body built from a CEL expression -- serialized to JSON automatically
+provider: http
+inputs:
+  url: https://api.example.com/graphql
+  method: POST
+  body:
+    expr: '{"query": _.graphQuery, "variables": {"id": _.recordId}}'
+```
 
 ### Pagination
 

--- a/docs/tutorials/run-provider-tutorial.md
+++ b/docs/tutorials/run-provider-tutorial.md
@@ -633,7 +633,7 @@ Provider Inputs (http):
   acceptableStatusCodes  array         Status codes treated as successful (e.g. [200, 404], "2xx", "200-204")
   authProvider   string                Authentication provider to use for this request
   autoParseJson  boolean               When true and the response Content-Type is application/json, automatically parse the body into a structured object
-  body           string                Request body for POST/PUT/PATCH requests
+  body           any                   Request body for POST/PUT/PATCH requests (string sent verbatim; object/array serialized to JSON)
   headers        any                   HTTP headers as key-value pairs
   method         string                HTTP method
   pagination     object                Pagination configuration for automatically following paginated API responses

--- a/examples/providers/README.md
+++ b/examples/providers/README.md
@@ -37,6 +37,7 @@ scafctl run resolver -f examples/providers/http-get.yaml
 |------|-------------|
 | [http-get.yaml](http-get.yaml) | Simple HTTP GET request |
 | [http-autoparse.yaml](http-autoparse.yaml) | Auto-parse JSON responses |
+| [http-structured-body.yaml](http-structured-body.yaml) | Structured object/array body serialized to JSON |
 | [http-acceptable-status.yaml](http-acceptable-status.yaml) | Treat selected non-2xx statuses as successful (acceptableStatusCodes) |
 | [http-empty-body.yaml](http-empty-body.yaml) | Non-JSON and empty response bodies |
 | [http-poll.yaml](http-poll.yaml) | Polling until a condition is met |

--- a/examples/providers/http-structured-body.yaml
+++ b/examples/providers/http-structured-body.yaml
@@ -1,0 +1,69 @@
+# Run: scafctl run resolver -f examples/providers/http-structured-body.yaml
+
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: http-structured-body-example
+  displayName: HTTP Structured JSON Body Example
+  category: providers
+  tags:
+    - http
+    - provider-example
+  description: |
+    The http provider accepts a structured `body` (object or array) and
+    serializes it to compact JSON. When no Content-Type header is set, the
+    provider defaults it to application/json. Passing a structured body lets
+    you build the payload directly from resolver values with a CEL expression,
+    avoiding a separate serializer resolver.
+
+spec:
+  resolvers:
+    # Values that feed the request payload.
+    graphQuery:
+      description: GraphQL query string
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "{ viewer { login } }"
+
+    recordId:
+      description: Record identifier included in the request variables
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: rec-42
+
+    # POST an object body built from a CEL expression. The provider serializes
+    # it to JSON and defaults Content-Type to application/json. httpbin echoes
+    # the request back so you can inspect the serialized json/headers fields.
+    createRecord:
+      description: POST a structured object body (serialized to JSON)
+      type: any
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://httpbin.org/post
+              method: POST
+              autoParseJson: true
+              body:
+                expr: '{"query": _.graphQuery, "variables": {"id": _.recordId}}'
+
+    # POST an array body. Arrays are serialized to JSON just like objects.
+    bulkTags:
+      description: POST an array body (serialized to JSON)
+      type: any
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://httpbin.org/post
+              method: POST
+              autoParseJson: true
+              body:
+                expr: '["alpha", "beta", "gamma"]'

--- a/pkg/provider/builtin/httpprovider/http.go
+++ b/pkg/provider/builtin/httpprovider/http.go
@@ -28,6 +28,11 @@ const (
 	Version      = "1.0.0"
 )
 
+// maxBodyBytes caps the size of a request body (in bytes) after it has been
+// serialized. This applies uniformly to string and structured (object/array)
+// bodies to bound memory use during serialization and request replay.
+const maxBodyBytes = 1048576
+
 // Field name constants for input/output map keys.
 const (
 	fieldURL                   = "url"
@@ -121,6 +126,42 @@ func parseRetryConfig(inputs map[string]any) *retryConfig {
 // shouldRetry and calculateBackoff have been removed — httpc.BuildStatusCodeCheckRetry
 // and httpc.BuildNamedBackoff now provide equivalent logic via retryablehttp.
 
+// serializeBody converts a request body input into the string that is written to
+// the wire. A string is returned verbatim. A nil or absent body yields an empty
+// string. Byte slices (including json.RawMessage) are treated as an already
+// serialized body and returned verbatim so they are not base64-encoded. Any
+// other value (map, slice, etc.) is serialized to compact JSON and reported as
+// structured so the caller can default the Content-Type header.
+func serializeBody(body any) (content string, structured bool, err error) {
+	switch v := body.(type) {
+	case nil:
+		return "", false, nil
+	case string:
+		return v, false, nil
+	case json.RawMessage:
+		return string(v), true, nil
+	case []byte:
+		return string(v), false, nil
+	default:
+		encoded, marshalErr := json.Marshal(v)
+		if marshalErr != nil {
+			return "", false, fmt.Errorf("failed to serialize request body to JSON: %w", marshalErr)
+		}
+		return string(encoded), true, nil
+	}
+}
+
+// hasContentType reports whether the headers map already contains a Content-Type
+// header, matching the key case-insensitively.
+func hasContentType(headers map[string]any) bool {
+	for k := range headers {
+		if strings.EqualFold(k, "Content-Type") {
+			return true
+		}
+	}
+	return false
+}
+
 // HTTPProvider implements the Provider interface for making HTTP requests.
 type HTTPProvider struct {
 	descriptor *provider.Descriptor
@@ -177,8 +218,11 @@ func NewHTTPProvider() *HTTPProvider {
 					schemahelper.WithExample("GET"),
 					schemahelper.WithMaxLength(*ptrs.IntPtr(10))),
 				fieldHeaders: schemahelper.AnyProp("HTTP headers as key-value pairs"),
-				fieldBody: schemahelper.StringProp("Request body for POST/PUT/PATCH requests",
-					schemahelper.WithMaxLength(*ptrs.IntPtr(1048576))),
+				fieldBody: {
+					Types:       []string{"string", "object", "array"},
+					Description: "Request body for POST/PUT/PATCH requests. A string is sent verbatim. A structured value (object or array) is serialized to JSON, and Content-Type defaults to application/json when not otherwise set.",
+					MaxLength:   ptrs.IntPtr(maxBodyBytes),
+				},
 				"timeout": schemahelper.IntProp("Request timeout in seconds",
 					schemahelper.WithExample(30),
 					schemahelper.WithMaximum(*ptrs.Float64Ptr(300.0))),
@@ -312,6 +356,17 @@ inputs:
   headers:
     Content-Type: "application/json"
   body: '{"name": "John Doe", "email": "john@example.com"}'`,
+				},
+				{
+					Name:        "POST request with a structured JSON body",
+					Description: "Pass an object as the body and let the provider serialize it to JSON. Content-Type defaults to application/json when not set. Use a CEL expression to build the body from resolver values without a separate serializer resolver.",
+					YAML: `name: run-graph-query
+provider: http
+inputs:
+  url: "https://api.example.com/graphql"
+  method: POST
+  body:
+    expr: '{"query": _.graphQuery}'`,
 				},
 				{
 					Name:        "Request with authentication header",
@@ -532,8 +587,15 @@ func (p *HTTPProvider) Execute(ctx context.Context, input any) (*provider.Output
 	}
 	timeoutDuration := time.Duration(timeout) * time.Second
 
-	// Get body content for potential retries
-	bodyContent, _ := inputs[fieldBody].(string)
+	// Get body content for potential retries. A string body is sent verbatim; a
+	// structured body (object/array) is serialized to JSON.
+	bodyContent, bodyStructured, err := serializeBody(inputs[fieldBody])
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", ProviderName, err)
+	}
+	if len(bodyContent) > maxBodyBytes {
+		return nil, fmt.Errorf("%s: request body exceeds maximum size of %d bytes (got %d)", ProviderName, maxBodyBytes, len(bodyContent))
+	}
 
 	// Get headers (make a copy to avoid modifying input)
 	headers := make(map[string]any)
@@ -541,6 +603,12 @@ func (p *HTTPProvider) Execute(ctx context.Context, input any) (*provider.Output
 		for k, v := range h {
 			headers[k] = v
 		}
+	}
+
+	// Default Content-Type to application/json when a structured body was
+	// serialized and the caller did not set a Content-Type header.
+	if bodyStructured && !hasContentType(headers) {
+		headers["Content-Type"] = "application/json"
 	}
 
 	// Build httpc client with timeout and user-supplied retry configuration.

--- a/pkg/provider/builtin/httpprovider/http_benchmark_test.go
+++ b/pkg/provider/builtin/httpprovider/http_benchmark_test.go
@@ -12,6 +12,20 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 )
 
+func BenchmarkSerializeBody(b *testing.B) {
+	body := map[string]any{
+		"query":  "graphQuery",
+		"count":  3,
+		"nested": map[string]any{"a": 1, "b": []any{"x", "y"}},
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _, _ = serializeBody(body)
+	}
+}
+
 func BenchmarkHTTPProvider_Execute_DryRun(b *testing.B) {
 	p := NewHTTPProvider()
 

--- a/pkg/provider/builtin/httpprovider/http_test.go
+++ b/pkg/provider/builtin/httpprovider/http_test.go
@@ -5,6 +5,7 @@ package httpprovider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -157,6 +158,227 @@ func TestHTTPProvider_Execute_POST(t *testing.T) {
 
 	headers := data["headers"].(map[string]any)
 	assert.Equal(t, "application/json", headers["Content-Type"])
+}
+
+func TestHTTPProvider_Execute_POST_StructuredBody(t *testing.T) {
+	t.Parallel()
+	receivedBody := ""
+	receivedContentType := ""
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		receivedBody = string(body)
+		receivedContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	inputs := map[string]any{
+		"url":    server.URL,
+		"method": "POST",
+		"body": map[string]any{
+			"query": "graphQuery",
+			"count": 3,
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	// The map body is serialized to compact JSON.
+	assert.JSONEq(t, `{"query":"graphQuery","count":3}`, receivedBody)
+	// Content-Type is defaulted to application/json when not supplied.
+	assert.Equal(t, "application/json", receivedContentType)
+}
+
+func TestHTTPProvider_Execute_POST_ArrayBody(t *testing.T) {
+	t.Parallel()
+	receivedBody := ""
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		receivedBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	inputs := map[string]any{
+		"url":    server.URL,
+		"method": "POST",
+		"body":   []any{"a", "b", "c"},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	assert.JSONEq(t, `["a","b","c"]`, receivedBody)
+}
+
+func TestHTTPProvider_Execute_StructuredBody_RespectsExplicitContentType(t *testing.T) {
+	t.Parallel()
+	receivedContentType := ""
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedContentType = r.Header.Get("Content-Type")
+		_, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	inputs := map[string]any{
+		"url":    server.URL,
+		"method": "POST",
+		"body":   map[string]any{"query": "x"},
+		// Explicit Content-Type must not be overridden (case-insensitive match).
+		"headers": map[string]any{"content-type": "application/vnd.api+json"},
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	assert.Equal(t, "application/vnd.api+json", receivedContentType)
+}
+
+func TestHTTPProvider_Execute_StringBody_NoContentTypeDefault(t *testing.T) {
+	t.Parallel()
+	receivedBody := ""
+	receivedContentType := "sentinel"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		receivedBody = string(body)
+		receivedContentType = r.Header.Get("Content-Type")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	inputs := map[string]any{
+		"url":    server.URL,
+		"method": "POST",
+		"body":   `{"raw":"string"}`,
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	// String bodies are sent verbatim and do not get an implicit Content-Type.
+	assert.Equal(t, `{"raw":"string"}`, receivedBody)
+	assert.Empty(t, receivedContentType)
+}
+
+func TestHTTPProvider_Execute_BodyExceedsMaxSize(t *testing.T) {
+	t.Parallel()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	inputs := map[string]any{
+		"url":    "https://api.example.com",
+		"method": "POST",
+		"body":   strings.Repeat("a", maxBodyBytes+1),
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "request body exceeds maximum size")
+}
+
+func TestSerializeBody(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil yields empty and unstructured", func(t *testing.T) {
+		t.Parallel()
+		content, structured, err := serializeBody(nil)
+		require.NoError(t, err)
+		assert.Empty(t, content)
+		assert.False(t, structured)
+	})
+
+	t.Run("string is verbatim and unstructured", func(t *testing.T) {
+		t.Parallel()
+		content, structured, err := serializeBody("hello")
+		require.NoError(t, err)
+		assert.Equal(t, "hello", content)
+		assert.False(t, structured)
+	})
+
+	t.Run("map is JSON and structured", func(t *testing.T) {
+		t.Parallel()
+		content, structured, err := serializeBody(map[string]any{"a": 1})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"a":1}`, content)
+		assert.True(t, structured)
+	})
+
+	t.Run("json.RawMessage is verbatim and structured", func(t *testing.T) {
+		t.Parallel()
+		content, structured, err := serializeBody(json.RawMessage(`{"a":1}`))
+		require.NoError(t, err)
+		assert.Equal(t, `{"a":1}`, content)
+		assert.True(t, structured)
+	})
+
+	t.Run("byte slice is verbatim and unstructured", func(t *testing.T) {
+		t.Parallel()
+		content, structured, err := serializeBody([]byte("raw-bytes"))
+		require.NoError(t, err)
+		assert.Equal(t, "raw-bytes", content)
+		assert.False(t, structured)
+	})
+
+	t.Run("unmarshalable value returns error", func(t *testing.T) {
+		t.Parallel()
+		content, structured, err := serializeBody(make(chan int))
+		require.Error(t, err)
+		assert.Empty(t, content)
+		assert.False(t, structured)
+	})
+}
+
+func TestHasContentType(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, hasContentType(map[string]any{"Content-Type": "application/json"}))
+	assert.True(t, hasContentType(map[string]any{"content-type": "text/plain"}))
+	assert.True(t, hasContentType(map[string]any{"CONTENT-TYPE": "x"}))
+	assert.False(t, hasContentType(map[string]any{"Authorization": "Bearer x"}))
+	assert.False(t, hasContentType(map[string]any{}))
+}
+
+func TestHTTPProvider_InputResolver_DoesNotMangleStructuredBody(t *testing.T) {
+	t.Parallel()
+
+	desc := NewHTTPProvider().Descriptor()
+	r := provider.NewInputResolver(context.Background(), desc.Schema, nil)
+
+	resolved, err := r.ResolveInputs(map[string]any{
+		"url":  "https://api.example.com",
+		"body": map[string]any{"query": "x"},
+	})
+	require.NoError(t, err)
+
+	// The union body schema must leave a structured body as a map (not coerce it
+	// into a Go "map[...]" string via fmt.Sprintf).
+	body, ok := resolved["body"].(map[string]any)
+	require.True(t, ok, "structured body should remain a map, got %T", resolved["body"])
+	assert.Equal(t, "x", body["query"])
 }
 
 func TestHTTPProvider_Execute_CustomHeaders(t *testing.T) {

--- a/tests/integration/solutions/providers/http/solution.yaml
+++ b/tests/integration/solutions/providers/http/solution.yaml
@@ -36,6 +36,32 @@ spec:
               headers:
                 Content-Type: application/json
 
+    postStructured:
+      description: POST an object body serialized to JSON with defaulted Content-Type
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/api/echo'"
+              method: POST
+              autoParseJson: true
+              body:
+                expr: '{"action": "create", "name": "test-item"}'
+
+    postStructuredArray:
+      description: POST an array body serialized to JSON
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url:
+                expr: "_.mockBaseUrl + '/api/echo'"
+              method: POST
+              autoParseJson: true
+              body:
+                expr: '["alpha", "beta", "gamma"]'
+
     notFoundEndpoint:
       description: GET request to non-existent endpoint
       resolve:
@@ -212,6 +238,26 @@ spec:
             message: "Echo response should contain the posted body content"
           - expression: __output.postData.body.contains("POST")
             message: "Echo response should contain the HTTP method"
+
+      post-structured-object-body:
+        description: Verify an object body is serialized to JSON with a defaulted Content-Type
+        extends: [_base]
+        assertions:
+          - expression: __output.postStructured.body.body.contains("\"action\":\"create\"")
+            message: "Object body should be serialized to compact JSON"
+          - expression: __output.postStructured.body.body.contains("\"name\":\"test-item\"")
+            message: "Serialized JSON should include all fields"
+          - expression: __output.postStructured.body.headers["Content-Type"] == "application/json"
+            message: "Content-Type should default to application/json for a structured body"
+
+      post-structured-array-body:
+        description: Verify an array body is serialized to JSON
+        extends: [_base]
+        assertions:
+          - expression: __output.postStructuredArray.body.body == "[\"alpha\",\"beta\",\"gamma\"]"
+            message: "Array body should be serialized to compact JSON"
+          - expression: __output.postStructuredArray.body.headers["Content-Type"] == "application/json"
+            message: "Content-Type should default to application/json for an array body"
 
       not-found-response:
         description: Verify 404 response from missing endpoint


### PR DESCRIPTION
- Accept object or array `body` inputs on the http provider and serialize them to compact JSON on the wire; string bodies are still sent verbatim
- Default Content-Type to application/json when a structured body is serialized and no Content-Type header is set
- Widen the body schema to accept string, object, and array types with an updated description and example
- Add http-structured-body.yaml example plus provider reference and README docs
- Cover serializeBody and hasContentType with unit tests and a benchmark