### PR TITLE
feat(dag): render dependency cycles as ordered chain paths

### DIFF
--- a/pkg/dag/dag.go
+++ b/pkg/dag/dag.go
@@ -281,19 +281,26 @@ func findCyclesInDependencies(deps map[string][]string) error {
 	return getInterdependencyError(dag)
 }
 
-// getInterdependencyError returns an error describing the interdependencies of the first
-// dagObject in the provided DAG map. If the DAG is empty, it returns nil.
-// The error message specifies which dagObject depends on which other objects.
-// Dependencies are listed in sorted order and quoted.
-// The function is intended to help diagnose cyclic or unexpected dependencies in a DAG structure.
+// getInterdependencyError returns an error describing a cycle within the provided
+// residual DAG map. Every key remaining in dag after Kahn's algorithm is blocked by
+// a cycle -- either it participates in one directly or it depends (transitively) on
+// nodes that do. The function reconstructs a concrete cycle chain and renders it as
+// an ordered path (e.g. "a -> b -> a"). If the DAG is empty it returns nil. When a
+// chain cannot be reconstructed it falls back to describing the first node and its
+// unsatisfied dependencies.
 func getInterdependencyError(dag map[string]sets.Set[string]) error {
 	if len(dag) == 0 {
 		return nil
 	}
+	if chain := findCycleChain(dag); len(chain) > 0 {
+		return fmt.Errorf("dependency cycle: %s", strings.Join(chain, " -> "))
+	}
+
+	// Defensive fallback: describe the first node and its dependencies.
 	firstChild := ""
-	for dagObject := range dag {
-		if firstChild == "" || firstChild > dagObject {
-			firstChild = dagObject
+	for node := range dag {
+		if firstChild == "" || firstChild > node {
+			firstChild = node
 		}
 	}
 	deps := sets.List(dag[firstChild])
@@ -302,7 +309,62 @@ func getInterdependencyError(dag map[string]sets.Set[string]) error {
 	for _, dep := range deps {
 		depNames = append(depNames, fmt.Sprintf("%q", dep))
 	}
-	return fmt.Errorf("dagObject %q depends on %s", firstChild, strings.Join(depNames, ", "))
+	return fmt.Errorf("dependency cycle involving %q (depends on %s)", firstChild, strings.Join(depNames, ", "))
+}
+
+// findCycleChain reconstructs a concrete, closed cycle path (first element equals
+// last) from the residual dependency map produced after Kahn's algorithm. Every
+// key in dag is blocked by a cycle, though some may be acyclic tails that only
+// depend on cyclic nodes rather than participating in a cycle themselves; the
+// search follows dependency edges until it closes a loop.
+//
+// Selection is deterministic: the search starts from the lexicographically
+// smallest node and, at each step, follows the lexicographically smallest
+// unsatisfied dependency. Identical graphs therefore always yield identical
+// chains. Returns nil if no cycle can be reconstructed.
+func findCycleChain(dag map[string]sets.Set[string]) []string {
+	starts := make([]string, 0, len(dag))
+	for node := range dag {
+		starts = append(starts, node)
+	}
+	sort.Strings(starts)
+
+	for _, start := range starts {
+		visited := make(map[string]bool, len(dag))
+		if chain := walkCycle(start, dag, visited, nil); chain != nil {
+			return chain
+		}
+	}
+	return nil
+}
+
+// walkCycle performs a depth-first search from node, following dependency edges
+// in sorted order, and returns the first closed cycle it discovers as an ordered
+// path. path holds the nodes on the current DFS stack (in visit order). It
+// returns nil when no cycle is reachable from node.
+func walkCycle(node string, dag map[string]sets.Set[string], visited map[string]bool, path []string) []string {
+	// If node is already on the current path, we found a back-edge: slice the
+	// path from the first occurrence and close the loop.
+	for i, p := range path {
+		if p == node {
+			cycle := append([]string(nil), path[i:]...)
+			return append(cycle, node)
+		}
+	}
+	if visited[node] {
+		return nil
+	}
+	visited[node] = true
+
+	deps := sets.List(dag[node])
+	sort.Strings(deps)
+	path = append(path, node)
+	for _, dep := range deps {
+		if chain := walkCycle(dep, dag, visited, path); chain != nil {
+			return chain
+		}
+	}
+	return nil
 }
 
 // addLink creates a link between two DAG nodes by connecting the node identified by

--- a/pkg/dag/dag_test.go
+++ b/pkg/dag/dag_test.go
@@ -77,7 +77,7 @@ func TestFindCyclesInDependencies(t *testing.T) {
 				"node1": {"node2"},
 				"node2": {"node1"},
 			},
-			want: fmt.Errorf("dagObject %q depends on %q", "node1", "node2"),
+			want: fmt.Errorf("dependency cycle: node1 -> node2 -> node1"),
 		},
 		{
 			name: "complex cycle",
@@ -86,7 +86,33 @@ func TestFindCyclesInDependencies(t *testing.T) {
 				"node2": {"node3"},
 				"node3": {"node1"},
 			},
-			want: fmt.Errorf("dagObject %q depends on %q", "node1", "node2"),
+			want: fmt.Errorf("dependency cycle: node1 -> node2 -> node3 -> node1"),
+		},
+		{
+			name: "self cycle",
+			deps: map[string][]string{
+				"node1": {"node1"},
+			},
+			want: fmt.Errorf("dependency cycle: node1 -> node1"),
+		},
+		{
+			name: "cycle excludes acyclic tail",
+			deps: map[string][]string{
+				"node1": {"node2"},
+				"node2": {"node1"},
+				"node3": {"node1"},
+			},
+			want: fmt.Errorf("dependency cycle: node1 -> node2 -> node1"),
+		},
+		{
+			name: "disjoint cycles pick smallest deterministically",
+			deps: map[string][]string{
+				"alpha": {"beta"},
+				"beta":  {"alpha"},
+				"gamma": {"delta"},
+				"delta": {"gamma"},
+			},
+			want: fmt.Errorf("dependency cycle: alpha -> beta -> alpha"),
 		},
 	}
 
@@ -150,7 +176,7 @@ func TestBuild(t *testing.T) {
 				"node2": {"node1"},
 			},
 			wantErr: true,
-			errMsg:  "cycle detected; dagObject \"node1\" depends on \"node2\"",
+			errMsg:  "cycle detected; dependency cycle: node1 -> node2 -> node1",
 		},
 		{
 			name: "missing previous dagObject",

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -4685,6 +4685,26 @@ func TestIntegration_SolutionProvider_CircularReference(t *testing.T) {
 	assert.Contains(t, stderr, "circular reference detected")
 }
 
+// TestIntegration_RunResolver_CycleChainMessage verifies that a circular
+// resolver dependency surfaces as an ordered, closed cycle chain
+// ("alpha -> beta -> alpha") rather than the legacy "dagObject depends on"
+// phrasing. The chain is deterministic: the search starts from the
+// lexicographically smallest node and follows the smallest dependency edge.
+func TestIntegration_RunResolver_CycleChainMessage(t *testing.T) {
+	t.Parallel()
+	_, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "tests/integration/solutions/lint-resolver-cycle/solution.yaml",
+	)
+	t.Logf("stderr: %s", stderr)
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "cycle detected")
+	assert.Contains(t, stderr, "dependency cycle: alpha -> beta -> alpha",
+		"cycle error must render an ordered, closed chain")
+	assert.NotContains(t, stderr, "dagObject",
+		"legacy 'dagObject depends on' phrasing must not appear")
+}
+
 func TestIntegration_SolutionProvider_DryRun(t *testing.T) {
 	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,


### PR DESCRIPTION
Replace the terse "dagObject depends on" phrasing with a concrete, closed cycle path (e.g. "alpha -> beta -> alpha") so circular resolver dependencies are easier to diagnose at a glance.

- Reconstruct a real cycle chain from the residual DAG left by Kahn's algorithm via a deterministic DFS (start at the lexicographically smallest node, follow the smallest dependency edge)
- Guarantee identical graphs always produce identical chains, and exclude acyclic tails and unrelated disjoint cycles from the output
- Keep a defensive fallback describing the first node and its unsatisfied dependencies when a chain cannot be reconstructed
- Cover self cycles, complex cycles, acyclic-tail exclusion, and disjoint-cycle determinism in unit tests
- Add a CLI integration test asserting the ordered chain surfaces on `run resolver` and the legacy phrasing no longer appears

Scope is limited to the edge-chain ask. Naming `solution` steps in the message is intentionally dropped: pkg/dag is a generic package with no provider-type knowledge, and threading that metadata down would be disproportionate coupling for a cosmetic label.

Closes #617
