### PR TITLE
fix(plugin): skip builtin providers in bundle.plugins fetch

### DIFF
--- a/docs/design/plugins.md
+++ b/docs/design/plugins.md
@@ -142,6 +142,18 @@ performance-critical remain in-process.
 | `message` | Terminal output only, coupled to host writer |
 | `solution` | Orchestration coupling -- invokes nested solution runs (rule 3) |
 
+### Built-in Providers in bundle.plugins
+
+Declaring a built-in provider in `bundle.plugins` is unnecessary and
+triggers the `builtin-in-bundle-plugins` lint warning. At runtime the
+plugin fetcher silently skips built-in entries before catalog resolution
+(they are already pre-registered), so the solution still works -- but the
+declaration is misleading and adds unnecessary noise.
+
+Only declare **external** (catalog-distributed) providers in
+`bundle.plugins`. Built-in providers are always available without an
+explicit plugin declaration.
+
 ---
 
 ## Plugin Architecture

--- a/docs/tutorials/bundle-plugins-tutorial.md
+++ b/docs/tutorials/bundle-plugins-tutorial.md
@@ -1,0 +1,191 @@
+---
+title: "Bundle Plugins & Built-in Providers"
+weight: 136
+---
+
+# Bundle Plugins & Built-in Providers
+
+This tutorial explains the `bundle.plugins` section, how it interacts with
+built-in providers, and how to avoid the common mistake of declaring a
+built-in provider as a plugin dependency.
+
+## Overview
+
+scafctl ships with a set of **built-in providers** compiled into the binary.
+These are always available without any plugin declaration:
+
+| Built-in Provider |
+|-------------------|
+| `cel` |
+| `debug` |
+| `file` |
+| `go-template` |
+| `http` |
+| `message` |
+| `parameter` |
+| `solution` |
+| `static` |
+| `validation` |
+
+**External providers** (e.g., `directory`, `env`, `exec`, `git`, `github`,
+`hcl`, `identity`, `metadata`, `secret`, `sleep`) are distributed as catalog
+plugins and must be declared in `bundle.plugins` so scafctl can fetch them at
+runtime. See the [Plugin Auto-Fetching](../plugin-auto-fetch-tutorial/) tutorial
+for details on how plugin resolution works.
+
+## The Problem: Built-in Provider in bundle.plugins
+
+A common mistake is declaring a built-in provider in `bundle.plugins`:
+
+~~~yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: my-solution
+  version: 1.0.0
+
+# BAD: cel is a built-in provider -- do not declare it here.
+bundle:
+  plugins:
+    - name: cel
+      kind: provider
+      version: "1.0.0"
+
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: "'hello world'"
+~~~
+
+This is **unnecessary and misleading**. The `cel` provider is already compiled
+into the binary and does not need to be fetched. Declaring it:
+
+1. Is silently skipped by the plugin fetcher at runtime (builtins are
+   filtered out before catalog resolution).
+2. Suggests the solution depends on an external plugin when it does not.
+
+At runtime, scafctl silently skips built-in entries in `bundle.plugins`, so
+the solution still works -- but the declaration is noise.
+
+## Detection: The `builtin-in-bundle-plugins` Lint Rule
+
+scafctl's linter catches this mistake automatically:
+
+~~~bash
+scafctl lint -f ./solution.yaml
+~~~
+
+Output:
+
+~~~
+WARNING  bundle  builtin-in-bundle-plugins
+  bundle.plugins entry "cel" is a builtin provider and will be ignored at runtime
+  Fix: Remove this entry; builtin providers are always available without an explicit plugin declaration
+~~~
+
+The rule fires for every `bundle.plugins` entry whose `name` matches a
+built-in provider and whose `kind` is `provider`.
+
+### Getting Help on the Rule
+
+To see a detailed explanation with examples:
+
+~~~bash
+scafctl lint rules --explain builtin-in-bundle-plugins
+~~~
+
+Or via the MCP server:
+
+~~~
+explain_lint_rule(ruleName: "builtin-in-bundle-plugins")
+~~~
+
+## The Fix
+
+Remove built-in provider entries from `bundle.plugins`. Only declare
+**external** (catalog-distributed) providers:
+
+~~~yaml
+# CORRECT: only declare external plugins
+bundle:
+  plugins:
+    - name: aws-provider
+      kind: provider
+      version: "^1.5.0"
+~~~
+
+If your solution only uses built-in providers, omit `bundle.plugins` entirely:
+
+~~~yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: my-solution
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+~~~
+
+## Mixing Built-in and External Providers
+
+When a solution uses both built-in and external providers, only declare the
+external ones:
+
+~~~yaml
+bundle:
+  plugins:
+    # Only external providers belong here:
+    - name: exec
+      kind: provider
+      version: "^1.0.0"
+    # Do NOT add: cel, static, file, http, etc.
+
+spec:
+  resolvers:
+    timestamp:
+      resolve:
+        with:
+          # Built-in -- no plugin declaration needed
+          - provider: cel
+            inputs:
+              expression: "now()"
+    script-output:
+      resolve:
+        with:
+          # External -- declared in bundle.plugins above
+          - provider: exec
+            inputs:
+              command: echo
+              args: ["hello"]
+~~~
+
+## Example Solution
+
+A complete example demonstrating the lint warning is available at
+[examples/plugins/builtin-in-bundle-plugins.yaml](https://github.com/oakwood-commons/scafctl/blob/main/examples/plugins/builtin-in-bundle-plugins.yaml).
+
+~~~bash
+# See the lint warning
+scafctl lint -f ./examples/plugins/builtin-in-bundle-plugins.yaml
+
+# Run resolvers (succeeds -- builtin entries are silently skipped)
+scafctl run resolver -f ./examples/plugins/builtin-in-bundle-plugins.yaml -o json
+~~~
+
+## Summary
+
+- **Built-in providers** are always available -- never declare them in `bundle.plugins`.
+- **External providers** must be declared in `bundle.plugins` for auto-fetching.
+- The `builtin-in-bundle-plugins` lint rule catches the mistake automatically.
+- At runtime, the plugin fetcher silently skips built-in entries, so existing
+  solutions are not broken -- but the unnecessary declaration should be removed.

--- a/examples/plugins/builtin-in-bundle-plugins.yaml
+++ b/examples/plugins/builtin-in-bundle-plugins.yaml
@@ -1,0 +1,48 @@
+# Built-in Provider in bundle.plugins
+#
+# This example demonstrates the WRONG and RIGHT way to declare bundle.plugins.
+# Built-in providers (cel, static, http, file, etc.) are compiled into the
+# scafctl binary and are always available. Declaring them in bundle.plugins
+# is silently skipped at fetch time and triggers a lint warning.
+#
+# Lint (shows the warning):
+#   scafctl lint -f examples/plugins/builtin-in-bundle-plugins.yaml
+#
+# Run resolver (succeeds -- builtin entries are silently skipped at fetch time):
+#   scafctl run resolver -f examples/plugins/builtin-in-bundle-plugins.yaml -o json
+
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: builtin-in-bundle-plugins-demo
+  displayName: Built-in Provider in bundle.plugins
+  category: developer-tools
+  tags:
+    - plugin
+    - lint
+    - builtin
+  version: 1.0.0
+  description: |
+    Shows what happens when a built-in provider is listed in bundle.plugins.
+    The linter warns and the fetcher silently skips the entry at runtime.
+
+# BAD: cel and static are built-in providers -- do not declare them here.
+# The linter will emit a "builtin-in-bundle-plugins" warning for each entry.
+# Only declare external (catalog-distributed) providers in bundle.plugins.
+bundle:
+  plugins:
+    - name: cel
+      kind: provider
+      version: "1.0.0"
+
+spec:
+  resolvers:
+    greeting:
+      type: string
+      description: A simple greeting produced by a built-in provider
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -119,6 +119,7 @@ func Solution(sol *solution.Solution, filePath string, registry *provider.Regist
 	lintTests(sol, filePath, result)
 	lintProviderInputs(sol, result, registry)
 	lintDeprecatedFields(sol, result)
+	lintBundlePlugins(sol, result)
 
 	// Apply suppression directives parsed from inline YAML comments.
 	suppressions := ParseDirectives(sol.RawContent(), filePath).WithSourceMap(result.sourceMap)
@@ -894,6 +895,24 @@ func registryWithBundlePlugins(registry *provider.Registry, sol *solution.Soluti
 		clone.MarkKnown(entry.Name)
 	}
 	return clone
+}
+
+// lintBundlePlugins warns when bundle.plugins entries reference built-in
+// providers. Builtins are compiled into the binary and will be ignored at
+// runtime, so declaring them in bundle.plugins is unnecessary.
+func lintBundlePlugins(sol *solution.Solution, result *Result) {
+	for i, p := range sol.Bundle.Plugins {
+		if p.Kind == solution.PluginKindProvider && provider.IsBuiltinProvider(p.Name) {
+			result.addFinding(
+				SeverityWarning,
+				"bundle",
+				fmt.Sprintf("bundle.plugins[%d]", i),
+				fmt.Sprintf("bundle.plugins entry %q is a builtin provider and will be ignored at runtime", p.Name),
+				"Remove this entry; builtin providers are always available without an explicit plugin declaration",
+				"builtin-in-bundle-plugins",
+			)
+		}
+	}
 }
 
 // registryAdapter adapts provider.Registry to action.RegistryInterface

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -1426,6 +1426,90 @@ func TestLintState_BundlePluginSuppressesFinding(t *testing.T) {
 	assert.Empty(t, findings, "bundle.plugins-declared provider should not trigger invalid-state-backend")
 }
 
+func TestLintBundlePlugins_BuiltinWarning(t *testing.T) {
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec:       solution.Spec{Resolvers: map[string]*resolver.Resolver{"a": {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "cel"}}}}}},
+		Bundle: solution.Bundle{
+			Plugins: []solution.PluginDependency{
+				{Name: "cel", Kind: solution.PluginKindProvider, Version: "1.0.0"},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "builtin-in-bundle-plugins")
+	require.Len(t, findings, 1)
+	assert.Equal(t, SeverityWarning, findings[0].Severity)
+	assert.Contains(t, findings[0].Message, "cel")
+	assert.Contains(t, findings[0].Message, "builtin provider")
+}
+
+func TestLintBundlePlugins_ExternalNoWarning(t *testing.T) {
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec:       solution.Spec{Resolvers: map[string]*resolver.Resolver{"a": {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}}}}},
+		Bundle: solution.Bundle{
+			Plugins: []solution.PluginDependency{
+				{Name: "aws-provider", Kind: solution.PluginKindProvider, Version: ">=1.0.0"},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "builtin-in-bundle-plugins")
+	assert.Empty(t, findings, "external provider should not trigger builtin-in-bundle-plugins")
+}
+
+func TestLintBundlePlugins_MultipleBuiltins(t *testing.T) {
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec:       solution.Spec{Resolvers: map[string]*resolver.Resolver{"a": {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}}}}},
+		Bundle: solution.Bundle{
+			Plugins: []solution.PluginDependency{
+				{Name: "cel", Kind: solution.PluginKindProvider, Version: "1.0.0"},
+				{Name: "aws-provider", Kind: solution.PluginKindProvider, Version: ">=1.0.0"},
+				{Name: "file", Kind: solution.PluginKindProvider, Version: ">=0.1.0"},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "builtin-in-bundle-plugins")
+	assert.Len(t, findings, 2, "should warn for both cel and file, not aws-provider")
+}
+
+func TestLintBundlePlugins_AuthHandlerNotWarned(t *testing.T) {
+	sol := &solution.Solution{
+		APIVersion: "scafctl.io/v1",
+		Kind:       "Solution",
+		Metadata:   solution.Metadata{Name: "test"},
+		Spec:       solution.Spec{Resolvers: map[string]*resolver.Resolver{"a": {Type: "string", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{Provider: "static"}}}}}},
+		Bundle: solution.Bundle{
+			Plugins: []solution.PluginDependency{
+				{Name: "cel", Kind: solution.PluginKindAuthHandler, Version: "1.0.0"},
+			},
+		},
+	}
+	reg := provider.NewRegistry()
+	_ = reg.Register(newFakeProvider("static", nil))
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "builtin-in-bundle-plugins")
+	assert.Empty(t, findings, "auth handler with builtin name should not trigger warning")
+}
+
 func TestLintState_ProviderWithoutCapabilityState(t *testing.T) {
 	sol := &solution.Solution{
 		APIVersion: "scafctl.io/v1",

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -104,6 +104,17 @@ var KnownRules = map[string]RuleMeta{
 		Why:         "The solution cannot execute if it references providers that don't exist. This usually indicates a typo in the provider name.",
 		Fix:         "Use list_providers to see all available provider names. Common providers: static, parameter, env, http, cel, file, exec, directory, go-template, validation.",
 	},
+	"builtin-in-bundle-plugins": {
+		Rule:        "builtin-in-bundle-plugins",
+		Severity:    string(SeverityWarning),
+		Category:    "bundle",
+		Description: "A bundle.plugins entry references a built-in provider that is compiled into the binary.",
+		Why:         "Built-in providers (cel, file, http, static, etc.) are always pre-registered and do not need to be declared in bundle.plugins. Declaring them is unnecessary because the plugin fetcher silently skips built-in entries before catalog resolution.",
+		Fix:         "Remove the built-in provider entry from bundle.plugins. Built-in providers are always available without an explicit plugin declaration.",
+		Examples: []string{
+			"# Wrong -- cel is a builtin:\nbundle:\n  plugins:\n    - name: cel\n      kind: provider\n      version: \"1.0.0\"\n\n# Correct -- only declare external plugins:\nbundle:\n  plugins:\n    - name: aws-provider\n      kind: provider\n      version: \"^1.5.0\"",
+		},
+	},
 	"call-not-found": {
 		Rule:        "call-not-found",
 		Severity:    string(SeverityError),

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 62 rules — update this when new rules are added
-	assert.Equal(t, 62, len(KnownRules), "expected 62 known lint rules")
+	// We expect exactly 63 rules — update this when new rules are added
+	assert.Equal(t, 63, len(KnownRules), "expected 63 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/plugin/fetcher.go
+++ b/pkg/plugin/fetcher.go
@@ -349,10 +349,26 @@ func (f *Fetcher) FetchPlugins(ctx context.Context, plugins []solution.PluginDep
 		return nil, nil
 	}
 
-	results := make([]FetchResult, len(plugins))
+	// Filter out built-in providers — they are compiled into the binary and
+	// must not be fetched from catalogs. This is the single enforcement point
+	// (analogous to Terraform's BuiltInProviderAvailable check in the
+	// provider installer).
+	var filtered []solution.PluginDependency
+	for _, dep := range plugins {
+		if dep.Kind == solution.PluginKindProvider && provider.IsBuiltinProvider(dep.Name) {
+			f.logger.V(1).Info("skipping builtin provider in plugin fetch", "name", dep.Name)
+			continue
+		}
+		filtered = append(filtered, dep)
+	}
+	if len(filtered) == 0 {
+		return nil, nil
+	}
+
+	results := make([]FetchResult, len(filtered))
 	errGroup, ctx := errgroup.WithContext(ctx)
 	errGroup.SetLimit(settings.DefaultFetchConcurrency)
-	for i, dep := range plugins {
+	for i, dep := range filtered {
 		errGroup.Go(func() error {
 			result, err := f.fetchOne(ctx, dep, lockPlugins)
 			if err != nil {

--- a/pkg/plugin/fetcher_test.go
+++ b/pkg/plugin/fetcher_test.go
@@ -1002,6 +1002,86 @@ func TestFetcher_FetchPlugins_CatalogFallback_InvalidConstraintReportsParseError
 	assert.Contains(t, err.Error(), "resolving version")
 }
 
+func TestFetcher_FetchPlugins_SkipsBuiltinProviders(t *testing.T) {
+	t.Parallel()
+
+	// Catalog has only the external plugin — builtins are never published.
+	cat := newMockCatalog()
+	ref := testRef("my-plugin", "1.0.0")
+	cat.addArtifact(ref, []byte("external-binary"))
+
+	cacheDir := t.TempDir()
+	f := NewFetcher(FetcherConfig{
+		Catalog:  cat,
+		Cache:    NewCache(cacheDir),
+		Platform: "linux/amd64",
+		Logger:   logr.Discard(),
+	})
+
+	deps := []solution.PluginDependency{
+		// Builtin providers — must be silently skipped.
+		{Name: "cel", Kind: solution.PluginKindProvider, Version: "1.0.0"},
+		{Name: "file", Kind: solution.PluginKindProvider, Version: ">=1.0.0"},
+		// External plugin — must be fetched normally.
+		{Name: "my-plugin", Kind: solution.PluginKindProvider, Version: "1.0.0"},
+	}
+
+	results, err := f.FetchPlugins(context.Background(), deps, nil)
+	require.NoError(t, err)
+	// Only the external plugin should appear in results.
+	require.Len(t, results, 1)
+	assert.Equal(t, "my-plugin", results[0].Name)
+}
+
+func TestFetcher_FetchPlugins_AllBuiltins_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	// When every declared plugin is a builtin, FetchPlugins should return nil.
+	cat := newMockCatalog()
+	f := NewFetcher(FetcherConfig{
+		Catalog:  cat,
+		Cache:    NewCache(t.TempDir()),
+		Platform: "linux/amd64",
+		Logger:   logr.Discard(),
+	})
+
+	deps := []solution.PluginDependency{
+		{Name: "cel", Kind: solution.PluginKindProvider, Version: "1.0.0"},
+		{Name: "http", Kind: solution.PluginKindProvider, Version: ">=0.1.0"},
+		{Name: "static", Kind: solution.PluginKindProvider, Version: "1.0.0"},
+	}
+
+	results, err := f.FetchPlugins(context.Background(), deps, nil)
+	require.NoError(t, err)
+	assert.Nil(t, results)
+}
+
+func TestFetcher_FetchPlugins_AuthHandlerBuiltinNotSkipped(t *testing.T) {
+	t.Parallel()
+
+	// Auth handler plugins with a builtin provider name should NOT be skipped
+	// (the builtin check only applies to provider-kind plugins).
+	cat := newMockCatalog()
+	ref := testRef("cel", "1.0.0")
+	cat.addArtifact(ref, []byte("auth-binary"))
+
+	f := NewFetcher(FetcherConfig{
+		Catalog:  cat,
+		Cache:    NewCache(t.TempDir()),
+		Platform: "linux/amd64",
+		Logger:   logr.Discard(),
+	})
+
+	deps := []solution.PluginDependency{
+		{Name: "cel", Kind: solution.PluginKindAuthHandler, Version: "1.0.0"},
+	}
+
+	results, err := f.FetchPlugins(context.Background(), deps, nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "cel", results[0].Name)
+}
+
 func TestCachedVersionSatisfies(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/provider/builtin/builtin_test.go
+++ b/pkg/provider/builtin/builtin_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -89,6 +90,16 @@ func TestProviderNames(t *testing.T) {
 
 	for _, expected := range expectedNames {
 		assert.Contains(t, names, expected, "should contain provider %q", expected)
+	}
+}
+
+func TestProviderNames_SyncWithIsBuiltinProvider(t *testing.T) {
+	// Ensures ProviderNames() and provider.IsBuiltinProvider() stay in sync.
+	// If a new builtin is added to one list but not the other, this test fails.
+	for _, name := range ProviderNames() {
+		assert.True(t, provider.IsBuiltinProvider(name),
+			"ProviderNames() includes %q but provider.IsBuiltinProvider(%q) returns false — update builtinProviderNames in provider.go",
+			name, name)
 	}
 }
 

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -71,3 +71,26 @@ func ValidateDescriptor(desc *Descriptor) error {
 func IsCapabilityValid(c Capability) bool {
 	return c.IsValid()
 }
+
+// builtinProviderNames is an O(1) lookup set of provider names that are
+// compiled into the scafctl binary. Built-in providers are always
+// pre-registered and must not be fetched from catalogs.
+var builtinProviderNames = map[string]bool{
+	"http":        true,
+	"cel":         true,
+	"file":        true,
+	"validation":  true,
+	"debug":       true,
+	"go-template": true,
+	"message":     true,
+	"static":      true,
+	"parameter":   true,
+	"solution":    true,
+}
+
+// IsBuiltinProvider reports whether name is a built-in provider shipped with
+// the scafctl binary. Built-in providers are always pre-registered and must
+// not be fetched from a catalog.
+func IsBuiltinProvider(name string) bool {
+	return builtinProviderNames[name]
+}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -264,3 +264,24 @@ func BenchmarkDescriptor_DescribeWhatIf_Fallback(b *testing.B) {
 		_ = d.DescribeWhatIf(ctx, nil)
 	}
 }
+
+func TestIsBuiltinProvider(t *testing.T) {
+	t.Run("returns true for all builtin providers", func(t *testing.T) {
+		builtins := []string{
+			"http", "cel", "file", "validation", "debug",
+			"go-template", "message", "static", "parameter", "solution",
+		}
+		for _, name := range builtins {
+			assert.True(t, IsBuiltinProvider(name), "expected %q to be builtin", name)
+		}
+	})
+
+	t.Run("returns false for external providers", func(t *testing.T) {
+		externals := []string{
+			"aws-provider", "custom", "my-plugin", "", "HTTP", "CEL",
+		}
+		for _, name := range externals {
+			assert.False(t, IsBuiltinProvider(name), "expected %q to NOT be builtin", name)
+		}
+	})
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -3020,6 +3020,70 @@ spec:
 	assert.True(t, exitCode == 0 || exitCode == 2, "lint should exit 0 or 2, got %d", exitCode)
 }
 
+func TestIntegration_Lint_BuiltinInBundlePlugins(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: builtin-bundle-test
+  version: 1.0.0
+bundle:
+  plugins:
+    - name: cel
+      kind: provider
+      version: "1.0.0"
+spec:
+  resolvers:
+    greeting:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: Hello
+`
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(solutionContent), 0o644))
+
+	stdout, _, exitCode := runScafctl(t, "lint", "-f", solutionPath, "-o", "json")
+	assert.Equal(t, 0, exitCode, "lint command should succeed")
+	assert.Contains(t, stdout, "builtin-in-bundle-plugins")
+}
+
+func TestIntegration_RunResolver_BuiltinInBundlePlugins(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: builtin-bundle-run-test
+  version: 1.0.0
+bundle:
+  plugins:
+    - name: cel
+      kind: provider
+      version: "1.0.0"
+spec:
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello-from-builtin
+`
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(solutionContent), 0o644))
+
+	stdout, stderr, exitCode := runScafctl(t, "run", "resolver", "-f", solutionPath, "-o", "json")
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode, "run resolver should succeed despite builtin in bundle.plugins")
+	assert.Contains(t, stdout, "hello-from-builtin")
+}
+
 // ============================================================================
 // Package Command Tests
 // ============================================================================

--- a/tests/integration/solutions/lint-builtin-bundle-plugins/solution.yaml
+++ b/tests/integration/solutions/lint-builtin-bundle-plugins/solution.yaml
@@ -1,0 +1,57 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: lint-builtin-bundle-plugins
+  version: 1.0.0
+  description: |
+    Tests the builtin-in-bundle-plugins lint rule that warns when
+    bundle.plugins entries reference built-in providers (cel, static, etc.)
+    that are compiled into the binary and do not need explicit declarations.
+
+bundle:
+  plugins:
+    - name: cel
+      kind: provider
+      version: "1.0.0"
+
+spec:
+  resolvers:
+    greeting:
+      description: Simple resolver to make the solution valid
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+
+  testing:
+    cases:
+      builtin-detected:
+        description: Lint detects built-in provider in bundle.plugins
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [lint, builtin-in-bundle-plugins]
+        assertions:
+          - expression: __exitCode == 0
+            message: "builtin-in-bundle-plugins is warning-level, should not cause non-zero exit"
+          - expression: >
+              __output.findings.exists(f, f.ruleName == "builtin-in-bundle-plugins")
+            message: "Should detect built-in provider in bundle.plugins"
+          - expression: >
+              __output.findings.filter(f, f.ruleName == "builtin-in-bundle-plugins").size() == 1
+            message: "Should flag exactly one builtin bundle.plugins entry"
+          - expression: >
+              __output.findings.exists(f, f.ruleName == "builtin-in-bundle-plugins" && f.severity == "warning")
+            message: "builtin-in-bundle-plugins finding should be warning severity"
+
+      resolver-still-works:
+        description: Resolver executes despite builtin in bundle.plugins
+        command: [run, resolver]
+        args: ["-o", "json"]
+        tags: [run, builtin-in-bundle-plugins]
+        assertions:
+          - expression: __exitCode == 0
+            message: "run resolver should succeed despite builtin in bundle.plugins"
+          - expression: '__output.greeting == "hello"'
+            message: "greeting resolver should resolve to hello"


### PR DESCRIPTION
- add IsBuiltinProvider() lookup set in pkg/provider for O(1) checks
- filter builtin provider-kind plugins in Fetcher.FetchPlugins before catalog resolution, preventing fetch failures for compiled-in providers
- add builtin-in-bundle-plugins lint rule (warning severity) to flag unnecessary builtin declarations in bundle.plugins
- add sync test ensuring ProviderNames() and IsBuiltinProvider() stay aligned
- add integration tests for lint detection and resolver execution with builtin bundle.plugins entries
- add bundle plugins tutorial and design doc section

Closes #627