### PR TITLE
feat(kube): add cluster commands, login flags, and host dir funcs

### DIFF
--- a/.github/skills/cel-patterns/SKILL.md
+++ b/.github/skills/cel-patterns/SKILL.md
@@ -141,6 +141,20 @@ filepath.join("path", "to", "file")        // Join segments
 guid.new()                                 // UUID v4
 ```
 
+### Host paths (`pkg/celexp/ext/host/`)
+
+```cel
+host.configDir()                           // Resolved config dir (branding-aware)
+hostConfigDir()                            // Portable alias; matches the Go template function
+host.configDir() + "/config.d/x.yaml"      // Build a config.d drop-in path
+```
+
+`host.configDir()` returns the host's resolved XDG config directory via
+`paths.ConfigDir()`, so it honors `paths.SetAppName` (a `cldctl` embedder gets
+`~/.config/cldctl`, not a hardcoded `scafctl` path). It is also registered under
+the dotless alias `hostConfigDir()` so the same name works in Go templates
+(`{{ hostConfigDir }}`).
+
 ### Map (`pkg/celexp/ext/map/`)
 
 ```cel

--- a/examples/auth/kube-login.md
+++ b/examples/auth/kube-login.md
@@ -65,9 +65,14 @@ Common flags:
 - `--server`: API server URL when no resolver is configured.
 - `--audience`: OIDC audience the minted token must target.
 - `--profile`: auth profile baked into the exec args (for example `work`).
+- `--namespace`, `-n`: default namespace set on the written context.
 - `--current`: set the new context as the current context.
 - `--verify`: confirm the authenticated identity via a post-login whoami
   (requires the kubeconfig provider).
+- `--refresh`: re-apply the resolved cluster details (CA bundle, server,
+  namespace) to an existing entry without a fresh interactive login when a valid
+  token is already cached. Falls back to a normal login when no valid token
+  exists.
 - `--kubeconfig`: target kubeconfig file (defaults to `KUBECONFIG` or
   `~/.kube/config`).
 
@@ -78,6 +83,30 @@ After login, `kubectl` reuses the scafctl-managed identity automatically:
 ```bash
 kubectl --context prod get pods
 ```
+
+## Discover and Inspect
+
+List the clusters your resolver knows about (static aliases plus dynamic
+inventory). scafctl ships no cluster data of its own, so an unconfigured resolver
+lists nothing:
+
+```bash
+scafctl kube list
+scafctl kube list -o json
+```
+
+Inspect the current kubeconfig context -- its cluster, server, namespace, and
+whether scafctl manages the entry. For a scafctl-managed context it also runs a
+best-effort whoami to report the authenticated identity, degrading gracefully
+when the provider or a token is unavailable. It reads the kubeconfig directly, so
+the static view works offline:
+
+```bash
+scafctl kube status
+scafctl kube status -o json
+```
+
+Cluster names complete on `<TAB>` for `kube login` and `kube logout`.
 
 ## Configure Cluster Resolution
 
@@ -134,6 +163,14 @@ while removing only the kubeconfig entry:
 
 ```bash
 scafctl kube logout prod --keep-credentials
+```
+
+Remove every scafctl-managed kubeconfig entry at once (for example to clean up a
+fleet). This removes only the entries scafctl wrote; it leaves handler
+credentials in place so a bulk cleanup never signs you out of every handler:
+
+```bash
+scafctl kube logout --all
 ```
 
 ## Scripting

--- a/pkg/celexp/ext/ext.go
+++ b/pkg/celexp/ext/ext.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/celexp/ext/debug"
 	"github.com/oakwood-commons/scafctl/pkg/celexp/ext/filepath"
 	"github.com/oakwood-commons/scafctl/pkg/celexp/ext/guid"
+	"github.com/oakwood-commons/scafctl/pkg/celexp/ext/host"
 	celmap "github.com/oakwood-commons/scafctl/pkg/celexp/ext/map"
 	"github.com/oakwood-commons/scafctl/pkg/celexp/ext/marshalling"
 	"github.com/oakwood-commons/scafctl/pkg/celexp/ext/out"
@@ -726,6 +727,9 @@ func Custom() celexp.ExtFunctionList {
 
 		// GUID functions
 		guid.NewFunc(),
+
+		// Host path functions (branding-aware config dir)
+		host.ConfigDirFunc(),
 
 		// Map functions
 		celmap.AddFunc(),

--- a/pkg/celexp/ext/host/host.go
+++ b/pkg/celexp/ext/host/host.go
@@ -1,0 +1,63 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package host provides CEL extension functions that expose the host's resolved
+// XDG configuration directory to in-process resolver expressions. The path
+// honors paths.SetAppName, so a solution that references it stays
+// branding-correct on any embedder instead of hardcoding ~/.config/scafctl.
+package host
+
+import (
+	"strings"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
+)
+
+// ConfigDirFunc returns the host's resolved configuration directory. It is
+// registered under two names: the namespaced, CEL-idiomatic host.configDir()
+// and the portable hostConfigDir() that matches the Go template function name,
+// so the same identifier works in resolver expressions and templates alike.
+func ConfigDirFunc() celexp.ExtFunction {
+	const dotted = "host.configDir"
+	const portable = "hostConfigDir"
+	binding := cel.FunctionBinding(func(_ ...ref.Val) ref.Val {
+		return types.String(paths.ConfigDir())
+	})
+	return celexp.ExtFunction{
+		Name:          dotted,
+		Signature:     "host.configDir() -> string",
+		Description:   "Returns the host's resolved configuration directory (branding-aware, honors the embedder's app name). Use host.configDir() (or the portable alias hostConfigDir(), which matches the Go template function) to build paths under the config dir without hardcoding a branded path",
+		FunctionNames: []string{dotted, portable},
+		Custom:        true,
+		Examples: []celexp.Example{
+			{
+				Description: "Build a config.d drop-in path",
+				Expression:  `host.configDir() + "/config.d/clusters.yaml"`,
+			},
+			{
+				Description: "Portable alias matching the Go template function name",
+				Expression:  `hostConfigDir() + "/config.d/clusters.yaml"`,
+			},
+		},
+		EnvOptions: []cel.EnvOption{
+			cel.Function(dotted,
+				cel.Overload(strings.ReplaceAll(dotted, ".", "_"),
+					[]*cel.Type{},
+					cel.StringType,
+					binding,
+				),
+			),
+			cel.Function(portable,
+				cel.Overload(portable,
+					[]*cel.Type{},
+					cel.StringType,
+					binding,
+				),
+			),
+		},
+	}
+}

--- a/pkg/celexp/ext/host/host_benchmark_test.go
+++ b/pkg/celexp/ext/host/host_benchmark_test.go
@@ -1,0 +1,48 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package host
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+)
+
+func BenchmarkConfigDirFunc_CEL(b *testing.B) {
+	fn := ConfigDirFunc()
+	env, err := cel.NewEnv(fn.EnvOptions...)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.Run("namespaced", func(b *testing.B) {
+		ast, iss := env.Compile(`host.configDir()`)
+		if iss.Err() != nil {
+			b.Fatal(iss.Err())
+		}
+		prg, err := env.Program(ast)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ReportAllocs()
+		for b.Loop() {
+			_, _, _ = prg.Eval(cel.NoVars())
+		}
+	})
+
+	b.Run("portable_alias", func(b *testing.B) {
+		ast, iss := env.Compile(`hostConfigDir()`)
+		if iss.Err() != nil {
+			b.Fatal(iss.Err())
+		}
+		prg, err := env.Program(ast)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ReportAllocs()
+		for b.Loop() {
+			_, _, _ = prg.Eval(cel.NoVars())
+		}
+	})
+}

--- a/pkg/celexp/ext/host/host_test.go
+++ b/pkg/celexp/ext/host/host_test.go
@@ -1,0 +1,42 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package host
+
+import (
+	"testing"
+
+	"github.com/google/cel-go/cel"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/paths"
+)
+
+func TestConfigDirFunc_Metadata(t *testing.T) {
+	fn := ConfigDirFunc()
+	assert.Equal(t, "host.configDir", fn.Name)
+	assert.True(t, fn.Custom)
+	assert.NotEmpty(t, fn.EnvOptions)
+	assert.NotEmpty(t, fn.Examples)
+	// Registered under both the namespaced and portable (template-matching) name.
+	assert.Contains(t, fn.FunctionNames, "host.configDir")
+	assert.Contains(t, fn.FunctionNames, "hostConfigDir")
+}
+
+func TestConfigDirFunc_CELIntegration(t *testing.T) {
+	fn := ConfigDirFunc()
+	env, err := cel.NewEnv(fn.EnvOptions...)
+	require.NoError(t, err)
+
+	// Both the namespaced and the portable alias must evaluate identically.
+	for _, expr := range []string{`host.configDir()`, `hostConfigDir()`} {
+		ast, iss := env.Compile(expr)
+		require.NoError(t, iss.Err(), expr)
+		prg, err := env.Program(ast)
+		require.NoError(t, err, expr)
+		out, _, err := prg.Eval(map[string]any{})
+		require.NoError(t, err, expr)
+		assert.Equal(t, paths.ConfigDir(), out.Value(), expr)
+	}
+}

--- a/pkg/cmd/scafctl/kube/kube.go
+++ b/pkg/cmd/scafctl/kube/kube.go
@@ -31,6 +31,8 @@ func CommandKube(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 			write a kubeconfig entry.
 			Use 'scafctl kube logout <cluster>' to remove the entry and optionally
 			revoke the handler's cached credentials.
+			Use 'scafctl kube list' to see clusters the resolver knows about, and
+			'scafctl kube status' to inspect the current kubeconfig context.
 		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
 	}
@@ -38,6 +40,8 @@ func CommandKube(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
 	cmd.AddCommand(CommandLogin(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(CommandLogout(cliParams, ioStreams, cmdPath))
+	cmd.AddCommand(CommandList(cliParams, ioStreams, cmdPath))
+	cmd.AddCommand(CommandStatus(cliParams, ioStreams, cmdPath))
 
 	return cmd
 }

--- a/pkg/cmd/scafctl/kube/kube_test.go
+++ b/pkg/cmd/scafctl/kube/kube_test.go
@@ -28,6 +28,8 @@ func TestCommandKube(t *testing.T) {
 	}
 	assert.True(t, sub["login"], "kube must expose the login subcommand")
 	assert.True(t, sub["logout"], "kube must expose the logout subcommand")
+	assert.True(t, sub["list"], "kube must expose the list subcommand")
+	assert.True(t, sub["status"], "kube must expose the status subcommand")
 }
 
 func TestCommandKube_LongHelpUsesBinaryName(t *testing.T) {

--- a/pkg/cmd/scafctl/kube/list.go
+++ b/pkg/cmd/scafctl/kube/list.go
@@ -1,0 +1,103 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	kubeapi "github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	skvx "github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// CommandList creates the 'kube list' subcommand.
+func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	var outputFlags flags.KvxOutputFlags
+	outputFlags.AppName = cliParams.BinaryName
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Aliases: []string{"ls"},
+		Short:   "List clusters known to the configured cluster resolver",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			List the clusters the configured cluster resolver can resolve by name.
+
+			The list combines static cluster aliases with any dynamic inventory the
+			resolver exposes. scafctl ships no cluster data of its own: when no
+			resolver is configured the list is empty and an informative message is
+			printed.
+
+			Examples:
+			  # List known clusters
+			  scafctl kube list
+
+			  # Machine-readable output
+			  scafctl kube list -o json
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			w := writer.FromContext(ctx)
+			if w == nil {
+				return fmt.Errorf("writer not initialized in context")
+			}
+
+			resolver := kubeapi.ResolverFromContext(ctx)
+
+			opts := flags.ToKvxOutputOptions(&outputFlags,
+				skvx.WithIOStreams(ioStreams),
+				skvx.WithOutputColumnOrder([]string{"name", "server", "authType", "console"}),
+			)
+
+			if resolver == nil {
+				// No resolver: still emit a valid empty list for structured
+				// formats so machine-readable mode is never broken. Human formats
+				// get an informative note on stderr, keyed off the binary name.
+				if skvx.IsStructuredFormat(opts.Format) {
+					return opts.Write([]map[string]any{})
+				}
+				w.PlainStderrf("No cluster resolver configured; %s ships no cluster data.", cliParams.BinaryName)
+				return nil
+			}
+
+			// List is best-effort: a partial result plus an error (for example a
+			// reachable static-alias set with an unavailable dynamic inventory)
+			// still renders the clusters that resolved, with a warning.
+			clusters, err := resolver.List(ctx)
+			if err != nil {
+				w.WarnStderrf("cluster listing was incomplete: %v", err)
+			}
+
+			rows := make([]map[string]any, 0, len(clusters))
+			for _, c := range clusters {
+				rows = append(rows, map[string]any{
+					"name":     c.Name,
+					"server":   c.APIServerURL,
+					"authType": string(c.AuthType),
+					"console":  c.ConsoleURL,
+				})
+			}
+
+			if skvx.IsStructuredFormat(opts.Format) {
+				return opts.Write(rows)
+			}
+
+			if len(rows) == 0 {
+				w.Infof("No clusters found.")
+				return nil
+			}
+			return opts.Write(rows)
+		},
+	}
+
+	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
+	return cmd
+}

--- a/pkg/cmd/scafctl/kube/list_test.go
+++ b/pkg/cmd/scafctl/kube/list_test.go
@@ -1,0 +1,74 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	kubeapi "github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+)
+
+func TestCommandList_NoResolver(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+
+	cmd := CommandList(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, cmd, ctx))
+	// Diagnostic keyed off the embedder binary name, not the "scafctl" brand.
+	assert.Contains(t, buf.String(), "No cluster resolver configured")
+	assert.Contains(t, buf.String(), "mycli ships no cluster data")
+	assert.NotContains(t, buf.String(), "scafctl ships no cluster data")
+}
+
+func TestCommandList_NoResolverStructuredEmitsEmptyList(t *testing.T) {
+	t.Parallel()
+	ctx, _ := newTestContext(t)
+	var out bytes.Buffer
+
+	// With no resolver, structured output must still be a valid empty list on
+	// stdout -- never the human diagnostic (which belongs on stderr).
+	cmd := CommandList(embedderParams(), terminal.NewIOStreams(nil, &out, &out, false), "mycli")
+	require.NoError(t, runCmd(t, cmd, ctx, "-o", "json"))
+	assert.Equal(t, "[]", strings.TrimSpace(out.String()))
+	assert.NotContains(t, out.String(), "No cluster resolver")
+}
+
+func TestCommandList_RendersClusters(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	resolver := &kubeapi.MockResolver{ListResult: []kubeapi.ClusterInfo{
+		{Name: "prod", APIServerURL: "https://api.prod.example.com:6443", AuthType: kubeapi.AuthTypeOIDC, ConsoleURL: "https://console.prod"},
+		{Name: "lab", APIServerURL: "https://api.lab.example.com:6443"},
+	}}
+	ctx = kubeapi.WithResolver(ctx, resolver)
+
+	cmd := CommandList(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, cmd, ctx, "-o", "json"))
+	out := buf.String()
+	assert.Contains(t, out, "prod")
+	assert.Contains(t, out, "lab")
+	assert.Contains(t, out, "https://api.prod.example.com:6443")
+}
+
+func TestCommandList_EmptyResolver(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx = kubeapi.WithResolver(ctx, &kubeapi.MockResolver{})
+
+	cmd := CommandList(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, cmd, ctx))
+	assert.Contains(t, buf.String(), "No clusters found")
+}
+
+func TestCommandList_HasAlias(t *testing.T) {
+	t.Parallel()
+	cmd := CommandList(embedderParams(), terminal.NewIOStreams(nil, nil, nil, false), "mycli")
+	assert.Contains(t, cmd.Aliases, "ls")
+}

--- a/pkg/cmd/scafctl/kube/login.go
+++ b/pkg/cmd/scafctl/kube/login.go
@@ -38,11 +38,13 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 		clusterName    string
 		contextName    string
 		userName       string
+		namespace      string
 		kubeconfigPath string
 		profile        string
 		setCurrent     bool
 		insecure       bool
 		verify         bool
+		refresh        bool
 		timeout        time.Duration
 		outputFlags    flags.KvxOutputFlags
 	)
@@ -92,8 +94,10 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				cluster = args[0]
 			}
 
+			mgr := kubeconfig.NewManager(cliParams.BinaryName)
+			defer func() { _ = mgr.Close() }()
 			deps := kubelogin.Deps{
-				Kubeconfig: kubeconfig.NewManager(cliParams.BinaryName),
+				Kubeconfig: mgr,
 				Resolver:   kubeapi.ResolverFromContext(ctx),
 				BinaryName: cliParams.BinaryName,
 				HandlerLookup: func(ctx context.Context, name string) (kubelogin.Authenticator, error) {
@@ -120,11 +124,13 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				ClusterName:       clusterName,
 				ContextName:       contextName,
 				UserName:          userName,
+				Namespace:         namespace,
 				KubeconfigPath:    kubeconfigPath,
 				Profile:           profile,
 				SetCurrentContext: setCurrent,
 				InsecureSkipTLS:   insecure,
 				Verify:            verify,
+				Refresh:           refresh,
 				Timeout:           timeout,
 			}
 
@@ -158,11 +164,13 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 	cmd.Flags().StringVar(&clusterName, "cluster-name", "", "kubeconfig cluster entry name (defaults to the cluster)")
 	cmd.Flags().StringVar(&contextName, "context", "", "kubeconfig context name (defaults to the cluster name)")
 	cmd.Flags().StringVar(&userName, "user", "", "kubeconfig user entry name (defaults to the cluster name)")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Default namespace set on the written context (overrides the resolved cluster)")
 	cmd.Flags().StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the kubeconfig file (defaults to KUBECONFIG or ~/.kube/config)")
 	cmd.Flags().StringVar(&profile, "profile", "", "Auth profile baked into the exec credential args")
 	cmd.Flags().BoolVar(&setCurrent, "current", false, "Set the new context as the current context")
 	cmd.Flags().BoolVar(&insecure, "insecure-skip-tls-verify", false, "Disable API server TLS verification (development only)")
 	cmd.Flags().BoolVar(&verify, "verify", false, "Verify the authenticated identity via a post-login whoami (requires the kubeconfig provider)")
+	cmd.Flags().BoolVar(&refresh, "refresh", false, "Re-apply resolved cluster details (CA, server, namespace) without a fresh interactive login when a valid token is cached")
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "Login timeout (e.g. 5m); zero uses the handler default")
 	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
 

--- a/pkg/cmd/scafctl/kube/login_test.go
+++ b/pkg/cmd/scafctl/kube/login_test.go
@@ -6,8 +6,10 @@ package kube
 import (
 	"bytes"
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -206,6 +208,53 @@ func TestCommandLogin_VerifyFailsWithoutProvider(t *testing.T) {
 	require.Error(t, err)
 	assert.FileExists(t, path, "kubeconfig entry is written even when verification fails")
 	assert.Contains(t, buf.String(), "was written", "user is told the entry was written despite the verify failure")
+}
+
+func TestCommandLogin_NamespaceWrittenToContext(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx, mock := withMockHandler(t, ctx)
+	mock.GetTokenResult = &auth.Token{AccessToken: "tok"}
+
+	path := filepath.Join(t.TempDir(), "config")
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(embedderParams(), ioStreams, "mycli")
+	err := runCmd(t, cmd, ctx, "prod",
+		"--handler", "oidc",
+		"--server", "https://api.example.com:6443",
+		"--kubeconfig", path,
+		"--namespace", "team-a",
+	)
+	require.NoError(t, err)
+
+	data, readErr := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, readErr)
+	assert.Contains(t, string(data), "namespace: team-a",
+		"--namespace must be written to the kubeconfig context (static fallback path)")
+}
+
+func TestCommandLogin_RefreshSkipsLoginWithValidToken(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx, mock := withMockHandler(t, ctx)
+	// A valid, non-expired cached token lets --refresh re-apply cluster details
+	// without a fresh interactive login.
+	mock.GetTokenResult = &auth.Token{AccessToken: "tok", ExpiresAt: time.Now().Add(time.Hour)}
+
+	path := filepath.Join(t.TempDir(), "config")
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(embedderParams(), ioStreams, "mycli")
+	err := runCmd(t, cmd, ctx, "prod",
+		"--handler", "oidc",
+		"--server", "https://api.example.com:6443",
+		"--kubeconfig", path,
+		"--refresh",
+	)
+	require.NoError(t, err)
+	assert.Empty(t, mock.LoginCalls, "refresh with a valid cached token must skip interactive login")
+	assert.FileExists(t, path)
 }
 
 func TestLoginTUIEligibleFormat(t *testing.T) {

--- a/pkg/cmd/scafctl/kube/logout.go
+++ b/pkg/cmd/scafctl/kube/logout.go
@@ -32,6 +32,7 @@ func CommandLogout(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 		userName        string
 		kubeconfigPath  string
 		keepCredentials bool
+		all             bool
 		outputFlags     flags.KvxOutputFlags
 	)
 	outputFlags.AppName = cliParams.BinaryName
@@ -74,14 +75,32 @@ func CommandLogout(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 				cluster = args[0]
 			}
 
+			mgr := kubeconfig.NewManager(cliParams.BinaryName)
+			defer func() { _ = mgr.Close() }()
 			deps := kubelogin.Deps{
-				Kubeconfig: kubeconfig.NewManager(cliParams.BinaryName),
+				Kubeconfig: mgr,
 				Resolver:   kubeapi.ResolverFromContext(ctx),
 				BinaryName: cliParams.BinaryName,
 				HandlerLookup: func(ctx context.Context, name string) (kubelogin.Authenticator, error) {
 					return auth.GetHandler(ctx, name)
 				},
 			}
+
+			if all {
+				if cluster != "" {
+					w.Errorf("--all cannot be combined with a cluster argument")
+					return exitcode.WithCode(fmt.Errorf("--all cannot be combined with a cluster argument"), exitcode.InvalidInput)
+				}
+				res, err := kubelogin.LogoutAll(ctx, deps, kubelogin.LogoutAllRequest{
+					KubeconfigPath: kubeconfigPath,
+				})
+				if err != nil {
+					w.Errorf("%v", err)
+					return exitcode.WithCode(err, exitcode.GeneralError)
+				}
+				return renderLogoutAllResult(ioStreams, &outputFlags, w, cliParams.BinaryName, res)
+			}
+
 			if handlerName != "" {
 				handler, err := auth.GetHandler(ctx, handlerName)
 				if err != nil {
@@ -127,6 +146,7 @@ func CommandLogout(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 	cmd.Flags().StringVar(&userName, "user", "", "kubeconfig user entry name (defaults to the cluster name)")
 	cmd.Flags().StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the kubeconfig file (defaults to KUBECONFIG or ~/.kube/config)")
 	cmd.Flags().BoolVar(&keepCredentials, "keep-credentials", false, "Leave the handler's cached credentials in place")
+	cmd.Flags().BoolVar(&all, "all", false, fmt.Sprintf("Remove every %s-managed kubeconfig entry (credentials are left in place)", cliParams.BinaryName))
 	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
 
 	return cmd
@@ -154,7 +174,42 @@ func renderLogoutResult(ioStreams *terminal.IOStreams, outputFlags *flags.KvxOut
 		w.Infof("No matching kubeconfig entry found")
 	}
 	if res.UsedFallback {
-		w.Warningf("kubeconfig provider unavailable; edited the kubeconfig directly")
+		w.WarnStderrf("kubeconfig provider unavailable; edited the kubeconfig directly")
 	}
 	return nil
+}
+
+// renderLogoutAllResult writes the outcome of a "logout --all" as structured
+// output or a human summary. binaryName keys the human strings so embedder CLIs
+// never leak the default brand.
+func renderLogoutAllResult(ioStreams *terminal.IOStreams, outputFlags *flags.KvxOutputFlags, w *writer.Writer, binaryName string, res *kubelogin.LogoutAllResult) error {
+	rows := make([]map[string]any, 0, len(res.Removed))
+	for _, ctxName := range res.Removed {
+		rows = append(rows, map[string]any{"context": ctxName, "removed": true})
+	}
+	opts := flags.ToKvxOutputOptions(outputFlags,
+		skvx.WithIOStreams(ioStreams),
+		skvx.WithOutputColumnOrder([]string{"context", "removed"}),
+	)
+	if skvx.IsStructuredFormat(opts.Format) {
+		return opts.Write(rows)
+	}
+
+	if len(res.Removed) == 0 {
+		w.Infof("No %s-managed kubeconfig entries found", binaryName)
+	} else {
+		w.Successf("Removed %d %s-managed kubeconfig entr%s", len(res.Removed), binaryName, plural(len(res.Removed)))
+	}
+	if res.UsedFallback {
+		w.WarnStderrf("kubeconfig provider unavailable; edited the kubeconfig directly")
+	}
+	return nil
+}
+
+// plural returns the pluralizing suffix for count "entry"/"entries".
+func plural(n int) string {
+	if n == 1 {
+		return "y"
+	}
+	return "ies"
 }

--- a/pkg/cmd/scafctl/kube/logout_all_test.go
+++ b/pkg/cmd/scafctl/kube/logout_all_test.go
@@ -1,0 +1,154 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+)
+
+// writeLogoutAllKubeconfig writes a fixture with one managed context (prod) for
+// binaryName and one foreign context (staging).
+func writeLogoutAllKubeconfig(t *testing.T, binaryName string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	content := `apiVersion: v1
+kind: Config
+current-context: prod
+clusters:
+  - name: prod
+    cluster:
+      server: https://api.prod.example.com:6443
+  - name: staging
+    cluster:
+      server: https://api.staging.example.com:6443
+contexts:
+  - name: prod
+    context:
+      cluster: prod
+      user: prod
+  - name: staging
+    context:
+      cluster: staging
+      user: staging
+users:
+  - name: prod
+    user:
+      exec:
+        command: ` + binaryName + `
+        args:
+          - auth
+          - token
+          - oidc
+  - name: staging
+    user:
+      token: static
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestCommandLogout_AllRemovesManagedEntries(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	path := writeLogoutAllKubeconfig(t, "mycli")
+
+	// No official registry in context: the kubeconfig provider is unavailable,
+	// so LogoutAll takes the static-fallback removal path.
+	cmd := CommandLogout(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, cmd, ctx, "--all", "--kubeconfig", path))
+
+	// Output is branding-safe: it uses the embedder binary name, not "scafctl".
+	assert.Contains(t, buf.String(), "Removed 1 mycli-managed")
+	assert.NotContains(t, buf.String(), "scafctl-managed")
+
+	data, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	// The managed prod entry is gone; the foreign staging entry remains.
+	assert.NotContains(t, string(data), "api.prod.example.com")
+	assert.Contains(t, string(data), "staging")
+}
+
+func TestCommandLogout_AllRejectsClusterArg(t *testing.T) {
+	t.Parallel()
+	ctx, _ := newTestContext(t)
+
+	cmd := CommandLogout(embedderParams(), terminal.NewIOStreams(nil, nil, nil, false), "mycli")
+	err := runCmd(t, cmd, ctx, "--all", "prod")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--all cannot be combined with a cluster argument")
+}
+
+func TestCommandLogout_AllRemovesMultipleEntries(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+
+	// Two managed contexts exercise the pluralized summary ("entries").
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	content := `apiVersion: v1
+kind: Config
+clusters:
+  - name: prod
+    cluster:
+      server: https://api.prod.example.com:6443
+  - name: dev
+    cluster:
+      server: https://api.dev.example.com:6443
+contexts:
+  - name: prod
+    context:
+      cluster: prod
+      user: prod
+  - name: dev
+    context:
+      cluster: dev
+      user: dev
+users:
+  - name: prod
+    user:
+      exec:
+        command: mycli
+        args: [auth, token, oidc]
+  - name: dev
+    user:
+      exec:
+        command: mycli
+        args: [auth, token, oidc]
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	cmd := CommandLogout(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, cmd, ctx, "--all", "--kubeconfig", path))
+
+	out := buf.String()
+	assert.Contains(t, out, "Removed 2 mycli-managed")
+	assert.Contains(t, out, "entries")
+	assert.NotContains(t, out, "scafctl-managed")
+
+	data, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "api.prod.example.com")
+	assert.NotContains(t, string(data), "api.dev.example.com")
+}
+
+func TestCommandLogout_AllNoManagedEntries(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	require.NoError(t, os.WriteFile(path, []byte("apiVersion: v1\nkind: Config\n"), 0o600))
+
+	cmd := CommandLogout(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, cmd, ctx, "--all", "--kubeconfig", path))
+	assert.Contains(t, buf.String(), "No mycli-managed kubeconfig entries found")
+}

--- a/pkg/cmd/scafctl/kube/status.go
+++ b/pkg/cmd/scafctl/kube/status.go
@@ -1,0 +1,117 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	kubelogin "github.com/oakwood-commons/scafctl/pkg/kube/login"
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	skvx "github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// CommandStatus creates the 'kube status' subcommand.
+func CommandStatus(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	var (
+		kubeconfigPath string
+		outputFlags    flags.KvxOutputFlags
+	)
+	outputFlags.AppName = cliParams.BinaryName
+
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show the current kubeconfig context and cluster",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Show the current kubeconfig context: its cluster, server, namespace, and
+			whether scafctl manages the entry (i.e. it was written by "kube login").
+
+			For a scafctl-managed context, the command also runs a best-effort whoami
+			to report the authenticated user, using the handler baked into the entry
+			and the kubeconfig provider. That step degrades gracefully: when the
+			provider or a valid token is unavailable, the static context data is still
+			shown. The static view never contacts the cluster and works offline.
+
+			Examples:
+			  # Show the current context
+			  scafctl kube status
+
+			  # Machine-readable output
+			  scafctl kube status -o json
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			w := writer.FromContext(ctx)
+			if w == nil {
+				return fmt.Errorf("writer not initialized in context")
+			}
+
+			mgr := kubeconfig.NewManager(cliParams.BinaryName)
+			defer func() { _ = mgr.Close() }()
+			deps := kubelogin.Deps{
+				Kubeconfig: mgr,
+				BinaryName: cliParams.BinaryName,
+				HandlerLookup: func(ctx context.Context, name string) (kubelogin.Authenticator, error) {
+					return auth.GetHandler(ctx, name)
+				},
+			}
+			st, err := kubelogin.Status(ctx, deps, kubeconfigPath)
+			if err != nil {
+				w.Errorf("%v", err)
+				return err
+			}
+
+			opts := flags.ToKvxOutputOptions(&outputFlags,
+				skvx.WithIOStreams(ioStreams),
+				skvx.WithOutputColumnOrder([]string{"context", "cluster", "server", "namespace", "userEntry", "managed", "identity", "groups"}),
+			)
+
+			if st.Context == "" {
+				if skvx.IsStructuredFormat(opts.Format) {
+					return opts.Write(map[string]any{})
+				}
+				w.Infof("No current kubeconfig context is set.")
+				return nil
+			}
+
+			// "userEntry" is the kubeconfig user entry name; "identity" is the
+			// authenticated subject from the best-effort whoami. They are distinct.
+			// A single object renders as an aligned key/value view in the default
+			// format and as a structured object under -o json/yaml. Optional
+			// fields are omitted when empty so the view stays clean.
+			row := map[string]any{
+				"context": st.Context,
+				"managed": st.Managed,
+			}
+			addIfSet := func(key, val string) {
+				if val != "" {
+					row[key] = val
+				}
+			}
+			addIfSet("cluster", st.Cluster)
+			addIfSet("server", st.Server)
+			addIfSet("namespace", st.Namespace)
+			addIfSet("userEntry", st.User)
+			addIfSet("identity", st.Username)
+			if len(st.Groups) > 0 {
+				row["groups"] = st.Groups
+			}
+			return opts.Write(row)
+		},
+	}
+
+	cmd.Flags().StringVar(&kubeconfigPath, "kubeconfig", "", "Path to the kubeconfig file (defaults to KUBECONFIG or ~/.kube/config)")
+	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
+	return cmd
+}

--- a/pkg/cmd/scafctl/kube/status_test.go
+++ b/pkg/cmd/scafctl/kube/status_test.go
@@ -1,0 +1,91 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+)
+
+// writeStatusKubeconfig writes a kubeconfig fixture whose current-context (prod)
+// is a scafctl-managed exec-credential entry for binaryName.
+func writeStatusKubeconfig(t *testing.T, binaryName string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	content := `apiVersion: v1
+kind: Config
+current-context: prod
+clusters:
+  - name: prod
+    cluster:
+      server: https://api.prod.example.com:6443
+contexts:
+  - name: prod
+    context:
+      cluster: prod
+      user: prod
+      namespace: team-a
+users:
+  - name: prod
+    user:
+      exec:
+        command: ` + binaryName + `
+        args:
+          - auth
+          - token
+          - oidc
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestCommandStatus_ShowsCurrentContext(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	path := writeStatusKubeconfig(t, "mycli")
+
+	cmd := CommandStatus(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, cmd, ctx, "--kubeconfig", path))
+	out := buf.String()
+	assert.Contains(t, out, "prod")
+	assert.Contains(t, out, "https://api.prod.example.com:6443")
+	assert.Contains(t, out, "team-a")
+}
+
+func TestCommandStatus_JSONReportsManaged(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	path := writeStatusKubeconfig(t, "mycli")
+
+	cmd := CommandStatus(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, cmd, ctx, "--kubeconfig", path, "-o", "json"))
+	out := buf.String()
+	assert.Contains(t, out, "\"managed\"")
+	assert.Contains(t, out, "true")
+	// A single status object (not an array) is emitted, and empty optional
+	// fields (identity/groups, absent without a successful whoami) are omitted.
+	assert.True(t, strings.HasPrefix(strings.TrimSpace(out), "{"), "status JSON must be a single object")
+	assert.NotContains(t, out, "\"identity\"")
+	assert.NotContains(t, out, "\"groups\"")
+}
+
+func TestCommandStatus_NoCurrentContext(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	require.NoError(t, os.WriteFile(path, []byte("apiVersion: v1\nkind: Config\n"), 0o600))
+
+	cmd := CommandStatus(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, cmd, ctx, "--kubeconfig", path))
+	assert.Contains(t, buf.String(), "No current kubeconfig context")
+}

--- a/pkg/gotmpl/ext/ext.go
+++ b/pkg/gotmpl/ext/ext.go
@@ -18,6 +18,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl/ext/collections"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl/ext/dns"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl/ext/hcl"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl/ext/host"
 	extyaml "github.com/oakwood-commons/scafctl/pkg/gotmpl/ext/yaml"
 )
 
@@ -77,6 +78,9 @@ func Custom() gotmpl.ExtFunctionList {
 		// DNS / slugify functions
 		dns.SlugifyFunc(),
 		dns.ToDNSStringFunc(),
+
+		// Host path functions (branding-aware config dir)
+		host.ConfigDirFunc(),
 
 		// Collection / list-filtering functions
 		collections.WhereFunc(),

--- a/pkg/gotmpl/ext/host/host.go
+++ b/pkg/gotmpl/ext/host/host.go
@@ -1,0 +1,40 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package host provides Go template extension functions that expose the host's
+// resolved XDG configuration directory. The path honors paths.SetAppName, so a
+// solution that writes under it stays branding-correct on any embedder instead
+// of hardcoding ~/.config/scafctl.
+package host
+
+import (
+	"text/template"
+
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	"github.com/oakwood-commons/scafctl/pkg/paths"
+)
+
+// ConfigDirFunc returns an ExtFunction that yields the host's resolved
+// configuration directory.
+//
+// Example usage in a Go template:
+//
+//	{{ hostConfigDir }}/config.d/clusters.yaml
+func ConfigDirFunc() gotmpl.ExtFunction {
+	return gotmpl.ExtFunction{
+		Name: "hostConfigDir",
+		Description: "Returns the host's resolved configuration directory (branding-aware, honors the embedder's app name). " +
+			"Use it to write config.d drop-ins without hardcoding a branded path. " +
+			"The same name is callable in CEL resolver expressions as hostConfigDir() (aliased to host.configDir()).",
+		Custom: true,
+		Examples: []gotmpl.Example{
+			{
+				Description: "Build a config.d drop-in path",
+				Template:    `{{ hostConfigDir }}/config.d/clusters.yaml`,
+			},
+		},
+		Func: template.FuncMap{
+			"hostConfigDir": paths.ConfigDir,
+		},
+	}
+}

--- a/pkg/gotmpl/ext/host/host_benchmark_test.go
+++ b/pkg/gotmpl/ext/host/host_benchmark_test.go
@@ -1,0 +1,29 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package host
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+)
+
+func BenchmarkHostConfigDir_Template(b *testing.B) {
+	funcs := template.FuncMap{}
+	for k, v := range ConfigDirFunc().Func {
+		funcs[k] = v
+	}
+	tmpl, err := template.New("bench").Funcs(funcs).Parse(`{{ hostConfigDir }}/config.d/x.yaml`)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		var sb strings.Builder
+		if err := tmpl.Execute(&sb, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/gotmpl/ext/host/host_test.go
+++ b/pkg/gotmpl/ext/host/host_test.go
@@ -1,0 +1,36 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package host
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/paths"
+)
+
+func TestConfigDirFunc_Metadata(t *testing.T) {
+	fn := ConfigDirFunc()
+	assert.Equal(t, "hostConfigDir", fn.Name)
+	assert.True(t, fn.Custom)
+	assert.NotEmpty(t, fn.Examples)
+	assert.Contains(t, fn.Func, "hostConfigDir")
+}
+
+func TestHostFuncs_RenderInTemplate(t *testing.T) {
+	funcs := template.FuncMap{}
+	for k, v := range ConfigDirFunc().Func {
+		funcs[k] = v
+	}
+
+	tmpl, err := template.New("t").Funcs(funcs).Parse(`{{ hostConfigDir }}/config.d/x.yaml`)
+	require.NoError(t, err)
+	var sb strings.Builder
+	require.NoError(t, tmpl.Execute(&sb, nil))
+	assert.Equal(t, paths.ConfigDir()+"/config.d/x.yaml", sb.String())
+}

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -82,6 +82,10 @@ type ClusterInfo struct {
 	// registry so users can run "login <cluster>" without naming a handler.
 	DefaultHandler string `json:"defaultHandler,omitempty" yaml:"defaultHandler,omitempty" doc:"Auth handler used when no explicit handler is supplied" maxLength:"253" example:"entra"`
 
+	// Namespace is the default namespace written to the kubeconfig context for
+	// this cluster. Optional; the caller's --namespace flag overrides it.
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty" doc:"Default namespace written to the kubeconfig context; overridden by --namespace" maxLength:"253" example:"prod"`
+
 	// CAData is the PEM-encoded cluster certificate authority bundle. When set,
 	// login pins the API server to this CA instead of falling back to
 	// InsecureSkipTLS. Embedders supply it from their cluster registry.

--- a/pkg/kube/login/fallback.go
+++ b/pkg/kube/login/fallback.go
@@ -55,10 +55,14 @@ func writeStaticKubeconfig(in kubeconfig.WriteInput) (kubeconfig.WriteResult, er
 
 	cfg[keyClusters] = upsertNamed(toAnySlice(cfg[keyClusters]), clusterName, "cluster", clusterValue(in))
 	cfg[keyUsers] = upsertNamed(toAnySlice(cfg[keyUsers]), userName, "user", userValue(in))
-	cfg[keyContexts] = upsertNamed(toAnySlice(cfg[keyContexts]), contextName, "context", map[string]any{
+	contextValue := map[string]any{
 		"cluster": clusterName,
 		"user":    userName,
-	})
+	}
+	if in.Namespace != "" {
+		contextValue["namespace"] = in.Namespace
+	}
+	cfg[keyContexts] = upsertNamed(toAnySlice(cfg[keyContexts]), contextName, "context", contextValue)
 	if in.SetCurrentContext {
 		cfg[keyCurrentContext] = contextName
 	}

--- a/pkg/kube/login/login.go
+++ b/pkg/kube/login/login.go
@@ -136,6 +136,11 @@ type Request struct {
 	ContextName string
 	UserName    string
 
+	// Namespace sets the written context's default namespace. Empty falls back
+	// to the resolved cluster's Namespace, then to no default. The flag
+	// overrides the resolver-supplied value.
+	Namespace string
+
 	// KubeconfigPath is the kubeconfig file to write. Empty resolves KUBECONFIG
 	// or ~/.kube/config.
 	KubeconfigPath string
@@ -153,6 +158,12 @@ type Request struct {
 	// does not succeed, Login returns ErrVerificationFailed. Verification needs
 	// the kubeconfig provider and is unavailable in the static-fallback path.
 	Verify bool
+
+	// Refresh re-applies the resolved cluster details (CAData, server, namespace)
+	// to the kubeconfig entry without prompting for a fresh interactive login
+	// when the handler already holds a valid cached token. When no valid token is
+	// cached it falls back to a normal interactive login.
+	Refresh bool
 
 	// Timeout bounds the interactive login. Zero uses the handler default.
 	Timeout time.Duration
@@ -247,8 +258,15 @@ func Login(ctx context.Context, deps Deps, req Request) (*Result, error) {
 			return h.Login(ctx, opts)
 		}
 	}
-	if _, err := loginRun(ctx, handler, loginOpts); err != nil {
-		return nil, fmt.Errorf("login with handler %q: %w", handler.Name(), err)
+	// In --refresh mode, skip the interactive login when the handler already
+	// holds a valid cached token: the goal is to re-apply resolved cluster
+	// details (CAData/server/namespace) to the kubeconfig entry, not to force a
+	// new sign-in. A missing or expired token falls through to a normal login.
+	skipLogin := req.Refresh && hasValidToken(ctx, handler, info)
+	if !skipLogin {
+		if _, err := loginRun(ctx, handler, loginOpts); err != nil {
+			return nil, fmt.Errorf("login with handler %q: %w", handler.Name(), err)
+		}
 	}
 
 	// Name the kubeconfig entries. Unlike resolveCluster (which derives the
@@ -271,6 +289,7 @@ func Login(ctx context.Context, deps Deps, req Request) (*Result, error) {
 		Audience:        info.OIDCAudience,
 		ClusterName:     clusterName,
 		ContextName:     contextName,
+		Namespace:       info.Namespace,
 		UserName:        userName,
 		KubeconfigPath:  req.KubeconfigPath,
 		ExecCommand:     binaryName,
@@ -365,6 +384,19 @@ func populateIdentity(ctx context.Context, deps Deps, handler Authenticator, inf
 	result.Username = who.Username
 	result.Groups = who.Groups
 	return true
+}
+
+// hasValidToken reports whether the handler already holds a usable cached token
+// for the cluster. It powers --refresh: a valid token lets login re-apply
+// resolved cluster details without prompting for a fresh interactive sign-in. A
+// token with a zero expiry is treated as valid (the handler manages its own
+// refresh); any lookup error or an already-expired token is treated as invalid.
+func hasValidToken(ctx context.Context, handler Authenticator, info kube.ClusterInfo) bool {
+	token, err := handler.GetToken(ctx, tokenOptionsFor(handler, info))
+	if err != nil || token == nil {
+		return false
+	}
+	return token.ExpiresAt.IsZero() || token.ExpiresAt.After(time.Now())
 }
 
 // tokenOptionsFor builds the token request, passing the cluster audience as a

--- a/pkg/kube/login/login_test.go
+++ b/pkg/kube/login/login_test.go
@@ -353,6 +353,171 @@ func TestLogin_ProvideClusterInfoAlwaysSet(t *testing.T) {
 		"kube login must set provideClusterInfo so kubectl passes cluster details via KUBERNETES_EXEC_INFO")
 }
 
+func TestLogin_NamespaceFlagPlumbedToWrite(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{name: "oidc"}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+	deps := Deps{Handler: handler, Kubeconfig: kc}
+
+	_, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+		Namespace:   "team-a",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "team-a", kc.writeIn.Namespace,
+		"the --namespace flag must reach the kubeconfig write input")
+}
+
+func TestLogin_NamespaceFlagOverridesResolvedCluster(t *testing.T) {
+	t.Parallel()
+
+	// The resolver supplies a default namespace; the explicit flag wins.
+	handler := &stubAuth{name: "oidc"}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+	resolver := &kube.MockResolver{ResolveResult: &kube.ClusterInfo{
+		Name:         "prod",
+		APIServerURL: "https://api.example.com:6443",
+		Namespace:    "from-resolver",
+	}}
+	deps := Deps{Handler: handler, Kubeconfig: kc, Resolver: resolver}
+
+	_, err := Login(context.Background(), deps, Request{Cluster: "prod", Namespace: "from-flag"})
+	require.NoError(t, err)
+	assert.Equal(t, "from-flag", kc.writeIn.Namespace)
+}
+
+func TestLogin_NamespaceFromResolverWhenNoFlag(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{name: "oidc"}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+	resolver := &kube.MockResolver{ResolveResult: &kube.ClusterInfo{
+		Name:         "prod",
+		APIServerURL: "https://api.example.com:6443",
+		Namespace:    "from-resolver",
+	}}
+	deps := Deps{Handler: handler, Kubeconfig: kc, Resolver: resolver}
+
+	_, err := Login(context.Background(), deps, Request{Cluster: "prod"})
+	require.NoError(t, err)
+	assert.Equal(t, "from-resolver", kc.writeIn.Namespace)
+}
+
+func TestLogin_RefreshSkipsInteractiveLoginWithValidToken(t *testing.T) {
+	t.Parallel()
+
+	// A valid cached token means --refresh should re-apply cluster details
+	// without calling the interactive login runner.
+	handler := &stubAuth{
+		name:  "oidc",
+		token: &auth.Token{AccessToken: "cached", ExpiresAt: time.Now().Add(time.Hour)},
+	}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+	loginCalls := 0
+	deps := Deps{
+		Handler:    handler,
+		Kubeconfig: kc,
+		LoginRunner: func(_ context.Context, _ Authenticator, _ auth.LoginOptions) (*auth.Result, error) {
+			loginCalls++
+			return &auth.Result{}, nil
+		},
+	}
+
+	_, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+		Refresh:     true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, loginCalls, "refresh with a valid cached token must skip interactive login")
+}
+
+func TestLogin_RefreshFallsBackToLoginWhenTokenExpired(t *testing.T) {
+	t.Parallel()
+
+	// No usable cached token: --refresh must fall through to a normal login.
+	handler := &stubAuth{
+		name:  "oidc",
+		token: &auth.Token{AccessToken: "old", ExpiresAt: time.Now().Add(-time.Hour)},
+	}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+	loginCalls := 0
+	deps := Deps{
+		Handler:    handler,
+		Kubeconfig: kc,
+		LoginRunner: func(_ context.Context, _ Authenticator, _ auth.LoginOptions) (*auth.Result, error) {
+			loginCalls++
+			return &auth.Result{}, nil
+		},
+	}
+
+	_, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+		Refresh:     true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, loginCalls, "refresh with an expired token must fall back to interactive login")
+}
+
+func TestLogin_NoRefreshAlwaysLogsIn(t *testing.T) {
+	t.Parallel()
+
+	// Without --refresh, a valid cached token must not short-circuit login.
+	handler := &stubAuth{
+		name:  "oidc",
+		token: &auth.Token{AccessToken: "cached", ExpiresAt: time.Now().Add(time.Hour)},
+	}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+	loginCalls := 0
+	deps := Deps{
+		Handler:    handler,
+		Kubeconfig: kc,
+		LoginRunner: func(_ context.Context, _ Authenticator, _ auth.LoginOptions) (*auth.Result, error) {
+			loginCalls++
+			return &auth.Result{}, nil
+		},
+	}
+
+	_, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, loginCalls)
+}
+
+func TestLogin_RefreshSkipsLoginWithZeroExpiryToken(t *testing.T) {
+	t.Parallel()
+
+	// A token with a zero expiry is treated as valid (the handler manages its
+	// own refresh), so --refresh must skip the interactive login.
+	handler := &stubAuth{
+		name:  "oidc",
+		token: &auth.Token{AccessToken: "cached"}, // ExpiresAt is the zero time
+	}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+	loginCalls := 0
+	deps := Deps{
+		Handler:    handler,
+		Kubeconfig: kc,
+		LoginRunner: func(_ context.Context, _ Authenticator, _ auth.LoginOptions) (*auth.Result, error) {
+			loginCalls++
+			return &auth.Result{}, nil
+		},
+	}
+
+	_, err := Login(context.Background(), deps, Request{
+		Server:      "https://api.example.com:6443",
+		ClusterName: "prod",
+		Refresh:     true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 0, loginCalls, "refresh with a zero-expiry token must skip interactive login")
+}
+
 func TestLogin_DirectURLDerivesEntryNames(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/kube/login/logout.go
+++ b/pkg/kube/login/logout.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 )
 
 // LogoutRequest configures a logout.
@@ -79,6 +80,80 @@ func Logout(ctx context.Context, deps Deps, req LogoutRequest) (*LogoutResult, e
 			if err := handler.Logout(ctx); err != nil {
 				return result, fmt.Errorf("logout handler %q: %w", handler.Name(), err)
 			}
+		}
+	}
+	return result, nil
+}
+
+// LogoutAllRequest configures a bulk logout that removes every scafctl-managed
+// kubeconfig entry.
+type LogoutAllRequest struct {
+	// KubeconfigPath is the kubeconfig file to edit. Empty resolves KUBECONFIG
+	// or ~/.kube/config.
+	KubeconfigPath string
+}
+
+// LogoutAllResult reports the outcome of a bulk logout.
+type LogoutAllResult struct {
+	// Removed lists the context names that were removed.
+	Removed []string
+
+	// UsedFallback reports that the static kubeconfig writer was used for at
+	// least one removal because the provider was unavailable.
+	UsedFallback bool
+}
+
+// LogoutAll removes every scafctl-managed kubeconfig entry (those written by
+// "kube login"). It never revokes handler credentials: a fleet-wide logout must
+// not silently sign the user out of every auth handler. Entries are removed via
+// the kubeconfig provider, falling back to a static edit when it is unavailable.
+func LogoutAll(ctx context.Context, deps Deps, req LogoutAllRequest) (*LogoutAllResult, error) {
+	if deps.Kubeconfig == nil {
+		return nil, ErrNoKubeconfigWriter
+	}
+	binaryName := deps.BinaryName
+	if binaryName == "" {
+		binaryName = settings.CliBinaryName
+	}
+
+	entries, err := ListManaged(binaryName, req.KubeconfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("list managed kubeconfig entries: %w", err)
+	}
+
+	result := &LogoutAllResult{}
+	for _, e := range entries {
+		removeIn := kubeconfig.RemoveInput{
+			ClusterName:    e.ClusterName,
+			ContextName:    e.ContextName,
+			UserName:       e.UserName,
+			KubeconfigPath: req.KubeconfigPath,
+		}
+		res, rerr := deps.Kubeconfig.RemoveEntry(ctx, removeIn)
+		switch {
+		case rerr == nil:
+			// A provider that completes without a Go error but reports
+			// Success=false failed the removal of an entry ListManaged just
+			// found; surface it rather than silently leaving it behind. A
+			// Success=true/Removed=false result is a benign no-op (the entry was
+			// already gone, e.g. a List->Remove race) and is skipped.
+			if !res.Success {
+				return result, fmt.Errorf("remove kubeconfig entry %q: provider reported failure", e.ContextName)
+			}
+			if res.Removed {
+				result.Removed = append(result.Removed, e.ContextName)
+			}
+		case errors.Is(rerr, kubeconfig.ErrProviderUnavailable):
+			removed, fbErr := removeStaticKubeconfig(removeIn)
+			if fbErr != nil {
+				return result, fmt.Errorf("kubeconfig provider unavailable and static fallback failed: %w", fbErr)
+			}
+			result.UsedFallback = true
+			if removed {
+				result.Removed = append(result.Removed, e.ContextName)
+			}
+		default:
+			return result, fmt.Errorf("remove kubeconfig entry %q: %w", e.ContextName, rerr)
 		}
 	}
 	return result, nil

--- a/pkg/kube/login/managed.go
+++ b/pkg/kube/login/managed.go
@@ -1,0 +1,292 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"encoding/base64"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+)
+
+// ManagedEntry describes a scafctl-managed kubeconfig context: a context whose
+// user is a scafctl exec-credential entry written by "kube login".
+type ManagedEntry struct {
+	// ClusterName is the kubeconfig cluster entry the context references.
+	ClusterName string
+
+	// ContextName is the kubeconfig context entry name.
+	ContextName string
+
+	// UserName is the kubeconfig user entry the context references.
+	UserName string
+
+	// Server is the referenced cluster's API server URL, when present.
+	Server string
+}
+
+// ContextStatus describes the current kubeconfig context for "kube status".
+type ContextStatus struct {
+	// Context is the current-context name; empty when none is set.
+	Context string
+
+	// Cluster and User are the entries the context references.
+	Cluster string
+	User    string
+
+	// Namespace is the context's default namespace, when set.
+	Namespace string
+
+	// Server is the referenced cluster's API server URL, when present.
+	Server string
+
+	// Managed reports whether the context's user is a scafctl exec-credential
+	// entry (written by "kube login") for the querying binary.
+	Managed bool
+
+	// Handler is the auth handler baked into a managed entry's exec block.
+	// Empty for non-managed contexts.
+	Handler string
+
+	// Profile is the auth profile baked into a managed entry's exec block
+	// (--profile). Empty when none was set.
+	Profile string
+
+	// Scope is the exec credential scope baked into a managed entry's exec block
+	// (--scope), i.e. the cluster's OIDC audience. Empty when none was set.
+	Scope string
+
+	// CAData is the PEM-encoded cluster CA bundle decoded from the kubeconfig
+	// cluster entry, when present. Used for a best-effort whoami over TLS.
+	CAData string
+
+	// InsecureSkipTLS mirrors the cluster entry's insecure-skip-tls-verify flag.
+	InsecureSkipTLS bool
+
+	// Username and Groups come from a best-effort whoami; empty when the whoami
+	// did not run or did not succeed.
+	Username string
+	Groups   []string
+}
+
+// managedUser captures the handler and profile baked into a managed user's exec
+// block, extracted from its "auth token <handler> ... --profile <profile>" args.
+type managedUser struct {
+	handler string
+	profile string
+	scope   string
+}
+
+// ListManaged reads the kubeconfig at path (empty resolves KUBECONFIG or
+// ~/.kube/config) and returns the contexts whose user is a scafctl exec-
+// credential entry for binaryName. An entry is scafctl-managed when its user's
+// exec block invokes binaryName with a leading "auth token" argument pair, which
+// is exactly what "kube login" writes. A missing kubeconfig yields an empty list
+// and no error.
+func ListManaged(binaryName, kubeconfigPath string) ([]ManagedEntry, error) {
+	if binaryName == "" {
+		binaryName = settings.CliBinaryName
+	}
+	path, err := resolveKubeconfigPath(kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := loadKubeconfig(path)
+	if err != nil {
+		return nil, err
+	}
+
+	managed := managedUsers(toAnySlice(cfg[keyUsers]), binaryName)
+	if len(managed) == 0 {
+		return nil, nil
+	}
+	servers := clusterServers(toAnySlice(cfg[keyClusters]))
+
+	var out []ManagedEntry
+	for _, item := range toAnySlice(cfg[keyContexts]) {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := m["name"].(string)
+		inner, _ := m["context"].(map[string]any)
+		if inner == nil {
+			continue
+		}
+		userName, _ := inner["user"].(string)
+		if _, ok := managed[userName]; !ok {
+			continue
+		}
+		clusterName, _ := inner["cluster"].(string)
+		out = append(out, ManagedEntry{
+			ClusterName: clusterName,
+			ContextName: name,
+			UserName:    userName,
+			Server:      servers[clusterName],
+		})
+	}
+	return out, nil
+}
+
+// CurrentContext reads the current-context from the kubeconfig at path (empty
+// resolves KUBECONFIG or ~/.kube/config) and reports its cluster, user,
+// namespace, and server. Managed reports whether the context's user is a
+// scafctl exec-credential entry for binaryName. A missing kubeconfig or absent
+// current-context yields a zero ContextStatus and no error.
+func CurrentContext(binaryName, kubeconfigPath string) (ContextStatus, error) {
+	if binaryName == "" {
+		binaryName = settings.CliBinaryName
+	}
+	path, err := resolveKubeconfigPath(kubeconfigPath)
+	if err != nil {
+		return ContextStatus{}, err
+	}
+	cfg, err := loadKubeconfig(path)
+	if err != nil {
+		return ContextStatus{}, err
+	}
+
+	current, _ := cfg[keyCurrentContext].(string)
+	st := ContextStatus{Context: current}
+	if current == "" {
+		return st, nil
+	}
+
+	inner := namedInner(toAnySlice(cfg[keyContexts]), current, "context")
+	if inner == nil {
+		return st, nil
+	}
+	st.Cluster, _ = inner["cluster"].(string)
+	st.User, _ = inner["user"].(string)
+	st.Namespace, _ = inner["namespace"].(string)
+
+	clusterEntry := namedInner(toAnySlice(cfg[keyClusters]), st.Cluster, "cluster")
+	st.Server, _ = clusterEntry["server"].(string)
+	st.CAData = decodeCAData(clusterEntry)
+	st.InsecureSkipTLS, _ = clusterEntry["insecure-skip-tls-verify"].(bool)
+
+	if mu, ok := managedUsers(toAnySlice(cfg[keyUsers]), binaryName)[st.User]; ok {
+		st.Managed = true
+		st.Handler = mu.handler
+		st.Profile = mu.profile
+		st.Scope = mu.scope
+	}
+	return st, nil
+}
+
+// managedUsers returns the managed user entries keyed by name. A user is managed
+// when its exec block invokes binaryName with a leading "auth token" argument
+// pair. The value captures the handler (args[2]) and the --profile value baked
+// into the exec args, when present.
+func managedUsers(users []any, binaryName string) map[string]managedUser {
+	out := make(map[string]managedUser)
+	for _, item := range users {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := m["name"].(string)
+		inner, _ := m["user"].(map[string]any)
+		if name == "" || inner == nil {
+			continue
+		}
+		exec, _ := inner["exec"].(map[string]any)
+		if exec == nil {
+			continue
+		}
+		if cmd, _ := exec["command"].(string); cmd != binaryName {
+			continue
+		}
+		args := toAnySlice(exec["args"])
+		if !isAuthTokenArgs(args) {
+			continue
+		}
+		out[name] = managedUser{
+			handler: argString(args, 2),
+			profile: argValue(args, execProfileFlag),
+			scope:   argValue(args, execScopeFlag),
+		}
+	}
+	return out
+}
+
+// argString returns the string at index i of the exec args, or "" when absent.
+func argString(args []any, i int) string {
+	if i < 0 || i >= len(args) {
+		return ""
+	}
+	s, _ := args[i].(string)
+	return s
+}
+
+// argValue returns the string argument immediately following flag in the exec
+// args (e.g. the value of --profile), or "" when the flag is absent or last.
+func argValue(args []any, flag string) string {
+	for i := 0; i < len(args)-1; i++ {
+		if s, _ := args[i].(string); s == flag {
+			next, _ := args[i+1].(string)
+			return next
+		}
+	}
+	return ""
+}
+
+// decodeCAData returns the PEM-encoded CA bundle from a kubeconfig cluster
+// entry's base64 certificate-authority-data, or "" when absent or malformed.
+func decodeCAData(cluster map[string]any) string {
+	b64, _ := cluster["certificate-authority-data"].(string)
+	if b64 == "" {
+		return ""
+	}
+	pem, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return ""
+	}
+	return string(pem)
+}
+
+// isAuthTokenArgs reports whether the exec args begin with the "auth token"
+// subcommand pair that "kube login" bakes into managed entries.
+func isAuthTokenArgs(args []any) bool {
+	if len(args) < 2 {
+		return false
+	}
+	a0, _ := args[0].(string)
+	a1, _ := args[1].(string)
+	return a0 == execAuthCmd && a1 == execTokenCmd
+}
+
+// clusterServers maps cluster entry names to their API server URLs.
+func clusterServers(clusters []any) map[string]string {
+	out := make(map[string]string)
+	for _, item := range clusters {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := m["name"].(string)
+		inner, _ := m["cluster"].(map[string]any)
+		if name == "" || inner == nil {
+			continue
+		}
+		server, _ := inner["server"].(string)
+		out[name] = server
+	}
+	return out
+}
+
+// namedInner returns the inner value map (keyed by key) of the list entry named
+// name, or nil when absent.
+func namedInner(list []any, name, key string) map[string]any {
+	for _, item := range list {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if n, _ := m["name"].(string); n == name {
+			inner, _ := m[key].(map[string]any)
+			return inner
+		}
+	}
+	return nil
+}

--- a/pkg/kube/login/managed_test.go
+++ b/pkg/kube/login/managed_test.go
@@ -1,0 +1,208 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+)
+
+// writeManagedKubeconfig writes a kubeconfig fixture with one scafctl-managed
+// context (prod), one foreign context (staging, a plain token user), and a
+// current-context of prod. It returns the file path. The managed entry is
+// written for the "scafctl" binary.
+func writeManagedKubeconfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	content := `apiVersion: v1
+kind: Config
+current-context: prod
+clusters:
+  - name: prod
+    cluster:
+      server: https://api.prod.example.com:6443
+  - name: staging
+    cluster:
+      server: https://api.staging.example.com:6443
+contexts:
+  - name: prod
+    context:
+      cluster: prod
+      user: prod
+      namespace: team-a
+  - name: staging
+    context:
+      cluster: staging
+      user: staging
+users:
+  - name: prod
+    user:
+      exec:
+        command: scafctl
+        args:
+          - auth
+          - token
+          - oidc
+  - name: staging
+    user:
+      token: static-token
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestListManaged_FindsOnlyManagedEntries(t *testing.T) {
+	t.Parallel()
+
+	path := writeManagedKubeconfig(t)
+	entries, err := ListManaged("scafctl", path)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "only the scafctl exec-credential context is managed")
+	assert.Equal(t, "prod", entries[0].ContextName)
+	assert.Equal(t, "prod", entries[0].ClusterName)
+	assert.Equal(t, "prod", entries[0].UserName)
+	assert.Equal(t, "https://api.prod.example.com:6443", entries[0].Server)
+}
+
+func TestListManaged_DifferentBinaryNameNotManaged(t *testing.T) {
+	t.Parallel()
+
+	// The entry was written by "scafctl"; querying as "othercli" must not match.
+	path := writeManagedKubeconfig(t)
+	entries, err := ListManaged("othercli", path)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestListManaged_MissingKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "does-not-exist")
+	entries, err := ListManaged("scafctl", path)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestCurrentContext_ReportsManagedCurrent(t *testing.T) {
+	t.Parallel()
+
+	path := writeManagedKubeconfig(t)
+	st, err := CurrentContext("scafctl", path)
+	require.NoError(t, err)
+	assert.Equal(t, "prod", st.Context)
+	assert.Equal(t, "prod", st.Cluster)
+	assert.Equal(t, "prod", st.User)
+	assert.Equal(t, "team-a", st.Namespace)
+	assert.Equal(t, "https://api.prod.example.com:6443", st.Server)
+	assert.True(t, st.Managed)
+}
+
+func TestCurrentContext_NoCurrentContext(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	require.NoError(t, os.WriteFile(path, []byte("apiVersion: v1\nkind: Config\n"), 0o600))
+
+	st, err := CurrentContext("scafctl", path)
+	require.NoError(t, err)
+	assert.Empty(t, st.Context)
+	assert.False(t, st.Managed)
+}
+
+func TestLogoutAll_RemovesManagedEntriesViaProvider(t *testing.T) {
+	t.Parallel()
+
+	path := writeManagedKubeconfig(t)
+	kc := &stubKube{removeRes: kubeconfig.RemoveResult{Success: true, Removed: true}}
+	deps := Deps{Kubeconfig: kc, BinaryName: "scafctl"}
+
+	res, err := LogoutAll(context.Background(), deps, LogoutAllRequest{KubeconfigPath: path})
+	require.NoError(t, err)
+	require.Len(t, res.Removed, 1)
+	assert.Equal(t, "prod", res.Removed[0])
+	assert.False(t, res.UsedFallback)
+	// The provider received the managed entry's names.
+	assert.Equal(t, "prod", kc.removeIn.ClusterName)
+}
+
+func TestLogoutAll_FallbackWhenProviderUnavailable(t *testing.T) {
+	t.Parallel()
+
+	path := writeManagedKubeconfig(t)
+	kc := &stubKube{removeErr: kubeconfig.ErrProviderUnavailable}
+	deps := Deps{Kubeconfig: kc, BinaryName: "scafctl"}
+
+	res, err := LogoutAll(context.Background(), deps, LogoutAllRequest{KubeconfigPath: path})
+	require.NoError(t, err)
+	assert.True(t, res.UsedFallback)
+	require.Len(t, res.Removed, 1)
+	assert.Equal(t, "prod", res.Removed[0])
+
+	// The managed context is gone; the foreign staging context remains.
+	remaining, err := ListManaged("scafctl", path)
+	require.NoError(t, err)
+	assert.Empty(t, remaining)
+	data, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "staging")
+}
+
+func TestLogoutAll_ProviderReportsFailure(t *testing.T) {
+	t.Parallel()
+
+	// The provider completes without a Go error but reports Success=false for an
+	// entry ListManaged found: LogoutAll must surface it, not silently skip it.
+	path := writeManagedKubeconfig(t)
+	kc := &stubKube{removeRes: kubeconfig.RemoveResult{Success: false}}
+	deps := Deps{Kubeconfig: kc, BinaryName: "scafctl"}
+
+	res, err := LogoutAll(context.Background(), deps, LogoutAllRequest{KubeconfigPath: path})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provider reported failure")
+	assert.Empty(t, res.Removed)
+}
+
+func TestLogoutAll_SuccessNoMatchIsBenignSkip(t *testing.T) {
+	t.Parallel()
+
+	// Success=true but Removed=false (entry already gone / List->Remove race) is
+	// a benign no-op: no error, nothing recorded as removed.
+	path := writeManagedKubeconfig(t)
+	kc := &stubKube{removeRes: kubeconfig.RemoveResult{Success: true, Removed: false}}
+	deps := Deps{Kubeconfig: kc, BinaryName: "scafctl"}
+
+	res, err := LogoutAll(context.Background(), deps, LogoutAllRequest{KubeconfigPath: path})
+	require.NoError(t, err)
+	assert.Empty(t, res.Removed)
+}
+
+func TestLogoutAll_NoManagedEntries(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	require.NoError(t, os.WriteFile(path, []byte("apiVersion: v1\nkind: Config\n"), 0o600))
+
+	kc := &stubKube{}
+	deps := Deps{Kubeconfig: kc, BinaryName: "scafctl"}
+	res, err := LogoutAll(context.Background(), deps, LogoutAllRequest{KubeconfigPath: path})
+	require.NoError(t, err)
+	assert.Empty(t, res.Removed)
+}
+
+func TestLogoutAll_NoKubeconfigWriter(t *testing.T) {
+	t.Parallel()
+
+	_, err := LogoutAll(context.Background(), Deps{}, LogoutAllRequest{})
+	assert.ErrorIs(t, err, ErrNoKubeconfigWriter)
+}

--- a/pkg/kube/login/resolve.go
+++ b/pkg/kube/login/resolve.go
@@ -51,6 +51,9 @@ func resolveCluster(ctx context.Context, deps Deps, req Request) (kube.ClusterIn
 	if req.Audience != "" {
 		info.OIDCAudience = req.Audience
 	}
+	if req.Namespace != "" {
+		info.Namespace = req.Namespace
+	}
 	if req.InsecureSkipTLS {
 		info.InsecureSkipTLS = true
 		// The kubeconfig writer prefers CAData over InsecureSkipTLS, so a

--- a/pkg/kube/login/status.go
+++ b/pkg/kube/login/status.go
@@ -1,0 +1,82 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"context"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+)
+
+// Status reads the current kubeconfig context and, for a scafctl-managed
+// context, attempts a best-effort whoami to populate Username/Groups. The whoami
+// needs the auth handler baked into the managed entry plus the kubeconfig
+// provider; every failure along that path is non-fatal and simply leaves the
+// identity fields empty. The static context data (context/cluster/server/
+// namespace/managed) is always returned, so `kube status` works offline and
+// without the provider.
+func Status(ctx context.Context, deps Deps, kubeconfigPath string) (ContextStatus, error) {
+	binaryName := deps.BinaryName
+	if binaryName == "" {
+		binaryName = settings.CliBinaryName
+	}
+	st, err := CurrentContext(binaryName, kubeconfigPath)
+	if err != nil {
+		return st, err
+	}
+	if st.Managed && st.Handler != "" && st.Server != "" &&
+		deps.Kubeconfig != nil && deps.HandlerLookup != nil {
+		populateStatusIdentity(ctx, deps, &st)
+	}
+	return st, nil
+}
+
+// populateStatusIdentity runs a best-effort whoami for a managed context. It
+// resolves the entry's handler, mints (or reuses) a token under the entry's
+// profile, and asks the kubeconfig provider who the token authenticates as. Any
+// error is swallowed: the identity is advisory, not required.
+func populateStatusIdentity(ctx context.Context, deps Deps, st *ContextStatus) {
+	// Look tokens up under the same profile the exec block passes via --profile,
+	// so the whoami sees the credential kubectl would actually use.
+	if st.Profile != "" {
+		ctx = auth.WithProfile(ctx, st.Profile)
+	}
+
+	handler, err := deps.HandlerLookup(ctx, st.Handler)
+	if err != nil {
+		return
+	}
+
+	tokenOpts := auth.TokenOptions{}
+	// Mirror the scope the exec block bakes in (--scope <audience>) so status
+	// mints/looks up the same token kubectl would use, for handlers that accept
+	// per-request scopes. Without this the whoami could use a different token
+	// and report the wrong identity.
+	if st.Scope != "" && auth.HasCapability(handler.Capabilities(), auth.CapScopesOnTokenRequest) {
+		tokenOpts.Scope = st.Scope
+	}
+	// Route the token request to this cluster only for handlers that honor a
+	// per-cluster hostname, mirroring the login/whoami path (issue #581).
+	if auth.HasCapability(handler.Capabilities(), auth.CapTokenHostname) {
+		tokenOpts.Hostname = st.Server
+	}
+	token, err := handler.GetToken(ctx, tokenOpts)
+	if err != nil || token == nil {
+		return
+	}
+
+	who, err := deps.Kubeconfig.Whoami(ctx, kubeconfig.WhoamiInput{
+		Server:          st.Server,
+		Token:           token.AccessToken,
+		CAData:          st.CAData,
+		InsecureSkipTLS: st.InsecureSkipTLS,
+	})
+	if err != nil || !who.Success {
+		return
+	}
+	st.Username = who.Username
+	st.Groups = who.Groups
+}

--- a/pkg/kube/login/status_test.go
+++ b/pkg/kube/login/status_test.go
@@ -1,0 +1,272 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package login
+
+import (
+	"context"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
+)
+
+func TestStatus_PopulatesIdentityForManaged(t *testing.T) {
+	t.Parallel()
+	path := writeManagedKubeconfig(t)
+
+	handler := &stubAuth{name: "oidc", token: &auth.Token{AccessToken: "tok"}}
+	kc := &stubKube{whoamiRes: kubeconfig.WhoamiResult{Success: true, Username: "alice", Groups: []string{"dev"}}}
+	deps := Deps{
+		Kubeconfig: kc,
+		BinaryName: "scafctl",
+		HandlerLookup: func(_ context.Context, name string) (Authenticator, error) {
+			assert.Equal(t, "oidc", name, "handler is taken from the managed entry's exec args")
+			return handler, nil
+		},
+	}
+
+	st, err := Status(context.Background(), deps, path)
+	require.NoError(t, err)
+	assert.True(t, st.Managed)
+	assert.Equal(t, "oidc", st.Handler)
+	assert.Equal(t, "alice", st.Username)
+	assert.Equal(t, []string{"dev"}, st.Groups)
+	// The whoami must target the current cluster with the handler's token.
+	assert.Equal(t, "tok", kc.whoamiIn.Token)
+	assert.Equal(t, "https://api.prod.example.com:6443", kc.whoamiIn.Server)
+}
+
+func TestStatus_DegradesWhenWhoamiUnavailable(t *testing.T) {
+	t.Parallel()
+	path := writeManagedKubeconfig(t)
+
+	handler := &stubAuth{name: "oidc", token: &auth.Token{AccessToken: "tok"}}
+	kc := &stubKube{whoamiErr: kubeconfig.ErrProviderUnavailable}
+	deps := Deps{
+		Kubeconfig: kc,
+		BinaryName: "scafctl",
+		HandlerLookup: func(_ context.Context, _ string) (Authenticator, error) {
+			return handler, nil
+		},
+	}
+
+	st, err := Status(context.Background(), deps, path)
+	require.NoError(t, err)
+	// Static data is still reported; identity is simply absent.
+	assert.True(t, st.Managed)
+	assert.Equal(t, "prod", st.Context)
+	assert.Empty(t, st.Username)
+}
+
+func TestStatus_DegradesWhenTokenMissing(t *testing.T) {
+	t.Parallel()
+	path := writeManagedKubeconfig(t)
+
+	// Handler has no token to offer: whoami is never attempted.
+	handler := &stubAuth{name: "oidc", tokenErr: assertErr("no token")}
+	kc := &stubKube{}
+	deps := Deps{
+		Kubeconfig: kc,
+		BinaryName: "scafctl",
+		HandlerLookup: func(_ context.Context, _ string) (Authenticator, error) {
+			return handler, nil
+		},
+	}
+
+	st, err := Status(context.Background(), deps, path)
+	require.NoError(t, err)
+	assert.True(t, st.Managed)
+	assert.Empty(t, st.Username)
+	assert.Empty(t, kc.whoamiIn.Token, "whoami must not run without a token")
+}
+
+func TestStatus_NoIdentityForUnmanagedContext(t *testing.T) {
+	t.Parallel()
+	// current-context points at a foreign (non-scafctl) user.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	content := `apiVersion: v1
+kind: Config
+current-context: foreign
+clusters:
+  - name: foreign
+    cluster:
+      server: https://api.foreign.example.com:6443
+contexts:
+  - name: foreign
+    context:
+      cluster: foreign
+      user: foreign
+users:
+  - name: foreign
+    user:
+      token: static
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	handler := &stubAuth{name: "oidc", token: &auth.Token{AccessToken: "tok"}}
+	kc := &stubKube{whoamiRes: kubeconfig.WhoamiResult{Success: true, Username: "alice"}}
+	deps := Deps{
+		Kubeconfig: kc,
+		BinaryName: "scafctl",
+		HandlerLookup: func(_ context.Context, _ string) (Authenticator, error) {
+			return handler, nil
+		},
+	}
+
+	st, err := Status(context.Background(), deps, path)
+	require.NoError(t, err)
+	assert.False(t, st.Managed)
+	assert.Empty(t, st.Username, "unmanaged contexts get no whoami")
+	assert.Empty(t, kc.whoamiIn.Token)
+}
+
+func TestCurrentContext_ExtractsHandlerProfileAndCAData(t *testing.T) {
+	t.Parallel()
+	caPEM := "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n"
+	caB64 := base64.StdEncoding.EncodeToString([]byte(caPEM))
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	content := `apiVersion: v1
+kind: Config
+current-context: prod
+clusters:
+  - name: prod
+    cluster:
+      server: https://api.prod.example.com:6443
+      certificate-authority-data: ` + caB64 + `
+contexts:
+  - name: prod
+    context:
+      cluster: prod
+      user: prod
+users:
+  - name: prod
+    user:
+      exec:
+        command: scafctl
+        args:
+          - auth
+          - token
+          - oidc
+          - --exec-credential
+          - --scope
+          - api://cluster-aud
+          - --profile
+          - work
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	st, err := CurrentContext("scafctl", path)
+	require.NoError(t, err)
+	assert.True(t, st.Managed)
+	assert.Equal(t, "oidc", st.Handler)
+	assert.Equal(t, "work", st.Profile)
+	assert.Equal(t, "api://cluster-aud", st.Scope)
+	assert.Equal(t, caPEM, st.CAData)
+}
+
+// assertErr is a tiny error helper for token-failure fixtures.
+type assertErr string
+
+func (e assertErr) Error() string { return string(e) }
+
+func TestStatus_PassesBakedScopeToTokenRequest(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	content := `apiVersion: v1
+kind: Config
+current-context: prod
+clusters:
+  - name: prod
+    cluster:
+      server: https://api.prod.example.com:6443
+contexts:
+  - name: prod
+    context:
+      cluster: prod
+      user: prod
+users:
+  - name: prod
+    user:
+      exec:
+        command: scafctl
+        args: [auth, token, oidc, --exec-credential, --scope, "api://aud"]
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	// A handler that accepts per-request scopes must receive the baked --scope
+	// so the whoami mints/looks up the same token kubectl would use.
+	handler := &stubAuth{
+		name:  "oidc",
+		caps:  []auth.Capability{auth.CapScopesOnTokenRequest},
+		token: &auth.Token{AccessToken: "tok"},
+	}
+	kc := &stubKube{whoamiRes: kubeconfig.WhoamiResult{Success: true, Username: "alice"}}
+	deps := Deps{
+		Kubeconfig: kc,
+		BinaryName: "scafctl",
+		HandlerLookup: func(_ context.Context, _ string) (Authenticator, error) {
+			return handler, nil
+		},
+	}
+
+	st, err := Status(context.Background(), deps, path)
+	require.NoError(t, err)
+	assert.Equal(t, "api://aud", st.Scope)
+	assert.Equal(t, "api://aud", handler.tokenOpts.Scope,
+		"the baked --scope must be passed to GetToken for scoped handlers")
+}
+
+func TestStatus_OmitsScopeForUnscopedHandler(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config")
+	content := `apiVersion: v1
+kind: Config
+current-context: prod
+clusters:
+  - name: prod
+    cluster:
+      server: https://api.prod.example.com:6443
+contexts:
+  - name: prod
+    context:
+      cluster: prod
+      user: prod
+users:
+  - name: prod
+    user:
+      exec:
+        command: scafctl
+        args: [auth, token, oidc, --exec-credential, --scope, "api://aud"]
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	// No CapScopesOnTokenRequest: the scope is captured for display but must not
+	// be forwarded to GetToken.
+	handler := &stubAuth{name: "oidc", token: &auth.Token{AccessToken: "tok"}}
+	kc := &stubKube{whoamiRes: kubeconfig.WhoamiResult{Success: true, Username: "alice"}}
+	deps := Deps{
+		Kubeconfig: kc,
+		BinaryName: "scafctl",
+		HandlerLookup: func(_ context.Context, _ string) (Authenticator, error) {
+			return handler, nil
+		},
+	}
+
+	st, err := Status(context.Background(), deps, path)
+	require.NoError(t, err)
+	assert.Equal(t, "api://aud", st.Scope)
+	assert.Empty(t, handler.tokenOpts.Scope,
+		"handlers without CapScopesOnTokenRequest must not receive a scope")
+}

--- a/pkg/kubeconfig/types.go
+++ b/pkg/kubeconfig/types.go
@@ -96,6 +96,10 @@ type WriteInput struct {
 	// cluster name inside the provider.
 	ContextName string `json:"context_name,omitempty" yaml:"context_name,omitempty" doc:"Kubeconfig context entry name" maxLength:"253"`
 
+	// Namespace is the default namespace set on the written context. Empty omits
+	// the namespace so the context has no default.
+	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty" doc:"Default namespace set on the written context" maxLength:"253" example:"prod"`
+
 	// UserName is the kubeconfig user entry name. Empty defaults to the cluster
 	// name inside the provider.
 	UserName string `json:"user_name,omitempty" yaml:"user_name,omitempty" doc:"Kubeconfig user entry name" maxLength:"253"`
@@ -143,6 +147,7 @@ func (in WriteInput) toInputs() map[string]any {
 		"audience":             in.Audience,
 		"cluster_name":         in.ClusterName,
 		"context_name":         in.ContextName,
+		"namespace":            in.Namespace,
 		"user_name":            in.UserName,
 		"kubeconfig_path":      in.KubeconfigPath,
 		"exec_command":         in.ExecCommand,

--- a/pkg/kubeconfig/types_test.go
+++ b/pkg/kubeconfig/types_test.go
@@ -20,6 +20,7 @@ func TestWriteInput_ToInputs(t *testing.T) {
 		Audience:           "aud",
 		ClusterName:        "prod",
 		ContextName:        "ctx",
+		Namespace:          "team-a",
 		UserName:           "user",
 		KubeconfigPath:     "/tmp/kubeconfig",
 		ExecCommand:        "scafctl",
@@ -34,6 +35,7 @@ func TestWriteInput_ToInputs(t *testing.T) {
 	got := in.toInputs()
 	assert.Equal(t, "https://api.example.com:6443", got["server"])
 	assert.Equal(t, "prod", got["cluster_name"])
+	assert.Equal(t, "team-a", got["namespace"])
 	assert.Equal(t, "scafctl", got["exec_command"])
 	assert.Equal(t, []string{"auth", "token"}, got["exec_args"])
 	assert.Equal(t, "-----BEGIN CERTIFICATE-----", got["ca_data"])

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2229,6 +2229,105 @@ func TestIntegration_LogoutNoCluster(t *testing.T) {
 	assert.Contains(t, stderr, "cluster name is required")
 }
 
+func TestIntegration_LoginHelp_NamespaceAndRefresh(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "kube", "login", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "--namespace")
+	assert.Contains(t, stdout, "--refresh")
+}
+
+func TestIntegration_LogoutHelp_All(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "kube", "logout", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "--all")
+}
+
+func TestIntegration_KubeListHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "kube", "list", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "clusters")
+}
+
+func TestIntegration_KubeListNoResolver(t *testing.T) {
+	t.Parallel()
+	// scafctl ships no cluster data; with no resolver configured, list reports
+	// that clearly instead of erroring.
+	stdout, stderr, exitCode := runScafctl(t, "kube", "list")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout+stderr, "No cluster resolver configured")
+}
+
+func TestIntegration_KubeStatusNoContext(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	kubeconfig := filepath.Join(tmpDir, "config")
+	require.NoError(t, os.WriteFile(kubeconfig, []byte("apiVersion: v1\nkind: Config\n"), 0o600))
+
+	stdout, stderr, exitCode := runScafctl(t, "kube", "status", "--kubeconfig", kubeconfig)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout+stderr, "No current kubeconfig context")
+}
+
+func TestIntegration_KubeStatusShowsContext(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	kubeconfig := filepath.Join(tmpDir, "config")
+	content := `apiVersion: v1
+kind: Config
+current-context: prod
+clusters:
+  - name: prod
+    cluster:
+      server: https://api.prod.example.com:6443
+contexts:
+  - name: prod
+    context:
+      cluster: prod
+      user: prod
+      namespace: team-a
+users:
+  - name: prod
+    user:
+      token: static
+`
+	require.NoError(t, os.WriteFile(kubeconfig, []byte(content), 0o600))
+
+	stdout, _, exitCode := runScafctl(t, "kube", "status", "--kubeconfig", kubeconfig, "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "prod")
+	assert.Contains(t, stdout, "https://api.prod.example.com:6443")
+	assert.Contains(t, stdout, "team-a")
+}
+
+func TestIntegration_KubeLogoutAllNoEntries(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	kubeconfig := filepath.Join(tmpDir, "config")
+	require.NoError(t, os.WriteFile(kubeconfig, []byte("apiVersion: v1\nkind: Config\n"), 0o600))
+
+	stdout, stderr, exitCode := runScafctl(t, "kube", "logout", "--all", "--kubeconfig", kubeconfig)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout+stderr, "No scafctl-managed kubeconfig entries found")
+}
+
+func TestIntegration_KubeLogoutAllRejectsClusterArg(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t, "kube", "logout", "--all", "prod")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "--all cannot be combined with a cluster argument")
+}
+
 func TestIntegration_AuthStatusGCP(t *testing.T) {
 	t.Parallel()
 	_, stderr, exitCode := runScafctl(t, "auth", "status", "gcp")


### PR DESCRIPTION
Add Kubernetes/OpenShift CLI surface plus branding-safe host paths:

- kube list: list clusters known to the configured cluster resolver
- kube status: show the current kubeconfig context with a best-effort whoami, rendered via kvx for clean key/value output
- kube logout --all: remove every scafctl-managed kubeconfig entry, leaving handler credentials in place
- kube login --namespace/-n: set the written context's default namespace
- kube login --refresh: re-apply resolved cluster details (CA, server, namespace) without a fresh interactive login when a token is cached
- host.configDir() (and hostConfigDir() alias) CEL and template functions for rebrand-safe config paths, backed by paths.ConfigDir()
- docs, benchmarks, and CLI integration tests for the new surface

Closes #560
Closes #561
Closes #572