### PR TITLE
docs(provider): document child-opt-in value override contract

### DIFF
--- a/docs/design/solution-provider.md
+++ b/docs/design/solution-provider.md
@@ -194,6 +194,94 @@ This keeps the provider focused on execution and delegates post-processing to th
 
 ---
 
+## Value Override Contract
+
+A recurring composition need (issue #616) is for a parent to **override a value the child computes internally** -- for example, the parent enriches a map with extra fields and wants the child's downstream rendering (actions, templates) to consume the enriched version.
+
+The provider deliberately keeps the child **opaque and isolated**: the parent cannot reach in and overwrite an arbitrary child resolver value. Instead, the child **opts in** to an override using mechanisms the engine already provides. This preserves encapsulation -- the child author decides which values are overridable and how the override is merged.
+
+### The contract
+
+The child author exposes an overridable value as three small resolvers:
+
+1. **Override input** -- a `parameter` resolver with a `default` (typically `{}`), so it is empty when the parent passes nothing. The `exists` flag lives in provider **metadata**, not in the resolver value, so downstream expressions cannot read it; rely on the default instead.
+2. **Internal value** -- the child's own computation.
+3. **Effective value** -- the internal value merged with the override, using `map.merge(internal, override)` (the second argument wins on key conflicts).
+
+~~~yaml
+# child.yaml
+spec:
+  resolvers:
+    labels_override:        # 1. optional parent override (empty by default)
+      type: any
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: labels_override
+              default: {}
+
+    labels_internal:        # 2. the child's own computation
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "{'app': 'child', 'tier': 'backend'}"
+
+    labels:                 # 3. effective value the child renders from
+      type: any
+      dependsOn: [labels_internal, labels_override]
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "map.merge(_.labels_internal, _.labels_override)"
+~~~
+
+The parent enriches the value and passes it into the child's override input using the nested `expr` form (a bare string would be a literal, not a resolver reference):
+
+~~~yaml
+# parent.yaml
+spec:
+  resolvers:
+    enriched_labels:
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "{'team': 'platform', 'costCenter': 'CC-42'}"
+
+    child_data:
+      type: any
+      dependsOn: [enriched_labels]
+      resolve:
+        with:
+          - provider: solution
+            inputs:
+              source: "./child.yaml"
+              inputs:
+                labels_override:
+                  expr: "_.enriched_labels"
+~~~
+
+The child's `labels` now contains both its internal keys (`app`, `tier`) and the parent's overrides (`team`, `costCenter`). When the parent omits `labels_override`, `map.merge(internal, {})` yields the internal value unchanged.
+
+### Conventions
+
+- **Use a distinct override key** (e.g. `labels_override`), never the effective resolver's own name (`labels`). Reusing the name triggers name-collision auto-wiring and can invent spurious dependency cycles.
+- **Scalars have no `exists` to test**, so use a sentinel default and a CEL ternary, e.g. `default: ""` with `_.x_override == "" ? _.x_internal : _.x_override`.
+- **Type/shape is the child's responsibility.** A shape mismatch (e.g. override is a scalar but the child expects a map) surfaces as a `map.merge` error at child resolve time and propagates through the normal `propagateErrors` path.
+
+A runnable example lives in [examples/solutions/composition/](../../examples/solutions/composition/) (`child.yaml` + `parent.yaml`).
+
+### Why not an engine-level override API
+
+An earlier proposal (issue #608, item 3) suggested letting the parent override arbitrary child resolver values directly from the `solution` provider input. This was rejected because it breaks the isolation invariant, has no clean answer for override precedence versus the child's own resolve/transform phases, and multiplies type/shape and validation-visibility concerns -- all with no safe default. The opt-in contract above delivers the same outcome while keeping the child in control.
+
+---
+
 ## Output Envelope
 
 ### `from` Capability

--- a/docs/tutorials/catalog-tutorial.md
+++ b/docs/tutorials/catalog-tutorial.md
@@ -1681,6 +1681,8 @@ Bundle analysis for nested-demo/parent.yaml:
 
 Notice that scafctl **recursively discovered** the child sub-solution (`sub/child.yaml`) and its file dependency (`sub/templates/greeting.tmpl`). No `bundle.include` is needed -- the solution provider reference is detected by static analysis.
 
+> **Tip:** To let a parent override a value the child computes internally (for example, enriching a map the child renders from), use the child-opt-in **value override contract**. See [Solution Provider -- Value Override Contract](../design/solution-provider.md#value-override-contract).
+
 ### Step 4: Build and Run
 
 {{< tabs "catalog-tutorial-cmd-46" >}}

--- a/examples/README.md
+++ b/examples/README.md
@@ -159,6 +159,7 @@ Complete solutions demonstrating real-world use cases.
 | Example | Description |
 |---------|-------------|
 | [comprehensive/](solutions/comprehensive/) | Full-featured solution with all capabilities |
+| [composition/](solutions/composition/) | Parent solution composes a child via the `solution` provider, including the child-opt-in value override contract |
 | [terraform/](solutions/terraform/) | Terraform project scaffolding |
 | [taskfile/](solutions/taskfile/) | Taskfile.yaml generation |
 | [email-notifier/](solutions/email-notifier/) | Email notification workflow |

--- a/examples/solutions/composition/child.yaml
+++ b/examples/solutions/composition/child.yaml
@@ -25,3 +25,46 @@ spec:
           - provider: parameter
             inputs:
               key: message
+
+    # --- Value override contract (issue #616) ---
+    # A child opts a value into being overridable by the parent. It reads an
+    # optional parameter (default {}) and merges it OVER its own internally
+    # computed value, so the parent can enrich the map the child renders from.
+    # The override key must NOT reuse the effective resolver name ("labels") to
+    # avoid name-collision auto-wiring; use a distinct "_override" suffix.
+
+    # 1. Optional parent override. Empty map when the parent passes nothing.
+    labels_override:
+      type: any
+      description: "Optional parent-provided label overrides"
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: labels_override
+              default: {}
+
+    # 2. The child's own internally computed value.
+    labels_internal:
+      type: any
+      description: "Labels the child computes on its own"
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "{'app': 'child', 'tier': 'backend'}"
+
+    # 3. Effective value the child renders from: internal merged with the
+    #    override. map.merge gives the second argument precedence, so any keys
+    #    the parent supplied win over the child's defaults.
+    labels:
+      type: any
+      description: "Effective labels: internal merged with parent overrides"
+      dependsOn:
+        - labels_internal
+        - labels_override
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "map.merge(_.labels_internal, _.labels_override)"

--- a/examples/solutions/composition/parent.yaml
+++ b/examples/solutions/composition/parent.yaml
@@ -14,11 +14,25 @@ metadata:
     as a structured envelope: { resolvers: {...}, status: "success", errors: [] }
 spec:
   resolvers:
+    # Parent computes an enriched data structure that the child also builds
+    # internally under the same logical name. The parent passes it down so the
+    # child renders from the enriched version (issue #616).
+    enriched_labels:
+      type: any
+      description: "Extra labels the parent wants the child to consume"
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "{'team': 'platform', 'costCenter': 'CC-42'}"
+
     # Use the solution provider to load and execute a child solution.
     # The child's resolver values are returned as a structured envelope.
     child_data:
       type: any
       description: "Data from the child solution"
+      dependsOn:
+        - enriched_labels
       resolve:
         with:
           - provider: solution
@@ -26,6 +40,12 @@ spec:
               source: "./child.yaml"
               inputs:
                 message: "hello from parent"
+                # Override contract: pass the parent's enriched value into the
+                # child's opt-in override parameter. Use the nested expr form so
+                # the resolver value is evaluated (a bare string would be a
+                # literal). The child merges this over its internal labels.
+                labels_override:
+                  expr: "_.enriched_labels"
               # Optional: only run specific resolvers from the child.
               # When omitted, all resolvers in the child are executed.
               # resolvers:
@@ -55,3 +75,17 @@ spec:
           - provider: cel
             inputs:
               expression: "_.child_data.resolvers['echo-param']"
+
+    # The child's effective labels, enriched with the parent's overrides.
+    # Contains the child's internal keys (app, tier) plus the parent's
+    # team and costCenter.
+    child_labels:
+      type: any
+      description: "The child's labels after the parent's override merge"
+      dependsOn:
+        - child_data
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.child_data.resolvers.labels"

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -4674,6 +4674,55 @@ func TestIntegration_SolutionProvider_WorkflowComposition(t *testing.T) {
 	assert.Contains(t, stdout, "succeeded")
 }
 
+func TestIntegration_SolutionProvider_ValueOverrideContract(t *testing.T) {
+	t.Parallel()
+
+	// With an override: the parent passes an enriched value into the child's
+	// opt-in override input, and the child merges it over its internal value.
+	stdout, stderr, exitCode := runScafctlLong(t,
+		"run", "resolver",
+		"-f", "tests/integration/testdata/solution-provider/override-parent.yaml",
+		"-o", "json",
+	)
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+	assert.Equal(t, 0, exitCode, "expected exit code 0, got %d", exitCode)
+	// child_labels merges the child's internal keys with the parent's overrides.
+	// Decode the output and assert on the object to avoid depending on JSON
+	// formatting (spacing, key ordering, pretty vs compact).
+	var parentResolvers struct {
+		ChildLabels map[string]any `json:"child_labels"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &parentResolvers))
+	assert.Equal(t, map[string]any{
+		"app":        "child",
+		"tier":       "backend",
+		"team":       "platform",
+		"costCenter": "CC-42",
+	}, parentResolvers.ChildLabels)
+
+	// Without an override: the child alone falls back to its internal value
+	// because labels_override defaults to {} (map.merge with {} is a no-op).
+	childOut, childErr, childExit := runScafctlLong(t,
+		"run", "resolver",
+		"-f", "tests/integration/testdata/solution-provider/override-child.yaml",
+		"-o", "json",
+	)
+	t.Logf("childOut: %s", childOut)
+	t.Logf("childErr: %s", childErr)
+	assert.Equal(t, 0, childExit, "expected exit code 0, got %d", childExit)
+	var childResolvers struct {
+		Labels map[string]any `json:"labels"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(childOut), &childResolvers))
+	assert.Equal(t, map[string]any{
+		"app":  "child",
+		"tier": "backend",
+	}, childResolvers.Labels)
+	assert.NotContains(t, childResolvers.Labels, "team")
+	assert.NotContains(t, childResolvers.Labels, "costCenter")
+}
+
 func TestIntegration_SolutionProvider_CircularReference(t *testing.T) {
 	t.Parallel()
 	_, stderr, exitCode := runScafctl(t,

--- a/tests/integration/testdata/solution-provider/override-child.yaml
+++ b/tests/integration/testdata/solution-provider/override-child.yaml
@@ -1,0 +1,37 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: override-child
+  version: 1.0.0
+spec:
+  resolvers:
+    # Optional parent override (empty map when the parent passes nothing).
+    labels_override:
+      type: any
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: labels_override
+              default: {}
+
+    # The child's own internally computed value.
+    labels_internal:
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "{'app': 'child', 'tier': 'backend'}"
+
+    # Effective value: internal merged with the override (override wins).
+    labels:
+      type: any
+      dependsOn:
+        - labels_internal
+        - labels_override
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "map.merge(_.labels_internal, _.labels_override)"

--- a/tests/integration/testdata/solution-provider/override-parent.yaml
+++ b/tests/integration/testdata/solution-provider/override-parent.yaml
@@ -1,0 +1,42 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: override-parent
+  version: 1.0.0
+spec:
+  resolvers:
+    # Parent computes an enriched value the child also builds internally.
+    enriched_labels:
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "{'team': 'platform', 'costCenter': 'CC-42'}"
+
+    child_data:
+      type: any
+      timeout: 90s
+      dependsOn:
+        - enriched_labels
+      resolve:
+        with:
+          - provider: solution
+            inputs:
+              source: "override-child.yaml"
+              inputs:
+                # Pass the enriched value into the child's opt-in override input.
+                labels_override:
+                  expr: "_.enriched_labels"
+              timeout: "90s"
+
+    # Extract the child's effective labels after the override merge.
+    child_labels:
+      type: any
+      dependsOn:
+        - child_data
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "_.child_data.resolvers.labels"


### PR DESCRIPTION
Add a composition pattern that lets a parent enrich a value the child computes internally, without breaking child isolation. The child opts in by exposing an override parameter (default {}) and merging it over its internal value; the parent passes its enriched value into that input.

- Document the value override contract, conventions, and rationale for rejecting an engine-level override API in the solution-provider design
- Add a runnable composition example (parent.yaml + child.yaml) and link it from the examples README and catalog tutorial
- Add an integration test plus override-parent/override-child testdata covering both the with-override merge and the no-override fallback

Closes #616