### PR TITLE
feat(provider): add per-entry data to go-template render-tree for fan-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🚀 Features
 
+- *(provider)* Add optional per-entry `data` map to the go-template `render-tree` operation, shallow-merged over the shared `data` (per-entry values win), enabling single-resolver fan-out where one template renders once per item with its own variables and output path
 - *(auth)* [**breaking**] Drop the legacy OAuth token-metadata compatibility shim when bumping scafctl-plugin-sdk to v0.11.0. Credentials persisted by earlier versions (which carried fields such as `refreshTokenExpiresAt` / `loginFlow`) no longer deserialize, so a one-time re-login is required after upgrading.
 - *(state)* Add `saveOverrides` field to state backend for save-time-only input resolution, enabling patterns like loading from `main` and saving to a resolver-derived feature branch
 - *(lint)* Add `resolver-cycle` rule (error) to detect circular dependencies in the resolver dependency graph

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -1517,6 +1517,7 @@ Result:
 - `write-tree` writes them to disk preserving directory structure
 - `outputPath` is a Go template for transforming output paths (variables: `__filePath`, `__fileName`, `__fileStem`, `__fileExtension`, `__fileDir`)
 - Use `expr: '_.resolver.entries'` to feed directory provider results into render-tree
+- Each entry may carry an optional `data` map, shallow-merged over the shared `data` (per-entry values win), so you can render one template per item with its own variables and output path in a single resolver
 
 For a complete walkthrough with advanced patterns, see the
 [Template Directory Rendering]({{< relref "template-directory-rendering" >}}) tutorial.

--- a/docs/tutorials/provider-output-shapes.md
+++ b/docs/tutorials/provider-output-shapes.md
@@ -213,7 +213,7 @@ Returns rendered template output. For `render-tree`, returns an array of rendere
 | Capability | Fields | Type | Description |
 |-----------|--------|------|-------------|
 | transform (`render`) | `<rendered text>` | string | Template output as string |
-| transform (`render-tree`) | `[{path, content}]` | array | Array of rendered file entries. Each entry has `path` (string) and `content` (string). |
+| transform (`render-tree`) | `[{path, content}]` | array | Array of rendered file entries. Each entry has `path` (string) and `content` (string). Input entries may include an optional `data` map (shallow-merged over the shared `data`) for per-entry fan-out. |
 
 ### `hcl`
 Varies by operation — parse returns structured data, format/validate return strings.

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -1164,7 +1164,7 @@ Transform data using Go text/template syntax. Supports single-template rendering
 | `operation` | string | ❌ | Operation: `render` (default) or `render-tree` |
 | `template` | string | ❌ | Go template content (required for `render`) |
 | `name` | string | ❌ | Template name for error messages (defaults to `"render-tree"` for render-tree) |
-| `entries` | array | ❌ | Array of `{path, content}` objects to render (required for `render-tree`) |
+| `entries` | array | ❌ | Array of `{path, content, data?}` objects to render (required for `render-tree`). Each entry may include an optional `data` map, shallow-merged over the shared `data` for that entry only. |
 | `missingKey` | string | ❌ | Behavior for missing keys: `default`, `zero`, `error` |
 | `leftDelim` | string | ❌ | Left delimiter (default: `{{`) |
 | `rightDelim` | string | ❌ | Right delimiter (default: `}}`) |
@@ -1178,6 +1178,36 @@ Transform data using Go text/template syntax. Supports single-template rendering
 **`render-tree` operation:** Returns an array of `{path, content}` objects where
 each `content` is the rendered result. Metadata includes `templateName` and
 `entryCount`.
+
+#### Per-entry data (fan-out)
+
+Each entry may carry an optional `data` map that is shallow-merged over the
+shared top-level `data` for that entry only. On key conflicts, per-entry values
+win over shared `data`, iteration variables, and resolver context. This enables
+fan-out -- one template rendered once per item, each with its own variables and
+output path -- in a single resolver, without a separate `forEach` render step
+or a manual index-zip:
+
+```yaml
+resolve:
+  with:
+    - provider: go-template
+      inputs:
+        operation: render-tree
+        data:
+          platformAppName: my-app        # shared default (merge base)
+        entries:
+          expr: |
+            _.environments.map(env, {
+              "path":    "envs/" + env.name + "/backend.tf",
+              "content": _.backendTemplate.entries[0].content,
+              "data":    {"environment": env}   # per-entry, wins over shared
+            })
+```
+
+Entries without a `data` field render against the shared `data` alone, so
+existing `render-tree` usage is unaffected. A non-map `data` value fails with a
+clear error naming the entry index and path.
 
 ### Ignored Blocks
 

--- a/docs/tutorials/template-directory-rendering.md
+++ b/docs/tutorials/template-directory-rendering.md
@@ -138,6 +138,39 @@ resolvers:
 The output is an array of `{path, content}` where each `content` is now the
 **rendered** result. The `path` is passed through unchanged from the input.
 
+### Per-entry data (fan-out)
+
+Each entry may carry an optional `data` map that is shallow-merged over the
+shared top-level `data` for that entry only. On key conflicts, per-entry values
+win over shared `data`, iteration variables, and resolver context. This turns
+the common "render one template per item, each with its own variables and its
+own output path" pattern into a single resolver -- no separate `forEach` render
+resolver and no manual index-zip:
+
+```yaml
+resolvers:
+  backendConfigs:
+    type: any
+    resolve:
+      with:
+        - provider: go-template
+          inputs:
+            operation: render-tree
+            data:
+              platformAppName: myapp      # shared default (merge base)
+            entries:
+              expr: |
+                _.environments.map(env, {
+                  "path":    "envs/" + env.name + "/backend.tf",
+                  "content": _.backendTemplate.entries[0].content,
+                  "data":    {"environment": env}   # per-entry, wins over shared
+                })
+```
+
+Entries without a `data` field render against the shared `data` alone, so
+existing `render-tree` usage is unaffected. A non-map `data` value fails with a
+clear error naming the entry index and path.
+
 ### Using a Separate Vars Resolver
 
 For cleaner solutions, define variables in their own resolver and reference them:

--- a/examples/solutions/template-fanout/README.md
+++ b/examples/solutions/template-fanout/README.md
@@ -1,0 +1,67 @@
+# Template Fan-Out Example (per-entry data)
+
+Demonstrates rendering a single shared template **once per collection item**,
+each with its own variables and its own output path, in a single `render-tree`
+resolver. This replaces the older "separate `forEach` render resolver plus a
+manual index-zip" pattern.
+
+## What It Does
+
+1. **Lists** the environments to generate config for (`environments` resolver)
+2. **Defines** one shared Terraform backend template (`backendTemplate` resolver)
+3. **Fans out** with `go-template` `render-tree`: builds one entry per
+   environment, each carrying its own `data` (the environment), shallow-merged
+   over the shared `data`
+4. **Writes** one `backend.tf` per environment under `./output/` using `file`
+   `write-tree`, preserving each entry's declared path
+
+## How Per-Entry Data Works
+
+Each entry may include an optional `data` map. It is shallow-merged over the
+shared top-level `data` for that entry only. On key conflicts, per-entry values
+win over shared `data`, iteration variables, and resolver context. Entries
+without a `data` field render against the shared `data` alone, so existing
+`render-tree` usage is unaffected.
+
+```yaml
+entries:
+  expr: |
+    _.environments.map(env, {
+      "path":    "envs/" + env.name + "/backend.tf",
+      "content": _.backendTemplate.entries[0].content,
+      "data":    {"environment": env}   # per-entry, wins over shared data
+    })
+```
+
+## Running
+
+```bash
+scafctl run solution -f examples/solutions/template-fanout/solution.yaml
+```
+
+## Output
+
+After running, the `./output/` directory will contain one file per environment:
+
+```
+output/
+└── envs/
+    ├── dev/
+    │   └── backend.tf
+    ├── staging/
+    │   └── backend.tf
+    └── prod/
+        └── backend.tf
+```
+
+Each `backend.tf` is rendered from the same template but with its own
+environment values (bucket, region, prefix) plus the shared `platformAppName`.
+
+## Key Concepts
+
+| Step | Provider | Operation | Purpose |
+|------|----------|-----------|---------|
+| 1 | `static` | -- | Collection to fan out over |
+| 2 | `static` | -- | Single shared template content |
+| 3 | `go-template` | `render-tree` | One entry per item, each with per-entry `data` |
+| 4 | `file` | `write-tree` | Write results preserving each entry's path |

--- a/examples/solutions/template-fanout/solution.yaml
+++ b/examples/solutions/template-fanout/solution.yaml
@@ -1,0 +1,98 @@
+# Run: scafctl run solution -f examples/solutions/template-fanout/solution.yaml
+#
+# After running: find ./output -type f && cat ./output/envs/dev/backend.tf
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: template-fanout
+  displayName: Template Fan-Out (per-entry data)
+  category: solutions
+  tags:
+    - solution
+    - template
+    - fan-out
+  description: |
+    Render a single shared template once per collection item, each with its own
+    variables and output path, in a single render-tree resolver. Per-entry
+    `data` is shallow-merged over the shared `data` and wins on key conflicts.
+
+spec:
+  resolvers:
+    # -------------------------------------------------------------------------
+    # The collection to fan out over. One rendered file is produced per item.
+    # -------------------------------------------------------------------------
+    environments:
+      description: Environments to generate a backend config for
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - name: dev
+                  bucket: tfstate-dev
+                  region: us-east1
+                - name: staging
+                  bucket: tfstate-staging
+                  region: us-east1
+                - name: prod
+                  bucket: tfstate-prod
+                  region: us-central1
+
+    # -------------------------------------------------------------------------
+    # Read the single shared template file. Its content is reused for every
+    # entry in the fan-out below.
+    # -------------------------------------------------------------------------
+    backendTemplate:
+      description: Read the shared Terraform backend template from disk
+      type: any
+      resolve:
+        with:
+          - provider: directory
+            inputs:
+              operation: list
+              path: templates
+              recursive: true
+              filterGlob: "*.tpl"
+              includeContent: true
+
+    # -------------------------------------------------------------------------
+    # Fan-out: build one entry per environment. Each entry carries its own
+    # `data` (the environment), shallow-merged over the shared `data`.
+    # -------------------------------------------------------------------------
+    rendered:
+      description: One rendered backend config per environment, each with its own path
+      type: any
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              operation: render-tree
+              # Shared data: merge base for every entry.
+              data:
+                platformAppName: myapp
+              # Per-entry entries: path + shared content + per-entry data.
+              entries:
+                expr: |
+                  _.environments.map(env, {
+                    "path":    "envs/" + env.name + "/backend.tf",
+                    "content": _.backendTemplate.entries[0].content,
+                    "data":    {"environment": env}
+                  })
+
+  # ===========================================================================
+  # ACTIONS: Write the fanned-out files to disk, preserving each entry's path.
+  # ===========================================================================
+  workflow:
+    actions:
+      write-rendered-files:
+        description: >
+          Write one backend.tf per environment under ./output/envs/<name>/,
+          preserving the path each entry declared in render-tree.
+        provider: file
+        inputs:
+          operation: write-tree
+          basePath: ./output
+          entries:
+            rslvr: rendered

--- a/examples/solutions/template-fanout/templates/backend.tf.tpl
+++ b/examples/solutions/template-fanout/templates/backend.tf.tpl
@@ -1,0 +1,9 @@
+# {{ .platformAppName }} - {{ .environment.name }} backend
+terraform {
+  backend "gcs" {
+    bucket = "{{ .environment.bucket }}"
+    prefix = "{{ .platformAppName }}/{{ .environment.name }}"
+  }
+}
+
+# Region: {{ .environment.region }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oakwood-commons/scafctl
 
-go 1.26.4
+go 1.26.5
 
 require (
 	charm.land/bubbletea/v2 v2.0.8

--- a/pkg/provider/builtin/gotmplprovider/gotmpl.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl.go
@@ -136,13 +136,15 @@ func NewGoTemplateProvider() *GoTemplateProvider {
 					)),
 					schemahelper.WithMaxItems(20),
 				),
-				"entries": schemahelper.ArrayProp("Array of file entry objects to render (required for 'render-tree' operation). Each entry must have 'path' (string) and 'content' (string) fields. Typically produced by the directory provider with includeContent: true.",
+				"entries": schemahelper.ArrayProp("Array of file entry objects to render (required for 'render-tree' operation). Each entry must have a 'path' (string) field; 'content' (string) is optional -- entries without string content (e.g., binary files or directories) are skipped with a warning. Each entry may also include an optional 'data' (map) field. Typically produced by the directory provider with includeContent: true.",
 					schemahelper.WithItems(schemahelper.ObjectProp(
-						"A file entry with path and content to render as a Go template",
-						[]string{"path", "content"},
+						"A file entry with a required path and optional content to render as a Go template, plus optional per-entry data. Entries without string content are skipped.",
+						[]string{"path"},
 						map[string]*jsonschema.Schema{
 							"path":    schemahelper.StringProp("Relative file path (preserved in output for downstream use)"),
-							"content": schemahelper.StringProp("File content to render as a Go template"),
+							"content": schemahelper.StringProp("File content to render as a Go template. Optional: entries without string content are skipped with a warning."),
+							"data": schemahelper.ObjectProp("Optional per-entry data map, shallow-merged over the shared top-level 'data' for this entry only. On key conflicts, per-entry values win over shared data, iteration variables, and resolver context. Enables fan-out: one template rendered per entry, each with its own variables and output path, without a separate forEach render resolver.",
+								nil, nil, schemahelper.WithAdditionalProperties(schemahelper.AnyProp("Per-entry data value of any type"))),
 						},
 					))),
 			}),
@@ -309,6 +311,23 @@ inputs:
     appName: my-app
     namespace: production
     replicas: 3`,
+				},
+				{
+					Name:        "Fan-out with per-entry data",
+					Description: "Render one template per collection item, each with its own variables and output path, in a single resolver. Per-entry 'data' is shallow-merged over the shared 'data' and wins on conflicts. Feeds the file provider's write-tree operation unchanged.",
+					YAML: `name: backend-configs
+provider: go-template
+inputs:
+  operation: render-tree
+  data:
+    platformAppName: my-app
+  entries:
+    expr: |
+      _.environments.map(env, {
+        "path":    "envs/" + env.name + "/backend.tf",
+        "content": _.backendTemplate.entries[0].content,
+        "data":    {"environment": env}
+      })`,
 				},
 			},
 		},
@@ -537,9 +556,20 @@ func (p *GoTemplateProvider) executeRenderTree(ctx context.Context, inputs map[s
 			continue
 		}
 
-		// Build per-entry template data: base data + entry content is the template
+		// Build per-entry template data: base data + per-entry data overrides.
 		templateData := make(map[string]any, len(baseData))
 		maps.Copy(templateData, baseData)
+
+		// Merge optional per-entry data (shallow: top-level keys win over shared
+		// data, iteration variables, and resolver context). baseData is left
+		// untouched so entries never leak values into one another.
+		if entryDataRaw, present := entry["data"]; present && entryDataRaw != nil {
+			entryData, ok := entryDataRaw.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("%s: entries[%d].data must be a map when present, got %T (path %q)", ProviderName, i, entryDataRaw, entryPath)
+			}
+			maps.Copy(templateData, entryData)
+		}
 
 		// Build ignored block replacements for this entry's content
 		replacements := buildIgnoredBlockReplacements(entryContent, ignoredBlocksCfg)

--- a/pkg/provider/builtin/gotmplprovider/gotmpl_benchmark_test.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl_benchmark_test.go
@@ -75,3 +75,71 @@ func BenchmarkGoTemplateProvider_Execute_DryRun(b *testing.B) {
 		_, _ = p.Execute(ctx, inputs)
 	}
 }
+
+func BenchmarkGoTemplateProvider_RenderTree(b *testing.B) {
+	p := NewGoTemplateProvider()
+	ctx := provider.WithResolverContext(context.Background(), map[string]any{})
+
+	b.Run("shared_data_only", func(b *testing.B) {
+		inputs := map[string]any{
+			"operation": "render-tree",
+			"name":      "shared-data-tree",
+			"entries": []any{
+				map[string]any{
+					"path":    "envs/dev/backend.tf",
+					"content": "app = {{ .platformAppName }}",
+				},
+				map[string]any{
+					"path":    "envs/staging/backend.tf",
+					"content": "app = {{ .platformAppName }}",
+				},
+				map[string]any{
+					"path":    "envs/prod/backend.tf",
+					"content": "app = {{ .platformAppName }}",
+				},
+			},
+			"data": map[string]any{
+				"platformAppName": "my-app",
+			},
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_, _ = p.Execute(ctx, inputs)
+		}
+	})
+
+	b.Run("per_entry_data_fanout", func(b *testing.B) {
+		inputs := map[string]any{
+			"operation": "render-tree",
+			"name":      "fanout-tree",
+			"entries": []any{
+				map[string]any{
+					"path":    "envs/dev/backend.tf",
+					"content": "app = {{ .platformAppName }}\nenv = {{ .environment }}",
+					"data":    map[string]any{"environment": "dev"},
+				},
+				map[string]any{
+					"path":    "envs/staging/backend.tf",
+					"content": "app = {{ .platformAppName }}\nenv = {{ .environment }}",
+					"data":    map[string]any{"environment": "staging"},
+				},
+				map[string]any{
+					"path":    "envs/prod/backend.tf",
+					"content": "app = {{ .platformAppName }}\nenv = {{ .environment }}",
+					"data":    map[string]any{"platformAppName": "prod-app", "environment": "prod"},
+				},
+			},
+			"data": map[string]any{
+				"platformAppName": "my-app",
+			},
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_, _ = p.Execute(ctx, inputs)
+		}
+	})
+}

--- a/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
@@ -1238,6 +1238,169 @@ func TestGoTemplateProvider_RenderTree_DataOverridesResolverContext(t *testing.T
 	assert.Equal(t, "environment: production", results[0]["content"])
 }
 
+func TestGoTemplateProvider_RenderTree_PerEntryDataFanOut(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	// A single shared template rendered once per entry, each with its own data
+	// and its own output path -- the fan-out use case.
+	inputs := map[string]any{
+		"operation": "render-tree",
+		"name":      "fan-out",
+		"data": map[string]any{
+			"shared": "S",
+		},
+		"entries": []any{
+			map[string]any{
+				"path":    "envs/dev/backend.tf",
+				"content": "env={{ .env }} shared={{ .shared }}",
+				"data":    map[string]any{"env": "dev"},
+			},
+			map[string]any{
+				"path":    "envs/prod/backend.tf",
+				"content": "env={{ .env }} shared={{ .shared }}",
+				"data":    map[string]any{"env": "prod"},
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	results, ok := output.Data.([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, results, 2)
+
+	assert.Equal(t, "envs/dev/backend.tf", results[0]["path"])
+	assert.Equal(t, "env=dev shared=S", results[0]["content"])
+
+	assert.Equal(t, "envs/prod/backend.tf", results[1]["path"])
+	assert.Equal(t, "env=prod shared=S", results[1]["content"])
+}
+
+func TestGoTemplateProvider_RenderTree_PerEntryDataOverridesShared(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "render-tree",
+		"name":      "entry-override",
+		"data": map[string]any{
+			"env": "FALLBACK",
+		},
+		"entries": []any{
+			map[string]any{
+				"path":    "a.txt",
+				"content": "env={{ .env }}",
+				"data":    map[string]any{"env": "dev"},
+			},
+			map[string]any{
+				// No per-entry data: falls back to shared data.
+				"path":    "b.txt",
+				"content": "env={{ .env }}",
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	results, ok := output.Data.([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, results, 2)
+	assert.Equal(t, "env=dev", results[0]["content"])
+	assert.Equal(t, "env=FALLBACK", results[1]["content"])
+}
+
+func TestGoTemplateProvider_RenderTree_PerEntryDataOverridesResolverContext(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	ctx = provider.WithResolverContext(ctx, map[string]any{
+		"env": "staging",
+	})
+
+	inputs := map[string]any{
+		"operation": "render-tree",
+		"name":      "entry-over-resolver",
+		"entries": []any{
+			map[string]any{
+				"path":    "config.yaml",
+				"content": "environment: {{ .env }}",
+				"data":    map[string]any{"env": "production"},
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	results, ok := output.Data.([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, results, 1)
+	assert.Equal(t, "environment: production", results[0]["content"])
+}
+
+func TestGoTemplateProvider_RenderTree_PerEntryDataDoesNotLeakBetweenEntries(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	// The first entry sets a key via per-entry data; the second entry (with no
+	// per-entry data) must not see it -- baseData must remain untouched.
+	inputs := map[string]any{
+		"operation":  "render-tree",
+		"name":       "no-leak",
+		"missingKey": "zero",
+		"entries": []any{
+			map[string]any{
+				"path":    "first.txt",
+				"content": "value={{ .only }}",
+				"data":    map[string]any{"only": "first"},
+			},
+			map[string]any{
+				"path":    "second.txt",
+				"content": "value={{ .only }}",
+			},
+		},
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+
+	results, ok := output.Data.([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, results, 2)
+	assert.Equal(t, "value=first", results[0]["content"])
+	// Second entry never received the first entry's "only" key.
+	assert.NotContains(t, results[1]["content"], "first")
+}
+
+func TestGoTemplateProvider_RenderTree_PerEntryDataInvalidType(t *testing.T) {
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"operation": "render-tree",
+		"name":      "bad-data",
+		"entries": []any{
+			map[string]any{
+				"path":    "ok.txt",
+				"content": "hello",
+			},
+			map[string]any{
+				"path":    "bad.txt",
+				"content": "{{ .x }}",
+				"data":    "not-a-map",
+			},
+		},
+	}
+
+	_, err := p.Execute(ctx, inputs)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "entries[1].data must be a map")
+	assert.Contains(t, err.Error(), "bad.txt")
+}
+
 func TestGoTemplateProvider_RenderTree_DryRun(t *testing.T) {
 	p := NewGoTemplateProvider()
 	ctx := context.Background()

--- a/tests/integration/solutions/template-directory/solution.yaml
+++ b/tests/integration/solutions/template-directory/solution.yaml
@@ -49,6 +49,38 @@ spec:
               data:
                 rslvr: vars
 
+    # Per-entry data fan-out: one shared template rendered once per item, each
+    # with its own `data` (shallow-merged over the shared `data`, per-entry wins)
+    # and its own output path -- all in a single render-tree resolver.
+    fanout:
+      type: any
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              operation: render-tree
+              # Shared data acts as the merge base for every entry.
+              data:
+                platformAppName: shared-app
+              entries:
+                expr: |
+                  [
+                    {
+                      "path":    "envs/dev/backend.tf",
+                      "content": "app={{ .platformAppName }} env={{ .environment }}",
+                      "data":    {"environment": "dev"}
+                    },
+                    {
+                      "path":    "envs/prod/backend.tf",
+                      "content": "app={{ .platformAppName }} env={{ .environment }}",
+                      "data":    {"platformAppName": "prod-app", "environment": "prod"}
+                    },
+                    {
+                      "path":    "envs/none/backend.tf",
+                      "content": "app={{ .platformAppName }}"
+                    }
+                  ]
+
   workflow:
     actions:
       write-output:
@@ -60,6 +92,15 @@ spec:
             rslvr: rendered
           outputPath: >-
             {{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}
+
+      # Write the per-entry fan-out output, preserving each entry's own path.
+      write-fanout:
+        provider: file
+        inputs:
+          operation: write-tree
+          basePath: $OUTPUT_DIR
+          entries:
+            rslvr: fanout
 
   testing:
     config:
@@ -92,3 +133,24 @@ spec:
             message: "Expected 4 rendered entries"
           - expression: '__output.rendered.exists(e, e.content.contains("test-app"))'
             message: "Rendered content should contain the appName variable"
+
+      fanout-per-entry-data:
+        description: Verify per-entry data fan-out merges over and overrides shared data
+        extends: [_base]
+        command: [run, resolver, fanout]
+        assertions:
+          - expression: size(__output.fanout) == 3
+            message: "Expected 3 fanned-out entries"
+          # Entry 0: per-entry data supplies `environment`; `platformAppName`
+          # falls through from the shared data.
+          - expression: '__output.fanout[0].content == "app=shared-app env=dev"'
+            message: "dev entry should merge shared platformAppName with per-entry environment"
+          # Entry 1: per-entry data overrides the shared `platformAppName`.
+          - expression: '__output.fanout[1].content == "app=prod-app env=prod"'
+            message: "prod entry per-entry data should win over shared data"
+          # Entry 2: no per-entry data -- renders against shared data alone.
+          - expression: '__output.fanout[2].content == "app=shared-app"'
+            message: "entry without per-entry data should use shared data unchanged"
+          - expression: '__output.fanout[0].path == "envs/dev/backend.tf"'
+            message: "each entry keeps its own declared output path"
+


### PR DESCRIPTION
- Accept an optional \data\ map on each \
ender-tree\ entry, shallow- merged over the shared top-level \data\ (per-entry keys win over shared data, iteration variables, and resolver context)
- Leave shared \aseData\ untouched so entries never leak values into one another; validate that per-entry \data\ is a map when present
- Enable single-resolver fan-out: one template rendered once per item, each with its own variables and output path, feeding the file provider's write-tree unchanged
- Widen the entries schema with the optional \data\ field and add a fan-out usage example to the provider descriptor
- Add unit tests, a render-tree benchmark, an integration solution and test case, and docs/examples covering the fan-out pattern