### PR TITLE
feat(resolver): decouple validation from resolution graph (two-phase)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### 🚀 Features
 
+- *(resolver)* [**breaking**] Decouple validation from the resolution dependency graph via two-phase execution. Validation rules that reference other resolvers (including message-only references) are now *deferred* and run after all resolvers resolve, so cross-resolver validation no longer forms false ordering cycles. Rules referencing only `__self` run *inline* and fail fast. Immutable-lock state now commits after deferred validation passes and before actions run (previously after actions). The old "sink resolver" workaround for cross-resolver validation is retired (#552)
+- *(lint)* Add `deferred-validation-not-fail-fast` rule (info) advising when a resolver has a cross-resolver validation rule that runs in the deferred phase
 - *(provider)* Add optional per-entry `data` map to the go-template `render-tree` operation, shallow-merged over the shared `data` (per-entry values win), enabling single-resolver fan-out where one template renders once per item with its own variables and output path
 - *(auth)* [**breaking**] Drop the legacy OAuth token-metadata compatibility shim when bumping scafctl-plugin-sdk to v0.11.0. Credentials persisted by earlier versions (which carried fields such as `refreshTokenExpiresAt` / `loginFlow`) no longer deserialize, so a one-time re-login is required after upgrading.
 - *(state)* Add `saveOverrides` field to state backend for save-time-only input resolution, enabling patterns like loading from `main` and saving to a resolver-derived feature branch

--- a/docs/design/resolvers.md
+++ b/docs/design/resolvers.md
@@ -924,6 +924,23 @@ Error: Resolver 'name' validation failed:
 
 Only the failed validation messages are included in the error. The transformed value `"A"` is still emitted to `_` for use by error handlers or logging.
 
+### Inline vs Deferred Validation
+
+Validation runs in **two phases** depending on what a rule references:
+
+- **Inline rules** reference only their own resolver (via `__self`). They run
+  during resolution, right after `resolve`/`transform`, and **fail fast**.
+- **Deferred rules** reference another resolver (via `_.other` in the rule
+  expression, its inputs, its `when:` condition, or its message template). They
+  run **after every resolver has resolved**, just before actions.
+
+The phase is chosen automatically -- authors never specify it. Because inline
+rules have no foreign references, the `validate` block contributes **no edges**
+to the resolution dependency graph. This is why two resolvers can validate
+against each other without forming a false ordering cycle. See
+[Two-Phase Validation](two-phase-validation.md) for the full model, execution
+order, and skipped/errored semantics.
+
 ### Validation Messages
 
 Validation messages support all four input forms:
@@ -1736,6 +1753,13 @@ spec:
 ~~~
 
 This is valid because the dependency flow is: `feature_flag` → `feature_config` → `app_config` (no cycles).
+
+**Validation references do not create cycles.** Only `resolve`, `transform`, and
+`when:` references contribute edges to the resolution graph. A cross-resolver
+reference inside a `validate` block -- including a message-only reference such as
+`message: "tmpl: {{ .other }} ..."` -- is handled by
+[deferred validation](two-phase-validation.md) and never forms an ordering cycle.
+Two resolvers may safely validate against each other.
 
 ---
 

--- a/docs/design/state/state.md
+++ b/docs/design/state/state.md
@@ -29,7 +29,10 @@ exclusively through the provider system.
 The replay backbone is the **input parameters**, not resolver outputs:
 scaffolding is deterministic, so the same inputs always produce the same
 resolver set. The only exception is resolvers marked `immutable: true`, whose
-resolved values are locked in state after the first run.
+resolved values are locked in state on the first run. Immutable locks are
+committed after resolvers and deferred validation succeed but **before** actions
+run; merged parameters are persisted **after** actions complete. See
+[Two-Phase Validation](../two-phase-validation.md) for the full lifecycle.
 
 State does not:
 
@@ -509,7 +512,7 @@ spec:
           title: { expr: "'feat: deploy ' + _.appName" }
 ~~~
 
-After actions complete, the state manager saves state as a second commit on `featureBranch`. The PR contains both the scaffolded files and the state file.
+Immutable locks (if any) are committed before actions run; after actions complete, the state manager saves the merged parameters as a second commit on `featureBranch`. The PR contains both the scaffolded files and the state file.
 
 ### Future Backends
 

--- a/docs/design/two-phase-validation.md
+++ b/docs/design/two-phase-validation.md
@@ -1,0 +1,134 @@
+---
+title: "Two-Phase Validation"
+weight: 51
+---
+
+# Two-Phase Validation
+
+## Overview
+
+Resolver validation runs in two phases so that a validation rule which
+references another resolver does not distort the resolution dependency graph:
+
+1. **Inline validation** (phase 1) runs during resolution, immediately after a
+   resolver's `resolve`/`transform` phases complete. Inline rules reference
+   only their own resolver (via `__self`). They fail fast: a failing inline rule
+   stops dependent resolvers just like a resolve error.
+2. **Deferred validation** (phase 2) runs after *every* resolver has resolved,
+   just before actions execute. Deferred rules reference one or more *other*
+   resolvers (via `_.other`, in the rule expression, its inputs, its `when:`
+   condition, or its message template).
+
+The classification is automatic. Authors do not choose the phase; scafctl
+inspects each rule's references and assigns it to the phase that can satisfy
+them.
+
+## Why Two Phases
+
+Before two-phase validation, the resolver dependency graph was built from *all*
+references found in a resolver -- including references inside `validate` blocks.
+A message-only reference such as
+`message: "tmpl: {{ .region }} must differ from backup"` was enough to add a
+resolution edge. When two resolvers validated against each other, those edges
+formed a **false ordering cycle**, and the entire solution failed to load with a
+`circular dependency detected` error -- even though neither resolver actually
+needed the other's value to *resolve*.
+
+The historical workaround was to extract cross-resolver validation into a
+dedicated "sink" resolver that depended on both. That workaround is no longer
+necessary and is retired.
+
+This pattern -- separating "compute the value" from "assert across values" --
+mirrors established tools: Terraform evaluates resource dependencies to build its
+graph, then runs cross-resource `precondition`/`postcondition` checks against the
+already-computed plan; Kubernetes admission validation runs after an object is
+otherwise resolved. scafctl follows the same principle.
+
+## Classification Rules
+
+A validation rule is **deferred** when any of the following reference a resolver
+other than the owner:
+
+- the rule expression or `match`/`notMatch` inputs
+- any provider input on the rule
+- the rule-level `when:` condition
+- the failure `message`
+
+When the phase-level `validate.when:` condition references a foreign resolver,
+the entire validate phase for that resolver is deferred.
+
+A rule that references only `__self` (or nothing) is **inline**.
+
+Because inline rules have, by definition, an empty foreign-reference set, the
+`validate` block contributes **zero edges** to the resolution dependency graph.
+Resolution ordering is derived solely from `resolve`, `transform`, and `when:`
+references.
+
+## Execution Order
+
+```text
+resolve  ->  inline validate  ->  (all resolvers done)
+         ->  deferred validate  ->  commit immutable locks
+         ->  actions            ->  commit merged parameters
+```
+
+Immutable-lock state is committed **after** deferred validation passes and
+**before** actions run, so an action never executes against a value that failed a
+cross-resolver check. Resolvers whose deferred validation failed are excluded
+from the immutable commit. Merged-parameter state is persisted after actions.
+
+## Skipped and Errored Resolvers
+
+Deferred validation is **fail-closed**. If a deferred rule references a resolver
+that produced no usable value (it was skipped by its own `when:` condition, or it
+errored during resolve/transform), the rule fails with a clear message:
+
+```text
+deferred validation references resolver "backupRegion" which did not produce a value
+```
+
+Two refinements keep this predictable:
+
+- **Own-skip exemption**: if the resolver that *owns* a deferred rule was itself
+  skipped, its deferred rules are skipped too (there is nothing to validate).
+- **Cascade suppression**: if a deferred rule references a resolver whose *own*
+  deferred validation already failed, the dependent rule is suppressed rather
+  than reported as an independent failure, so the root cause is surfaced once.
+
+For genuinely conditional cross-checks, guard the rule with a rule-level `when:`
+so it only runs when the referenced value is present.
+
+## Reporting Graph Cycle Tolerance
+
+Deferred rules can reference each other freely -- including mutually -- because
+they run after resolution. To order the *failure report* deterministically (and
+surface root causes first), scafctl builds a separate reporting graph over the
+deferred units and runs Tarjan SCC over it. Cycles in this reporting graph are
+**tolerated**: they only affect report ordering, never execution. This is the
+key difference from the resolution graph, where a cycle is a hard error.
+
+## Failure Modes
+
+The behavior on a deferred validation failure depends on the execution mode:
+
+| Mode | Flag | Behavior |
+| --- | --- | --- |
+| Default (fatal) | none | Execution stops; an `AggregatedDeferredValidationError` is returned before actions run. |
+| Non-fatal | (default for `run resolver`) | Values are still emitted; failures are reported as validation diagnostics on stderr; state persistence is skipped; `--fail-on-validation` makes the process exit non-zero. |
+| Validate-all | `--validate-all` | Failures are folded into the aggregated execution error alongside inline failures. |
+| Skip validation | `--skip-validation` | Both phases are skipped entirely. |
+
+## Linting
+
+The `resolver-cycle` rule now only fires on genuine `resolve`/`transform`/`when`
+cycles; cross-resolver validation references never trigger it.
+
+A new advisory, `deferred-validation-not-fail-fast` (severity `info`), fires for
+each resolver that has a deferred validation rule. It is informational -- it
+reminds authors that the rule runs late (after all resolvers resolve) rather than
+failing fast during resolution.
+
+## Related
+
+- [Resolvers](resolvers.md) -- resolver phases and the validate phase
+- [Providers](providers.md) -- the `validation` provider

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -743,7 +743,8 @@ spec:
 
 The cycle `alpha -> beta -> alpha` means neither resolver can run first.
 
-**Fix**: Break the cycle by removing one of the dependencies. Often, the real pattern is that a `validate` block creates the cycle -- extract it into a separate resolver:
+**Fix**: Break the cycle by reordering or removing one of the dependencies so the
+references flow in one direction.
 
 ```yaml
 spec:
@@ -763,18 +764,13 @@ spec:
             inputs:
               expression:
                 expr: '_.alpha + "-derived"'
-
-    # Validation extracted into its own resolver
-    validateAlpha:
-      dependsOn: [alpha, beta]
-      validate:
-        with:
-          - provider: validation
-            inputs:
-              expression:
-                expr: '_.beta != ""'
-              message: "Beta must not be empty"
 ```
+
+> **Note**: Only `resolve`, `transform`, and `when:` references create resolution
+> edges. A cross-resolver reference inside a `validate` block no longer causes a
+> cycle -- it is handled by [deferred validation](../design/two-phase-validation.md).
+> The old workaround of extracting cross-resolver validation into a dedicated
+> "sink" resolver is no longer needed.
 
 This is an **error**-level finding because cycles always prevent execution.
 

--- a/docs/tutorials/validation-patterns-tutorial.md
+++ b/docs/tutorials/validation-patterns-tutorial.md
@@ -648,6 +648,87 @@ Common validation error patterns and their meaning:
 
 ---
 
+## 8. Cross-Resolver (Two-Phase) Validation
+
+Most validation rules check a single value against itself with `__self`. Sometimes
+you need to validate one resolver *against another* -- for example, ensuring a
+primary and backup region differ. scafctl handles this with **two-phase
+validation**:
+
+- **Inline rules** reference only `__self`. They run during resolution and fail
+  fast.
+- **Deferred rules** reference another resolver (via `_.other`, or a message
+  template like `{{ .other }}`). They run after every resolver has resolved,
+  just before actions.
+
+The phase is chosen automatically. Cross-resolver references inside a `validate`
+block **do not** create a resolution dependency, so two resolvers can safely
+validate against each other without triggering a `circular dependency` error.
+
+```yaml
+spec:
+  resolvers:
+    region:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+              default: us-east1
+      validate:
+        with:
+          # INLINE: references only __self -> fails fast during resolution
+          - provider: validation
+            inputs:
+              expression: "__self != ''"
+              message: "region is required"
+          # DEFERRED: references _.backupRegion -> runs after all resolvers
+          - provider: validation
+            inputs:
+              expression: "_.region != _.backupRegion"
+              message: "tmpl: region must differ from backupRegion (both were {{ .region }})"
+
+    backupRegion:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: backupRegion
+              default: us-west1
+```
+
+> **Tip**: Put dynamic messages under `inputs.message` (with a `tmpl:` or `expr:`
+> prefix) so the template renders with resolver values.
+
+Run it -- equal regions fail, differing regions pass:
+
+{{< tabs "validation-patterns-tutorial-cmd-cross" >}}
+{{% tab "Bash" %}}
+```bash
+# Fails: regions equal
+scafctl run resolver -f my-solution.yaml -r region=us-east1 -r backupRegion=us-east1
+# Passes: regions differ
+scafctl run resolver -f my-solution.yaml -r region=us-east1 -r backupRegion=us-west1
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Fails: regions equal
+scafctl run resolver -f my-solution.yaml -r region=us-east1 -r backupRegion=us-east1
+# Passes: regions differ
+scafctl run resolver -f my-solution.yaml -r region=us-east1 -r backupRegion=us-west1
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+In `run resolver` (non-fatal) mode, a failing deferred rule still shows the
+resolved values, reports the failure on stderr, and skips state persistence. Add
+`--fail-on-validation` to exit non-zero. See the
+[Two-Phase Validation design doc](../design/two-phase-validation.md) for the full
+execution order and skipped/errored semantics.
+
+---
+
 ## Next Steps
 
 - [CEL Expressions Tutorial](cel-tutorial.md) — dive deeper into CEL functions for validation

--- a/examples/README.md
+++ b/examples/README.md
@@ -133,6 +133,7 @@ Resolvers demonstrate dynamic value computation, validation, and transformation.
 | [dependencies.yaml](resolvers/dependencies.yaml) | Resolver dependencies & phases | `scafctl run resolver -f examples/resolvers/dependencies.yaml` |
 | [env-config.yaml](resolvers/env-config.yaml) | Environment-based configuration | `scafctl run resolver -f examples/resolvers/env-config.yaml -r env=production` |
 | [validation.yaml](resolvers/validation.yaml) | Input validation patterns | `scafctl run resolver -f examples/resolvers/validation.yaml` |
+| [cross-validation-demo.yaml](resolvers/cross-validation-demo.yaml) | Two-phase (inline + deferred cross-resolver) validation | `scafctl run resolver -f examples/resolvers/cross-validation-demo.yaml` |
 | [transform-pipeline.yaml](resolvers/transform-pipeline.yaml) | Data transformation pipeline | `scafctl run resolver -f examples/resolvers/transform-pipeline.yaml` |
 | [feature-flags.yaml](resolvers/feature-flags.yaml) | Feature flag patterns | `scafctl run resolver -f examples/resolvers/feature-flags.yaml` |
 | [secrets.yaml](resolvers/secrets.yaml) | Secret management (requires secret store) | `scafctl run resolver -f examples/resolvers/secrets.yaml` |

--- a/examples/resolvers/cross-validation-demo.yaml
+++ b/examples/resolvers/cross-validation-demo.yaml
@@ -1,0 +1,67 @@
+# Run: scafctl run resolver -f examples/resolvers/cross-validation-demo.yaml
+# Run: scafctl run resolver -f examples/resolvers/cross-validation-demo.yaml region=us-east1 backupRegion=us-west1
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: cross-validation-demo
+  displayName: Cross-Resolver Validation Demo
+  category: resolvers
+  tags:
+    - resolver-example
+    - validation
+  description: |
+    Demonstrates the two-phase validation model. A validation rule that
+    references only its own resolver (via `__self`) runs INLINE during
+    resolution and fails fast. A rule that references ANOTHER resolver
+    (via `_.other`) is DEFERRED: it runs after every resolver has resolved,
+    just before actions.
+
+    Because deferred rules are excluded from the resolution dependency graph,
+    two resolvers can validate against each other -- including message-only
+    references -- without creating a false ordering cycle. Before two-phase
+    validation, the mutual references below would have failed to load with a
+    "circular dependency" error.
+
+spec:
+  resolvers:
+    # Primary region. Has one INLINE rule (self-only, fails fast) and one
+    # DEFERRED rule (reads backupRegion).
+    region:
+      description: Primary deployment region
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+              default: us-east1
+      validate:
+        with:
+          # INLINE: references only __self -> runs during resolution, fails fast.
+          - provider: validation
+            inputs:
+              expression: "__self != ''"
+              message: "region is required"
+          # DEFERRED: references _.backupRegion -> runs after all resolvers.
+          - provider: validation
+            inputs:
+              expression: "_.region != _.backupRegion"
+              message: "tmpl: region must differ from backupRegion (both were {{ .region }})"
+
+    # Backup region. Its validation message references the primary region --
+    # a message-only cross-reference that no longer forms a cycle.
+    backupRegion:
+      description: Backup deployment region
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: backupRegion
+              default: us-west1
+      validate:
+        with:
+          # DEFERRED via message-only reference to _.region.
+          - provider: validation
+            inputs:
+              expression: "__self != ''"
+              message: "tmpl: backupRegion is required and must differ from region {{ .region }}"

--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -411,6 +411,17 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 	}
 	resolverElapsed := time.Since(start)
 
+	// State lifecycle (D1): commit immutable locks after resolvers and deferred
+	// validation succeed, before running side-effecting actions. Merged
+	// parameters are saved after actions complete.
+	if stateMgr != nil && stateData != nil {
+		solMeta := buildStateSolutionMeta(sol)
+		skip := deferredValidationFailures(resolverCtx)
+		if saveErr := stateMgr.SaveImmutables(ctx, stateData, resolverCtx, resolvers, params, resolverData, solMeta, skip); saveErr != nil {
+			return o.exitWithCode(ctx, fmt.Errorf("state save immutables: %w", saveErr), exitcode.GeneralError)
+		}
+	}
+
 	// Build action graph from filtered workflow
 	graph, err := action.BuildGraph(ctx, workflow, resolverData, nil)
 	if err != nil {
@@ -453,11 +464,11 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 		return o.exitWithCode(ctx, fmt.Errorf("action execution failed: %w", err), exitcode.ActionFailed)
 	}
 
-	// State lifecycle: save merged parameters and check immutable values
-	// after successful action execution.
+	// State lifecycle: save merged parameters after successful action execution.
+	// Immutable locks were already committed before actions (D1).
 	if stateMgr != nil && stateData != nil {
 		solMeta := buildStateSolutionMeta(sol)
-		if saveErr := stateMgr.Save(ctx, stateData, resolverCtx, resolvers, params, resolverData, solMeta); saveErr != nil {
+		if saveErr := stateMgr.SaveParams(ctx, stateData, params, resolverData, solMeta); saveErr != nil {
 			return o.exitWithCode(ctx, fmt.Errorf("state save: %w", saveErr), exitcode.GeneralError)
 		}
 	}

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -609,6 +609,25 @@ func (o *sharedResolverOptions) executeResolvers(
 	return resolverData, resolverCtx, nil
 }
 
+// deferredValidationFailures returns the set of resolver names whose deferred
+// (cross-resolver) validation failed, so their immutable values are not locked
+// even in collect-errors modes. Returns nil when the deferred validation phase
+// did not run or reported no failures.
+func deferredValidationFailures(resolverCtx *resolver.Context) map[string]bool {
+	if resolverCtx == nil {
+		return nil
+	}
+	summary := resolverCtx.DeferredValidation()
+	if summary == nil || len(summary.Results) == 0 {
+		return nil
+	}
+	failed := make(map[string]bool, len(summary.Results))
+	for _, rf := range summary.Results {
+		failed[rf.ResolverName] = true
+	}
+	return failed
+}
+
 // prepareSolutionForExecution loads a solution, sets up the provider registry,
 // and registers the solution provider. It handles bundle extraction, plugin merging,
 // and working directory changes. Returns cleanup function that must be deferred.

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -529,6 +529,20 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 
 	resolverElapsed := time.Since(start)
 
+	// State lifecycle (D1): commit immutable locks now -- after resolvers and
+	// deferred validation have succeeded, but before running side-effecting
+	// actions. An immutable lock represents a value that is now fixed; it must be
+	// persisted independent of whether a downstream action later fails, so the
+	// next run does not regenerate a different value. Resolvers whose deferred
+	// validation failed are not locked. Merged parameters are saved after actions.
+	if stateMgr != nil && stateData != nil {
+		solMeta := buildStateSolutionMeta(sol)
+		skip := deferredValidationFailures(resolverCtx)
+		if saveErr := stateMgr.SaveImmutables(ctx, stateData, resolverCtx, resolvers, params, resolverData, solMeta, skip); saveErr != nil {
+			return o.exitWithCode(ctx, fmt.Errorf("state save immutables: %w", saveErr), exitcode.GeneralError)
+		}
+	}
+
 	// Build action graph
 	graph, err := action.BuildGraph(ctx, workflow, resolverData, nil)
 	if err != nil {
@@ -576,11 +590,11 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 		return o.exitWithCode(ctx, fmt.Errorf("action execution failed: %w", err), exitcode.ActionFailed)
 	}
 
-	// State lifecycle: save merged parameters and check immutable values
-	// after successful action execution.
+	// State lifecycle: save merged parameters after successful action execution.
+	// Immutable locks were already committed before actions (D1).
 	if stateMgr != nil && stateData != nil {
 		solMeta := buildStateSolutionMeta(sol)
-		if saveErr := stateMgr.Save(ctx, stateData, resolverCtx, resolvers, params, resolverData, solMeta); saveErr != nil {
+		if saveErr := stateMgr.SaveParams(ctx, stateData, params, resolverData, solMeta); saveErr != nil {
 			return o.exitWithCode(ctx, fmt.Errorf("state save: %w", saveErr), exitcode.GeneralError)
 		}
 	}

--- a/pkg/concepts/builtin.go
+++ b/pkg/concepts/builtin.go
@@ -15,9 +15,9 @@ var builtinConcepts = []Concept{
 
 1. **resolve** — one or more provider steps that produce the initial value (e.g., prompt user, read file, call API).
 2. **transform** — optional steps that reshape or enrich the resolved value.
-3. **validate** — optional steps that enforce constraints on the final value.
+3. **validate** — optional steps that enforce constraints on the value. Validation runs in two phases: rules that reference only the owning resolver (via __self) run **inline** during resolution and fail fast; rules that reference another resolver (via _.other, in the expression, inputs, when, or message) are **deferred** and run after every resolver has resolved, just before actions. The phase is chosen automatically, and deferred references do not add edges to the resolution dependency graph — so two resolvers can validate against each other without forming a false ordering cycle.
 
-Resolvers can depend on each other via 'dependsOn' or implicit CEL references (_.otherResolver). The dependency graph must be a DAG — circular references are rejected at lint time.`,
+Resolvers can depend on each other via 'dependsOn' or implicit CEL references (_.otherResolver). The dependency graph must be a DAG — circular references in resolve/transform/when are rejected at lint time (cross-resolver validation references do not count).`,
 		Examples: []string{
 			"spec:\n  resolvers:\n    region:\n      type: string\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              name: region\n              default: us-east-1",
 		},

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -110,6 +110,7 @@ func Solution(sol *solution.Solution, filePath string, registry *provider.Regist
 	lintResolvers(sol, result, registry, referencedResolvers)
 	lintTemplateFileDependencies(sol, solutionDir, result, registry)
 	lintResolverCycles(sol, result, registry)
+	lintDeferredValidation(sol, result, registry)
 	lintTemplateAccessors(sol, result)
 	lintWorkflow(sol, result, registry)
 	lintCalls(sol, result, registry)
@@ -626,8 +627,9 @@ func isNonTrivialGuard(c *resolver.Condition) bool {
 }
 
 // lintResolverCycles checks for circular dependencies in the resolver dependency graph.
-// When a cycle involves a resolver with a validate block, the suggestion specifically
-// recommends extracting the validation into a separate resolver.
+// Only resolution-phase references (resolve/transform/when) form edges; deferred
+// cross-resolver validation references are excluded by ExtractDependencies and
+// therefore never reported here as cycles.
 func lintResolverCycles(sol *solution.Solution, result *Result, registry *provider.Registry) {
 	if sol.Spec.Resolvers == nil {
 		return
@@ -647,30 +649,48 @@ func lintResolverCycles(sol *solution.Solution, result *Result, registry *provid
 		deps[name] = resolver.ExtractDependencies(res, lookup)
 	}
 
-	// Detect cycles using DFS-based cycle detection.
+	// Detect cycles using DFS-based cycle detection. Any cycle found is a genuine
+	// resolve/transform ordering cycle; validation references cannot contribute.
 	cycles := findResolverCycles(deps)
 	for _, cycle := range cycles {
-		// Check if any resolver in the cycle has a validate block.
-		hasValidate := false
-		for _, name := range cycle {
-			if res, ok := sol.Spec.Resolvers[name]; ok && res != nil && res.Validate != nil && len(res.Validate.With) > 0 {
-				hasValidate = true
-				break
-			}
-		}
-
 		location := fmt.Sprintf("resolvers.%s", cycle[0])
 		cycleStr := strings.Join(cycle, " → ")
 
-		suggestion := "Break the cycle by reordering dependencies or removing unnecessary references"
-		if hasValidate {
-			suggestion = "A validate block is part of this cycle. Extract the validation into a separate resolver that depends on all required values, breaking the cycle"
-		}
-
 		result.addFinding(SeverityError, "dependency", location,
 			fmt.Sprintf("circular dependency detected: %s", cycleStr),
-			suggestion,
+			"Break the cycle by reordering dependencies or removing unnecessary references",
 			"resolver-cycle")
+	}
+}
+
+// lintDeferredValidation emits an advisory finding for each resolver that has a
+// cross-resolver (deferred) validation rule. Deferred rules run after all
+// resolvers resolve and therefore cannot fail fast, so authors are guided to
+// keep cheap self-only checks (required/regex) as separate inline rules to
+// preserve early feedback.
+func lintDeferredValidation(sol *solution.Solution, result *Result, registry *provider.Registry) {
+	if sol.Spec.Resolvers == nil {
+		return
+	}
+
+	var lookup resolver.DescriptorLookup
+	if registry != nil {
+		lookup = registry.DescriptorLookup()
+	}
+
+	for _, res := range sol.Spec.ResolversToSlice() {
+		if res == nil || res.Validate == nil {
+			continue
+		}
+		part := resolver.PartitionValidatePhase(res, lookup)
+		if !part.HasDeferred() {
+			continue
+		}
+		location := fmt.Sprintf("resolvers.%s.validate", res.Name)
+		result.addFinding(SeverityInfo, "structure", location,
+			fmt.Sprintf("resolver %q has a cross-resolver validation rule that runs in the deferred phase; it cannot fail fast", res.Name),
+			"Keep cheap self-only checks (required/regex) as separate inline validation rules so they still fail fast; deferred rules run after all resolvers resolve",
+			"deferred-validation-not-fail-fast")
 	}
 }
 

--- a/pkg/lint/lint_extra_test.go
+++ b/pkg/lint/lint_extra_test.go
@@ -1196,7 +1196,7 @@ func TestLintResolverCycles_SimpleCycle(t *testing.T) {
 	assert.Contains(t, cycleFindings[0].Message, "circular dependency")
 }
 
-func TestLintResolverCycles_ValidateCycleSuggestion(t *testing.T) {
+func TestLintResolverCycles_GenericSuggestion(t *testing.T) {
 	reg := provider.NewRegistry()
 	require.NoError(t, reg.Register(newFakeProvider("static", nil)))
 	require.NoError(t, reg.Register(newFakeProviderWithCapabilities("validation", []provider.Capability{provider.CapabilityValidation})))
@@ -1249,8 +1249,69 @@ func TestLintResolverCycles_ValidateCycleSuggestion(t *testing.T) {
 	}
 
 	require.Len(t, cycleFindings, 1)
-	assert.Contains(t, cycleFindings[0].Suggestion, "validate block",
-		"cycle involving validate block should suggest extracting validation")
+	assert.Contains(t, cycleFindings[0].Suggestion, "Break the cycle",
+		"a genuine resolve cycle should give the generic break-the-cycle suggestion")
+	assert.NotContains(t, cycleFindings[0].Suggestion, "validate block",
+		"validation references no longer form cycles, so the validate-specific suggestion is retired")
+}
+
+func TestLintDeferredValidation(t *testing.T) {
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("static", nil)))
+	require.NoError(t, reg.Register(newFakeProviderWithCapabilities("validation", []provider.Capability{provider.CapabilityValidation})))
+
+	selfExpr := celexp.Expression("__self != ''")
+	crossExpr := celexp.Expression("_.region != _.backupRegion")
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"backupRegion": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: "us-west1"}}},
+				},
+			},
+		},
+		"selfOnly": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: "x"}}},
+				},
+			},
+			Validate: &resolver.ValidatePhase{
+				With: []resolver.ProviderValidation{
+					{Provider: "validation", Inputs: map[string]*spec.ValueRef{"expression": {Expr: &selfExpr}}},
+				},
+			},
+		},
+		"region": {
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*spec.ValueRef{"value": {Literal: "us-east1"}}},
+				},
+			},
+			Validate: &resolver.ValidatePhase{
+				With: []resolver.ProviderValidation{
+					{Provider: "validation", Inputs: map[string]*spec.ValueRef{"expression": {Expr: &crossExpr}}},
+				},
+			},
+		},
+	}
+
+	result := &Result{}
+	lintDeferredValidation(sol, result, reg)
+
+	var advisories []*Finding
+	for _, f := range result.Findings {
+		if f.RuleName == "deferred-validation-not-fail-fast" {
+			advisories = append(advisories, f)
+		}
+	}
+
+	// Only the cross-resolver rule ("region") is deferred; the self-only rule is not.
+	require.Len(t, advisories, 1)
+	assert.Equal(t, SeverityInfo, advisories[0].Severity)
+	assert.Equal(t, "resolvers.region.validate", advisories[0].Location)
 }
 
 // ---- collectTemplateFileResolverRefs ----

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -579,10 +579,21 @@ var KnownRules = map[string]RuleMeta{
 		Severity:    string(SeverityError),
 		Category:    "dependency",
 		Description: "The resolver dependency graph contains a circular dependency.",
-		Why:         "Circular dependencies between resolvers create infinite loops that prevent the DAG from being scheduled. The dependency graph must be acyclic.",
-		Fix:         "Break the cycle by reordering dependencies, removing unnecessary references, or extracting cycle-causing logic into a separate resolver. When a validate block causes the cycle, extract the validation into a dedicated resolver that runs after all its dependencies.",
+		Why:         "Circular dependencies between resolvers create infinite loops that prevent the DAG from being scheduled. The dependency graph must be acyclic. Only resolution-phase references (resolve, transform, when) form edges; cross-resolver validation references are evaluated in a deferred phase after resolution and never create resolution cycles.",
+		Fix:         "Break the cycle by reordering dependencies, removing unnecessary references, or extracting cycle-causing logic into a separate resolver.",
 		Examples: []string{
-			"# Problem: validate block creates a cycle\n# resolverA validate needs resolverB, but resolverB depends on resolverA\n\n# Fix: extract the validation into a separate resolver\nresolvers:\n  resolverA:\n    resolve:\n      with:\n        - provider: parameter\n          inputs:\n            key: inputA\n  validateA:\n    dependsOn: [resolverA, resolverB]\n    validate:\n      with:\n        - provider: validation\n          inputs:\n            expression:\n              expr: '_.resolverB.valid == true'\n            message: 'Validation failed'",
+			"# Problem: resolverA.resolve reads _.resolverB while resolverB.resolve reads _.resolverA\n# Fix: remove one direction or introduce an independent resolver both can read\nresolvers:\n  shared:\n    resolve:\n      with:\n        - provider: parameter\n          inputs:\n            key: shared\n  resolverA:\n    dependsOn: [shared]\n    resolve:\n      with:\n        - provider: cel\n          inputs:\n            expression:\n              expr: '_.shared'\n  resolverB:\n    dependsOn: [shared]\n    resolve:\n      with:\n        - provider: cel\n          inputs:\n            expression:\n              expr: '_.shared'",
+		},
+	},
+	"deferred-validation-not-fail-fast": {
+		Rule:        "deferred-validation-not-fail-fast",
+		Severity:    string(SeverityInfo),
+		Category:    "structure",
+		Description: "A resolver has a cross-resolver validation rule that runs in the deferred (post-resolution) validation phase.",
+		Why:         "scafctl uses a two-phase validation model. Inline rules reference only the owning resolver and run during resolution so they fail fast. A rule that references another resolver is deferred: it runs after all resolvers resolve and before actions, so it cannot fail fast. Mixing a cheap self-only check into a deferred rule delays the feedback the author would otherwise get immediately.",
+		Fix:         "Keep cheap self-only checks (required, regex, length) as separate inline validation rules so they still fail fast. Reserve deferred rules for genuine cross-resolver invariants. Use a rule-level 'when:' guard for conditional cross-checks.",
+		Examples: []string{
+			"# Inline rule fails fast; deferred rule enforces the cross-resolver invariant\nresolvers:\n  region:\n    resolve:\n      with:\n        - provider: parameter\n          inputs:\n            key: region\n    validate:\n      with:\n        - provider: validation   # inline: self-only, fails fast\n          inputs:\n            expression:\n              expr: '__self != \"\"'\n            message: 'region is required'\n        - provider: validation   # deferred: references another resolver\n          inputs:\n            expression:\n              expr: '_.region != _.backupRegion'\n            message: 'region must differ from backupRegion'",
 		},
 	},
 	"invalid-fingerprint-scope": {

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 61 rules — update this when new rules are added
-	assert.Equal(t, 61, len(KnownRules), "expected 61 known lint rules")
+	// We expect exactly 62 rules — update this when new rules are added
+	assert.Equal(t, 62, len(KnownRules), "expected 62 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/resolver/benchmark_test.go
+++ b/pkg/resolver/benchmark_test.go
@@ -197,3 +197,58 @@ func BenchmarkBuildGraph_Large(b *testing.B) {
 		_, _ = BuildGraph(resolvers, lookup)
 	}
 }
+
+// BenchmarkExecutor_DeferredValidation measures the overhead of the deferred
+// (cross-resolver) validation phase: two resolvers where one validates against
+// the other, forcing a deferred rule that runs after resolution completes.
+func BenchmarkExecutor_DeferredValidation(b *testing.B) {
+	registry := newMockRegistry()
+	_ = registry.Register(&mockProvider{
+		name: "static",
+		executeFunc: func(_ context.Context, inputs map[string]any) (*provider.Output, error) {
+			return &provider.Output{Data: inputs["value"]}, nil
+		},
+	})
+	_ = registry.Register(&mockProvider{
+		name: "validation",
+		executeFunc: func(_ context.Context, _ map[string]any) (*provider.Output, error) {
+			return &provider.Output{Data: nil}, nil
+		},
+	})
+
+	resolvers := []*Resolver{
+		{
+			Name: "a",
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{{
+					Provider: "static",
+					Inputs:   map[string]*ValueRef{"value": {Literal: "east"}},
+				}},
+			},
+		},
+		{
+			Name: "b",
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{{
+					Provider: "static",
+					Inputs:   map[string]*ValueRef{"value": {Literal: "west"}},
+				}},
+			},
+			// Cross-resolver rule -> classified as deferred.
+			Validate: &ValidatePhase{
+				With: []ProviderValidation{{
+					Provider: "validation",
+					Inputs:   map[string]*ValueRef{"expression": {Literal: "_.a != _.b"}},
+				}},
+			},
+		},
+	}
+
+	executor := NewExecutor(registry)
+
+	b.ResetTimer()
+	for b.Loop() {
+		ctx := context.Background()
+		_, _ = executor.Execute(ctx, resolvers, nil)
+	}
+}

--- a/pkg/resolver/context.go
+++ b/pkg/resolver/context.go
@@ -67,6 +67,9 @@ type ExecutionResult struct {
 type Context struct {
 	data    *sync.Map // map[string]any - stores actual values for CEL access
 	results *sync.Map // map[string]*ExecutionResult - stores full results with metadata
+
+	deferredMu         sync.RWMutex
+	deferredValidation *DeferredValidationSummary // set once after all resolvers resolve
 }
 
 // NewContext creates a new resolver context
@@ -140,6 +143,21 @@ func (c *Context) GetAllResults() map[string]*ExecutionResult {
 		return true
 	})
 	return result
+}
+
+// SetDeferredValidation stores the deferred (cross-resolver) validation summary.
+func (c *Context) SetDeferredValidation(summary *DeferredValidationSummary) {
+	c.deferredMu.Lock()
+	c.deferredValidation = summary
+	c.deferredMu.Unlock()
+}
+
+// DeferredValidation returns the deferred validation summary, or nil if the
+// deferred validation phase did not run.
+func (c *Context) DeferredValidation() *DeferredValidationSummary {
+	c.deferredMu.RLock()
+	defer c.deferredMu.RUnlock()
+	return c.deferredValidation
 }
 
 // WithContext adds resolver context to a Go context

--- a/pkg/resolver/deferred_graph.go
+++ b/pkg/resolver/deferred_graph.go
@@ -1,0 +1,133 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package resolver
+
+import "sort"
+
+// DeferredReportingPlan describes the order in which deferred (cross-resolver)
+// validation results should be evaluated and reported.
+//
+// The reporting graph is derived from DeferredValidationUnit.DependsOn edges
+// (which resolver a rule references). Unlike the resolution DAG, this graph is
+// used only for ordering and reporting -- it MAY contain cycles (two resolvers
+// can validate against each other). Cycles are tolerated: they are condensed
+// into strongly connected components so a deterministic, root-cause-first order
+// can still be produced.
+type DeferredReportingPlan struct {
+	// Order lists the resolver names owning deferred units in root-cause-first
+	// order: a resolver whose deferred rules reference other resolvers is reported
+	// after those referenced resolvers, so upstream failures surface first and can
+	// suppress cascaded failures.
+	Order []string
+	// Cycles lists strongly connected components with more than one member. These
+	// are informational: a cycle in the reporting graph is not an error (deferred
+	// rules only read final values), but surfacing it helps authors understand why
+	// ordering within the component is name-sorted rather than dependency-driven.
+	Cycles [][]string
+}
+
+// buildDeferredReportingPlan computes a deterministic, cycle-tolerant reporting
+// order for the given deferred validation units.
+//
+// It builds a graph whose edges are the depends-on references between unit
+// owners (references to resolvers without deferred units are irrelevant to
+// ordering and are ignored), then runs Tarjan's strongly-connected-components
+// algorithm. Tarjan emits SCCs in reverse topological order of the condensation,
+// which for depends-on edges is dependencies-first (root-cause-first). Nodes are
+// visited in sorted order and each component is name-sorted so the result is
+// stable across runs.
+func buildDeferredReportingPlan(units []DeferredValidationUnit) DeferredReportingPlan {
+	owners := make(map[string]bool, len(units))
+	for _, u := range units {
+		owners[u.ResolverName] = true
+	}
+
+	adj := make(map[string][]string, len(units))
+	nodes := make([]string, 0, len(units))
+	for _, u := range units {
+		nodes = append(nodes, u.ResolverName)
+		var edges []string
+		for _, dep := range u.DependsOn {
+			if dep != u.ResolverName && owners[dep] {
+				edges = append(edges, dep)
+			}
+		}
+		sort.Strings(edges)
+		adj[u.ResolverName] = edges
+	}
+	sort.Strings(nodes)
+
+	tj := &tarjan{
+		index:   make(map[string]int, len(nodes)),
+		lowlink: make(map[string]int, len(nodes)),
+		onStack: make(map[string]bool, len(nodes)),
+		adj:     adj,
+	}
+	for _, n := range nodes {
+		if _, seen := tj.index[n]; !seen {
+			tj.strongConnect(n)
+		}
+	}
+
+	plan := DeferredReportingPlan{Order: make([]string, 0, len(units))}
+	for _, scc := range tj.sccs {
+		sort.Strings(scc)
+		plan.Order = append(plan.Order, scc...)
+		if len(scc) > 1 {
+			plan.Cycles = append(plan.Cycles, scc)
+		}
+	}
+	return plan
+}
+
+// tarjan holds the mutable state for Tarjan's SCC algorithm.
+type tarjan struct {
+	index   map[string]int
+	lowlink map[string]int
+	onStack map[string]bool
+	stack   []string
+	adj     map[string][]string
+	counter int
+	sccs    [][]string
+}
+
+// strongConnect performs the recursive depth-first traversal of Tarjan's
+// algorithm. Recursion depth is bounded by the number of resolvers with deferred
+// validation rules, which is small in practice.
+func (t *tarjan) strongConnect(v string) {
+	t.index[v] = t.counter
+	t.lowlink[v] = t.counter
+	t.counter++
+	t.stack = append(t.stack, v)
+	t.onStack[v] = true
+
+	for _, w := range t.adj[v] {
+		if _, seen := t.index[w]; !seen {
+			t.strongConnect(w)
+			if t.lowlink[w] < t.lowlink[v] {
+				t.lowlink[v] = t.lowlink[w]
+			}
+		} else if t.onStack[w] {
+			if t.index[w] < t.lowlink[v] {
+				t.lowlink[v] = t.index[w]
+			}
+		}
+	}
+
+	// v is a root node of an SCC: pop the stack down to v.
+	if t.lowlink[v] == t.index[v] {
+		var scc []string
+		for {
+			n := len(t.stack) - 1
+			w := t.stack[n]
+			t.stack = t.stack[:n]
+			t.onStack[w] = false
+			scc = append(scc, w)
+			if w == v {
+				break
+			}
+		}
+		t.sccs = append(t.sccs, scc)
+	}
+}

--- a/pkg/resolver/deferred_graph_test.go
+++ b/pkg/resolver/deferred_graph_test.go
@@ -1,0 +1,113 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildDeferredReportingPlan(t *testing.T) {
+	tests := []struct {
+		name       string
+		units      []DeferredValidationUnit
+		wantOrder  []string
+		wantCycles [][]string
+	}{
+		{
+			name:      "empty units",
+			units:     nil,
+			wantOrder: []string{},
+		},
+		{
+			name: "single unit with no owner deps",
+			units: []DeferredValidationUnit{
+				{ResolverName: "checker", DependsOn: []string{"env", "region"}},
+			},
+			// env/region have no deferred units, so they are not reporting nodes.
+			wantOrder: []string{"checker"},
+		},
+		{
+			name: "dependency reported before dependent (root-cause-first)",
+			units: []DeferredValidationUnit{
+				{ResolverName: "checker", DependsOn: []string{"env"}},
+				{ResolverName: "env", DependsOn: []string{}},
+			},
+			wantOrder: []string{"env", "checker"},
+		},
+		{
+			name: "chain a->b->c reports c,b,a",
+			units: []DeferredValidationUnit{
+				{ResolverName: "a", DependsOn: []string{"b"}},
+				{ResolverName: "b", DependsOn: []string{"c"}},
+				{ResolverName: "c", DependsOn: []string{}},
+			},
+			wantOrder: []string{"c", "b", "a"},
+		},
+		{
+			name: "independent units ordered by name",
+			units: []DeferredValidationUnit{
+				{ResolverName: "zeta"},
+				{ResolverName: "alpha"},
+				{ResolverName: "mike"},
+			},
+			wantOrder: []string{"alpha", "mike", "zeta"},
+		},
+		{
+			name: "two-node cycle is tolerated and name-ordered",
+			units: []DeferredValidationUnit{
+				{ResolverName: "b", DependsOn: []string{"a"}},
+				{ResolverName: "a", DependsOn: []string{"b"}},
+			},
+			wantOrder:  []string{"a", "b"},
+			wantCycles: [][]string{{"a", "b"}},
+		},
+		{
+			name: "cycle plus an independent root-cause chain",
+			units: []DeferredValidationUnit{
+				{ResolverName: "a", DependsOn: []string{"b"}},
+				{ResolverName: "b", DependsOn: []string{"a"}},
+				{ResolverName: "root", DependsOn: []string{}},
+				{ResolverName: "a2", DependsOn: []string{"root"}},
+			},
+			// Nodes are visited in sorted order (a, a2, b, root). Visiting "a"
+			// first emits the {a,b} cycle before the root->a2 chain; within the
+			// chain, root (dependency) precedes a2 (dependent).
+			wantOrder:  []string{"a", "b", "root", "a2"},
+			wantCycles: [][]string{{"a", "b"}},
+		},
+		{
+			name: "self reference is ignored (no self cycle)",
+			units: []DeferredValidationUnit{
+				{ResolverName: "solo", DependsOn: []string{"solo"}},
+			},
+			wantOrder: []string{"solo"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := buildDeferredReportingPlan(tt.units)
+			assert.Equal(t, tt.wantOrder, plan.Order, "reporting order")
+			assert.Equal(t, tt.wantCycles, plan.Cycles, "cycles")
+		})
+	}
+}
+
+func TestBuildDeferredReportingPlan_OrderIsDeterministic(t *testing.T) {
+	units := []DeferredValidationUnit{
+		{ResolverName: "d", DependsOn: []string{"a", "b"}},
+		{ResolverName: "c", DependsOn: []string{"a"}},
+		{ResolverName: "b", DependsOn: []string{}},
+		{ResolverName: "a", DependsOn: []string{}},
+	}
+	first := buildDeferredReportingPlan(units).Order
+	for i := 0; i < 20; i++ {
+		got := buildDeferredReportingPlan(units).Order
+		assert.Equal(t, first, got, "order must be stable across runs")
+	}
+	// a and b are roots; c depends on a; d depends on a,b. Roots come first.
+	assert.Equal(t, []string{"a", "b", "c", "d"}, first)
+}

--- a/pkg/resolver/deferred_validation.go
+++ b/pkg/resolver/deferred_validation.go
@@ -1,0 +1,250 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+)
+
+// DeferredValidationSummary reports the outcome of the post-resolution deferred
+// (cross-resolver) validation phase. It is attached to the execution context so
+// collect-errors-mode callers (for example `run resolver`) can inspect and gate
+// on deferred validation without treating it as a fatal error.
+type DeferredValidationSummary struct {
+	// Evaluated is the number of deferred rules whose provider was invoked.
+	Evaluated int
+	// Failed is the number of deferred rules that failed.
+	Failed int
+	// Skipped is the number of deferred rules that did not run (owning resolver
+	// had no value, or a phase/rule when condition evaluated false).
+	Skipped int
+	// Results holds the per-resolver failures, ordered root-cause-first.
+	Results []DeferredValidationFailure
+	// Suppressed lists resolvers whose deferred rules were suppressed because a
+	// referenced resolver already failed its own deferred validation.
+	Suppressed []string
+	// Cycles lists cross-validation cycles detected in the reporting graph. These
+	// are informational (tolerated), not errors.
+	Cycles [][]string
+}
+
+// HasFailures reports whether any deferred validation rule failed.
+func (s *DeferredValidationSummary) HasFailures() bool {
+	return s != nil && s.Failed > 0
+}
+
+// DeferredValidationResultFromContext returns the deferred validation summary
+// attached to ctx by Execute, if any. Callers use it to gate state persistence
+// and actions on deferred validation results in non-fatal modes.
+func DeferredValidationResultFromContext(ctx context.Context) (*DeferredValidationSummary, bool) {
+	rc, ok := FromContext(ctx)
+	if !ok {
+		return nil, false
+	}
+	s := rc.DeferredValidation()
+	return s, s != nil
+}
+
+// runDeferredValidation evaluates every resolver's deferred (cross-resolver)
+// validation rules after all resolver phases have completed. Rules are evaluated
+// in root-cause-first order so upstream failures surface before, and suppress,
+// the cascaded failures they cause.
+//
+// Semantics (decision D2):
+//   - If the owning resolver was skipped or produced no usable value, its own
+//     deferred rules are skipped.
+//   - If a deferred rule references a resolver that produced no usable value
+//     (skipped/errored/absent), every deferred rule for that owner fails closed
+//     with a clear message.
+//   - If a referenced resolver already failed its own deferred validation, the
+//     owner's deferred rules are suppressed (the referenced resolver is the root
+//     cause) rather than emitting duplicate failures.
+func (e *Executor) runDeferredValidation(
+	ctx context.Context,
+	units []DeferredValidationUnit,
+	resolverMap map[string]*Resolver,
+	failed *sync.Map,
+) *DeferredValidationSummary {
+	lgr := logger.FromContext(ctx)
+	resolverCtx, _ := FromContext(ctx)
+
+	plan := buildDeferredReportingPlan(units)
+	unitByName := make(map[string]DeferredValidationUnit, len(units))
+	for _, u := range units {
+		unitByName[u.ResolverName] = u
+	}
+
+	summary := &DeferredValidationSummary{Cycles: plan.Cycles}
+	deferredFailed := make(map[string]bool) // resolvers that failed their own deferred validation
+
+	for _, name := range plan.Order {
+		unit := unitByName[name]
+		r := resolverMap[name]
+		if r == nil || r.Validate == nil {
+			continue
+		}
+		ruleCount := len(unit.RuleIndices)
+
+		// The owning resolver must itself have produced a usable value.
+		ownResult, ok := resolverCtx.GetResult(name)
+		if !ok || ownResult == nil || !resolverHasUsableValue(ownResult, failed, name) {
+			summary.Skipped += ruleCount
+			lgr.V(1).Info("skipping deferred validation: owning resolver produced no value", "resolver", name)
+			continue
+		}
+		value := ownResult.Value
+
+		// Cascade suppression: if a referenced resolver already failed its own
+		// deferred validation, that is the root cause -- suppress this resolver's
+		// rules rather than reporting a duplicate downstream failure.
+		if upstream := firstDeferredFailure(unit.DependsOn, deferredFailed); upstream != "" {
+			summary.Suppressed = append(summary.Suppressed, name)
+			summary.Skipped += ruleCount
+			lgr.V(1).Info("suppressing deferred validation due to upstream failure",
+				"resolver", name, "upstream", upstream)
+			continue
+		}
+
+		// Strict fail-closed: a referenced resolver with no usable value makes the
+		// cross-resolver rule unevaluable.
+		if missing := firstValuelessRef(unit.DependsOn, resolverCtx, failed); missing != "" {
+			rvf := DeferredValidationFailure{ResolverName: name, Sensitive: r.Sensitive}
+			for _, idx := range unit.RuleIndices {
+				// The referenced resolver produced no value, so no provider is
+				// invoked -- this is a failure, not an evaluation.
+				summary.Failed++
+				rvf.Failures = append(rvf.Failures, ValidationFailure{
+					Rule:      idx,
+					Provider:  r.Validate.With[idx].Provider,
+					Message:   fmt.Sprintf("deferred validation references resolver %q which did not produce a value", missing),
+					Sensitive: r.Sensitive,
+				})
+			}
+			summary.Results = append(summary.Results, rvf)
+			deferredFailed[name] = true
+			continue
+		}
+
+		// Phase-level when gates the deferred rules too. It is evaluated here (not
+		// inline) so it can reference foreign resolvers when needed.
+		if r.Validate.When != nil {
+			shouldExecute, err := e.evaluateConditionWithSelf(ctx, r.Validate.When, value)
+			if err != nil {
+				// The phase-level when failed to evaluate, so no provider ran for any
+				// rule in this block. Record one failure per affected rule so the
+				// summary counters stay consistent with the detailed Results and each
+				// failure is attributable to a specific rule/provider.
+				rvf := DeferredValidationFailure{ResolverName: name, Sensitive: r.Sensitive}
+				for _, idx := range unit.RuleIndices {
+					summary.Failed++
+					rvf.Failures = append(rvf.Failures, ValidationFailure{
+						Rule:      idx,
+						Provider:  r.Validate.With[idx].Provider,
+						Message:   fmt.Sprintf("failed to evaluate deferred validate phase when condition: %v", err),
+						Cause:     err,
+						Sensitive: r.Sensitive,
+					})
+				}
+				summary.Results = append(summary.Results, rvf)
+				deferredFailed[name] = true
+				continue
+			}
+			if !shouldExecute {
+				summary.Skipped += ruleCount
+				lgr.V(1).Info("skipping deferred validation due to phase when condition", "resolver", name)
+				continue
+			}
+		}
+
+		rvf := DeferredValidationFailure{ResolverName: name, Sensitive: r.Sensitive}
+		for _, idx := range unit.RuleIndices {
+			validation := r.Validate.With[idx]
+			calls, failure, err := e.evaluateValidationRule(ctx, idx, r.Sensitive, validation, value)
+			if err != nil {
+				// A fatal rule-evaluation error (for example a bad when condition)
+				// is recorded as a failure so it is surfaced to the author. No
+				// provider was invoked, so it is not counted as evaluated.
+				failure = &ValidationFailure{
+					Rule:      idx,
+					Provider:  validation.Provider,
+					Message:   err.Error(),
+					Cause:     err,
+					Sensitive: r.Sensitive,
+				}
+			}
+			switch {
+			case calls > 0:
+				// The provider was invoked for this rule.
+				summary.Evaluated++
+			case failure == nil:
+				// The rule's own when condition evaluated false; nothing ran.
+				summary.Skipped++
+			}
+			if failure == nil {
+				continue
+			}
+			summary.Failed++
+			rvf.Failures = append(rvf.Failures, *failure)
+			lgr.V(1).Info("deferred validation rule failed",
+				"resolver", name, "rule", idx+1,
+				logKeyProvider, validation.Provider,
+				"message", redactForLog(failure.Message, r.Sensitive))
+		}
+		if len(rvf.Failures) > 0 {
+			summary.Results = append(summary.Results, rvf)
+			deferredFailed[name] = true
+		}
+	}
+
+	return summary
+}
+
+// resolverHasUsableValue reports whether a resolver produced a value that a
+// deferred validation rule can read. A skipped resolver has no value; a failed
+// resolver has a usable value only when the failure was a (partial-emission)
+// validation failure rather than a resolve/transform failure.
+func resolverHasUsableValue(result *ExecutionResult, failed *sync.Map, name string) bool {
+	switch result.Status {
+	case ExecutionStatusSkipped:
+		return false
+	case ExecutionStatusSuccess:
+		return true
+	case ExecutionStatusFailed:
+		if kindVal, ok := failed.Load(name); ok {
+			if kind, ok := kindVal.(resolverFailureKind); ok {
+				return kind == failureValidation
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// firstDeferredFailure returns the first referenced resolver (in the given order)
+// that has already failed its own deferred validation, or "" if none.
+func firstDeferredFailure(refs []string, deferredFailed map[string]bool) string {
+	for _, ref := range refs {
+		if deferredFailed[ref] {
+			return ref
+		}
+	}
+	return ""
+}
+
+// firstValuelessRef returns the first referenced resolver that did not produce a
+// usable value, or "" if every reference has one.
+func firstValuelessRef(refs []string, resolverCtx *Context, failed *sync.Map) string {
+	for _, ref := range refs {
+		res, ok := resolverCtx.GetResult(ref)
+		if !ok || res == nil || !resolverHasUsableValue(res, failed, ref) {
+			return ref
+		}
+	}
+	return ""
+}

--- a/pkg/resolver/deferred_validation_executor_test.go
+++ b/pkg/resolver/deferred_validation_executor_test.go
@@ -1,0 +1,321 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package resolver
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deferredTestRegistry returns a registry with a "static" source provider and an
+// "assert" validation provider that fails when its "ok" input is not true.
+func deferredTestRegistry(t *testing.T) *mockRegistry {
+	t.Helper()
+	registry := newMockRegistry()
+	require.NoError(t, registry.Register(&mockProvider{
+		name: "static",
+		executeFunc: func(_ context.Context, inputs map[string]any) (*provider.Output, error) {
+			return &provider.Output{Data: inputs["value"]}, nil
+		},
+	}))
+	require.NoError(t, registry.Register(&mockProvider{
+		name: "assert",
+		executeFunc: func(_ context.Context, inputs map[string]any) (*provider.Output, error) {
+			if ok, _ := inputs["ok"].(bool); !ok {
+				return nil, fmt.Errorf("assertion failed")
+			}
+			return &provider.Output{Data: true}, nil
+		},
+	}))
+	return registry
+}
+
+func staticResolver(name, value string) *Resolver {
+	return &Resolver{
+		Name: name,
+		Resolve: &ResolvePhase{
+			With: []ProviderSource{{
+				Provider: "static",
+				Inputs:   map[string]*ValueRef{"value": {Literal: value}},
+			}},
+		},
+	}
+}
+
+// crossChecker builds a resolver whose validate rule asserts env != region across
+// two other resolvers -- a deferred (cross-resolver) validation.
+func crossChecker() *Resolver {
+	r := staticResolver("checker", "check")
+	r.Validate = &ValidatePhase{
+		With: []ProviderValidation{{
+			Provider: "assert",
+			Inputs:   map[string]*ValueRef{"ok": {Expr: celExpPtr("_.env != _.region")}},
+		}},
+	}
+	return r
+}
+
+func TestExecute_DeferredValidation_Passes(t *testing.T) {
+	registry := deferredTestRegistry(t)
+	executor := NewExecutor(registry)
+
+	resolvers := []*Resolver{
+		staticResolver("env", "prod"),
+		staticResolver("region", "us-east1"),
+		crossChecker(),
+	}
+
+	ctx, err := executor.Execute(context.Background(), resolvers, nil)
+	require.NoError(t, err)
+
+	summary, ok := DeferredValidationResultFromContext(ctx)
+	require.True(t, ok)
+	assert.Equal(t, 1, summary.Evaluated)
+	assert.Equal(t, 0, summary.Failed)
+	assert.False(t, summary.HasFailures())
+}
+
+func TestExecute_DeferredValidation_Fails(t *testing.T) {
+	registry := deferredTestRegistry(t)
+	executor := NewExecutor(registry)
+
+	resolvers := []*Resolver{
+		staticResolver("env", "prod"),
+		staticResolver("region", "prod"), // equal -> assertion fails
+		crossChecker(),
+	}
+
+	ctx, err := executor.Execute(context.Background(), resolvers, nil)
+	require.Error(t, err)
+
+	var derr *AggregatedDeferredValidationError
+	require.True(t, errors.As(err, &derr), "expected AggregatedDeferredValidationError, got %T", err)
+	require.Len(t, derr.Failures, 1)
+	assert.Equal(t, "checker", derr.Failures[0].ResolverName)
+
+	summary, ok := DeferredValidationResultFromContext(ctx)
+	require.True(t, ok)
+	assert.Equal(t, 1, summary.Failed)
+}
+
+func TestExecute_DeferredValidation_MessageOnlyRefNoCycle(t *testing.T) {
+	registry := deferredTestRegistry(t)
+	executor := NewExecutor(registry)
+
+	// checker's rule is self-only in its provider inputs, but its message
+	// references another resolver. Historically this created a false dependency
+	// cycle; it must now defer cleanly.
+	checker := staticResolver("checker", "ok")
+	checker.Validate = &ValidatePhase{
+		With: []ProviderValidation{{
+			Provider: "assert",
+			Inputs:   map[string]*ValueRef{"ok": {Expr: celExpPtr("__self == 'ok'")}},
+			Message:  &ValueRef{Tmpl: tmplPtr("checker conflicts with env {{ ._.env }}")},
+		}},
+	}
+	// env references checker in ITS validate message too -- a mutual message-only
+	// reference that would previously form a cycle.
+	env := staticResolver("env", "prod")
+	env.Validate = &ValidatePhase{
+		With: []ProviderValidation{{
+			Provider: "assert",
+			Inputs:   map[string]*ValueRef{"ok": {Expr: celExpPtr("__self == 'prod'")}},
+			Message:  &ValueRef{Tmpl: tmplPtr("env conflicts with checker {{ ._.checker }}")},
+		}},
+	}
+
+	_, err := executor.Execute(context.Background(), []*Resolver{checker, env}, nil)
+	require.NoError(t, err, "mutual message-only references must not form a cycle")
+}
+
+func TestExecute_DeferredValidation_NonFatalCollects(t *testing.T) {
+	registry := deferredTestRegistry(t)
+	executor := NewExecutor(registry, WithNonFatalValidation(true))
+
+	resolvers := []*Resolver{
+		staticResolver("env", "prod"),
+		staticResolver("region", "prod"), // equal -> assertion fails
+		crossChecker(),
+	}
+
+	ctx, err := executor.Execute(context.Background(), resolvers, nil)
+	// Non-fatal mode folds deferred failures into a collect-errors aggregated
+	// error (values stay inspectable via the context) rather than a hard
+	// deferred-validation error.
+	require.Error(t, err)
+	var aggErr *AggregatedExecutionError
+	require.True(t, errors.As(err, &aggErr), "expected AggregatedExecutionError, got %T", err)
+
+	// Deferred failures are reported as an extra phase after the last resolver
+	// phase, satisfying FailedResolver.Phase's minimum:"1" contract (never 0).
+	require.NotEmpty(t, aggErr.Errors)
+	for _, fr := range aggErr.Errors {
+		assert.GreaterOrEqual(t, fr.Phase, 1, "deferred validation phase must be >= 1")
+	}
+
+	summary, ok := DeferredValidationResultFromContext(ctx)
+	require.True(t, ok)
+	assert.Equal(t, 1, summary.Failed)
+	assert.True(t, summary.HasFailures())
+}
+
+func TestExecute_DeferredValidation_FailClosedOnSkippedRef(t *testing.T) {
+	registry := deferredTestRegistry(t)
+	executor := NewExecutor(registry)
+
+	// "maybe" is skipped via a false when condition, so it produces no value.
+	maybe := staticResolver("maybe", "x")
+	maybe.When = &Condition{Expr: celExpPtr("false")}
+
+	checker := staticResolver("checker", "check")
+	checker.Validate = &ValidatePhase{
+		With: []ProviderValidation{{
+			Provider: "assert",
+			Inputs:   map[string]*ValueRef{"ok": {Expr: celExpPtr("_.env != _.maybe")}},
+		}},
+	}
+
+	resolvers := []*Resolver{
+		staticResolver("env", "prod"),
+		maybe,
+		checker,
+	}
+
+	ctx, err := executor.Execute(context.Background(), resolvers, nil)
+	require.Error(t, err)
+
+	var derr *AggregatedDeferredValidationError
+	require.True(t, errors.As(err, &derr))
+	require.Len(t, derr.Failures, 1)
+	require.Len(t, derr.Failures[0].Failures, 1)
+	assert.Contains(t, derr.Failures[0].Failures[0].Message, "did not produce a value")
+
+	summary, ok := DeferredValidationResultFromContext(ctx)
+	require.True(t, ok)
+	assert.Equal(t, 1, summary.Failed)
+	// No provider is invoked when a referenced resolver has no value, so the
+	// fail-closed rule must not be counted as evaluated.
+	assert.Equal(t, 0, summary.Evaluated)
+}
+
+func TestExecute_DeferredValidation_RuleWhenFalseCountsSkipped(t *testing.T) {
+	registry := deferredTestRegistry(t)
+	executor := NewExecutor(registry)
+
+	// checker's cross-resolver rule is gated by a rule-level when that evaluates
+	// false, so no provider runs: it must be counted as skipped, not evaluated.
+	checker := staticResolver("checker", "check")
+	checker.Validate = &ValidatePhase{
+		With: []ProviderValidation{{
+			Provider: "assert",
+			When:     &Condition{Expr: celExpPtr("_.env == 'never'")},
+			Inputs:   map[string]*ValueRef{"ok": {Expr: celExpPtr("_.env != _.region")}},
+		}},
+	}
+
+	resolvers := []*Resolver{
+		staticResolver("env", "prod"),
+		staticResolver("region", "us-east1"),
+		checker,
+	}
+
+	ctx, err := executor.Execute(context.Background(), resolvers, nil)
+	require.NoError(t, err)
+
+	summary, ok := DeferredValidationResultFromContext(ctx)
+	require.True(t, ok)
+	assert.Equal(t, 0, summary.Evaluated)
+	assert.Equal(t, 1, summary.Skipped)
+	assert.Equal(t, 0, summary.Failed)
+}
+
+func TestExecute_DeferredValidation_SkippedWhenValidationDisabled(t *testing.T) {
+	registry := deferredTestRegistry(t)
+	executor := NewExecutor(registry, WithSkipValidation(true))
+
+	resolvers := []*Resolver{
+		staticResolver("env", "prod"),
+		staticResolver("region", "prod"), // would fail if validated
+		crossChecker(),
+	}
+
+	ctx, err := executor.Execute(context.Background(), resolvers, nil)
+	require.NoError(t, err)
+
+	_, ok := DeferredValidationResultFromContext(ctx)
+	assert.False(t, ok, "deferred validation must not run when validation is skipped")
+}
+
+func TestExecute_DeferredValidation_DisabledViaOption(t *testing.T) {
+	registry := deferredTestRegistry(t)
+	executor := NewExecutor(registry, WithDeferredValidation(false))
+
+	resolvers := []*Resolver{
+		staticResolver("env", "prod"),
+		staticResolver("region", "prod"), // would fail if deferred validation ran
+		crossChecker(),
+	}
+
+	ctx, err := executor.Execute(context.Background(), resolvers, nil)
+	require.NoError(t, err)
+
+	_, ok := DeferredValidationResultFromContext(ctx)
+	assert.False(t, ok)
+}
+
+// TestExecute_DeferredValidation_WhenEvalError_CounterConsistency verifies that
+// when a deferred validate-phase when: condition fails to evaluate, the summary
+// counters stay consistent with the detailed Results: one failure is recorded
+// per deferred rule (not a single failure with an inflated Failed count).
+func TestExecute_DeferredValidation_WhenEvalError_CounterConsistency(t *testing.T) {
+	registry := deferredTestRegistry(t)
+	executor := NewExecutor(registry)
+
+	// checker's validate phase references a foreign resolver (env) so it is
+	// classified as deferred, and its when: condition evaluates to a non-boolean
+	// value, forcing an evaluation error that fails every rule in the block.
+	checker := staticResolver("checker", "check")
+	checker.Validate = &ValidatePhase{
+		When: &Condition{Expr: celExpPtr("_.env")}, // string, not bool -> eval error
+		With: []ProviderValidation{
+			{Provider: "assert", Inputs: map[string]*ValueRef{"ok": {Literal: "true"}}},
+			{Provider: "assert", Inputs: map[string]*ValueRef{"ok": {Literal: "true"}}},
+		},
+	}
+
+	resolvers := []*Resolver{
+		staticResolver("env", "prod"),
+		checker,
+	}
+
+	ctx, err := executor.Execute(context.Background(), resolvers, nil)
+	require.Error(t, err)
+
+	summary, ok := DeferredValidationResultFromContext(ctx)
+	require.True(t, ok)
+
+	// Two rules in the block -> two recorded failures, and the Failed counter
+	// must equal the number of detailed failures.
+	assert.Equal(t, 2, summary.Failed)
+	totalFailures := 0
+	for _, rf := range summary.Results {
+		totalFailures += len(rf.Failures)
+	}
+	assert.Equal(t, summary.Failed, totalFailures,
+		"Failed counter must match the number of detailed failures")
+
+	// Each failure must be attributable to a specific rule/provider.
+	require.Len(t, summary.Results, 1)
+	require.Len(t, summary.Results[0].Failures, 2)
+	for _, f := range summary.Results[0].Failures {
+		assert.Equal(t, "assert", f.Provider)
+		assert.Contains(t, f.Message, "when condition")
+	}
+}

--- a/pkg/resolver/errors.go
+++ b/pkg/resolver/errors.go
@@ -122,6 +122,66 @@ func (e *AggregatedValidationError) AddFailure(failure ValidationFailure) {
 	e.Failures = append(e.Failures, failure)
 }
 
+// DeferredValidationFailure holds the deferred (cross-resolver) validation
+// failures for a single resolver. It reuses ValidationFailure for each failing
+// rule so the inline and deferred paths report failures identically.
+type DeferredValidationFailure struct {
+	ResolverName string              `json:"resolverName" yaml:"resolverName" doc:"Name of the resolver whose deferred validation failed" example:"checker"`
+	Failures     []ValidationFailure `json:"failures" yaml:"failures" doc:"List of deferred validation failures" minItems:"1"`
+	Sensitive    bool                `json:"sensitive,omitempty" yaml:"sensitive,omitempty" doc:"Whether the resolver value is sensitive"`
+}
+
+// AggregatedDeferredValidationError aggregates deferred (cross-resolver)
+// validation failures across resolvers, ordered root-cause-first. Deferred
+// validation runs after every resolver has resolved, so failures cannot be
+// attributed to a single resolve phase; this error type carries per-resolver
+// failure groups plus the set of rules suppressed because an upstream deferred
+// validation already failed.
+type AggregatedDeferredValidationError struct {
+	Failures   []DeferredValidationFailure `json:"failures" yaml:"failures" doc:"Per-resolver deferred validation failures, root-cause-first" minItems:"1"`
+	Suppressed []string                    `json:"suppressed,omitempty" yaml:"suppressed,omitempty" doc:"Resolvers whose deferred rules were suppressed due to an upstream failure"`
+}
+
+// Error implements the error interface.
+func (e *AggregatedDeferredValidationError) Error() string {
+	total := 0
+	for _, rf := range e.Failures {
+		total += len(rf.Failures)
+	}
+
+	if len(e.Failures) == 0 {
+		return "deferred validation failed (no details)"
+	}
+
+	if len(e.Failures) == 1 && len(e.Failures[0].Failures) == 1 {
+		return fmt.Sprintf("deferred validation failed: resolver %q: %s",
+			e.Failures[0].ResolverName, e.Failures[0].Failures[0].Error())
+	}
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "deferred validation failed with %d error(s) across %d resolver(s):\n", total, len(e.Failures))
+	for _, rf := range e.Failures {
+		for _, f := range rf.Failures {
+			fmt.Fprintf(&sb, "  - resolver %q: %s\n", rf.ResolverName, f.Error())
+		}
+	}
+	if len(e.Suppressed) > 0 {
+		fmt.Fprintf(&sb, "  (suppressed due to upstream failures: %s)\n", strings.Join(e.Suppressed, ", "))
+	}
+	return strings.TrimSuffix(sb.String(), "\n")
+}
+
+// Unwrap returns nil since this error aggregates multiple failures.
+// Use errors.As with *ValidationFailure to inspect individual failures.
+func (e *AggregatedDeferredValidationError) Unwrap() error {
+	return nil
+}
+
+// HasFailures returns true if there are any deferred validation failures.
+func (e *AggregatedDeferredValidationError) HasFailures() bool {
+	return len(e.Failures) > 0
+}
+
 // CircularDependencyError represents a cycle detected in resolver dependencies.
 type CircularDependencyError struct {
 	Cycle []string `json:"cycle" yaml:"cycle" doc:"List of resolver names forming the cycle" minItems:"2" example:"[\"resolver-a\", \"resolver-b\", \"resolver-a\"]"`

--- a/pkg/resolver/errors_test.go
+++ b/pkg/resolver/errors_test.go
@@ -142,6 +142,45 @@ func TestAggregatedValidationError(t *testing.T) {
 	})
 }
 
+func TestAggregatedDeferredValidationError(t *testing.T) {
+	t.Run("single failure", func(t *testing.T) {
+		err := &AggregatedDeferredValidationError{
+			Failures: []DeferredValidationFailure{
+				{
+					ResolverName: "checker",
+					Failures:     []ValidationFailure{{Rule: 0, Message: "env must differ from region"}},
+				},
+			},
+		}
+		expected := `deferred validation failed: resolver "checker": env must differ from region`
+		assert.Equal(t, expected, err.Error())
+		assert.True(t, err.HasFailures())
+		assert.Nil(t, err.Unwrap())
+	})
+
+	t.Run("multiple failures across resolvers", func(t *testing.T) {
+		err := &AggregatedDeferredValidationError{
+			Failures: []DeferredValidationFailure{
+				{ResolverName: "a", Failures: []ValidationFailure{{Rule: 0, Message: "first"}}},
+				{ResolverName: "b", Failures: []ValidationFailure{{Rule: 0, Message: "second"}, {Rule: 1, Message: "third"}}},
+			},
+			Suppressed: []string{"c"},
+		}
+		msg := err.Error()
+		assert.Contains(t, msg, "deferred validation failed with 3 error(s) across 2 resolver(s)")
+		assert.Contains(t, msg, `resolver "a": first`)
+		assert.Contains(t, msg, `resolver "b": second`)
+		assert.Contains(t, msg, `resolver "b": third`)
+		assert.Contains(t, msg, "suppressed due to upstream failures: c")
+	})
+
+	t.Run("no failures", func(t *testing.T) {
+		err := &AggregatedDeferredValidationError{}
+		assert.Equal(t, "deferred validation failed (no details)", err.Error())
+		assert.False(t, err.HasFailures())
+	})
+}
+
 func TestCircularDependencyError(t *testing.T) {
 	t.Run("with cycle", func(t *testing.T) {
 		err := NewCircularDependencyError([]string{"a", "b", "c", "a"})

--- a/pkg/resolver/executor.go
+++ b/pkg/resolver/executor.go
@@ -68,6 +68,7 @@ type Executor struct {
 	nonFatalValidation bool                  // Treat validation failures as non-fatal: collect them but do not skip dependents
 	skipValidation     bool                  // Skip the validation phase of all resolvers
 	skipTransform      bool                  // Skip the transform and validation phases of all resolvers
+	deferredValidation bool                  // Run the post-resolution deferred (cross-resolver) validation phase
 	mockedResolvers    map[string]any        // Pre-populated resolver values that skip execution
 	calls              map[string]*spec.Call // Reusable call definitions invoked via call + args
 	dedupMemo          *call.Memo            // Per-run memo for opt-in call de-duplication
@@ -161,6 +162,18 @@ func WithSkipTransform(enabled bool) ExecutorOption {
 	}
 }
 
+// WithDeferredValidation enables or disables the post-resolution deferred
+// validation phase, which evaluates cross-resolver validation rules (rules that
+// reference resolvers other than their owner) after every resolver has resolved.
+// It is enabled by default; disable it to evaluate only inline (self-only)
+// validations. Disabling has no effect when validation is already skipped via
+// WithSkipValidation or WithSkipTransform.
+func WithDeferredValidation(enabled bool) ExecutorOption {
+	return func(e *Executor) {
+		e.deferredValidation = enabled
+	}
+}
+
 // WithMockedResolvers pre-populates resolver values so that the corresponding
 // resolvers skip execution entirely and return the mocked value. This enables
 // functional testing of downstream resolvers and CEL expressions without
@@ -183,11 +196,12 @@ func WithCalls(calls map[string]*spec.Call) ExecutorOption {
 // NewExecutor creates a new resolver executor
 func NewExecutor(registry RegistryInterface, opts ...ExecutorOption) *Executor {
 	executor := &Executor{
-		registry:       registry,
-		timeout:        settings.DefaultResolverTimeout,
-		maxConcurrency: 0, // unlimited by default
-		phaseTimeout:   settings.DefaultPhaseTimeout,
-		dedupMemo:      call.NewMemo(),
+		registry:           registry,
+		timeout:            settings.DefaultResolverTimeout,
+		maxConcurrency:     0, // unlimited by default
+		phaseTimeout:       settings.DefaultPhaseTimeout,
+		deferredValidation: true, // deferred cross-resolver validation is on by default
+		dedupMemo:          call.NewMemo(),
 	}
 
 	for _, opt := range opts {
@@ -350,6 +364,52 @@ func (e *Executor) Execute(ctx context.Context, resolvers []*Resolver, params ma
 	}
 
 	lgr.V(1).Info("resolver execution complete", "total_phases", len(buildResult.Phases))
+
+	// Deferred (cross-resolver) validation phase. Runs after all resolvers have
+	// resolved so rules that reference other resolvers can read their final
+	// values. Skipped when validation is disabled or deferred validation is off.
+	if e.deferredValidation && !e.skipValidation && !e.skipTransform && len(buildResult.DeferredWork) > 0 {
+		resolverMap := make(map[string]*Resolver, len(resolvers))
+		for _, r := range resolvers {
+			resolverMap[r.Name] = r
+		}
+
+		summary := e.runDeferredValidation(ctx, buildResult.DeferredWork, resolverMap, &failedResolvers)
+		resolverCtx.SetDeferredValidation(summary)
+
+		if summary.HasFailures() {
+			switch {
+			case e.nonFatalValidation, e.validateAll:
+				// Collect-errors modes (run resolver non-fatal, validate-all): fold
+				// deferred failures into the aggregated error so they surface through
+				// the same validation-diagnostic path as inline failures. Values stay
+				// inspectable and state persistence is skipped. The typed summary is
+				// also available via the context.
+				if aggregatedError == nil {
+					aggregatedError = &AggregatedExecutionError{}
+				}
+				// Deferred validation runs after all resolver phases, so report it
+				// as an extra 1-based phase after the last resolver phase to satisfy
+				// FailedResolver.Phase's minimum:"1" contract.
+				deferredPhase := len(buildResult.Phases) + 1
+				for _, rf := range summary.Results {
+					aggregatedError.Add(rf.ResolverName, deferredPhase, &AggregatedValidationError{
+						ResolverName: rf.ResolverName,
+						Failures:     rf.Failures,
+						Sensitive:    rf.Sensitive,
+					})
+				}
+			default:
+				derr := &AggregatedDeferredValidationError{
+					Failures:   summary.Results,
+					Suppressed: summary.Suppressed,
+				}
+				span.RecordError(derr)
+				span.SetStatus(codes.Error, derr.Error())
+				return ctx, derr
+			}
+		}
+	}
 
 	// In collect-errors mode, return aggregated error if there were any failures
 	if e.collectErrors() && aggregatedError != nil && aggregatedError.HasErrors() {
@@ -1668,8 +1728,14 @@ func (e *Executor) executeValidatePhase(ctx context.Context, resolverName string
 	lgr := logger.FromContext(ctx)
 	providerCallCount := 0
 
-	// Get resolver context from context
-	resolverCtx, _ := FromContext(ctx)
+	// Partition the phase: only inline (self-only) rules run here. Cross-resolver
+	// rules -- and every rule when the phase-level when references a foreign
+	// resolver -- are deferred to runDeferredValidation, which executes after all
+	// resolvers have resolved.
+	part := partitionValidatePhaseFor(phase, resolverName, e.registry.DescriptorLookup())
+	if part.PhaseWhenDeferred || len(part.InlineRules) == 0 {
+		return providerCallCount, nil
+	}
 
 	// Check phase-level when condition (with __self so conditions can reference the resolved value)
 	if phase.When != nil {
@@ -1691,58 +1757,20 @@ func (e *Executor) executeValidatePhase(ctx context.Context, resolverName string
 		Failures:     make([]ValidationFailure, 0),
 	}
 
-	// Run ALL validation rules and collect failures
-	for i, validation := range phase.With {
-		// Check rule-level when condition (with __self so conditions can
-		// reference the resolved value). A false condition skips the rule.
-		if validation.When != nil {
-			shouldExecute, err := e.evaluateConditionWithSelf(ctx, validation.When, value)
-			if err != nil {
-				return providerCallCount, fmt.Errorf("failed to evaluate validate rule %d when condition: %w", i+1, err)
-			}
-			if !shouldExecute {
-				lgr.V(1).Info("skipping validate rule due to when condition", "rule", i+1)
-				continue
-			}
-		}
-
-		// Execute validation provider (or expanded call) with __self set to value being validated
-		_, err := e.runStepProvider(ctx, validation.CallRef, validation.Provider, validation.Inputs, value)
-		providerCallCount++
-
+	// Run only the inline validation rules and collect failures.
+	for _, i := range part.InlineRules {
+		validation := phase.With[i]
+		calls, failure, err := e.evaluateValidationRule(ctx, i, sensitive, validation, value)
+		providerCallCount += calls
 		if err != nil {
-			// Build failure message
-			message := err.Error()
-
-			// Use custom message if provided
-			if validation.Message != nil {
-				customMsg, msgErr := validation.Message.Resolve(ctx, resolverCtx.ToMap(), &value)
-				if msgErr == nil {
-					if msgStr, ok := customMsg.(string); ok {
-						message = msgStr
-					}
-				}
-			}
-
-			// Redact message if sensitive
-			if sensitive {
-				message = "[REDACTED]"
-			}
-
-			failure := ValidationFailure{
-				Rule:      i,
-				Provider:  validation.Provider,
-				Message:   message,
-				Cause:     err,
-				Sensitive: sensitive,
-			}
-
-			validationErr.AddFailure(failure)
-
+			return providerCallCount, err
+		}
+		if failure != nil {
+			validationErr.AddFailure(*failure)
 			lgr.V(1).Info("validation rule failed",
 				"rule", i+1,
 				logKeyProvider, validation.Provider,
-				"message", redactForLog(message, sensitive))
+				"message", redactForLog(failure.Message, sensitive))
 		}
 	}
 
@@ -1752,6 +1780,57 @@ func (e *Executor) executeValidatePhase(ctx context.Context, resolverName string
 	}
 
 	return providerCallCount, nil
+}
+
+// evaluateValidationRule evaluates a single validation rule against value with
+// __self set to value. It returns the number of provider calls made and a
+// non-nil *ValidationFailure when the rule's provider reports a failure. A
+// returned error indicates a fatal problem evaluating the rule itself (for
+// example a malformed when condition), which is distinct from a validation
+// failure. This helper is shared by the inline validate phase and the deferred
+// (cross-resolver) validation phase so both report failures identically.
+func (e *Executor) evaluateValidationRule(ctx context.Context, ruleIndex int, sensitive bool, validation ProviderValidation, value any) (int, *ValidationFailure, error) {
+	// Check rule-level when condition (with __self so conditions can reference the
+	// resolved value). A false condition skips the rule.
+	if validation.When != nil {
+		shouldExecute, err := e.evaluateConditionWithSelf(ctx, validation.When, value)
+		if err != nil {
+			return 0, nil, fmt.Errorf("failed to evaluate validate rule %d when condition: %w", ruleIndex+1, err)
+		}
+		if !shouldExecute {
+			return 0, nil, nil
+		}
+	}
+
+	// Execute validation provider (or expanded call) with __self set to value being validated
+	_, err := e.runStepProvider(ctx, validation.CallRef, validation.Provider, validation.Inputs, value)
+	if err == nil {
+		return 1, nil, nil
+	}
+
+	// Build failure message, preferring a custom message when provided.
+	message := err.Error()
+	if validation.Message != nil {
+		resolverCtx, _ := FromContext(ctx)
+		if customMsg, msgErr := validation.Message.Resolve(ctx, resolverCtx.ToMap(), &value); msgErr == nil {
+			if msgStr, ok := customMsg.(string); ok {
+				message = msgStr
+			}
+		}
+	}
+
+	// Redact message if sensitive
+	if sensitive {
+		message = "[REDACTED]"
+	}
+
+	return 1, &ValidationFailure{
+		Rule:      ruleIndex,
+		Provider:  validation.Provider,
+		Message:   message,
+		Cause:     err,
+		Sensitive: sensitive,
+	}, nil
 }
 
 // executeProviderWithSelf executes a provider with resolved inputs and __self set to the provided value

--- a/pkg/resolver/graph.go
+++ b/pkg/resolver/graph.go
@@ -90,16 +90,12 @@ func extractInferredDependencies(r *Resolver, lookup DescriptorLookup) []string 
 		}
 	}
 
-	// Extract from validate phase (excluding self-refs)
-	if r.Validate != nil {
-		validateDeps := make(map[string]bool)
-		extractDepsFromValidatePhase(r.Validate, validateDeps, lookup)
-		for dep := range validateDeps {
-			if dep != r.Name {
-				deps[dep] = true
-			}
-		}
-	}
+	// Validate-phase references are intentionally NOT part of the resolution
+	// dependency graph. Validation runs in a separate post-resolution phase
+	// (two-phase execution): a cross-resolver validation rule is deferred and its
+	// references must not create resolve-ordering edges (or cycles). Self-only
+	// (inline) rules reference nothing but __self, so they contribute no foreign
+	// deps either. See partitionValidatePhase for the deferred-validation machinery.
 
 	result := make([]string, 0, len(deps))
 	for dep := range deps {
@@ -147,16 +143,13 @@ func extractDependencies(r *Resolver, lookup DescriptorLookup) []string {
 		}
 	}
 
-	// Extract from validate phase (same self-ref filtering as transform above)
-	if r.Validate != nil {
-		validateDeps := make(map[string]bool)
-		extractDepsFromValidatePhase(r.Validate, validateDeps, lookup)
-		for dep := range validateDeps {
-			if dep != r.Name {
-				deps[dep] = true
-			}
-		}
-	}
+	// Validate-phase references are intentionally NOT part of the resolution
+	// dependency graph. Validation runs in a separate post-resolution phase
+	// (two-phase execution): a cross-resolver validation rule is deferred and its
+	// references (including refs that appear only inside a rule's message
+	// template) must not create resolve-ordering edges or cycles. Self-only
+	// (inline) rules reference nothing but __self. The deferred rules and their
+	// reporting-graph edges are computed by partitionValidatePhase.
 
 	// Convert to slice
 	result := make([]string, 0, len(deps))
@@ -195,7 +188,11 @@ func extractStrictDependencies(r *Resolver) map[string]bool {
 
 	extractStrictFromResolvePhase(r.Resolve, deps)
 	extractStrictFromTransformPhase(r.Transform, deps)
-	extractStrictFromValidatePhase(r.Validate, deps)
+	// The validate phase contributes no strict resolution edges: deferred
+	// (cross-resolver) rules are excluded from the resolution DAG by design, and
+	// inline (self-only) rules reference nothing but __self. A typo in a deferred
+	// validation reference surfaces at the deferred-validation phase (fail-closed),
+	// not during graph construction.
 
 	// A resolver is never a strict dependency of itself.
 	delete(deps, r.Name)
@@ -252,26 +249,6 @@ func extractStrictFromTransformPhase(phase *TransformPhase, deps map[string]bool
 			extractStrictFromValueRef(transform.ForEach.In, deps)
 		}
 		extractStrictFromInputs(transform.Inputs, deps)
-	}
-}
-
-// extractStrictFromValidatePhase collects strict references from a validate phase.
-func extractStrictFromValidatePhase(phase *ValidatePhase, deps map[string]bool) {
-	if phase == nil {
-		return
-	}
-	if phase.When != nil && phase.When.Expr != nil {
-		extractDepsFromExpression(string(*phase.When.Expr), deps)
-	}
-	for _, validation := range phase.With {
-		for _, arg := range validation.Args {
-			extractStrictFromValueRef(arg, deps)
-		}
-		if validation.When != nil && validation.When.Expr != nil {
-			extractDepsFromExpression(string(*validation.When.Expr), deps)
-		}
-		extractStrictFromInputs(validation.Inputs, deps)
-		extractStrictFromValueRef(validation.Message, deps)
 	}
 }
 
@@ -847,44 +824,156 @@ func extractDepsFromTransformPhase(phase *TransformPhase, deps map[string]bool, 
 	}
 }
 
-// extractDepsFromValidatePhase extracts dependencies from a validate phase
+// extractDepsFromValidatePhase extracts dependencies from a validate phase.
+//
+// NOTE: these references are NOT resolution-graph edges. Validation runs in a
+// separate post-resolution phase (see partitionValidatePhase). This helper is
+// retained for callers that need the full validate-phase reference set (e.g.
+// tooling and tests); the resolution-dependency extractors deliberately do not
+// call it.
 func extractDepsFromValidatePhase(phase *ValidatePhase, deps map[string]bool, lookup DescriptorLookup) {
 	if phase == nil {
 		return
 	}
 
-	// Extract from when condition
+	// Extract from phase-level when condition
 	if phase.When != nil && phase.When.Expr != nil {
 		extractDepsFromExpression(string(*phase.When.Expr), deps)
 	}
 
 	// Extract from each validation rule
-	for _, validation := range phase.With {
-		// Extract from call-site args (a call validation references resolvers via args).
-		for _, arg := range validation.Args {
-			extractDepsFromValueRef(arg, deps)
-		}
+	for i := range phase.With {
+		extractDepsFromValidationRule(phase.With[i], deps, lookup)
+	}
+}
 
-		// Extract from the rule-level when condition
-		if validation.When != nil && validation.When.Expr != nil {
-			extractDepsFromExpression(string(*validation.When.Expr), deps)
-		}
+// extractDepsFromValidationRule extracts every resolver reference a single
+// validation rule makes: call-site args, the rule-level when condition, provider
+// inputs, and the custom message template. It uses the same provider-aware
+// extraction the full-phase helper uses so a rule is classified identically
+// regardless of provider.
+func extractDepsFromValidationRule(v ProviderValidation, deps map[string]bool, lookup DescriptorLookup) {
+	// Extract from call-site args (a call validation references resolvers via args).
+	for _, arg := range v.Args {
+		extractDepsFromValueRef(arg, deps)
+	}
 
-		// Try provider-specific extraction first
-		if extractDepsFromProviderInputs(validation.Provider, validation.Inputs, nil, deps, lookup) {
-			// Still extract from message even if provider handled inputs
-			extractDepsFromValueRef(validation.Message, deps)
+	// Extract from the rule-level when condition
+	if v.When != nil && v.When.Expr != nil {
+		extractDepsFromExpression(string(*v.When.Expr), deps)
+	}
+
+	// Try provider-specific extraction first
+	if extractDepsFromProviderInputs(v.Provider, v.Inputs, nil, deps, lookup) {
+		// Still extract from message even if the provider handled inputs
+		extractDepsFromValueRef(v.Message, deps)
+		return
+	}
+
+	// Fall back to generic extraction from inputs
+	for _, input := range v.Inputs {
+		extractDepsFromValueRef(input, deps)
+	}
+
+	// Extract from message
+	extractDepsFromValueRef(v.Message, deps)
+}
+
+// ValidatePartition classifies a resolver's validation rules into those that run
+// inline (during resolution, preserving fail-fast) and those deferred to the
+// post-resolution validation phase.
+//
+// A rule is inline iff it references nothing but the owning resolver itself
+// (self / __self). Any rule that references another resolver -- in its args,
+// inputs, rule-level when, or message template -- is deferred and excluded from
+// the resolution DAG. A phase-level validate.when that references a foreign
+// resolver forces every rule in the block to defer (PhaseWhenDeferred).
+type ValidatePartition struct {
+	// InlineRules holds indices into Validate.With for rules that stay inline.
+	InlineRules []int
+	// DeferredRules holds indices into Validate.With for rules that defer.
+	DeferredRules []int
+	// DeferredRefs is the union of foreign resolver references contributed by the
+	// deferred rules (and the phase-level when, when it forces deferral). These
+	// are used only to order and report deferred validation results; they are
+	// never resolution-graph edges.
+	DeferredRefs map[string]bool
+	// PhaseWhenDeferred indicates the phase-level validate.when referenced a
+	// foreign resolver, forcing the whole block to defer.
+	PhaseWhenDeferred bool
+}
+
+// HasDeferred reports whether the partition contains any deferred rules.
+func (p ValidatePartition) HasDeferred() bool {
+	return len(p.DeferredRules) > 0
+}
+
+// PartitionValidatePhase splits a resolver's validate phase into inline and
+// deferred (cross-resolver) rule sets. It is the exported entry point used by
+// tooling such as linters and embedders to reason about which validation rules
+// run in the deferred phase. A nil resolver or nil validate phase yields an
+// empty partition.
+func PartitionValidatePhase(r *Resolver, lookup DescriptorLookup) ValidatePartition {
+	return partitionValidatePhase(r, lookup)
+}
+
+// classifyValidationRule returns the set of foreign resolver references a single
+// validation rule makes, excluding the owning resolver's own name (self) and the
+// injected __self accessor (which is never a resolver reference). An empty result
+// means the rule is inline-eligible.
+func classifyValidationRule(v ProviderValidation, selfName string, lookup DescriptorLookup) map[string]bool {
+	deps := make(map[string]bool)
+	extractDepsFromValidationRule(v, deps, lookup)
+	delete(deps, selfName)
+	return deps
+}
+
+// partitionValidatePhase splits a resolver's validate phase into inline and
+// deferred rule sets and collects the foreign references contributed by the
+// deferred rules. A nil resolver or nil validate phase yields an empty partition.
+func partitionValidatePhase(r *Resolver, lookup DescriptorLookup) ValidatePartition {
+	if r == nil {
+		return ValidatePartition{DeferredRefs: make(map[string]bool)}
+	}
+	return partitionValidatePhaseFor(r.Validate, r.Name, lookup)
+}
+
+// partitionValidatePhaseFor is the phase-based core of partitionValidatePhase. It
+// operates directly on a validate phase and the owning resolver's name, so the
+// executor can partition without holding the full *Resolver.
+func partitionValidatePhaseFor(phase *ValidatePhase, selfName string, lookup DescriptorLookup) ValidatePartition {
+	part := ValidatePartition{DeferredRefs: make(map[string]bool)}
+	if phase == nil {
+		return part
+	}
+
+	// A phase-level validate.when that references a foreign resolver forces the
+	// entire block to defer (the guard cannot be evaluated until that resolver
+	// has resolved).
+	phaseWhen := make(map[string]bool)
+	if phase.When != nil && phase.When.Expr != nil {
+		extractDepsFromExpression(string(*phase.When.Expr), phaseWhen)
+	}
+	delete(phaseWhen, selfName)
+	if len(phaseWhen) > 0 {
+		part.PhaseWhenDeferred = true
+		for ref := range phaseWhen {
+			part.DeferredRefs[ref] = true
+		}
+	}
+
+	for i := range phase.With {
+		foreign := classifyValidationRule(phase.With[i], selfName, lookup)
+		if part.PhaseWhenDeferred || len(foreign) > 0 {
+			part.DeferredRules = append(part.DeferredRules, i)
+			for ref := range foreign {
+				part.DeferredRefs[ref] = true
+			}
 			continue
 		}
-
-		// Fall back to generic extraction from inputs
-		for _, input := range validation.Inputs {
-			extractDepsFromValueRef(input, deps)
-		}
-
-		// Extract from message
-		extractDepsFromValueRef(validation.Message, deps)
+		part.InlineRules = append(part.InlineRules, i)
 	}
+	return part
 }
 
 // TemplateAccessor identifies a root-level Go template accessor in a resolver's

--- a/pkg/resolver/graph_test.go
+++ b/pkg/resolver/graph_test.go
@@ -143,7 +143,9 @@ func TestExtractDependencies(t *testing.T) {
 					},
 				},
 			},
-			want: []string{"base", "region", "invalid", "environment"},
+			// Two-phase validation: validate-phase refs (invalid, environment) are
+			// NOT resolution dependencies; only resolve/transform refs remain.
+			want: []string{"base", "region"},
 		},
 		{
 			name: "phase-level when conditions",
@@ -274,7 +276,9 @@ func TestExtractDependencies(t *testing.T) {
 					},
 				},
 			},
-			want: []string{"environment"},
+			// Two-phase validation: a validate message referencing another resolver
+			// (environment) is deferred, not a resolution dependency.
+			want: []string{},
 		},
 		{
 			name: "go-template provider with direct root-level references",
@@ -472,7 +476,7 @@ func TestExtractDependencies(t *testing.T) {
 			want: []string{"selfRef"},
 		},
 		{
-			name: "validate self-ref with other deps keeps other deps",
+			name: "validate cross-resolver ref is deferred, not a resolution dep",
 			resolver: &Resolver{
 				Name: "checker",
 				Resolve: &ResolvePhase{
@@ -496,8 +500,9 @@ func TestExtractDependencies(t *testing.T) {
 					},
 				},
 			},
-			// _.checker is self-ref (filtered), _.otherResolver is a real dep
-			want: []string{"otherResolver"},
+			// Two-phase validation: _.otherResolver is referenced only in a validate
+			// rule, so it is deferred and does NOT create a resolution-graph edge.
+			want: []string{},
 		},
 		{
 			name: "bracket notation CEL expression dependency",
@@ -551,6 +556,218 @@ func TestExtractDependencies(t *testing.T) {
 			}
 
 			assert.Equal(t, wantMap, gotMap, "dependencies should match")
+		})
+	}
+}
+
+func TestClassifyValidationRule(t *testing.T) {
+	tests := []struct {
+		name string
+		self string
+		rule ProviderValidation
+		want []string
+	}{
+		{
+			name: "self-only rule has no foreign refs",
+			self: "env",
+			rule: ProviderValidation{
+				Provider: "validation",
+				Inputs: map[string]*ValueRef{
+					"expression": {Expr: celExpPtr("__self != ''")},
+				},
+			},
+			want: []string{},
+		},
+		{
+			name: "self reference by name is filtered",
+			self: "env",
+			rule: ProviderValidation{
+				Provider: "validation",
+				Inputs: map[string]*ValueRef{
+					"expression": {Expr: celExpPtr("_.env != ''")},
+				},
+			},
+			want: []string{},
+		},
+		{
+			name: "foreign ref in inputs is returned",
+			self: "env",
+			rule: ProviderValidation{
+				Provider: "validation",
+				Inputs: map[string]*ValueRef{
+					"expression": {Expr: celExpPtr("_.env != _.other")},
+				},
+			},
+			want: []string{"other"},
+		},
+		{
+			name: "foreign ref in rule-level when is returned",
+			self: "env",
+			rule: ProviderValidation{
+				Provider: "validation",
+				When:     &Condition{Expr: celExpPtr("_.enabled == true")},
+				Inputs: map[string]*ValueRef{
+					"expression": {Expr: celExpPtr("__self != ''")},
+				},
+			},
+			want: []string{"enabled"},
+		},
+		{
+			name: "foreign ref only in message template is returned",
+			self: "env",
+			rule: ProviderValidation{
+				Provider: "validation",
+				Inputs: map[string]*ValueRef{
+					"match": {Literal: "^[a-z]+$"},
+				},
+				Message: &ValueRef{Tmpl: tmplPtr("bad value, see {{ ._.other }}")},
+			},
+			want: []string{"other"},
+		},
+		{
+			name: "multiple foreign refs across inputs and message",
+			self: "env",
+			rule: ProviderValidation{
+				Provider: "validation",
+				Inputs: map[string]*ValueRef{
+					"expression": {Expr: celExpPtr("_.env != _.a")},
+				},
+				Message: &ValueRef{Tmpl: tmplPtr("conflict with {{ ._.b }}")},
+			},
+			want: []string{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classifyValidationRule(tt.rule, tt.self, nil)
+
+			wantMap := make(map[string]bool)
+			for _, ref := range tt.want {
+				wantMap[ref] = true
+			}
+			assert.Equal(t, wantMap, got, "foreign refs should match")
+		})
+	}
+}
+
+func TestPartitionValidatePhase(t *testing.T) {
+	tests := []struct {
+		name              string
+		resolver          *Resolver
+		wantInline        []int
+		wantDeferred      []int
+		wantDeferredRefs  []string
+		wantPhaseDeferred bool
+	}{
+		{
+			name:         "nil resolver yields empty partition",
+			resolver:     nil,
+			wantInline:   nil,
+			wantDeferred: nil,
+		},
+		{
+			name: "nil validate phase yields empty partition",
+			resolver: &Resolver{
+				Name: "env",
+			},
+			wantInline:   nil,
+			wantDeferred: nil,
+		},
+		{
+			name: "self-only rules stay inline",
+			resolver: &Resolver{
+				Name: "env",
+				Validate: &ValidatePhase{
+					With: []ProviderValidation{
+						{Provider: "validation", Inputs: map[string]*ValueRef{"expression": {Expr: celExpPtr("__self != ''")}}},
+						{Provider: "validation", Inputs: map[string]*ValueRef{"expression": {Expr: celExpPtr("_.env.size() > 0")}}},
+					},
+				},
+			},
+			wantInline:   []int{0, 1},
+			wantDeferred: nil,
+		},
+		{
+			name: "foreign ref defers only that rule",
+			resolver: &Resolver{
+				Name: "env",
+				Validate: &ValidatePhase{
+					With: []ProviderValidation{
+						{Provider: "validation", Inputs: map[string]*ValueRef{"expression": {Expr: celExpPtr("__self != ''")}}},
+						{Provider: "validation", Inputs: map[string]*ValueRef{"expression": {Expr: celExpPtr("_.env != _.other")}}},
+					},
+				},
+			},
+			wantInline:       []int{0},
+			wantDeferred:     []int{1},
+			wantDeferredRefs: []string{"other"},
+		},
+		{
+			name: "message-only foreign ref defers the rule",
+			resolver: &Resolver{
+				Name: "env",
+				Validate: &ValidatePhase{
+					With: []ProviderValidation{
+						{
+							Provider: "validation",
+							Inputs:   map[string]*ValueRef{"match": {Literal: "^[a-z]+$"}},
+							Message:  &ValueRef{Tmpl: tmplPtr("conflicts with {{ ._.other }}")},
+						},
+					},
+				},
+			},
+			wantInline:       nil,
+			wantDeferred:     []int{0},
+			wantDeferredRefs: []string{"other"},
+		},
+		{
+			name: "phase-level foreign when forces whole block to defer",
+			resolver: &Resolver{
+				Name: "env",
+				Validate: &ValidatePhase{
+					When: &Condition{Expr: celExpPtr("_.gate == true")},
+					With: []ProviderValidation{
+						{Provider: "validation", Inputs: map[string]*ValueRef{"expression": {Expr: celExpPtr("__self != ''")}}},
+						{Provider: "validation", Inputs: map[string]*ValueRef{"expression": {Expr: celExpPtr("_.env != _.other")}}},
+					},
+				},
+			},
+			wantInline:        nil,
+			wantDeferred:      []int{0, 1},
+			wantDeferredRefs:  []string{"gate", "other"},
+			wantPhaseDeferred: true,
+		},
+		{
+			name: "phase-level self-only when does not force deferral",
+			resolver: &Resolver{
+				Name: "env",
+				Validate: &ValidatePhase{
+					When: &Condition{Expr: celExpPtr("_.env != ''")},
+					With: []ProviderValidation{
+						{Provider: "validation", Inputs: map[string]*ValueRef{"expression": {Expr: celExpPtr("__self != ''")}}},
+					},
+				},
+			},
+			wantInline:   []int{0},
+			wantDeferred: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := partitionValidatePhase(tt.resolver, nil)
+
+			assert.Equal(t, tt.wantInline, got.InlineRules, "inline rule indices")
+			assert.Equal(t, tt.wantDeferred, got.DeferredRules, "deferred rule indices")
+			assert.Equal(t, tt.wantPhaseDeferred, got.PhaseWhenDeferred, "phase-when deferred flag")
+
+			wantRefs := make(map[string]bool)
+			for _, ref := range tt.wantDeferredRefs {
+				wantRefs[ref] = true
+			}
+			assert.Equal(t, wantRefs, got.DeferredRefs, "deferred refs")
+			assert.Equal(t, len(tt.wantDeferred) > 0, got.HasDeferred(), "HasDeferred")
 		})
 	}
 }

--- a/pkg/resolver/phase.go
+++ b/pkg/resolver/phase.go
@@ -5,6 +5,7 @@ package resolver
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/oakwood-commons/scafctl/pkg/dag"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
@@ -49,12 +50,35 @@ func (p PlanData) ToMap() map[string]any {
 	return out
 }
 
+// DeferredValidationUnit describes the deferred (cross-resolver) validation
+// rules for a single resolver. These rules reference other resolvers and are
+// excluded from the resolution DAG; they run in a dedicated post-resolution
+// validation phase once every resolver has resolved.
+type DeferredValidationUnit struct {
+	// ResolverName is the resolver that owns the deferred rules.
+	ResolverName string
+	// RuleIndices are indices into the resolver's Validate.With slice identifying
+	// which rules are deferred. Preserves declaration order.
+	RuleIndices []int
+	// DependsOn is the sorted set of foreign resolvers referenced by the deferred
+	// rules. Used only to order and report deferred validation results -- these are
+	// never resolution-graph edges.
+	DependsOn []string
+	// PhaseWhenDeferred indicates the phase-level validate.when referenced a
+	// foreign resolver, forcing every rule in the block to defer.
+	PhaseWhenDeferred bool
+}
+
 // BuildResult is the output of BuildPhases, bundling the phase groups with the
 // pre-execution plan topology so callers can inject __plan without re-computing deps.
 type BuildResult struct {
 	Phases []*PhaseGroup       `json:"phases" yaml:"phases" doc:"Execution phase groups"`
 	Plan   PlanData            `json:"plan"   yaml:"plan"   doc:"Pre-execution resolver topology snapshot"`
 	Deps   map[string][]string `json:"-"      yaml:"-"      doc:"Effective dependency map (reusable by callers)"`
+	// DeferredWork lists resolvers with cross-resolver validation rules that must
+	// run in the post-resolution validation phase. Empty when no resolver has any
+	// deferred validation rules.
+	DeferredWork []DeferredValidationUnit `json:"-" yaml:"-" doc:"Deferred cross-resolver validation work"`
 }
 
 // resolverDagObject implements the dag.Object interface for resolvers
@@ -226,11 +250,43 @@ func BuildPhasesWithCalls(resolvers []*Resolver, lookup DescriptorLookup, calls 
 		}
 	}
 
+	// Partition each resolver's validate phase and collect the deferred
+	// (cross-resolver) validation work. Deferred rules are excluded from the
+	// resolution DAG above; they run in a dedicated post-resolution phase.
+	deferredWork := buildDeferredWork(resolvers, lookup)
+
 	return &BuildResult{
-		Phases: phases,
-		Plan:   plan,
-		Deps:   deps,
+		Phases:       phases,
+		Plan:         plan,
+		Deps:         deps,
+		DeferredWork: deferredWork,
 	}, nil
+}
+
+// buildDeferredWork partitions every resolver's validate phase and returns the
+// deferred validation units in resolver declaration order. Resolvers without any
+// deferred rules are omitted. The returned slice is nil when no deferred work
+// exists.
+func buildDeferredWork(resolvers []*Resolver, lookup DescriptorLookup) []DeferredValidationUnit {
+	var deferredWork []DeferredValidationUnit
+	for _, r := range resolvers {
+		part := partitionValidatePhase(r, lookup)
+		if !part.HasDeferred() {
+			continue
+		}
+		dependsOn := make([]string, 0, len(part.DeferredRefs))
+		for ref := range part.DeferredRefs {
+			dependsOn = append(dependsOn, ref)
+		}
+		sort.Strings(dependsOn)
+		deferredWork = append(deferredWork, DeferredValidationUnit{
+			ResolverName:      r.Name,
+			RuleIndices:       part.DeferredRules,
+			DependsOn:         dependsOn,
+			PhaseWhenDeferred: part.PhaseWhenDeferred,
+		})
+	}
+	return deferredWork
 }
 
 // GetPhaseForResolver returns the phase number for a given resolver name

--- a/pkg/resolver/phase_test.go
+++ b/pkg/resolver/phase_test.go
@@ -1173,3 +1173,84 @@ func TestExtractDepsFromTemplate_UnderscoreVariant(t *testing.T) {
 	extractDepsFromTemplate("{{ ._var2 }}", deps)
 	assert.Contains(t, deps, "var2")
 }
+
+func TestBuildPhases_DeferredWork(t *testing.T) {
+	staticSource := &ResolvePhase{
+		With: []ProviderSource{{
+			Provider: "static",
+			Inputs:   map[string]*ValueRef{"value": {Literal: "x"}},
+		}},
+	}
+
+	t.Run("no deferred work when validations are self-only", func(t *testing.T) {
+		resolvers := []*Resolver{
+			{
+				Name:    "env",
+				Resolve: staticSource,
+				Validate: &ValidatePhase{
+					With: []ProviderValidation{
+						{Provider: "validation", Inputs: map[string]*ValueRef{"expression": {Expr: celExpPtr("__self != ''")}}},
+					},
+				},
+			},
+		}
+		result, err := BuildPhases(resolvers, nil)
+		require.NoError(t, err)
+		assert.Empty(t, result.DeferredWork)
+	})
+
+	t.Run("cross-resolver validation is deferred and excluded from DAG", func(t *testing.T) {
+		resolvers := []*Resolver{
+			{Name: "env", Resolve: staticSource},
+			{Name: "region", Resolve: staticSource},
+			{
+				Name:    "checker",
+				Resolve: staticSource,
+				Validate: &ValidatePhase{
+					With: []ProviderValidation{
+						{Provider: "validation", Inputs: map[string]*ValueRef{"expression": {Expr: celExpPtr("__self != ''")}}},
+						{Provider: "validation", Inputs: map[string]*ValueRef{"expression": {Expr: celExpPtr("_.env != _.region")}}},
+					},
+				},
+			},
+		}
+		result, err := BuildPhases(resolvers, nil)
+		require.NoError(t, err)
+
+		// The cross-resolver validation must NOT create resolution-graph edges.
+		assert.Empty(t, result.Deps["checker"], "validate refs must not be resolution deps")
+
+		require.Len(t, result.DeferredWork, 1)
+		unit := result.DeferredWork[0]
+		assert.Equal(t, "checker", unit.ResolverName)
+		assert.Equal(t, []int{1}, unit.RuleIndices)
+		assert.Equal(t, []string{"env", "region"}, unit.DependsOn)
+		assert.False(t, unit.PhaseWhenDeferred)
+	})
+
+	t.Run("phase-level foreign when defers entire block", func(t *testing.T) {
+		resolvers := []*Resolver{
+			{Name: "gate", Resolve: staticSource},
+			{
+				Name:    "checker",
+				Resolve: staticSource,
+				Validate: &ValidatePhase{
+					When: &Condition{Expr: celExpPtr("_.gate == true")},
+					With: []ProviderValidation{
+						{Provider: "validation", Inputs: map[string]*ValueRef{"expression": {Expr: celExpPtr("__self != ''")}}},
+					},
+				},
+			},
+		}
+		result, err := BuildPhases(resolvers, nil)
+		require.NoError(t, err)
+		assert.Empty(t, result.Deps["checker"])
+
+		require.Len(t, result.DeferredWork, 1)
+		unit := result.DeferredWork[0]
+		assert.Equal(t, "checker", unit.ResolverName)
+		assert.Equal(t, []int{0}, unit.RuleIndices)
+		assert.Equal(t, []string{"gate"}, unit.DependsOn)
+		assert.True(t, unit.PhaseWhenDeferred)
+	})
+}

--- a/pkg/solution/execute/results.go
+++ b/pkg/solution/execute/results.go
@@ -239,10 +239,54 @@ func BuildExecutionData(
 		"phaseCount":    phaseCount,
 	}
 
-	return map[string]any{
+	data := map[string]any{
 		"resolvers": resolverMeta,
 		"summary":   summary,
 	}
+
+	if dv := buildDeferredValidationData(resolverCtx.DeferredValidation()); dv != nil {
+		data["deferredValidation"] = dv
+	}
+
+	return data
+}
+
+// buildDeferredValidationData converts a deferred validation summary into a
+// serializable map for the __execution metadata. Returns nil when the deferred
+// validation phase did not run.
+func buildDeferredValidationData(summary *resolver.DeferredValidationSummary) map[string]any {
+	if summary == nil {
+		return nil
+	}
+
+	dv := map[string]any{
+		"evaluated": summary.Evaluated,
+		"failed":    summary.Failed,
+		"skipped":   summary.Skipped,
+	}
+
+	if len(summary.Suppressed) > 0 {
+		dv["suppressed"] = summary.Suppressed
+	}
+	if len(summary.Cycles) > 0 {
+		dv["cycles"] = summary.Cycles
+	}
+	if len(summary.Results) > 0 {
+		results := make([]map[string]any, 0, len(summary.Results))
+		for _, rf := range summary.Results {
+			messages := make([]string, 0, len(rf.Failures))
+			for _, f := range rf.Failures {
+				messages = append(messages, f.Message)
+			}
+			results = append(results, map[string]any{
+				"resolver": rf.ResolverName,
+				"messages": messages,
+			})
+		}
+		dv["results"] = results
+	}
+
+	return dv
 }
 
 // BuildProviderSummary aggregates per-provider usage statistics from resolver execution.

--- a/pkg/solution/execute/results_test.go
+++ b/pkg/solution/execute/results_test.go
@@ -226,6 +226,64 @@ func TestBuildExecutionData(t *testing.T) {
 	assert.Equal(t, 2, summary["resolverCount"])
 }
 
+func TestBuildExecutionData_NoDeferredValidation(t *testing.T) {
+	t.Parallel()
+
+	resolverCtx := resolver.NewContext()
+	resolverCtx.SetResult("env", &resolver.ExecutionResult{
+		Value:  "prod",
+		Status: resolver.ExecutionStatusSuccess,
+		Phase:  1,
+	})
+
+	data := BuildExecutionData(resolverCtx, []*resolver.Resolver{{Name: "env"}}, time.Second)
+
+	assert.NotContains(t, data, "deferredValidation",
+		"deferredValidation must be omitted when the phase did not run")
+}
+
+func TestBuildExecutionData_WithDeferredValidation(t *testing.T) {
+	t.Parallel()
+
+	resolverCtx := resolver.NewContext()
+	resolverCtx.SetResult("checker", &resolver.ExecutionResult{
+		Value:  "check",
+		Status: resolver.ExecutionStatusSuccess,
+		Phase:  1,
+	})
+	resolverCtx.SetDeferredValidation(&resolver.DeferredValidationSummary{
+		Evaluated:  2,
+		Failed:     1,
+		Skipped:    1,
+		Suppressed: []string{"downstream"},
+		Cycles:     [][]string{{"a", "b"}},
+		Results: []resolver.DeferredValidationFailure{
+			{
+				ResolverName: "checker",
+				Failures: []resolver.ValidationFailure{
+					{Rule: 0, Provider: "assert", Message: "env must differ from region"},
+				},
+			},
+		},
+	})
+
+	data := BuildExecutionData(resolverCtx, []*resolver.Resolver{{Name: "checker"}}, time.Second)
+
+	dv, ok := data["deferredValidation"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, 2, dv["evaluated"])
+	assert.Equal(t, 1, dv["failed"])
+	assert.Equal(t, 1, dv["skipped"])
+	assert.Equal(t, []string{"downstream"}, dv["suppressed"])
+	assert.Equal(t, [][]string{{"a", "b"}}, dv["cycles"])
+
+	results, ok := dv["results"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, results, 1)
+	assert.Equal(t, "checker", results[0]["resolver"])
+	assert.Equal(t, []string{"env must differ from region"}, results[0]["messages"])
+}
+
 func TestBuildExecutionData_MissingResult(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/state/immutable.go
+++ b/pkg/state/immutable.go
@@ -17,8 +17,13 @@ import (
 //   - If a prior value exists and matches, no action is taken.
 //   - If a prior value exists and differs, an error is returned.
 //
+// Resolvers whose names are present in skip are not locked on first run: a new
+// immutable value is not persisted when its deferred (cross-resolver) validation
+// failed. Existing locks are still verified so an immutable value cannot drift
+// undetected.
+//
 // Returns the updated state data (with any newly locked immutables).
-func CheckImmutables(stateData *Data, resolverCtx *resolver.Context, resolvers []*resolver.Resolver) error {
+func CheckImmutables(stateData *Data, resolverCtx *resolver.Context, resolvers []*resolver.Resolver, skip map[string]bool) error {
 	if stateData == nil {
 		return nil
 	}
@@ -40,6 +45,11 @@ func CheckImmutables(stateData *Data, resolverCtx *resolver.Context, resolvers [
 
 		existing, exists := stateData.Immutables[r.Name]
 		if !exists {
+			if skip[r.Name] {
+				// Deferred validation failed: do not persist a new lock, but there is
+				// no existing lock to verify either.
+				continue
+			}
 			// First run: save the value
 			stateData.Immutables[r.Name] = &ImmutableEntry{
 				Value:     result.Value,

--- a/pkg/state/immutable_test.go
+++ b/pkg/state/immutable_test.go
@@ -1,0 +1,82 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newImmutableResolverCtx(t *testing.T, value any) *resolver.Context {
+	t.Helper()
+	rctx := resolver.NewContext()
+	rctx.SetResult("cluster_id", &resolver.ExecutionResult{
+		Value:  value,
+		Status: resolver.ExecutionStatusSuccess,
+	})
+	return rctx
+}
+
+func TestCheckImmutables(t *testing.T) {
+	resolvers := []*resolver.Resolver{
+		{Name: "cluster_id", Type: "string", Immutable: true},
+	}
+
+	t.Run("first run locks the value", func(t *testing.T) {
+		sd := NewData()
+		rctx := newImmutableResolverCtx(t, "uuid-1234")
+
+		err := CheckImmutables(sd, rctx, resolvers, nil)
+		require.NoError(t, err)
+		require.Contains(t, sd.Immutables, "cluster_id")
+		assert.Equal(t, "uuid-1234", sd.Immutables["cluster_id"].Value)
+	})
+
+	t.Run("skip prevents locking a new value on first run", func(t *testing.T) {
+		sd := NewData()
+		rctx := newImmutableResolverCtx(t, "uuid-1234")
+
+		err := CheckImmutables(sd, rctx, resolvers, map[string]bool{"cluster_id": true})
+		require.NoError(t, err)
+		assert.NotContains(t, sd.Immutables, "cluster_id")
+	})
+
+	t.Run("existing lock with matching value passes", func(t *testing.T) {
+		sd := NewData()
+		sd.Immutables["cluster_id"] = &ImmutableEntry{Value: "uuid-1234", Type: "string"}
+		rctx := newImmutableResolverCtx(t, "uuid-1234")
+
+		err := CheckImmutables(sd, rctx, resolvers, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("existing lock with differing value fails", func(t *testing.T) {
+		sd := NewData()
+		sd.Immutables["cluster_id"] = &ImmutableEntry{Value: "uuid-1234", Type: "string"}
+		rctx := newImmutableResolverCtx(t, "uuid-9999")
+
+		err := CheckImmutables(sd, rctx, resolvers, nil)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrImmutableEntry))
+	})
+
+	t.Run("skip still verifies an existing lock and detects drift", func(t *testing.T) {
+		sd := NewData()
+		sd.Immutables["cluster_id"] = &ImmutableEntry{Value: "uuid-1234", Type: "string"}
+		rctx := newImmutableResolverCtx(t, "uuid-9999")
+
+		err := CheckImmutables(sd, rctx, resolvers, map[string]bool{"cluster_id": true})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrImmutableEntry))
+	})
+
+	t.Run("nil state data is a no-op", func(t *testing.T) {
+		err := CheckImmutables(nil, resolver.NewContext(), resolvers, nil)
+		require.NoError(t, err)
+	})
+}

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -145,10 +145,51 @@ func (m *Manager) Save(ctx context.Context, stateData *Data, resolverCtx *resolv
 	stateData.Parameters = mergedParams
 
 	// Check and save immutable resolver values
-	if err := CheckImmutables(stateData, resolverCtx, resolvers); err != nil {
+	if err := CheckImmutables(stateData, resolverCtx, resolvers, nil); err != nil {
 		return err
 	}
 
+	return m.commit(ctx, stateData, resolverData, mergedParams, solMeta)
+}
+
+// SaveImmutables checks and persists immutable resolver locks without touching
+// the saved parameter set. It is used by entrypoints that run side-effecting
+// actions: immutable locks are committed after deferred validation passes and
+// before actions run, so a value that is now fixed is persisted even if a
+// downstream action later fails.
+//
+// skip contains resolver names whose deferred validation failed; their
+// immutable values are not locked.
+func (m *Manager) SaveImmutables(ctx context.Context, stateData *Data, resolverCtx *resolver.Context, resolvers []*resolver.Resolver, mergedParams, resolverData map[string]any, solMeta SolutionMeta, skip map[string]bool) error {
+	if m.config == nil || stateData == nil {
+		return nil
+	}
+
+	// Check and save immutable resolver values. Parameters are intentionally not
+	// updated here -- they are persisted after actions complete via SaveParams.
+	if err := CheckImmutables(stateData, resolverCtx, resolvers, skip); err != nil {
+		return err
+	}
+
+	return m.commit(ctx, stateData, resolverData, mergedParams, solMeta)
+}
+
+// SaveParams persists the merged parameter set. It is called after actions
+// complete so that ordinary (mutable) parameters are only saved on a fully
+// successful run.
+func (m *Manager) SaveParams(ctx context.Context, stateData *Data, mergedParams, resolverData map[string]any, solMeta SolutionMeta) error {
+	if m.config == nil || stateData == nil {
+		return nil
+	}
+
+	stateData.Parameters = mergedParams
+
+	return m.commit(ctx, stateData, resolverData, mergedParams, solMeta)
+}
+
+// commit updates state metadata and writes the current state document to the
+// configured backend.
+func (m *Manager) commit(ctx context.Context, stateData *Data, resolverData, mergedParams map[string]any, solMeta SolutionMeta) error {
 	// Update metadata
 	now := time.Now().UTC()
 	if stateData.Metadata.CreatedAt.IsZero() {

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // mockBackendProvider implements provider.Provider for testing the manager.
@@ -374,6 +375,88 @@ func TestManagerSave(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestManagerSaveImmutablesAndParams(t *testing.T) {
+	baseConfig := &Config{
+		Enabled: literalValueRef(true),
+		Backend: Backend{
+			Provider: "mock-state",
+			Inputs:   map[string]*spec.ValueRef{},
+		},
+	}
+	solMeta := SolutionMeta{Name: "my-app", Version: "1.0.0"}
+
+	t.Run("SaveImmutables locks immutable without persisting parameters", func(t *testing.T) {
+		backend := &mockBackendProvider{}
+		reg := newTestRegistry(t, backend)
+		mgr := NewManager(baseConfig, reg, "test-version")
+
+		rctx := resolver.NewContext()
+		rctx.SetResult("cluster_id", &resolver.ExecutionResult{
+			Value:  "uuid-1234",
+			Status: resolver.ExecutionStatusSuccess,
+		})
+		resolvers := []*resolver.Resolver{
+			{Name: "cluster_id", Type: "string", Immutable: true},
+		}
+		sd := NewData()
+
+		err := mgr.SaveImmutables(context.Background(), sd, rctx, resolvers,
+			map[string]any{"appName": "demo"}, nil, solMeta, nil)
+		require.NoError(t, err)
+
+		// Immutable locked, but parameters were not persisted to the document.
+		assert.Equal(t, "uuid-1234", sd.Immutables["cluster_id"].Value)
+		assert.Empty(t, sd.Parameters)
+		assert.Len(t, backend.saveCalls, 1)
+	})
+
+	t.Run("SaveImmutables skips resolvers whose deferred validation failed", func(t *testing.T) {
+		backend := &mockBackendProvider{}
+		reg := newTestRegistry(t, backend)
+		mgr := NewManager(baseConfig, reg, "test-version")
+
+		rctx := resolver.NewContext()
+		rctx.SetResult("cluster_id", &resolver.ExecutionResult{
+			Value:  "uuid-1234",
+			Status: resolver.ExecutionStatusSuccess,
+		})
+		resolvers := []*resolver.Resolver{
+			{Name: "cluster_id", Type: "string", Immutable: true},
+		}
+		sd := NewData()
+
+		err := mgr.SaveImmutables(context.Background(), sd, rctx, resolvers,
+			nil, nil, solMeta, map[string]bool{"cluster_id": true})
+		require.NoError(t, err)
+
+		// The failed immutable must NOT be locked.
+		assert.NotContains(t, sd.Immutables, "cluster_id")
+	})
+
+	t.Run("SaveParams persists the merged parameter set", func(t *testing.T) {
+		backend := &mockBackendProvider{}
+		reg := newTestRegistry(t, backend)
+		mgr := NewManager(baseConfig, reg, "test-version")
+
+		sd := NewData()
+		params := map[string]any{"appName": "demo", "region": "us-east1"}
+
+		err := mgr.SaveParams(context.Background(), sd, params, nil, solMeta)
+		require.NoError(t, err)
+
+		assert.Equal(t, params, sd.Parameters)
+		assert.Len(t, backend.saveCalls, 1)
+	})
+
+	t.Run("nil config is a no-op", func(t *testing.T) {
+		mgr := NewManager(nil, provider.NewRegistry(), "test-version")
+		sd := NewData()
+
+		require.NoError(t, mgr.SaveImmutables(context.Background(), sd, resolver.NewContext(), nil, nil, nil, solMeta, nil))
+		require.NoError(t, mgr.SaveParams(context.Background(), sd, nil, nil, solMeta))
+	})
 }
 
 func TestManagerSave_Immutable(t *testing.T) {

--- a/tests/integration/api_test.go
+++ b/tests/integration/api_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/fileprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/messageprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/staticprovider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/validationprovider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 )
@@ -1779,6 +1780,117 @@ spec:
 	data.HasValue("spanish", "Hola, Mundo!")   // call-site override
 	data.HasValue("requestor", "Ada")          // base value for the ref below
 	data.HasValue("personalized", "Hey, Ada!") // arg sourced from a resolver ref
+}
+
+// TestAPI_DeferredValidation exercises the two-phase (deferred cross-resolver)
+// validation feature over the API. Two resolvers validate against each other --
+// one via a value reference (_.backupRegion) and one via a message-only
+// reference ({{ .region }}). Before two-phase validation these mutual
+// references formed a false ordering cycle. The render endpoint must now load
+// and resolve them cleanly, and the lint endpoint must NOT report a
+// resolver-cycle while still surfacing the informational
+// deferred-validation-not-fail-fast advisory.
+func TestAPI_DeferredValidation(t *testing.T) {
+	cfg := &config.Config{
+		APIServer: config.APIServerConfig{
+			APIVersion: settings.DefaultAPIVersion,
+		},
+	}
+
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(staticprovider.New()))
+	require.NoError(t, reg.Register(validationprovider.NewValidationProvider()))
+
+	srv, err := api.NewServer(
+		api.WithServerConfig(cfg),
+		api.WithServerVersion("test-dev"),
+		api.WithServerRegistry(reg),
+	)
+	require.NoError(t, err)
+
+	apiRouter, err := api.SetupMiddleware(t.Context(), srv.Router(), &cfg.APIServer, logr.Discard())
+	require.NoError(t, err)
+	srv.SetAPIRouter(apiRouter)
+	srv.InitAPI()
+	endpoints.RegisterAll(srv.API(), srv.Router(), srv.HandlerCtx())
+
+	ts := httptest.NewServer(srv.Router())
+	defer ts.Close()
+	e := httpexpect.Default(t, ts.URL)
+
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: api-deferred-validation-test
+  version: 1.0.0
+  description: Two-phase cross-resolver validation exercised over the API
+spec:
+  resolvers:
+    region:
+      description: Primary deployment region
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: us-east1
+      validate:
+        with:
+          # DEFERRED: references _.backupRegion -> runs after all resolvers.
+          - provider: validation
+            inputs:
+              expression: "_.region != _.backupRegion"
+              message: "tmpl: region must differ from backupRegion (both were {{ .region }})"
+    backupRegion:
+      description: Backup deployment region (message-only cross-reference)
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: us-west1
+      validate:
+        with:
+          # DEFERRED via message-only reference to _.region.
+          - provider: validation
+            inputs:
+              expression: "__self != ''"
+              message: "tmpl: backupRegion must differ from region {{ .region }}"
+`
+
+	solServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/x-yaml")
+		_, _ = w.Write([]byte(content))
+	}))
+	defer solServer.Close()
+	solURL := solServer.URL + "/solution.yaml"
+
+	// Render: mutual cross-resolver validation loads without a cycle error and
+	// deferred rules pass because the regions differ.
+	renderObj := e.POST("/v1/solutions/render").
+		WithJSON(map[string]any{"path": solURL}).
+		Expect().
+		Status(http.StatusOK).
+		JSON().Object()
+
+	data := renderObj.Value("resolverData").Object()
+	data.HasValue("region", "us-east1")
+	data.HasValue("backupRegion", "us-west1")
+
+	// Lint: cross-resolver validation references must NOT trigger resolver-cycle,
+	// and each deferred rule emits the info-level advisory.
+	lintObj := e.POST("/v1/solutions/lint").
+		WithJSON(map[string]any{"path": solURL}).
+		Expect().
+		Status(http.StatusOK).
+		JSON().Object()
+
+	findings := lintObj.Value("findings").Array()
+	rules := map[string]int{}
+	for _, f := range findings.Iter() {
+		rules[f.Object().Value("ruleName").String().Raw()]++
+	}
+	assert.Zero(t, rules["resolver-cycle"], "cross-resolver validation must not trigger resolver-cycle")
+	assert.GreaterOrEqual(t, rules["deferred-validation-not-fail-fast"], 1,
+		"deferred validation should emit the info advisory")
 }
 
 func TestAPI_SolutionTest_MissingPath(t *testing.T) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -976,6 +976,87 @@ func TestIntegration_RunSolution_NoWorkflowErrors(t *testing.T) {
 	assert.Contains(t, stderr, "scafctl run resolver")
 }
 
+// TestIntegration_RunSolution_DeferredValidationImmutableNotLocked verifies the
+// two-phase validation D1 guarantee: when a deferred (cross-resolver) validation
+// rule fails on an immutable resolver, execution stops before actions run and
+// the immutable value is NOT persisted to state. A subsequent run whose deferred
+// validation passes then locks the value and runs the action.
+func TestIntegration_RunSolution_DeferredValidationImmutableNotLocked(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: d1-immutable-defer
+  version: 1.0.0
+state:
+  enabled: true
+  backend:
+    provider: file
+    inputs:
+      path: state.json
+spec:
+  resolvers:
+    region:
+      type: string
+      immutable: true
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+              default: us-east1
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "_.region != _.backupRegion"
+              message: "region must differ from backupRegion"
+    backupRegion:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: backupRegion
+              default: us-east1
+  workflow:
+    actions:
+      notify:
+        provider: message
+        inputs:
+          message: "ACTION_RAN"
+          type: info
+`
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(solutionContent), 0o600))
+	statePath := filepath.Join(tmpDir, "state.json")
+
+	// Run 1: regions equal -> deferred validation fails. The action must not run
+	// and the immutable value must not be locked (state file absent).
+	stdout, stderr, exitCode := runScafctlInDir(t, tmpDir, "run", "solution", "-f", solutionPath)
+	assert.NotEqual(t, 0, exitCode, "failing deferred validation should exit non-zero")
+	assert.Contains(t, stderr, "region must differ from backupRegion")
+	assert.NotContains(t, stdout, "ACTION_RAN", "action must not run when deferred validation fails")
+	assert.NoFileExists(t, statePath, "immutable value must not be persisted when deferred validation fails")
+
+	// Run 2: regions differ -> deferred validation passes. The action runs and
+	// the immutable value is now locked in state.
+	stdout, _, exitCode = runScafctlInDir(t, tmpDir, "run", "solution", "-f", solutionPath, "-r", "backupRegion=us-west1")
+	assert.Equal(t, 0, exitCode, "passing deferred validation should exit zero")
+	assert.Contains(t, stdout, "ACTION_RAN", "action should run when deferred validation passes")
+	require.FileExists(t, statePath, "state file should be written after a successful run")
+
+	raw, err := os.ReadFile(statePath) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	var stateDoc struct {
+		Immutables map[string]any `json:"immutables"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &stateDoc))
+	assert.Contains(t, stateDoc.Immutables, "region", "immutable region should be locked after a passing run")
+}
+
 func TestIntegration_RunSolution_FileNotFound(t *testing.T) {
 	t.Parallel()
 	_, stderr, exitCode := runScafctl(t,
@@ -5768,6 +5849,103 @@ func TestIntegration_Test_Functional_Calls(t *testing.T) {
 		"array-arg",
 		"validate-call",
 		"action-call",
+	} {
+		assert.Equal(t, "pass", byTest[name], "case %q should pass", name)
+	}
+}
+
+// TestIntegration_Test_Functional_CrossValidation exercises the two-phase
+// (deferred cross-resolver) validation feature end-to-end by running the
+// functional test cases bundled with the cross-validation fixture solution.
+// The fixture covers the load-without-cycle guarantee, deferred rules passing
+// when the cross-resolver assertion holds, and both fatal (--fail-on-validation)
+// and non-fatal failure modes when the assertion is violated.
+func TestIntegration_Test_Functional_CrossValidation(t *testing.T) {
+	t.Parallel()
+
+	const solution = "tests/integration/solutions/resolvers/cross-validation/solution.yaml"
+
+	type resultItem struct {
+		Test   string `json:"test"`
+		Status string `json:"status"`
+	}
+
+	stdout, stderr, exitCode := runScafctlLong(t,
+		"test", "functional",
+		"-f", solution,
+		"--skip-builtins",
+		"--no-color",
+		"-o", "json",
+	)
+	require.Equal(t, 0, exitCode, "stdout: %s\nstderr: %s", stdout, stderr)
+
+	var report struct {
+		Results []resultItem `json:"results"`
+		Summary struct {
+			Passed int `json:"passed"`
+			Failed int `json:"failed"`
+		} `json:"summary"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &report))
+
+	assert.Zero(t, report.Summary.Failed, "no cross-validation test case should fail")
+
+	byTest := map[string]string{}
+	for _, r := range report.Results {
+		byTest[r.Test] = r.Status
+	}
+	for _, name := range []string{
+		"loads-without-cycle",
+		"differing-regions-pass",
+		"equal-regions-fail",
+		"equal-regions-nonfatal-shows-values",
+	} {
+		assert.Equal(t, "pass", byTest[name], "case %q should pass", name)
+	}
+}
+
+// TestIntegration_Test_Functional_LintDeferredValidation exercises the linting
+// side of two-phase validation by running the functional test cases bundled
+// with the lint-deferred-validation fixture. The fixture asserts that
+// cross-resolver validation references do NOT trigger the resolver-cycle rule
+// and DO emit the informational deferred-validation-not-fail-fast advisory.
+func TestIntegration_Test_Functional_LintDeferredValidation(t *testing.T) {
+	t.Parallel()
+
+	const solution = "tests/integration/solutions/lint-deferred-validation/solution.yaml"
+
+	type resultItem struct {
+		Test   string `json:"test"`
+		Status string `json:"status"`
+	}
+
+	stdout, stderr, exitCode := runScafctlLong(t,
+		"test", "functional",
+		"-f", solution,
+		"--skip-builtins",
+		"--no-color",
+		"-o", "json",
+	)
+	require.Equal(t, 0, exitCode, "stdout: %s\nstderr: %s", stdout, stderr)
+
+	var report struct {
+		Results []resultItem `json:"results"`
+		Summary struct {
+			Passed int `json:"passed"`
+			Failed int `json:"failed"`
+		} `json:"summary"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &report))
+
+	assert.Zero(t, report.Summary.Failed, "no lint deferred-validation test case should fail")
+
+	byTest := map[string]string{}
+	for _, r := range report.Results {
+		byTest[r.Test] = r.Status
+	}
+	for _, name := range []string{
+		"lint-no-cycle",
+		"lint-emits-advisory",
 	} {
 		assert.Equal(t, "pass", byTest[name], "case %q should pass", name)
 	}

--- a/tests/integration/solutions/lint-deferred-validation/solution.yaml
+++ b/tests/integration/solutions/lint-deferred-validation/solution.yaml
@@ -1,0 +1,60 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-lint-deferred-validation
+  version: 1.0.0
+  description: |
+    Tests that cross-resolver validation references do NOT trigger the
+    resolver-cycle rule and DO trigger the informational
+    deferred-validation-not-fail-fast advisory. Two resolvers validate against
+    each other; the solution must lint cleanly (no error) with an info finding
+    per deferred rule.
+
+spec:
+  resolvers:
+    region:
+      description: Primary region with a deferred cross-resolver rule
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: us-east1
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              expression: "_.region != _.backupRegion"
+              message: "region must differ from backupRegion"
+
+    backupRegion:
+      description: Backup region
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: us-west1
+
+  testing:
+    cases:
+      lint-no-cycle:
+        description: Cross-resolver validation lints without a cycle error
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [lint, deferred-validation]
+        assertions:
+          - expression: __exitCode == 0
+            message: "Cross-resolver validation must not fail lint"
+          - expression: >
+              !__stderr.contains("cycle") && !__stdout.contains("resolver-cycle")
+            message: "Validation references must not trigger the resolver-cycle rule"
+
+      lint-emits-advisory:
+        description: Deferred validation emits the informational advisory
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [lint, deferred-validation]
+        assertions:
+          - expression: >
+              __stdout.contains("deferred-validation-not-fail-fast")
+            message: "Deferred validation should emit the info advisory"

--- a/tests/integration/solutions/resolvers/cross-validation/solution.yaml
+++ b/tests/integration/solutions/resolvers/cross-validation/solution.yaml
@@ -1,0 +1,105 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-cross-validation
+  version: 1.0.0
+  description: |
+    Functional tests for two-phase (cross-resolver) validation. Two resolvers
+    validate against each other -- one via a value reference (_.backupRegion)
+    and one via a message-only reference ({{ .region }}). Before two-phase
+    validation these mutual references formed a false ordering cycle and the
+    solution failed to load. Now they are deferred and the solution loads and
+    runs cleanly; deferred rules fail only when the cross-resolver assertion
+    is violated (regions equal).
+
+spec:
+  resolvers:
+    region:
+      description: Primary deployment region
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+              default: us-east1
+      validate:
+        with:
+          # INLINE: references only __self -> runs during resolution, fails fast.
+          - provider: validation
+            inputs:
+              expression: "__self != ''"
+              message: "region is required"
+          # DEFERRED: references _.backupRegion -> runs after all resolvers.
+          - provider: validation
+            inputs:
+              expression: "_.region != _.backupRegion"
+              message: "tmpl: region must differ from backupRegion (both were {{ .region }})"
+
+    backupRegion:
+      description: Backup deployment region (message-only cross-reference)
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: backupRegion
+              default: us-west1
+      validate:
+        with:
+          # DEFERRED via message-only reference to _.region.
+          - provider: validation
+            inputs:
+              expression: "__self != ''"
+              message: "tmpl: backupRegion is required and must differ from region {{ .region }}"
+
+  testing:
+    cases:
+      _base:
+        description: Base template running run resolver as JSON
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [resolver, validation, cross-validation]
+
+      loads-without-cycle:
+        description: Mutual validation references load without a cycle error
+        extends: [_base]
+        tags: [smoke]
+        assertions:
+          - expression: __exitCode == 0
+            message: "Cross-resolver validation must not form a load-time cycle"
+          - expression: '__output.region == "us-east1"'
+          - expression: '__output.backupRegion == "us-west1"'
+
+      differing-regions-pass:
+        description: Deferred validation passes when regions differ
+        extends: [_base]
+        args: ["-r", "region=us-east1", "-r", "backupRegion=us-west1"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: '__output.region == "us-east1"'
+          - expression: '__output.backupRegion == "us-west1"'
+
+      equal-regions-fail:
+        description: Deferred validation fails (non-zero) when regions are equal
+        extends: [_base]
+        args: ["-r", "region=us-east1", "-r", "backupRegion=us-east1", "--fail-on-validation"]
+        tags: [negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+            message: "Equal regions must fail the deferred cross-resolver rule"
+          - expression: >
+              __stderr.contains("must differ from backupRegion")
+            message: "Failure should surface the rendered deferred validation message"
+
+      equal-regions-nonfatal-shows-values:
+        description: Without --fail-on-validation, values still emit but the failure is reported
+        extends: [_base]
+        args: ["-r", "region=us-east1", "-r", "backupRegion=us-east1"]
+        assertions:
+          - expression: __exitCode == 0
+            message: "Non-fatal mode exits zero and still emits values"
+          - expression: '__output.region == "us-east1"'
+          - expression: >
+              __stderr.contains("must differ from backupRegion")
+            message: "Deferred failure is reported as a diagnostic on stderr"


### PR DESCRIPTION
Split resolver validation into two phases so cross-resolver validation rules no longer distort the resolution dependency graph or trigger false circular-dependency errors. Rules are classified automatically: rules referencing only their own resolver run inline during resolution; rules referencing other resolvers are deferred until after all resolvers resolve, just before actions run.

- Add deferred validation engine with automatic inline/deferred rule classification based on foreign resolver references (expression, inputs, when condition, and message template)
- Build a separate reporting graph (Tarjan SCC) for deferred units that tolerates cycles for deterministic failure ordering, while the resolution DAG still treats cycles as hard errors
- Make deferred validation fail-closed with own-skip exemption and cascade suppression so root-cause failures surface once
- Commit immutable-lock state only after deferred validation passes and before actions run; exclude failed resolvers from the commit
- Add run flags --fail-on-validation and --validate-all; retire the cross-resolver "sink resolver" workaround
- Scope resolver-cycle lint to resolve/transform/when cycles and add advisory deferred-validation-not-fail-fast rule
- Expose deferred validation via builtin concepts and MCP prompts
- Add design doc, validation-patterns tutorial, cross-validation example, and CLI/API integration tests

Closes #552