### PR TITLE
docs(catalog): add reference-data lookup tutorial and example

### DIFF
--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -25,6 +25,7 @@ Step-by-step guides for learning scafctl features.
 - [Linting Tutorial](linting-tutorial.md) — Validate solutions, explore lint rules, and fix issues
 - [CEL Expressions Tutorial](cel-tutorial.md) — Master CEL expressions and extension functions
 - [Go Templates Tutorial](go-templates-tutorial.md) — Generate files with Go template rendering
+- [Reference-Data Lookups](reference-data-lookups.md) -- Look up taxonomy values from inline, file, or HTTP datasets
 - [Catalog Tutorial](catalog-tutorial.md) — Store and manage solutions in your local catalog
 - [MCP Server Tutorial](mcp-server-tutorial.md) — Set up AI agent integration with VS Code Copilot, Claude, Cursor, and Windsurf
 - [Security Hardening](security-hardening.md) — Secure your solutions and workflows

--- a/docs/tutorials/cel-tutorial.md
+++ b/docs/tutorials/cel-tutorial.md
@@ -1048,6 +1048,7 @@ scafctl run resolver -f examples/resolvers/cel-transforms.yaml -o json
 ## Next Steps
 
 - [Go Templates Tutorial](go-templates-tutorial.md) — When to use `tmpl` vs `expr`
+- [Reference-Data Lookups](reference-data-lookups.md) -- Query taxonomy datasets with `json.unmarshal` and `cel.bind`
 - [Catalog Tutorial](catalog-tutorial.md) — Store and manage solutions in your local catalog
 - [Resolver Tutorial](resolver-tutorial.md) — Use CEL in resolver pipelines
 - [Actions Tutorial](actions-tutorial.md) — Dynamic inputs with `expr`

--- a/docs/tutorials/file-provider-tutorial.md
+++ b/docs/tutorials/file-provider-tutorial.md
@@ -670,6 +670,7 @@ inputs:
 ## Next Steps
 
 - [Directory Provider Tutorial](directory-provider-tutorial.md) — List, create, copy, and remove directories
+- [Reference-Data Lookups](reference-data-lookups.md) -- Read a dataset file and query it with CEL
 - [Dry-Run Tutorial](dryrun-tutorial.md) — Preview solution changes without side effects
 - [Provider Reference](provider-reference.md) — Complete file provider input/output schema
 - [File Conflict Strategies Design](../design/file-conflict-strategies.md) — Detailed design rationale

--- a/docs/tutorials/reference-data-lookups.md
+++ b/docs/tutorials/reference-data-lookups.md
@@ -1,0 +1,278 @@
+---
+title: "Reference-Data Lookups"
+weight: 92
+---
+
+# Reference-Data Lookups
+
+This tutorial shows how to resolve values from curated reference data --
+taxonomies such as region tables, quota maps, classification codes, or option
+lists -- by composing providers scafctl already ships. You supply the data with
+`static`, `file`, or `http`, and query it with CEL.
+
+There is deliberately **no dedicated `dataset` provider**. A lookup is just
+"get the data" + "parse it" + "index it", and each of those is already a
+first-class capability:
+
+- **Get the data**: `static` (inline), `file` (`read`, local), `http` (remote),
+  or `directory` (a folder of tables).
+- **Parse it**: CEL `json.unmarshal` / `yaml.unmarshal`.
+- **Index it**: CEL map indexing (`m[key]`), plus `map.select`, `map.omit`,
+  and `map.merge`.
+
+A single dedicated provider would only re-wrap those primitives, so this recipe
+keeps the data-loading strategy explicit and swappable.
+
+## Prerequisites
+
+- scafctl installed and available in your PATH
+- Basic familiarity with resolvers and CEL expressions
+
+## Table of Contents
+
+1. [Pattern 1: Inline Table](#pattern-1-inline-table)
+2. [Pattern 2: Local Dataset File](#pattern-2-local-dataset-file)
+3. [Pattern 3: Remote Dataset](#pattern-3-remote-dataset)
+4. [Safe Lookups and Defaults](#safe-lookups-and-defaults)
+5. [Choosing a Pattern](#choosing-a-pattern)
+6. [Runnable Example](#runnable-example)
+
+---
+
+## Pattern 1: Inline Table
+
+Embed the taxonomy directly in the solution with `static`. Best for small,
+rarely-changing tables that should live with the solution.
+
+~~~yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: reference-data-inline
+  version: 1.0.0
+
+spec:
+  resolvers:
+    # Overridable lookup key with a default: -r region=<name>
+    region:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+          - provider: static
+            inputs:
+              value: us-east
+
+    regionTable:
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                us-east: { code: use1, quota: 40, tier: primary }
+                us-west: { code: usw2, quota: 30, tier: primary }
+                eu-west: { code: euw1, quota: 25, tier: secondary }
+
+    # Keyed lookup, guarded with `in` so a missing key does not error.
+    regionCode:
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                _.region in _.regionTable
+                  ? _.regionTable[_.region].code
+                  : "unknown"
+~~~
+
+The DAG infers `regionCode`'s dependency on `region` and `regionTable` from the
+`_.` references -- no explicit `dependsOn` is needed.
+
+## Pattern 2: Local Dataset File
+
+Keep the taxonomy in its own JSON (or YAML) file and read it with the `file`
+provider. Best when the table is large, shared across solutions, or maintained
+separately from solution logic.
+
+Given `regions.json`:
+
+~~~json
+{
+  "us-east": { "code": "use1", "quota": 40, "tier": "primary" },
+  "us-west": { "code": "usw2", "quota": 30, "tier": "primary" },
+  "eu-west": { "code": "euw1", "quota": 25, "tier": "secondary" }
+}
+~~~
+
+Read it, then parse and query with CEL:
+
+~~~yaml
+spec:
+  resolvers:
+    region:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+          - provider: static
+            inputs:
+              value: us-east
+
+    # `file` read returns an object; access the file body via `.content`.
+    regionsFile:
+      type: any
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: regions.json
+
+    # Parse once with cel.bind, then look up the key with a safe default.
+    quota:
+      type: number
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                cel.bind(t, json.unmarshal(_.regionsFile.content),
+                  _.region in t ? t[_.region].quota : 0
+                )
+~~~
+
+For a YAML dataset, swap `json.unmarshal` for `yaml.unmarshal`. The `file` read
+returns `{ content, path, size }`, so the payload is always at `.content`.
+
+## Pattern 3: Remote Dataset
+
+Fetch the table from an HTTP endpoint with the `http` provider, then parse the
+response body. Best when the taxonomy is owned by another service or updated
+independently of your solution.
+
+~~~yaml
+spec:
+  resolvers:
+    region:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+          - provider: static
+            inputs:
+              value: us-east
+
+    # `http` returns { success, statusCode, body, headers } -- do not set `type: string`.
+    regionsResponse:
+      resolve:
+        with:
+          - provider: http
+            inputs:
+              url: https://config.example.com/regions.json
+              method: GET
+
+    quota:
+      type: number
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                cel.bind(t, json.unmarshal(_.regionsResponse.body),
+                  _.region in t ? t[_.region].quota : 0
+                )
+~~~
+
+Authentication, headers, and retries are configured on the `http` provider
+itself; the lookup half is identical to the local-file pattern. See the
+[Provider Reference](provider-reference.md) for `http` inputs.
+
+## Safe Lookups and Defaults
+
+Indexing a key that does not exist raises a CEL error. Always guard a lookup
+with `in` and supply a fallback:
+
+~~~cel
+_.region in _.regionTable
+  ? _.regionTable[_.region]
+  : {"code": "unknown", "quota": 0, "tier": "unknown"}
+~~~
+
+When the source is a parsed file or HTTP body, bind the parsed value once with
+`cel.bind` so you do not unmarshal it twice:
+
+~~~cel
+cel.bind(t, json.unmarshal(_.regionsFile.content),
+  _.region in t ? t[_.region].quota : 0
+)
+~~~
+
+To reshape a looked-up record, use the map helpers: `map.select` to keep an
+allow-list of keys, `map.omit` to drop sensitive fields, and `map.merge` to
+overlay computed values. See the [CEL Expressions Tutorial](cel-tutorial.md).
+
+## Choosing a Pattern
+
+| Source | Provider | Use when |
+|--------|----------|----------|
+| Inline | `static` | Small, stable table that belongs with the solution |
+| Local file | `file` (`read`) | Larger or shared table maintained as a data file |
+| Remote | `http` | Table is owned/updated by another service |
+| Folder of tables | `directory` | Many dataset files loaded together |
+
+In every case the lookup half is the same: `json.unmarshal` (or
+`yaml.unmarshal`) followed by a guarded index.
+
+## Runnable Example
+
+A complete, runnable version covering the inline and local-file patterns lives
+at `examples/solutions/reference-data-lookup/`:
+
+{{< tabs "reference-data-lookups-run" >}}
+{{% tab "Bash" %}}
+~~~bash
+# Default key (us-east)
+scafctl run resolver -f examples/solutions/reference-data-lookup/solution.yaml -o json
+
+# Override the key
+scafctl run resolver -f examples/solutions/reference-data-lookup/solution.yaml -r region=eu-west -o json
+~~~
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+~~~powershell
+# Default key (us-east)
+scafctl run resolver -f examples/solutions/reference-data-lookup/solution.yaml -o json
+
+# Override the key
+scafctl run resolver -f examples/solutions/reference-data-lookup/solution.yaml -r region=eu-west -o json
+~~~
+{{% /tab %}}
+{{< /tabs >}}
+
+Selected output for the default key:
+
+~~~json
+{
+  "quota": 40,
+  "region": "us-east",
+  "regionCode": "use1"
+}
+~~~
+
+A missing key (`-r region=antarctica`) falls back to the safe defaults --
+`regionCode` becomes `unknown` and `quota` becomes `0`.
+
+## Related
+
+- [Resolver Tutorial](resolver-tutorial.md) -- dynamic value resolution
+- [File Provider Tutorial](file-provider-tutorial.md) -- reading files
+- [CEL Expressions Tutorial](cel-tutorial.md) -- `json.unmarshal`, `cel.bind`,
+  and the `map.*` helpers

--- a/docs/tutorials/resolver-tutorial.md
+++ b/docs/tutorials/resolver-tutorial.md
@@ -1768,4 +1768,5 @@ Solution: Check your input values meet the validation requirements.
 - [Run Provider Tutorial](run-provider-tutorial.md) — Test providers in isolation
 - [Actions Tutorial](actions-tutorial.md) — Learn about workflows
 - [CEL Expressions Tutorial](cel-tutorial.md) — Master CEL expressions and extension functions
+- [Reference-Data Lookups](reference-data-lookups.md) -- Resolve values from curated taxonomy datasets
 - [Provider Reference](provider-reference.md) — Complete provider documentation

--- a/examples/solutions/reference-data-lookup/README.md
+++ b/examples/solutions/reference-data-lookup/README.md
@@ -1,0 +1,70 @@
+# Reference-Data Lookup Example
+
+Resolve values from curated reference data (a region/quota taxonomy) by
+composing existing providers. There is no dedicated "dataset" provider -- and
+you do not need one. `static`/`file`/`http` supply the data, CEL parses and
+queries it.
+
+## What It Does
+
+1. **Reads a lookup key** (`region`) from `-r region=<name>`, defaulting to
+   `us-east` via the `parameter` -> `static` fallback chain.
+2. **Pattern 1 -- inline table**: embeds the taxonomy with `static`
+   (`regionTable`) and looks up the record with a safe default (`regionRecord`),
+   then derives a scalar (`regionCode`).
+3. **Pattern 2 -- local dataset file**: reads `regions.json` with the `file`
+   provider (`regionsFile`), parses it with `json.unmarshal`, and looks up the
+   `quota` for the key (`quota`).
+
+A remote dataset uses the same shape with `provider: http` in place of `file`;
+that snippet lives in the tutorial so this example stays hermetic.
+
+## Running
+
+```bash
+# Default key (us-east)
+scafctl run resolver -f examples/solutions/reference-data-lookup/solution.yaml -o json
+
+# Override the key
+scafctl run resolver -f examples/solutions/reference-data-lookup/solution.yaml -r region=eu-west -o json
+
+# Missing key falls back to the safe default
+scafctl run resolver -f examples/solutions/reference-data-lookup/solution.yaml -r region=antarctica -o json
+```
+
+## Output
+
+| `-r region=` | `regionCode` | `quota` |
+|--------------|--------------|---------|
+| (default) `us-east` | `use1` | `40` |
+| `eu-west` | `euw1` | `25` |
+| `antarctica` (absent) | `unknown` | `0` |
+
+## Key Concepts
+
+| Step | Provider | Purpose |
+|------|----------|---------|
+| `region` | `parameter` -> `static` | Overridable lookup key with a default |
+| `regionTable` | `static` | Inline taxonomy (name -> attributes) |
+| `regionRecord` | `cel` | Keyed lookup with `in` guard + fallback record |
+| `regionCode` | `cel` | Derive a scalar from the record |
+| `regionsFile` | `file` (`read`) | Load an on-disk dataset |
+| `quota` | `cel` | `json.unmarshal` + `cel.bind` + guarded lookup |
+
+## Safe Lookups
+
+Indexing a missing key errors in CEL, so guard every lookup:
+
+```cel
+_.region in _.regionTable
+  ? _.regionTable[_.region]
+  : {"code": "unknown", "quota": 0, "tier": "unknown"}
+```
+
+For a parsed file, bind the parsed value once to avoid re-parsing:
+
+```cel
+cel.bind(t, json.unmarshal(_.regionsFile.content),
+  _.region in t ? t[_.region].quota : 0
+)
+```

--- a/examples/solutions/reference-data-lookup/regions.json
+++ b/examples/solutions/reference-data-lookup/regions.json
@@ -1,0 +1,6 @@
+{
+  "us-east": { "code": "use1", "displayName": "US East (N. Virginia)", "quota": 40, "tier": "primary" },
+  "us-west": { "code": "usw2", "displayName": "US West (Oregon)", "quota": 30, "tier": "primary" },
+  "eu-west": { "code": "euw1", "displayName": "EU West (Ireland)", "quota": 25, "tier": "secondary" },
+  "ap-south": { "code": "aps1", "displayName": "Asia Pacific (Mumbai)", "quota": 15, "tier": "secondary" }
+}

--- a/examples/solutions/reference-data-lookup/solution.yaml
+++ b/examples/solutions/reference-data-lookup/solution.yaml
@@ -1,0 +1,113 @@
+# Run: scafctl run resolver -f examples/solutions/reference-data-lookup/solution.yaml -o json
+#
+# Override the lookup key:
+#   scafctl run resolver -f examples/solutions/reference-data-lookup/solution.yaml -r region=eu-west -o json
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: reference-data-lookup
+  displayName: Reference-Data Lookups
+  category: solutions
+  tags:
+    - reference-data
+    - taxonomy
+    - lookup
+    - cel
+  description: |
+    Resolve values from curated reference data (a region/quota taxonomy) by
+    composing existing providers -- no dedicated "dataset" provider required.
+
+    Demonstrates the three canonical source patterns:
+      1. Inline table via the `static` provider + keyed CEL lookup.
+      2. Local dataset file via the `file` provider (`read`) + `json.unmarshal`.
+      3. Safe lookups that fall back to a default when the key is absent.
+
+    A remote/HTTP dataset follows the same shape with `provider: http` in place
+    of `file` -- see the tutorial for that snippet (kept out of this runnable
+    example so it stays hermetic).
+
+spec:
+  resolvers:
+    # The lookup key. Override with `-r region=<name>`.
+    region:
+      description: Region key to look up in the reference data
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+          - provider: static
+            inputs:
+              value: us-east
+
+    # ─────────────────────────────────────────────
+    # Pattern 1: Inline table (static) + keyed lookup
+    # ─────────────────────────────────────────────
+    # An inline taxonomy embedded directly in the solution. Best for small,
+    # rarely-changing tables that live with the solution.
+    regionTable:
+      description: Inline region taxonomy (name -> attributes)
+      type: any
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                us-east: { code: use1, quota: 40, tier: primary }
+                us-west: { code: usw2, quota: 30, tier: primary }
+                eu-west: { code: euw1, quota: 25, tier: secondary }
+                ap-south: { code: aps1, quota: 15, tier: secondary }
+
+    # Keyed lookup with a safe default. Indexing a missing key errors in CEL,
+    # so guard with `in` and provide a fallback record.
+    regionRecord:
+      description: The record for `region`, or a fallback if the key is absent
+      type: any
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                _.region in _.regionTable
+                  ? _.regionTable[_.region]
+                  : {"code": "unknown", "quota": 0, "tier": "unknown"}
+
+    # Derive a single scalar from the looked-up record.
+    regionCode:
+      description: Short region code resolved from the inline table
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: _.regionRecord.code
+
+    # ─────────────────────────────────────────────
+    # Pattern 2: Local dataset file (file read + json.unmarshal)
+    # ─────────────────────────────────────────────
+    # Read a curated JSON file, then parse and query it with CEL. Best when the
+    # taxonomy is large, shared across solutions, or maintained separately.
+    regionsFile:
+      description: Raw contents of the curated regions.json dataset
+      type: any
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: regions.json
+
+    # Parse the file content, then look up the same key with a safe default.
+    quota:
+      description: Quota for `region`, read from the on-disk dataset
+      type: number
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: >
+                cel.bind(t, json.unmarshal(_.regionsFile.content),
+                  _.region in t ? t[_.region].quota : 0
+                )


### PR DESCRIPTION
Document how to resolve values from curated reference data (region tables, quota maps, classification codes, option lists) by composing existing providers instead of adding a dedicated dataset provider.

- Add reference-data-lookups tutorial covering inline (static), local (file), and remote (http) dataset patterns, safe lookups with defaults, and pattern-selection guidance
- Explain the get + parse + index model using json.unmarshal, map indexing, and map.select/omit/merge
- Add a runnable reference-data-lookup example (solution.yaml, regions.json, README) demonstrating the file-backed lookup
- Cross-link the new tutorial from the CEL, file provider, and tutorials index pages

Closes #609
