### PR TITLE
feat(file): inject resolver context into write-tree outputPath template

### DIFF
--- a/docs/design/providers.md
+++ b/docs/design/providers.md
@@ -1009,7 +1009,7 @@ resolve:
 **`write-tree` inputs:**
 - `basePath` (required): Destination root directory
 - `entries` (required): Array of `{path, content}` objects
-- `outputPath`: Go template to transform each entry’s output path. Variables: `__filePath`, `__fileName`, `__fileStem`, `__fileExtension`, `__fileDir`
+- `outputPath`: Go template to transform each entry's output path. Variables: `__filePath`, `__fileName`, `__fileStem`, `__fileExtension`, `__fileDir`. Resolver values are also available (e.g. `{{ .environment }}`); the `__file*` variables take precedence on name collisions.
 
 ~~~yaml
 # Batch-write rendered templates, stripping .tpl extensions

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -1515,7 +1515,7 @@ Result:
 
 - `render-tree` batch-renders an array of `{path, content}` entries
 - `write-tree` writes them to disk preserving directory structure
-- `outputPath` is a Go template for transforming output paths (variables: `__filePath`, `__fileName`, `__fileStem`, `__fileExtension`, `__fileDir`)
+- `outputPath` is a Go template for transforming output paths (variables: `__filePath`, `__fileName`, `__fileStem`, `__fileExtension`, `__fileDir`; resolver values are also available, e.g. `{{ .environment }}`)
 - Use `expr: '_.resolver.entries'` to feed directory provider results into render-tree
 - Each entry may carry an optional `data` map, shallow-merged over the shared `data` (per-entry values win), so you can render one template per item with its own variables and output path in a single resolver
 

--- a/docs/tutorials/template-directory-rendering.md
+++ b/docs/tutorials/template-directory-rendering.md
@@ -247,9 +247,38 @@ writing. It receives these variables:
 | `__fileExtension` | Last extension including dot | `.tpl` |
 | `__fileDir` | Directory part (empty for root files) | `k8s` |
 
+Resolver values are also available in the template (for example `{{ .environment }}`),
+so you can route files into dynamic, resolver-derived directories. The `__file*`
+variables take precedence if a resolver has the same name.
+
+### Routing into a Resolver-Derived Directory
+
+The `outputPath` template renders against the solution's **top-level resolver
+values** (keyed by resolver name), so to use `{{ .environment }}` you need a
+top-level `environment` resolver:
+
+```yaml
+resolvers:
+  environment:
+    type: string
+    resolve:
+      with:
+        - provider: static
+          inputs:
+            value: prod
+```
+
+Then reference it in `outputPath`:
+
+```yaml
+outputPath: "{{ .environment }}/{{ .__fileDir }}/{{ .__fileStem }}"
+```
+
+Result (with `environment: prod`): `k8s/deployment.yaml.tpl` -> `prod/k8s/deployment.yaml`
+
 ### Stripping the `.tpl` Extension
 
-The most common pattern — reconstruct the path using the stem (which drops `.tpl`):
+The most common pattern -- reconstruct the path using the stem (which drops `.tpl`):
 
 ```yaml
 outputPath: >-

--- a/examples/solutions/template-directory/solution.yaml
+++ b/examples/solutions/template-directory/solution.yaml
@@ -105,3 +105,9 @@ spec:
           #   README.md.tpl           → README.md
           outputPath: >-
             {{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}
+          # Resolver values are also available in outputPath. To route the
+          # rendered files into an environment-specific directory, prefix the
+          # path with a resolver value (the __file* variables take precedence
+          # on name collisions):
+          #   outputPath: >-
+          #     {{ .vars.environment }}/{{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}

--- a/pkg/action/executor.go
+++ b/pkg/action/executor.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"sync"
 	"time"
@@ -752,11 +753,22 @@ func (e *Executor) executeAction(ctx context.Context, graph *Graph, actionName s
 
 	// Create the execution function
 	execFunc := func(execCtx context.Context) (*provider.Output, error) {
-		// Call-based actions install the enriched resolver data (carrying the
-		// args namespace) as the provider resolver context so providers that
-		// evaluate against it (e.g. cel) can read _.args.* like resolver calls.
-		if callPlan != nil && callPlan.ResolverData != nil {
-			execCtx = provider.WithResolverContext(execCtx, callPlan.ResolverData)
+		// Install the resolver data as the provider resolver context so
+		// providers that render templates or expressions internally (e.g. the
+		// file provider's write-tree outputPath, or cel) can read resolver
+		// values. Call-based actions use the enriched resolver data (carrying
+		// the args namespace) so providers can read _.args.* like resolver
+		// calls; regular actions use the base resolver data.
+		//
+		// Clone the map before installing it: actions run concurrently and
+		// some providers mutate the resolver context they receive (e.g. the
+		// cel provider deletes special keys), so sharing the map by reference
+		// would cause data races and cross-action interference.
+		switch {
+		case callPlan != nil && callPlan.ResolverData != nil:
+			execCtx = provider.WithResolverContext(execCtx, maps.Clone(callPlan.ResolverData))
+		case e.resolverData != nil:
+			execCtx = provider.WithResolverContext(execCtx, maps.Clone(e.resolverData))
 		}
 		return e.callProvider(execCtx, providerName, resolvedInputs)
 	}

--- a/pkg/action/executor_test.go
+++ b/pkg/action/executor_test.go
@@ -146,6 +146,41 @@ func TestExecutor_Execute_SingleAction(t *testing.T) {
 	assert.Equal(t, StatusSucceeded, result.Actions["test-action"].Status)
 }
 
+func TestExecutor_Execute_InstallsResolverContext(t *testing.T) {
+	var gotResolverCtx map[string]any
+	var gotOK bool
+
+	registry := newExecMockRegistry()
+	registry.register(&execMockProvider{
+		name: "ctx-provider",
+		execute: func(ctx context.Context, _ any) (*provider.Output, error) {
+			gotResolverCtx, gotOK = provider.ResolverContextFromContext(ctx)
+			return &provider.Output{Data: map[string]any{"success": true}}, nil
+		},
+	})
+
+	executor := NewExecutor(
+		WithRegistry(registry),
+		WithResolverData(map[string]any{"environment": "prod"}),
+		WithDefaultTimeout(5*time.Second),
+	)
+
+	workflow := &Workflow{
+		Actions: map[string]*Action{
+			"ctx-action": {
+				Provider: "ctx-provider",
+			},
+		},
+	}
+
+	result, err := executor.Execute(context.Background(), workflow)
+
+	require.NoError(t, err)
+	assert.Equal(t, ExecutionSucceeded, result.FinalStatus)
+	require.True(t, gotOK, "provider should receive resolver context for a regular action")
+	assert.Equal(t, "prod", gotResolverCtx["environment"])
+}
+
 func TestExecutor_Execute_ActionChain(t *testing.T) {
 	executionOrder := make([]string, 0)
 	var mu sync.Mutex

--- a/pkg/provider/builtin/fileprovider/file.go
+++ b/pkg/provider/builtin/fileprovider/file.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -117,6 +118,7 @@ func NewFileProvider() *FileProvider {
 				"outputPath": schemahelper.StringProp("Go template for transforming each entry's output path before writing (write-tree only). "+
 					"Available variables: __filePath (relative path), __fileName (base name), __fileStem (name without final extension), "+
 					"__fileExtension (final extension with dot), __fileDir (parent directory). "+
+					"Resolver values are also available (e.g. {{ .environment }}); the __file* variables take precedence on name collisions. "+
 					"Sprig functions are available. If omitted, the original entry path is used unchanged.",
 					schemahelper.WithExample("{{ .__fileDir }}/{{ .__fileStem }}"),
 					schemahelper.WithMaxLength(4096)),
@@ -704,7 +706,7 @@ func (p *FileProvider) executeWriteTree(ctx context.Context, absBasePath string,
 			outputPath = strings.TrimSuffix(outputPath, stripSuffix)
 		}
 		if outputPathTmpl != "" {
-			transformed, tmplErr := p.renderOutputPath(outputPathTmpl, outputPath)
+			transformed, tmplErr := p.renderOutputPath(ctx, outputPathTmpl, outputPath)
 			if tmplErr != nil {
 				return nil, fmt.Errorf("outputPath template failed for entries[%d] (%s): %w", i, entry.path, tmplErr)
 			}
@@ -997,8 +999,10 @@ func (p *FileProvider) parseWriteTreeEntries(inputs map[string]any) ([]writeTree
 }
 
 // renderOutputPath renders the outputPath Go template for a given file path,
-// injecting __file* variables computed from the path.
-func (p *FileProvider) renderOutputPath(outputPathTmpl, filePath string) (string, error) {
+// injecting __file* variables computed from the path. Resolver values from the
+// context are also made available; the __file* variables take precedence in
+// case of name collisions.
+func (p *FileProvider) renderOutputPath(ctx context.Context, outputPathTmpl, filePath string) (string, error) {
 	// Compute __file* variables
 	fileName := filepath.Base(filePath)
 	fileExt := filepath.Ext(fileName)
@@ -1008,16 +1012,21 @@ func (p *FileProvider) renderOutputPath(outputPathTmpl, filePath string) (string
 		fileDir = ""
 	}
 
-	data := map[string]any{
-		"__filePath":      filepath.ToSlash(filePath),
-		"__fileName":      fileName,
-		"__fileStem":      fileStem,
-		"__fileExtension": fileExt,
-		"__fileDir":       fileDir,
+	data := make(map[string]any)
+
+	// Inject resolver context first so __file* variables take precedence.
+	if resolverData, ok := provider.ResolverContextFromContext(ctx); ok && resolverData != nil {
+		maps.Copy(data, resolverData)
 	}
 
+	data["__filePath"] = filepath.ToSlash(filePath)
+	data["__fileName"] = fileName
+	data["__fileStem"] = fileStem
+	data["__fileExtension"] = fileExt
+	data["__fileDir"] = fileDir
+
 	svc := gotmpl.NewService(nil)
-	result, err := svc.Execute(context.Background(), gotmpl.TemplateOptions{
+	result, err := svc.Execute(ctx, gotmpl.TemplateOptions{
 		Content:    outputPathTmpl,
 		Name:       "outputPath",
 		Data:       data,
@@ -1074,7 +1083,7 @@ func (p *FileProvider) executeDryRunWriteTree(ctx context.Context, absBasePath s
 			outputPath = strings.TrimSuffix(outputPath, stripSuffix)
 		}
 		if outputPathTmpl != "" {
-			transformed, tmplErr := p.renderOutputPath(outputPathTmpl, outputPath)
+			transformed, tmplErr := p.renderOutputPath(ctx, outputPathTmpl, outputPath)
 			if tmplErr != nil {
 				return nil, fmt.Errorf("%s: outputPath template failed for entries[%d] (%s): %w", ProviderName, i, entry.path, tmplErr)
 			}

--- a/pkg/provider/builtin/fileprovider/file_test.go
+++ b/pkg/provider/builtin/fileprovider/file_test.go
@@ -993,6 +993,84 @@ func TestFileProvider_WriteTree_OutputPathFlatten(t *testing.T) {
 	assert.Equal(t, "flat", string(b))
 }
 
+func TestFileProvider_WriteTree_OutputPathResolverContext(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := provider.WithResolverContext(context.Background(), map[string]any{
+		"environment": "prod",
+	})
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "app.conf", "content": "key=value"},
+		},
+		// Route into an env-specific directory using a resolver value.
+		"outputPath": `{{ .environment }}/{{ .__fileName }}`,
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	paths := data["paths"].([]string)
+	assert.Equal(t, []string{"prod/app.conf"}, paths)
+
+	b, err := os.ReadFile(filepath.Join(tmpDir, "prod", "app.conf"))
+	require.NoError(t, err)
+	assert.Equal(t, "key=value", string(b))
+}
+
+func TestFileProvider_WriteTree_OutputPathFileVarsTakePrecedence(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	// Resolver context defines __fileName; the computed __file* variable must win.
+	ctx := provider.WithResolverContext(context.Background(), map[string]any{
+		"__fileName": "collision.txt",
+	})
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "real.txt", "content": "data"},
+		},
+		"outputPath": `{{ .__fileName }}`,
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	paths := data["paths"].([]string)
+	assert.Equal(t, []string{"real.txt"}, paths)
+}
+
+func TestFileProvider_WriteTree_DryRunOutputPathResolverContext(t *testing.T) {
+	p := NewFileProvider()
+	tmpDir := t.TempDir()
+
+	ctx := provider.WithResolverContext(provider.WithDryRun(context.Background(), true), map[string]any{
+		"environment": "dev",
+	})
+	inputs := map[string]any{
+		"operation": "write-tree",
+		"basePath":  tmpDir,
+		"entries": []any{
+			map[string]any{"path": "app.conf", "content": "key=value"},
+		},
+		"outputPath": `{{ .environment }}/{{ .__fileName }}`,
+	}
+
+	result, err := p.Execute(ctx, inputs)
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	paths := data["paths"].([]string)
+	assert.Equal(t, []string{"dev/app.conf"}, paths)
+}
+
 func TestFileProvider_WriteTree_NoOutputPath(t *testing.T) {
 	p := NewFileProvider()
 	tmpDir := t.TempDir()

--- a/tests/integration/solutions/providers/file-write-tree/solution.yaml
+++ b/tests/integration/solutions/providers/file-write-tree/solution.yaml
@@ -36,6 +36,14 @@ spec:
                 - path: "README.md.tpl"
                   content: "# Docs"
 
+    environment:
+      description: Target environment used to route output paths
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "prod"
+
   workflow:
     actions:
       write-basic:
@@ -59,6 +67,18 @@ spec:
           outputPath: >-
             {{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}
 
+      write-with-resolver-output-path:
+        description: Route output into a resolver-derived directory via outputPath
+        provider: file
+        dependsOn: [write-with-output-path]
+        inputs:
+          operation: write-tree
+          basePath: ./write-tree-env
+          entries:
+            rslvr: entries
+          outputPath: >-
+            {{ .environment }}/{{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileName }}
+
   testing:
 
 
@@ -69,7 +89,7 @@ spec:
         args: ["-o", "json"]
         tags: [provider, file, write-tree]
         cleanup:
-          - command: "rm -rf write-tree-output write-tree-transformed"
+          - command: "rm -rf write-tree-output write-tree-transformed write-tree-env"
         assertions:
           - expression: __exitCode == 0
 
@@ -114,3 +134,18 @@ spec:
             message: "Should strip .tpl from k8s/deploy.yaml.tpl preserving directory"
           - expression: '__output.actions["write-with-output-path"].results.paths.exists(p, p == "README.md")'
             message: "Should strip .tpl from README.md.tpl"
+
+      write-tree-resolver-output-path:
+        description: Verify write-tree outputPath can use resolver values
+        extends: [_base]
+        assertions:
+          - expression: __output.actions["write-with-resolver-output-path"].status == "succeeded"
+            message: "write-with-resolver-output-path action should succeed"
+          - expression: __output.actions["write-with-resolver-output-path"].results.filesWritten == 3
+            message: "Should write 3 files into the env directory"
+          - expression: '__output.actions["write-with-resolver-output-path"].results.paths.exists(p, p == "prod/hello.txt")'
+            message: "Should route hello.txt under the environment resolver value"
+          - expression: '__output.actions["write-with-resolver-output-path"].results.paths.exists(p, p == "prod/sub/nested.yaml")'
+            message: "Should route nested path under the environment resolver value"
+          - expression: '__output.actions["write-with-resolver-output-path"].results.paths.exists(p, p == "prod/deep/dir/file.md")'
+            message: "Should route deep path under the environment resolver value"


### PR DESCRIPTION
- write-tree outputPath templates can now reference resolver values (e.g. {{ .environment }}) to route rendered files into dynamic, resolver-derived directories
- __file* variables (__filePath, __fileName, __fileStem, __fileExtension, __fileDir) take precedence on name collisions with resolver values
- action executor now installs base resolver data as the provider resolver context for regular (non-call) actions, so providers can read resolver values during execution
- thread context through renderOutputPath for both write and dry-run paths
- add unit tests for resolver-context routing, __file* precedence, and dry-run; add integration coverage for env-directory routing
- document the pattern in provider design, go-templates tutorial, template-directory tutorial, and the example solution

Closes #623