### PR TITLE
fix(mcp): anchor solution-relative file reads to the solution directory

### DIFF
--- a/docs/design/cwd.md
+++ b/docs/design/cwd.md
@@ -14,7 +14,7 @@ scafctl --cwd /path/to/project run solution -f solution.yaml
 scafctl -C /path/to/project run resolver -f demo.yaml -o json
 ```
 
-When `--cwd` is set, **all** relative paths—including `-f`, `--output-dir`, snapshot paths, and auto-discovery—resolve against the specified directory instead of the process CWD.
+When `--cwd` is set, **all** relative paths -- including `-f`, `--output-dir`, snapshot paths, and auto-discovery -- resolve against the specified directory instead of the process CWD.
 
 ---
 
@@ -86,6 +86,17 @@ All MCP tools that accept file paths support an optional `cwd` parameter. When p
 }
 ```
 
+### Solution Directory Anchoring
+
+MCP tools that load and execute a solution (`preview_resolvers`, `render_solution`, `run_solution`, `dry_run_solution`, `preview_action`) also anchor the **solution's own directory** onto the context via `provider.WithSolutionDirectory()` after the solution is loaded, provided the solution has a local directory (a local file path or an extracted catalog bundle). This mirrors the CLI `run` commands and ensures that:
+
+- `relativeTo: solution` reads resolve against the solution file's directory
+- The `directory` and `hcl` providers resolve their default base path against the solution directory when `cwd` is not supplied (see the precedence note below -- when `cwd` is set, `AbsFromContext` prefers it first)
+
+For stdin (`-`) and unbundled catalog references there is no solution directory, so nothing is anchored and `relativeTo: solution` falls back to the process CWD.
+
+This anchoring is **independent of `cwd`**. Even when `cwd` is not supplied, solution-relative reads resolve against the solution directory rather than the MCP server's process CWD. The `cwd` parameter still controls where the solution `path` itself and other non-solution-relative paths resolve from. When both apply, `AbsFromContext` prefers the working directory (`cwd`), then the solution directory, then `os.Getwd()`.
+
 ### Tools with `cwd` Support
 
 | Tool | File |
@@ -122,8 +133,9 @@ All MCP tools that accept file paths support an optional `cwd` parameter. When p
 
 When `--cwd` is **not** set:
 1. `WorkingDirectoryFromContext` returns `("", false)`
-2. `AbsFromContext` falls through to `filepath.Abs()` which uses `os.Getwd()`
-3. Behavior is identical to running without `--cwd`—fully backward compatible
+2. `AbsFromContext` next checks `SolutionDirectoryFromContext`. For MCP solution-executing tools this is set to the loaded solution's directory (see [Solution Directory Anchoring](#solution-directory-anchoring)); for other cases it is unset.
+3. If neither is set, `AbsFromContext` falls through to `filepath.Abs()` which uses `os.Getwd()`
+4. Behavior is identical to running without `--cwd` -- fully backward compatible
 
 ---
 
@@ -145,7 +157,7 @@ When running a catalog solution (bare name), the bundle is extracted to a tempor
 directory and the process CWD is changed there so resolvers can read bundled files.
 
 However, file-writing **actions** need to resolve relative paths against the
-caller's original working directory — not the temporary bundle directory. The CLI
+caller's original working directory -- not the temporary bundle directory. The CLI
 injects the caller's CWD into the action execution context via
 `provider.WithWorkingDirectory(actionCtx, originalCwd)`. This ensures
 `AbsFromContext` resolves relative action paths against the caller's CWD, matching
@@ -163,7 +175,7 @@ Catalog run:  scafctl run solution my-app
 ```
 
 This aligns with how tools like `npm init`, `cargo init`, and `cookiecutter` work
-— they scaffold into the directory you run them from, regardless of where the
+-- they scaffold into the directory you run them from, regardless of where the
 template source lives.
 
 When `--output-dir` is specified, it takes precedence over the context CWD for

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -136,7 +136,7 @@ The AI client (VS Code, Claude Desktop, etc.) connects to this local server proc
 
 ### Working Directory Override
 
-All MCP tools that accept file paths support an optional `cwd` parameter. This allows AI agents to specify the project directory for path resolution without requiring the MCP server process to be started from that directory. See the [cwd design doc](cwd.md) for details.
+All MCP tools that accept file paths support an optional `cwd` parameter. This allows AI agents to specify the project directory for path resolution without requiring the MCP server process to be started from that directory. Tools that load and execute a solution additionally anchor path resolution to the solution file's own directory when the solution has a local directory (a local file path or an extracted catalog bundle), so `relativeTo: solution` reads resolve correctly even when `cwd` is not supplied. For stdin (`-`) and unbundled catalog references there is no solution directory, so `relativeTo: solution` falls back to the process CWD. See the [cwd design doc](cwd.md) for details.
 
 ## What Is Required
 

--- a/pkg/mcp/context.go
+++ b/pkg/mcp/context.go
@@ -142,3 +142,16 @@ func (s *Server) contextWithCwd(cwd string) (context.Context, error) {
 	}
 	return provider.WithWorkingDirectory(s.ctx, absCwd), nil
 }
+
+// withSolutionDir anchors path resolution to the solution file's directory so
+// that relativeTo:"solution" reads and the directory/hcl providers resolve
+// against the solution being executed rather than the MCP server's CWD. When
+// solutionDir is empty (e.g. stdin or unbundled catalog runs), the context is
+// returned unchanged. This mirrors the CLI run commands, which set the solution
+// directory after loading the solution.
+func withSolutionDir(ctx context.Context, solutionDir string) context.Context {
+	if solutionDir == "" {
+		return ctx
+	}
+	return provider.WithSolutionDirectory(ctx, solutionDir)
+}

--- a/pkg/mcp/tools_action.go
+++ b/pkg/mcp/tools_action.go
@@ -38,7 +38,7 @@ func (s *Server) registerActionTools() {
 			mcp.Description("Preview a specific action by name. If omitted, previews all actions."),
 		),
 		mcp.WithString("cwd",
-			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD."),
+			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD. Solution-relative reads (relativeTo: solution) resolve against the solution's own directory regardless of this setting when the solution has a local directory (a local file path or an extracted catalog bundle); for stdin (-) and unbundled catalog references there is no solution directory, so these reads fall back to the process CWD."),
 		),
 	)
 	s.addTool(previewActionTool, s.handlePreviewAction)
@@ -101,6 +101,10 @@ func (s *Server) handlePreviewAction(_ context.Context, request mcp.CallToolRequ
 	if prepResult.ProviderCtx != nil {
 		ctx = prepResult.ProviderCtx(ctx)
 	}
+
+	// Anchor solution-relative reads (relativeTo: solution, directory, hcl) to
+	// the solution file's directory instead of the MCP server's CWD.
+	ctx = withSolutionDir(ctx, prepResult.SolutionDir)
 
 	// If bundle extraction changed the process CWD, pin the resolver context
 	// to the bundle dir so file reads resolve within the extracted bundle,

--- a/pkg/mcp/tools_dryrun.go
+++ b/pkg/mcp/tools_dryrun.go
@@ -39,7 +39,7 @@ func (s *Server) registerDryRunTools() {
 			mcp.Description("Override specific resolver values instead of using the real resolved output. Keys are resolver names, values are the override values. Useful for testing action behavior with specific resolver outputs. Example: {\"api_url\": \"https://staging.example.com\", \"config\": {\"env\": \"test\"}}"),
 		),
 		mcp.WithString("cwd",
-			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD."),
+			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD. Solution-relative reads (relativeTo: solution) resolve against the solution's own directory regardless of this setting when the solution has a local directory (a local file path or an extracted catalog bundle); for stdin (-) and unbundled catalog references there is no solution directory, so these reads fall back to the process CWD."),
 		),
 		mcp.WithString("on_conflict",
 			mcp.Description("Default conflict strategy for file write actions. Controls what happens when a target file already exists. Valid values: error (fail if exists), overwrite (always replace), skip (never write if exists), skip-unchanged (overwrite only when content differs, default), append (add to end of file)."),
@@ -137,6 +137,10 @@ func (s *Server) handleDryRunSolution(_ context.Context, request mcp.CallToolReq
 	if prepResult.ProviderCtx != nil {
 		ctx = prepResult.ProviderCtx(ctx)
 	}
+
+	// Anchor solution-relative reads (relativeTo: solution, directory, hcl) to
+	// the solution file's directory instead of the MCP server's CWD.
+	ctx = withSolutionDir(ctx, prepResult.SolutionDir)
 
 	// If bundle extraction changed the process CWD, pin the resolver context
 	// to the bundle dir so file reads resolve within the extracted bundle,

--- a/pkg/mcp/tools_run.go
+++ b/pkg/mcp/tools_run.go
@@ -53,7 +53,7 @@ func (s *Server) registerRunTools() {
 			mcp.Description("Create .bak backup files before overwriting existing files."),
 		),
 		mcp.WithString("cwd",
-			mcp.Description("Working directory for path resolution. Relative paths resolve against this directory instead of the process CWD."),
+			mcp.Description("Working directory for path resolution. Relative paths resolve against this directory instead of the process CWD. Solution-relative reads (relativeTo: solution) resolve against the solution's own directory regardless of this setting when the solution has a local directory (a local file path or an extracted catalog bundle); for stdin (-) and unbundled catalog references there is no solution directory, so these reads fall back to the process CWD."),
 		),
 		mcp.WithBoolean("show_execution",
 			mcp.Description("Include execution metadata (timing, phases, providers) in the response."),
@@ -134,6 +134,10 @@ func (s *Server) handleRunSolution(_ context.Context, request mcp.CallToolReques
 	if prepResult.ProviderCtx != nil {
 		ctx = prepResult.ProviderCtx(ctx)
 	}
+
+	// Anchor solution-relative reads (relativeTo: solution, directory, hcl) to
+	// the solution file's directory instead of the MCP server's CWD.
+	ctx = withSolutionDir(ctx, prepResult.SolutionDir)
 
 	// If bundle extraction changed the process CWD, pin the resolver context
 	// to the bundle dir so file reads resolve within the extracted bundle.

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -120,7 +120,7 @@ func (s *Server) registerSolutionTools() {
 			mcp.Description("Target directory for action output. When set, actions resolve relative paths against this directory instead of CWD. Resolvers always use CWD regardless of this setting."),
 		),
 		mcp.WithString("cwd",
-			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD."),
+			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD. Solution-relative reads (relativeTo: solution) resolve against the solution's own directory regardless of this setting when the solution has a local directory (a local file path or an extracted catalog bundle); for stdin (-) and unbundled catalog references there is no solution directory, so these reads fall back to the process CWD."),
 		),
 	)
 	s.addTool(renderSolutionTool, s.handleRenderSolution)
@@ -152,7 +152,7 @@ func (s *Server) registerSolutionTools() {
 			mcp.Description("Target directory for action output. Included for path preview purposes — resolvers always use CWD regardless of this setting."),
 		),
 		mcp.WithString("cwd",
-			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD."),
+			mcp.Description("Working directory for path resolution. When set, relative paths (including the solution path itself) resolve against this directory instead of the process CWD. Solution-relative reads (relativeTo: solution) resolve against the solution's own directory regardless of this setting when the solution has a local directory (a local file path or an extracted catalog bundle); for stdin (-) and unbundled catalog references there is no solution directory, so these reads fall back to the process CWD."),
 		),
 	)
 	s.addTool(previewResolversTool, s.handlePreviewResolvers)
@@ -469,6 +469,10 @@ func (s *Server) handleRenderSolution(_ context.Context, request mcp.CallToolReq
 		ctx = prepResult.ProviderCtx(ctx)
 	}
 
+	// Anchor solution-relative reads (relativeTo: solution, directory, hcl) to
+	// the solution file's directory instead of the MCP server's CWD.
+	ctx = withSolutionDir(ctx, prepResult.SolutionDir)
+
 	// If bundle extraction changed the process CWD, pin the resolver context
 	// to the bundle dir so file reads resolve within the extracted bundle,
 	// not against any caller-provided cwd override.
@@ -726,6 +730,10 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 	if prepResult.ProviderCtx != nil {
 		ctx = prepResult.ProviderCtx(ctx)
 	}
+
+	// Anchor solution-relative reads (relativeTo: solution, directory, hcl) to
+	// the solution file's directory instead of the MCP server's CWD.
+	ctx = withSolutionDir(ctx, prepResult.SolutionDir)
 
 	sol := prepResult.Solution
 	reg := prepResult.Registry

--- a/pkg/mcp/tools_solution_test.go
+++ b/pkg/mcp/tools_solution_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/solution/soltesting"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -739,6 +740,214 @@ spec:
 		resolvers := parsed["resolvers"].(map[string]any)
 		name := resolvers["name"].(map[string]any)
 		assert.Equal(t, "Bob", name["value"], "values must still be included in strict mode")
+	})
+}
+
+// TestHandlePreviewResolvers_RelativeToSolution verifies that resolver file
+// reads using relativeTo: solution resolve against the solution file's
+// directory rather than the MCP server's process CWD (issue #607). The server
+// process CWD (the test package directory) intentionally differs from the
+// solution's temp directory, so a read that succeeds proves the solution
+// directory is anchored on the context.
+func TestHandlePreviewResolvers_RelativeToSolution(t *testing.T) {
+	const fileContent = "hello from solution dir"
+
+	newSolution := func(t *testing.T) string {
+		t.Helper()
+		tmpDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "data.txt"), []byte(fileContent), 0o644))
+		solFile := filepath.Join(tmpDir, "reads-relative.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: reads-relative
+  version: 1.0.0
+spec:
+  resolvers:
+    fileData:
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: data.txt
+              relativeTo: solution
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+		return solFile
+	}
+
+	assertResolved := func(t *testing.T, result *mcp.CallToolResult) {
+		t.Helper()
+		require.False(t, result.IsError, "read with relativeTo: solution should succeed regardless of server CWD")
+
+		require.NotEmpty(t, result.Content, "tool result should include content")
+		textContent, ok := result.Content[0].(mcp.TextContent)
+		require.True(t, ok, "first content item should be text, got %T", result.Content[0])
+		text := textContent.Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+
+		resolvers := parsed["resolvers"].(map[string]any)
+		fileData := resolvers["fileData"].(map[string]any)
+		assert.Equal(t, "resolved", fileData["status"])
+		value := fileData["value"].(map[string]any)
+		assert.Equal(t, fileContent, value["content"])
+	}
+
+	t.Run("without cwd anchors to solution dir", func(t *testing.T) {
+		solFile := newSolution(t)
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_resolvers"
+		request.Params.Arguments = map[string]any{
+			"path": solFile,
+		}
+
+		result, err := srv.handlePreviewResolvers(context.Background(), request)
+		require.NoError(t, err)
+		assertResolved(t, result)
+	})
+
+	t.Run("cwd override does not affect relativeTo solution", func(t *testing.T) {
+		solFile := newSolution(t)
+		// An unrelated working directory that does NOT contain data.txt.
+		otherDir := t.TempDir()
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_resolvers"
+		request.Params.Arguments = map[string]any{
+			"path": solFile,
+			"cwd":  otherDir,
+		}
+
+		result, err := srv.handlePreviewResolvers(context.Background(), request)
+		require.NoError(t, err)
+		assertResolved(t, result)
+	})
+}
+
+// TestHandleSolutionExecutors_RelativeToSolution verifies that the remaining
+// solution-executing tools (render_solution, run_solution, dry_run_solution,
+// preview_action) anchor resolver file reads using relativeTo: solution to the
+// solution file's directory rather than the MCP server's process CWD
+// (issue #607). Each solution reads data.txt via relativeTo: solution and
+// surfaces the content through a message action, so the resolved value appears
+// in every tool's output. The server process CWD (the test package directory)
+// intentionally differs from the solution's temp directory, so the content
+// only appears when the solution directory is anchored on the context.
+func TestHandleSolutionExecutors_RelativeToSolution(t *testing.T) {
+	const fileContent = "hello from solution dir"
+
+	newSolution := func(t *testing.T) string {
+		t.Helper()
+		tmpDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "data.txt"), []byte(fileContent), 0o644))
+		solFile := filepath.Join(tmpDir, "reads-relative.yaml")
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: reads-relative
+  version: 1.0.0
+spec:
+  resolvers:
+    fileData:
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: data.txt
+              relativeTo: solution
+  workflow:
+    actions:
+      showData:
+        provider: message
+        inputs:
+          message:
+            expr: _.fileData.content
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+		return solFile
+	}
+
+	type handlerFn func(*Server, context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)
+
+	tools := []struct {
+		tool    string
+		handler handlerFn
+	}{
+		{"render_solution", (*Server).handleRenderSolution},
+		{"run_solution", (*Server).handleRunSolution},
+		{"dry_run_solution", (*Server).handleDryRunSolution},
+		{"preview_action", (*Server).handlePreviewAction},
+	}
+
+	scenarios := []struct {
+		name    string
+		withCwd bool
+	}{
+		{"without cwd anchors to solution dir", false},
+		{"cwd override does not affect relativeTo solution", true},
+	}
+
+	for _, tc := range tools {
+		for _, sc := range scenarios {
+			t.Run(tc.tool+"/"+sc.name, func(t *testing.T) {
+				solFile := newSolution(t)
+
+				srv, err := NewServer(WithServerVersion("test"))
+				require.NoError(t, err)
+
+				args := map[string]any{"path": solFile}
+				if sc.withCwd {
+					// An unrelated working directory that does NOT contain data.txt.
+					args["cwd"] = t.TempDir()
+				}
+
+				request := mcp.CallToolRequest{}
+				request.Params.Name = tc.tool
+				request.Params.Arguments = args
+
+				result, err := tc.handler(srv, context.Background(), request)
+				require.NoError(t, err)
+				require.False(t, result.IsError, "read with relativeTo: solution should succeed regardless of server CWD")
+
+				require.NotEmpty(t, result.Content, "tool result should include content")
+				textContent, ok := result.Content[0].(mcp.TextContent)
+				require.True(t, ok, "first content item should be text, got %T", result.Content[0])
+				text := textContent.Text
+				assert.Contains(t, text, fileContent, "resolved file content should appear in the %s output", tc.tool)
+			})
+		}
+	}
+}
+
+// TestWithSolutionDir verifies the withSolutionDir helper: an empty directory
+// leaves the context untouched (stdin / unbundled catalog runs), while a
+// non-empty directory is anchored on the context for solution-relative reads.
+func TestWithSolutionDir(t *testing.T) {
+	t.Run("empty solutionDir leaves context unchanged", func(t *testing.T) {
+		ctx := context.Background()
+		got := withSolutionDir(ctx, "")
+
+		_, ok := provider.SolutionDirectoryFromContext(got)
+		assert.False(t, ok, "no solution directory should be set for empty input")
+	})
+
+	t.Run("non-empty solutionDir is anchored on the context", func(t *testing.T) {
+		dir := t.TempDir()
+		got := withSolutionDir(context.Background(), dir)
+
+		solDir, ok := provider.SolutionDirectoryFromContext(got)
+		require.True(t, ok, "solution directory should be set")
+		assert.Equal(t, dir, solDir)
 	})
 }
 

--- a/tests/integration/mcp_test.go
+++ b/tests/integration/mcp_test.go
@@ -1,0 +1,84 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	mcpclient "github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+	scafmcp "github.com/oakwood-commons/scafctl/pkg/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntegration_MCPPreviewResolvers_RelativeToSolution exercises the full MCP
+// dispatch stack (in-process client -> middleware -> preview_resolvers handler
+// -> real file provider) and verifies that a resolver read using
+// relativeTo: solution resolves against the solution file's directory rather
+// than the MCP server's process CWD (issue #607). The solution lives in a temp
+// directory that is not the test process CWD, so a successful read proves the
+// solution directory is anchored on the execution context.
+func TestIntegration_MCPPreviewResolvers_RelativeToSolution(t *testing.T) {
+	const fileContent = "hello from solution dir"
+
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "data.txt"), []byte(fileContent), 0o644))
+	solFile := filepath.Join(tmpDir, "reads-relative.yaml")
+	solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: reads-relative
+  version: 1.0.0
+spec:
+  resolvers:
+    fileData:
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: data.txt
+              relativeTo: solution
+`
+	require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+	srv, err := scafmcp.NewServer(scafmcp.WithServerVersion("test"))
+	require.NoError(t, err)
+
+	c, err := mcpclient.NewInProcessClient(srv.MCPServer())
+	require.NoError(t, err)
+	defer c.Close()
+
+	ctx := context.Background()
+	_, err = c.Initialize(ctx, mcp.InitializeRequest{})
+	require.NoError(t, err)
+
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "preview_resolvers"
+	req.Params.Arguments = map[string]any{
+		"path": solFile,
+	}
+
+	result, err := c.CallTool(ctx, req)
+	require.NoError(t, err)
+	require.False(t, result.IsError, "read with relativeTo: solution should succeed regardless of server CWD")
+
+	require.NotEmpty(t, result.Content, "tool result should include content")
+	textContent, ok := result.Content[0].(mcp.TextContent)
+	require.True(t, ok, "first content item should be text, got %T", result.Content[0])
+	text := textContent.Text
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+
+	resolvers := parsed["resolvers"].(map[string]any)
+	fileData := resolvers["fileData"].(map[string]any)
+	assert.Equal(t, "resolved", fileData["status"])
+	value := fileData["value"].(map[string]any)
+	assert.Equal(t, fileContent, value["content"])
+}


### PR DESCRIPTION
MCP tools that load and execute a solution (preview_resolvers, render_solution, run_solution, dry_run_solution, preview_action) now anchor path resolution to the solution file's own directory via provider.WithSolutionDirectory(). This ensures relativeTo: solution reads and the directory/hcl providers resolve against the solution being executed rather than the MCP server's process CWD.

- Add withSolutionDir helper that anchors the solution directory on the context, leaving it unchanged for stdin / unbundled catalog runs
- Apply anchoring after solution load in all five solution-executing tool handlers
- Keep anchoring independent of cwd: solution-relative reads resolve correctly even when cwd is not supplied
- Update cwd and mcp-server design docs and tool descriptions
- Add unit tests plus an integration suite covering both with-cwd and without-cwd scenarios

Closes #607