### PR TITLE
feat(provider): degrade gracefully on child solution load/parse failure

### DIFF
--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -2384,6 +2384,16 @@ resolve:
       inputs:
         source: "./optional-enrichment.yaml"
         propagateErrors: false
+
+# Load-tolerant composition: if the child YAML is missing or malformed,
+# the parent continues with a degraded envelope (status: "failed",
+# errors: [{resolver: "_loader", message: "..."}]) instead of aborting.
+resolve:
+  with:
+    - provider: solution
+      inputs:
+        source: "./optional-child.yaml"
+        propagateErrors: false
 ```
 
 ---

--- a/examples/solutions/load-tolerant-compose/solution.yaml
+++ b/examples/solutions/load-tolerant-compose/solution.yaml
@@ -1,0 +1,46 @@
+# Run: scafctl run resolver -f examples/solutions/load-tolerant-compose/solution.yaml -o json
+#
+# Demonstrates the load-tolerant compose pattern: using propagateErrors: false
+# with the solution provider so that a missing or broken child solution degrades
+# gracefully instead of aborting the parent.
+#
+# The child-data resolver references a non-existent file. Because
+# propagateErrors is false, the parent continues and child-data resolves to an
+# envelope with status "failed" and the error detail in errors[].
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: load-tolerant-compose
+  displayName: Load-Tolerant Compose
+  category: solutions
+  tags:
+    - composition
+    - solution
+    - error-handling
+  description: >-
+    Demonstrates graceful degradation when a composed child solution
+    fails to load or parse.
+
+spec:
+  resolvers:
+    child-data:
+      description: >-
+        Attempts to load an optional child solution. If the child is missing
+        or malformed, the envelope reports status "failed" with error details
+        instead of aborting the parent.
+      resolve:
+        with:
+          - provider: solution
+            inputs:
+              source: "./optional-child.yaml"
+              propagateErrors: false
+
+    fallback:
+      description: >-
+        Provides a fallback value when child-data fails to load.
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "fallback-value (child unavailable)"

--- a/pkg/provider/builtin/solutionprovider/solution.go
+++ b/pkg/provider/builtin/solutionprovider/solution.go
@@ -254,14 +254,20 @@ func (p *SolutionProvider) Execute(ctx context.Context, input any) (*provider.Ou
 
 	sol, loadErr := loader.Get(ctx, source)
 	if loadErr != nil {
-		return nil, fmt.Errorf("solution %q: failed to load: %w", in.Source, loadErr)
+		if in.shouldPropagateErrors() {
+			return nil, fmt.Errorf("solution %q: failed to load: %w", source, loadErr)
+		}
+		return buildLoadFailureOutput(ctx, source, loadErr), nil
 	}
 
 	// Auto-resolve official providers needed by the child solution.
 	// Clients are tracked at the struct level and cleaned up via Close()
 	// to avoid killing shared plugins while parallel Execute calls are in flight.
 	if err := p.autoResolveChildProviders(ctx, sol, reg); err != nil {
-		return nil, fmt.Errorf("solution %q: %w", in.Source, err)
+		if in.shouldPropagateErrors() {
+			return nil, fmt.Errorf("solution %q: %w", source, err)
+		}
+		return buildLoadFailureOutput(ctx, source, err), nil
 	}
 
 	// Dry-run: validate source (by loading) but don't execute.
@@ -463,6 +469,32 @@ func (p *SolutionProvider) executeWithWorkflow(ctx context.Context, sol *solutio
 	return output, nil
 }
 
+// buildLoadFailureOutput constructs a degraded envelope for load/parse failures
+// when propagateErrors is false. The envelope reports status "failed" with the
+// error detail, allowing the parent to continue execution.
+func buildLoadFailureOutput(ctx context.Context, source string, loadErr error) *provider.Output {
+	errMsg := fmt.Sprintf("%s: %s", source, loadErr.Error())
+	errors := []ResolverError{{
+		Resolver: "_loader",
+		Message:  errMsg,
+	}}
+
+	mode, _ := provider.ExecutionModeFromContext(ctx)
+	var envelope *Envelope
+	if mode == provider.CapabilityAction {
+		envelope = BuildActionEnvelope(nil, nil, errors)
+	} else {
+		envelope = BuildFromEnvelope(nil, errors)
+	}
+
+	return &provider.Output{
+		Data: envelope.ToMap(),
+		Warnings: []string{
+			fmt.Sprintf("sub-solution failed to load: %s", errMsg),
+		},
+	}
+}
+
 // buildIsolatedContext constructs an isolated context for sub-solution execution.
 // The sub-solution gets a fresh resolver context and parameters, but inherits
 // logger, writer, auth, config, dry-run, and ancestor stack from the parent.
@@ -527,7 +559,7 @@ type Input struct {
 	Source          string         `json:"source" yaml:"source" doc:"Sub-solution location (file path, catalog reference, or URL)" example:"deploy-to-k8s@2.0.0"`
 	Inputs          map[string]any `json:"inputs,omitempty" yaml:"inputs,omitempty" doc:"Parameters passed to the sub-solution's parameter provider"`
 	Resolvers       []string       `json:"resolvers,omitempty" yaml:"resolvers,omitempty" doc:"Resolver names to execute from the child solution; when empty all resolvers run" maxItems:"100"`
-	PropagateErrors *bool          `json:"propagateErrors,omitempty" yaml:"propagateErrors,omitempty" doc:"Whether sub-solution failures cause a Go error (default: true)"`
+	PropagateErrors *bool          `json:"propagateErrors,omitempty" yaml:"propagateErrors,omitempty" doc:"Whether sub-solution failures (including load/parse) cause a Go error (default: true)"`
 	MaxDepth        *int           `json:"maxDepth,omitempty" yaml:"maxDepth,omitempty" doc:"Maximum nesting depth for recursive composition (default: 10)" minimum:"1" maximum:"100"`
 	Timeout         *string        `json:"timeout,omitempty" yaml:"timeout,omitempty" doc:"Maximum duration for sub-solution execution (e.g. 30s, 5m)" example:"30s" pattern:"^[0-9]+(ns|us|µs|ms|s|m|h)+$" patternDescription:"Go duration string"`
 }

--- a/pkg/provider/builtin/solutionprovider/solution_test.go
+++ b/pkg/provider/builtin/solutionprovider/solution_test.go
@@ -732,6 +732,144 @@ func TestExecute_LoaderError(t *testing.T) {
 	assert.Contains(t, err.Error(), "network timeout")
 }
 
+func TestExecute_LoadFailure_PropagateFalse_From(t *testing.T) {
+	loader := &mockLoader{
+		err: fmt.Errorf("YAML parse error at line 12"),
+	}
+
+	p := New(
+		WithLoader(loader),
+		WithRegistry(provider.NewRegistry()),
+	)
+
+	ctx := testContext()
+	ctx = provider.WithExecutionMode(ctx, provider.CapabilityFrom)
+	input := &Input{
+		Source:          "./broken-child.yaml",
+		PropagateErrors: boolPtr(false),
+	}
+
+	output, err := p.Execute(ctx, input)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "failed", data["status"])
+
+	errors, ok := data["errors"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, errors, 1)
+	assert.Equal(t, "_loader", errors[0]["resolver"])
+	assert.Contains(t, errors[0]["message"], "YAML parse error")
+	assert.Contains(t, errors[0]["message"], "./broken-child.yaml")
+
+	// from capability should not have workflow or success fields
+	_, hasWorkflow := data["workflow"]
+	assert.False(t, hasWorkflow)
+	_, hasSuccess := data["success"]
+	assert.False(t, hasSuccess)
+
+	// Should have a warning
+	require.NotEmpty(t, output.Warnings)
+	assert.Contains(t, output.Warnings[0], "failed to load")
+}
+
+func TestExecute_LoadFailure_PropagateFalse_Action(t *testing.T) {
+	loader := &mockLoader{
+		err: fmt.Errorf("child resolver cycle detected"),
+	}
+
+	p := New(
+		WithLoader(loader),
+		WithRegistry(provider.NewRegistry()),
+	)
+
+	ctx := testContext()
+	ctx = provider.WithExecutionMode(ctx, provider.CapabilityAction)
+	input := &Input{
+		Source:          "./cyclic-child.yaml",
+		PropagateErrors: boolPtr(false),
+	}
+
+	output, err := p.Execute(ctx, input)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	data, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "failed", data["status"])
+	assert.Equal(t, false, data["success"])
+
+	errors, ok := data["errors"].([]map[string]any)
+	require.True(t, ok)
+	require.Len(t, errors, 1)
+	assert.Equal(t, "_loader", errors[0]["resolver"])
+	assert.Contains(t, errors[0]["message"], "resolver cycle")
+	assert.Contains(t, errors[0]["message"], "./cyclic-child.yaml")
+
+	require.NotEmpty(t, output.Warnings)
+	assert.Contains(t, output.Warnings[0], "failed to load")
+}
+
+func TestExecute_CircularRef_PropagateFalse_StillErrors(t *testing.T) {
+	// Circular reference detection is a hard error regardless of propagateErrors.
+	loader := &mockLoader{
+		solutions: map[string]*solution.Solution{
+			"./self.yaml": newTestSolution(nil, nil),
+		},
+	}
+
+	p := New(
+		WithLoader(loader),
+		WithRegistry(provider.NewRegistry()),
+	)
+
+	ctx := testContext()
+	// Push the canonical name as ancestor to simulate a cycle.
+	ctx = WithAncestorStack(ctx, []string{})
+	var err error
+	ctx, err = PushAncestor(ctx, Canonicalize(ctx, "./self.yaml"))
+	require.NoError(t, err)
+
+	input := &Input{
+		Source:          "./self.yaml",
+		PropagateErrors: boolPtr(false),
+	}
+
+	_, execErr := p.Execute(ctx, input)
+	require.Error(t, execErr)
+	assert.Contains(t, execErr.Error(), "circular")
+}
+
+func TestExecute_DepthExceeded_PropagateFalse_StillErrors(t *testing.T) {
+	// Depth limit is a hard error regardless of propagateErrors.
+	loader := &mockLoader{
+		solutions: map[string]*solution.Solution{
+			"./deep.yaml": newTestSolution(nil, nil),
+		},
+	}
+
+	p := New(
+		WithLoader(loader),
+		WithRegistry(provider.NewRegistry()),
+	)
+
+	ctx := testContext()
+	// Push enough ancestors to exceed MaxDepth of 1.
+	ctx = WithAncestorStack(ctx, []string{"/parent.yaml"})
+
+	input := &Input{
+		Source:          "./deep.yaml",
+		MaxDepth:        intPtr(1),
+		PropagateErrors: boolPtr(false),
+	}
+
+	_, err := p.Execute(ctx, input)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "depth")
+}
+
 func TestExecute_DryRun_From(t *testing.T) {
 	loader := &mockLoader{
 		solutions: map[string]*solution.Solution{

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -4825,6 +4825,91 @@ spec:
 	assert.Contains(t, stdout, "failed")
 }
 
+func TestIntegration_SolutionProvider_PropagateErrorsFalse_LoadFailure(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	// Create a parent that references a non-existent child with propagateErrors: false.
+	// This exercises the load-tolerant compose mode where child parse/load failures
+	// degrade gracefully into the envelope instead of aborting the parent.
+	parentSolution := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: parent-load-tolerant
+  version: 1.0.0
+spec:
+  resolvers:
+    child-result:
+      type: any
+      resolve:
+        with:
+          - provider: solution
+            inputs:
+              source: "` + filepath.ToSlash(filepath.Join(tmpDir, "does-not-exist.yaml")) + `"
+              propagateErrors: false
+`
+	parentPath := filepath.Join(tmpDir, "parent.yaml")
+	require.NoError(t, os.WriteFile(parentPath, []byte(parentSolution), 0o644))
+
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", parentPath,
+		"-o", "json",
+	)
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+	// With propagateErrors: false, a load failure should NOT abort the parent.
+	assert.Equal(t, 0, exitCode, "expected exit code 0 with propagateErrors=false on load failure, got %d", exitCode)
+	assert.Contains(t, stdout, "failed")
+	assert.Contains(t, stdout, "_loader")
+}
+
+func TestIntegration_SolutionProvider_PropagateErrorsFalse_MalformedChild(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	// Create a malformed child YAML (parse failure).
+	malformedChild := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: malformed
+  [[[invalid yaml
+`
+	childPath := filepath.Join(tmpDir, "malformed-child.yaml")
+	require.NoError(t, os.WriteFile(childPath, []byte(malformedChild), 0o644))
+
+	parentSolution := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: parent-parse-tolerant
+  version: 1.0.0
+spec:
+  resolvers:
+    child-result:
+      type: any
+      resolve:
+        with:
+          - provider: solution
+            inputs:
+              source: "` + filepath.ToSlash(childPath) + `"
+              propagateErrors: false
+`
+	parentPath := filepath.Join(tmpDir, "parent.yaml")
+	require.NoError(t, os.WriteFile(parentPath, []byte(parentSolution), 0o644))
+
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", parentPath,
+		"-o", "json",
+	)
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+	// With propagateErrors: false, a parse failure should degrade gracefully.
+	assert.Equal(t, 0, exitCode, "expected exit code 0 with propagateErrors=false on parse failure, got %d", exitCode)
+	assert.Contains(t, stdout, "failed")
+	assert.Contains(t, stdout, "_loader")
+}
+
 func TestIntegration_SolutionProvider_MaxDepthExceeded(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()


### PR DESCRIPTION
- solution provider now returns a degraded envelope (status: "failed", errors: [{resolver: "_loader", message: "..."}]) instead of aborting the parent when propagateErrors is false and the child fails to load
- hard errors (circular refs, depth exceeded) still propagate regardless
- add unit tests for From and Action mode load failures, and for circular/depth guards remaining hard errors
- add integration tests for missing-file and malformed-child scenarios
- add example solution and docs for load-tolerant compose pattern

Closes #614