### PR TITLE
fix(plugin): resolve cached plugin versions across catalog registry layouts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oakwood-commons/scafctl
 
-go 1.26.4
+go 1.26.5
 
 require (
 	charm.land/bubbletea/v2 v2.0.8

--- a/pkg/plugin/cache.go
+++ b/pkg/plugin/cache.go
@@ -138,35 +138,8 @@ func (c *Cache) Get(name, version, platform, expectedDigest string, opts ...Cach
 	if c.managed != nil {
 		return c.getManaged(name, version, platform, expectedDigest, o.registryHash)
 	}
-	p := c.binaryPath(name, version, platform, o.registryHash)
-
-	info, err := os.Stat(p)
-	if err != nil || info.IsDir() {
-		// Migration fallback: check legacy path without .exe for existing Windows caches.
-		// Only attempt migration when the new path genuinely doesn't exist (not for
-		// permission errors or other transient failures).
-		if platformIsWindows(platform) && os.IsNotExist(err) {
-			legacy := c.legacyBinaryPath(name, version, platform, o.registryHash)
-			if li, lerr := os.Stat(legacy); lerr == nil && !li.IsDir() {
-				// Rename legacy binary to new .exe path for future lookups.
-				if mkErr := os.MkdirAll(filepath.Dir(p), 0o755); mkErr != nil {
-					return "", false
-				}
-				if os.Rename(legacy, p) == nil {
-					info = li
-				} else {
-					return "", false
-				}
-			} else {
-				return "", false
-			}
-		} else {
-			return "", false
-		}
-	}
-
-	// Verify executable permission (skip on Windows where permission bits are not meaningful)
-	if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
+	p, ok := c.statCachedBinary(name, version, platform, o.registryHash)
+	if !ok {
 		return "", false
 	}
 
@@ -184,6 +157,191 @@ func (c *Cache) Get(name, version, platform, expectedDigest string, opts ...Cach
 	return p, true
 }
 
+// versionDir identifies a cached version directory and the registry-hash
+// layout it belongs to. registryHash is empty for the flat (no-registry)
+// layout and non-empty for catalog-installed plugins nested under a hash.
+type versionDir struct {
+	version      string
+	registryHash string
+}
+
+// enumerateVersionDirs returns every cached version directory for a plugin
+// name in an unmanaged cache. When registryHash is non-empty, only that
+// registry's versions are returned. When empty, both the flat layout and every
+// registry-hash layout are scanned. A directory whose name matches
+// registryHashPattern is treated as a registry-hash layer; anything else is a
+// direct version directory.
+func (c *Cache) enumerateVersionDirs(name, registryHash string) []versionDir {
+	if registryHash != "" {
+		entries, err := os.ReadDir(filepath.Join(c.dir, name, registryHash))
+		if err != nil {
+			return nil
+		}
+		var dirs []versionDir
+		for _, e := range entries {
+			if e.IsDir() {
+				dirs = append(dirs, versionDir{version: e.Name(), registryHash: registryHash})
+			}
+		}
+		return dirs
+	}
+
+	entries, err := os.ReadDir(filepath.Join(c.dir, name))
+	if err != nil {
+		return nil
+	}
+	var dirs []versionDir
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		dirName := entry.Name()
+		if registryHashPattern.MatchString(dirName) {
+			// Registry-hash layer — scan its version subdirectories.
+			subEntries, err := os.ReadDir(filepath.Join(c.dir, name, dirName))
+			if err != nil {
+				continue
+			}
+			for _, se := range subEntries {
+				if se.IsDir() {
+					dirs = append(dirs, versionDir{version: se.Name(), registryHash: dirName})
+				}
+			}
+			continue
+		}
+		// Direct version directory (flat, no-registry layout).
+		dirs = append(dirs, versionDir{version: dirName, registryHash: ""})
+	}
+	return dirs
+}
+
+// statCachedBinary resolves and validates the on-disk binary for an exact
+// (name, version, platform, registryHash) tuple in an unmanaged cache. It
+// performs the Windows legacy-path migration and verifies the executable
+// permission bit, but does not perform digest verification. It returns the
+// resolved path and true when a usable binary exists.
+func (c *Cache) statCachedBinary(name, version, platform, registryHash string) (string, bool) {
+	p := c.binaryPath(name, version, platform, registryHash)
+
+	info, err := os.Stat(p)
+	if err != nil || info.IsDir() {
+		// Migration fallback: check legacy path without .exe for existing Windows caches.
+		// Only attempt migration when the new path genuinely doesn't exist (not for
+		// permission errors or other transient failures).
+		if !platformIsWindows(platform) || !os.IsNotExist(err) {
+			return "", false
+		}
+		legacy := c.legacyBinaryPath(name, version, platform, registryHash)
+		li, lerr := os.Stat(legacy)
+		if lerr != nil || li.IsDir() {
+			return "", false
+		}
+		// Rename legacy binary to new .exe path for future lookups.
+		if mkErr := os.MkdirAll(filepath.Dir(p), 0o755); mkErr != nil {
+			return "", false
+		}
+		if os.Rename(legacy, p) != nil {
+			return "", false
+		}
+		info = li
+	}
+
+	// Verify executable permission. Skip when the target platform is Windows
+	// (its binaries carry no Unix executable bit) or when the host OS is
+	// Windows (permission bits are not meaningful there). Using the target
+	// platform — not just the host — keeps cross-platform cache inspection
+	// (e.g. validating a windows/amd64 entry on a non-Windows host) correct.
+	if !platformIsWindows(platform) && runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
+		return "", false
+	}
+
+	return p, true
+}
+
+// ResolveVersion returns the on-disk path to a cached plugin binary for an
+// exact version, searching across both the flat (no-registry) cache layout and
+// every registry-hash layout. This lets callers that do not know a plugin's
+// catalog registry hash still resolve catalog-installed plugins, which live
+// under <name>/<registryHash>/<version>/... rather than the flat
+// <name>/<version>/... layout.
+//
+// When the same version resolves under multiple registry layouts with
+// differing binary contents, the result is ambiguous and an error is returned
+// rather than silently choosing one. Identical binaries (matching digests)
+// resolve to a single match.
+func (c *Cache) ResolveVersion(name, version, platform string) (string, bool, error) {
+	if c.managed != nil {
+		// The managed (API server) cache is keyed per registry namespace and
+		// does not support cross-registry enumeration; fall back to the flat
+		// lookup to preserve existing behavior.
+		path, ok := c.getManaged(name, version, platform, "", "")
+		return path, ok, nil
+	}
+
+	var matches []string
+	// Probe the flat (no-registry) layout directly plus every registry-hash
+	// layer present for this plugin. The flat layout is always probed so a
+	// version that happens to look like a registry hash (16 lowercase hex) is
+	// never misclassified as a registry layer and lost.
+	registryHashes := []string{""}
+	if entries, err := os.ReadDir(filepath.Join(c.dir, name)); err == nil {
+		for _, e := range entries {
+			if e.IsDir() && registryHashPattern.MatchString(e.Name()) {
+				registryHashes = append(registryHashes, e.Name())
+			}
+		}
+	}
+
+	seen := make(map[string]bool)
+	for _, rh := range registryHashes {
+		if p, ok := c.statCachedBinary(name, version, platform, rh); ok && !seen[p] {
+			seen[p] = true
+			matches = append(matches, p)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", false, nil
+	case 1:
+		return matches[0], true, nil
+	default:
+		identical, err := identicalDigests(matches)
+		if err != nil {
+			return "", false, err
+		}
+		if identical {
+			return matches[0], true, nil
+		}
+		return "", false, fmt.Errorf(
+			"cached plugin %q version %q resolves to %d differing binaries across catalog registries; remove the duplicate cache entries or reinstall from a single catalog",
+			name, version, len(matches),
+		)
+	}
+}
+
+// identicalDigests reports whether all files at the given paths share the same
+// sha256 digest. Fewer than two paths are trivially identical.
+func identicalDigests(paths []string) (bool, error) {
+	if len(paths) < 2 {
+		return true, nil
+	}
+	first, err := fileDigest(paths[0])
+	if err != nil {
+		return false, fmt.Errorf("digesting %s: %w", paths[0], err)
+	}
+	for _, p := range paths[1:] {
+		d, err := fileDigest(p)
+		if err != nil {
+			return false, fmt.Errorf("digesting %s: %w", p, err)
+		}
+		if d != first {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
 // GetLatestCached returns the path to the newest cached binary for the given
 // name and platform, regardless of version. When WithRegistryHash is provided,
 // only that registry's versions are searched. Otherwise, all versions across
@@ -195,79 +353,14 @@ func (c *Cache) GetLatestCached(name, platform string, opts ...CacheOption) (str
 		return c.getLatestCachedManaged(name, platform, o.registryHash)
 	}
 
-	// Collect version directories to scan.
-	type versionDir struct {
-		version      string
-		registryHash string
-	}
-	var versionDirs []versionDir
-
-	if o.registryHash != "" {
-		// Specific registry hash — scan only that subdir.
-		entries, err := os.ReadDir(filepath.Join(c.dir, name, o.registryHash))
-		if err == nil {
-			for _, e := range entries {
-				if e.IsDir() {
-					versionDirs = append(versionDirs, versionDir{version: e.Name(), registryHash: o.registryHash})
-				}
-			}
-		}
-	} else {
-		// No specific registry hash — scan <name>/ and distinguish hash dirs from version dirs.
-		entries, err := os.ReadDir(filepath.Join(c.dir, name))
-		if err != nil {
-			return "", "", false
-		}
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				continue
-			}
-			dirName := entry.Name()
-			if registryHashPattern.MatchString(dirName) {
-				// This is a registry hash dir — scan its version subdirs.
-				subEntries, err := os.ReadDir(filepath.Join(c.dir, name, dirName))
-				if err != nil {
-					continue
-				}
-				for _, se := range subEntries {
-					if se.IsDir() {
-						versionDirs = append(versionDirs, versionDir{version: se.Name(), registryHash: dirName})
-					}
-				}
-			} else {
-				// Not a hash — treat as a direct version dir (no-registry path).
-				versionDirs = append(versionDirs, versionDir{version: dirName, registryHash: ""})
-			}
-		}
-	}
+	versionDirs := c.enumerateVersionDirs(name, o.registryHash)
 
 	var bestSemver *semver.Version
 	var bestVersion string
 	var bestPath string
 	for _, vd := range versionDirs {
-		p := c.binaryPath(name, vd.version, platform, vd.registryHash)
-		info, err := os.Stat(p)
-		if err != nil || info.IsDir() {
-			if platformIsWindows(platform) && os.IsNotExist(err) {
-				legacy := c.legacyBinaryPath(name, vd.version, platform, vd.registryHash)
-				if li, lerr := os.Stat(legacy); lerr == nil && !li.IsDir() {
-					if mkErr := os.MkdirAll(filepath.Dir(p), 0o755); mkErr == nil {
-						if os.Rename(legacy, p) == nil {
-							info = li
-						} else {
-							continue
-						}
-					} else {
-						continue
-					}
-				} else {
-					continue
-				}
-			} else {
-				continue
-			}
-		}
-		if runtime.GOOS != "windows" && info.Mode()&0o111 == 0 {
+		p, ok := c.statCachedBinary(name, vd.version, platform, vd.registryHash)
+		if !ok {
 			continue
 		}
 		parsed, parseErr := semver.NewVersion(vd.version)

--- a/pkg/plugin/cache_test.go
+++ b/pkg/plugin/cache_test.go
@@ -658,3 +658,143 @@ func TestManagedCache_WarmUpNoOp(t *testing.T) {
 	err := cache.WarmUp()
 	assert.NoError(t, err)
 }
+
+// registryHashA/B are valid 16-hex registry-hash directory names used to
+// exercise the nested (catalog-installed) cache layout.
+const (
+	registryHashA = "0123456789abcdef"
+	registryHashB = "fedcba9876543210"
+)
+
+func TestCache_ResolveVersion_FlatLayout(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	name, version, platform := "flat-plugin", "1.2.3", "linux/amd64"
+
+	want, err := cache.Put(name, version, platform, []byte("flat-binary"))
+	require.NoError(t, err)
+
+	got, ok, err := cache.ResolveVersion(name, version, platform)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, want, got)
+}
+
+// TestCache_ResolveVersion_NestedLayout is the core #598 regression: a
+// catalog-installed plugin lives under <name>/<registryHash>/<version>/... and
+// must resolve even though the caller does not supply the registry hash. The
+// old Get(name, version, platform, "") lookup missed this.
+func TestCache_ResolveVersion_NestedLayout(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	name, version, platform := "catalog-plugin", "2.0.0", "linux/amd64"
+
+	want, err := cache.Put(name, version, platform, []byte("nested-binary"), WithRegistryHash(registryHashA))
+	require.NoError(t, err)
+
+	// The flat lookup must miss it (proves the layout difference).
+	_, ok := cache.Get(name, version, platform, "")
+	assert.False(t, ok, "flat Get should not find a nested plugin")
+
+	// ResolveVersion must find it across the registry-hash layout.
+	got, ok, err := cache.ResolveVersion(name, version, platform)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, want, got)
+}
+
+func TestCache_ResolveVersion_Missing(t *testing.T) {
+	cache := NewCache(t.TempDir())
+
+	got, ok, err := cache.ResolveVersion("nope", "9.9.9", "linux/amd64")
+	require.NoError(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, got)
+}
+
+// TestCache_ResolveVersion_HexLookingVersion guards against misclassifying a
+// flat cache entry whose version happens to look like a registry hash (16
+// lowercase hex). Such a version must still resolve from the flat layout
+// rather than being treated as a registry-hash directory.
+func TestCache_ResolveVersion_HexLookingVersion(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	name, platform := "hex-plugin", "linux/amd64"
+	version := "0123456789abcdef" // 16 lowercase hex, matches registryHashPattern
+
+	want, err := cache.Put(name, version, platform, []byte("hex-version-binary"))
+	require.NoError(t, err)
+
+	got, ok, err := cache.ResolveVersion(name, version, platform)
+	require.NoError(t, err)
+	assert.True(t, ok, "flat entry with a hash-looking version must resolve")
+	assert.Equal(t, want, got)
+}
+
+func TestCache_ResolveVersion_WrongPlatform(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	name, version := "plat-plugin", "1.0.0"
+
+	_, err := cache.Put(name, version, "linux/amd64", []byte("bin"), WithRegistryHash(registryHashA))
+	require.NoError(t, err)
+
+	_, ok, err := cache.ResolveVersion(name, version, "darwin/arm64")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// TestCache_ResolveVersion_WindowsTargetOnNonWindowsHost verifies that a
+// windows/amd64 cache entry resolves on a non-Windows host even though its
+// binary lacks the Unix executable bit — the exec-bit check must key off the
+// target platform, not the host GOOS.
+func TestCache_ResolveVersion_WindowsTargetOnNonWindowsHost(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("exercises non-Windows host handling of a windows target platform")
+	}
+	cache := NewCache(t.TempDir())
+	name, version, platform := "win-plugin", "1.0.0", "windows/amd64"
+
+	want, err := cache.Put(name, version, platform, []byte("MZ fake-windows-binary"))
+	require.NoError(t, err)
+
+	// Strip the executable bit to mimic a Windows binary stored on a Unix host.
+	require.NoError(t, os.Chmod(want, 0o644))
+
+	got, ok, err := cache.ResolveVersion(name, version, platform)
+	require.NoError(t, err)
+	assert.True(t, ok, "windows target binary must resolve despite missing Unix exec bit")
+	assert.Equal(t, want, got)
+}
+
+func TestCache_ResolveVersion_DuplicateIdenticalAcrossLayouts(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	name, version, platform := "dup-plugin", "1.0.0", "linux/amd64"
+	data := []byte("identical-binary")
+
+	_, err := cache.Put(name, version, platform, data)
+	require.NoError(t, err)
+	_, err = cache.Put(name, version, platform, data, WithRegistryHash(registryHashA))
+	require.NoError(t, err)
+
+	// Same content in two layouts is unambiguous — resolves without error.
+	got, ok, err := cache.ResolveVersion(name, version, platform)
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.NotEmpty(t, got)
+}
+
+func TestCache_ResolveVersion_AmbiguousDifferingContent(t *testing.T) {
+	cache := NewCache(t.TempDir())
+	name, version, platform := "ambiguous-plugin", "1.0.0", "linux/amd64"
+
+	_, err := cache.Put(name, version, platform, []byte("binary-from-registry-a"), WithRegistryHash(registryHashA))
+	require.NoError(t, err)
+	_, err = cache.Put(name, version, platform, []byte("binary-from-registry-b"), WithRegistryHash(registryHashB))
+	require.NoError(t, err)
+
+	// Two registries hold the same version with different content — ambiguous.
+	got, ok, err := cache.ResolveVersion(name, version, platform)
+	require.Error(t, err)
+	assert.False(t, ok)
+	assert.Empty(t, got)
+	assert.Contains(t, err.Error(), "differing binaries")
+	// The message must point at an action the user can actually take.
+	assert.Contains(t, err.Error(), "remove the duplicate cache entries")
+}

--- a/pkg/plugin/fetcher.go
+++ b/pkg/plugin/fetcher.go
@@ -818,7 +818,13 @@ func RegisterCachedPlugin(ctx context.Context, name string, registry *provider.R
 func RegisterCachedPluginVersion(ctx context.Context, name, version string, registry *provider.Registry, cfg *ProviderConfig, cacheDir string, clientOpts ...ClientOption) ([]*Client, error) {
 	cache := NewCache(cacheDir)
 	platform := CurrentPlatform()
-	path, ok := cache.Get(name, version, platform, "")
+	// ResolveVersion searches both the flat (no-registry) layout and every
+	// registry-hash layout so catalog-installed plugins are found even when the
+	// caller does not know the plugin's catalog registry hash.
+	path, ok, err := cache.ResolveVersion(name, version, platform)
+	if err != nil {
+		return nil, fmt.Errorf("resolving cached plugin %q version %q: %w", name, version, err)
+	}
 	if !ok {
 		return nil, fmt.Errorf("plugin %q version %q not found in cache (platform: %s)", name, version, platform)
 	}

--- a/pkg/plugin/fetcher_test.go
+++ b/pkg/plugin/fetcher_test.go
@@ -783,6 +783,28 @@ func TestRegisterCachedPluginVersion_WrongVersion(t *testing.T) {
 	assert.Nil(t, clients)
 }
 
+// TestRegisterCachedPluginVersion_AmbiguousRegistries verifies the ambiguity
+// error from cache.ResolveVersion is surfaced to the caller when the same
+// version exists under multiple catalog registries with differing content.
+func TestRegisterCachedPluginVersion_AmbiguousRegistries(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	reg := provider.NewRegistry()
+
+	cacheDir := t.TempDir()
+	cache := NewCache(cacheDir)
+	platform := CurrentPlatform()
+	_, err := cache.Put("test-plugin", "1.0.0", platform, []byte("#!/bin/sh\nexit 0"), WithRegistryHash("0123456789abcdef"))
+	require.NoError(t, err)
+	_, err = cache.Put("test-plugin", "1.0.0", platform, []byte("#!/bin/sh\nexit 1"), WithRegistryHash("fedcba9876543210"))
+	require.NoError(t, err)
+
+	clients, err := RegisterCachedPluginVersion(ctx, "test-plugin", "1.0.0", reg, nil, cacheDir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "differing binaries")
+	assert.Nil(t, clients)
+}
+
 func TestPluginCacheName(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Catalog-installed plugins are stored under a nested <name>/<registryHash>/<version>/... cache layout, but `run provider --plugin-version` looked them up only in the flat <name>/<version>/... layout, so a plugin installed from a catalog was reported as "not found in cache".

- Add Cache.ResolveVersion to resolve an exact version across both the flat (no-registry) and every registry-hash layout
- Detect cross-registry ambiguity: identical binaries resolve to one match, differing binaries return an actionable error
- Rewire RegisterCachedPluginVersion off the catalog-blind Get lookup onto ResolveVersion, wrapping resolution errors with plugin context
- Extract shared statCachedBinary and enumerateVersionDirs helpers and refactor Get and GetLatestCached onto them (no behavior change)

Closes #598

## Build toolchain

This PR also bumps the `go` directive in `go.mod` to `1.26.5` to clear the CI
**govulncheck** failure. go1.26.4 triggers two standard-library advisories --
`GO-2026-5856` (crypto/tls) and `GO-2026-4970` (os) -- both fixed in go1.26.5.

A `toolchain go1.26.5` directive alone is not viable here: several CI jobs run
with `GOTOOLCHAIN=local` (e.g. CodeQL Analyze, Plugin SDK Compatibility) and
cannot download a newer toolchain. Bumping the `go` directive makes
`actions/setup-go` (via `go-version-file: go.mod`) install 1.26.5 across all
jobs, which both satisfies `GOTOOLCHAIN=local` and provides the patched stdlib.
