### PR TITLE
feat(auth,kube): add --save-alias to auth login and kube login

### DIFF
--- a/examples/auth/hostname-resolution.md
+++ b/examples/auth/hostname-resolution.md
@@ -46,6 +46,23 @@ auth:
           stg: https://api.stg.example.com:6443
 ```
 
+### Save an alias at login time
+
+When you log in by concrete URL (or via the dynamic resolver), add
+`--save-alias <name>` to persist the resolved endpoint as a `hostname.aliases`
+entry under the handler. This turns a one-off login into a reusable selector:
+
+```bash
+scafctl auth login openshift --hostname https://api.prod.example.com:6443 --save-alias prod
+scafctl auth login openshift --hostname prod        # resolves via the saved alias
+scafctl auth token openshift --server prod          # same selector resolves here too
+```
+
+`--save-alias` requires `--hostname` (there must be a resolved endpoint to
+record) and only works with handlers that advertise the `hostname` capability.
+Saving is best-effort: if the config cannot be written, scafctl warns on stderr
+without failing the login, and re-saving an existing alias updates it in place.
+
 ## Dynamic resolution
 
 When a fleet has too many endpoints to alias by hand, configure a resolver. At

--- a/examples/auth/kube-login.md
+++ b/examples/auth/kube-login.md
@@ -73,10 +73,11 @@ Common flags:
   namespace) to an existing entry without a fresh interactive login when a valid
   token is already cached. Falls back to a normal login when no valid token
   exists.
+- `--save-alias`: after a successful login, remember the resolved cluster under
+   this short name as a `kube.clusters` static alias (see
+   [Remember a Cluster](#remember-a-cluster-after-login)).
 - `--kubeconfig`: target kubeconfig file (defaults to `KUBECONFIG` or
-  `~/.kube/config`).
-
-## Use It
+   `~/.kube/config`).
 
 After login, `kubectl` reuses the scafctl-managed identity automatically:
 
@@ -149,6 +150,28 @@ scafctl kube login https://api.x:6443 --handler oidc   # direct URL, no config
 
 Embedders can still supply a `RootOptions.ClusterResolver` implementation, which
 takes precedence over the config-driven resolver.
+
+## Remember a Cluster After Login
+
+When you log in to a cluster by direct URL (or any cluster not yet in your
+config), add `--save-alias <name>` to persist the resolved cluster as a
+`kube.clusters` static alias. The saved alias records the server, default
+handler, auth type, audience, CA data, and console URL that login resolved:
+
+```bash
+scafctl kube login https://api.x:6443 --handler oidc --save-alias staging
+```
+
+Afterwards the short name resolves with no flags:
+
+```bash
+scafctl kube login staging
+scafctl kube list          # staging now appears
+```
+
+Saving is best-effort and never fails the login: if the config cannot be written,
+or the login produced no resolved server, scafctl warns on stderr and leaves your
+session intact. Re-saving an existing alias updates it in place.
 
 ## Log Out
 

--- a/pkg/cmd/scafctl/aliassave/aliassave.go
+++ b/pkg/cmd/scafctl/aliassave/aliassave.go
@@ -1,0 +1,53 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package aliassave provides the shared post-login "--save-alias" persistence
+// flow used by both `auth login` and `kube login`. It centralizes the config
+// load/mutate/save sequence and the consistent warning behavior: because the
+// login has already succeeded by the time an alias is persisted, a load or save
+// failure is surfaced as a warning (never an error) so it cannot fail the login.
+package aliassave
+
+import (
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+)
+
+// Mutator applies an alias change to the loaded config and reports whether it
+// overwrote an existing alias of the same name.
+type Mutator func(cfg *config.Config) (overwrote bool)
+
+// Persist loads the config at configPath, applies mutate, and saves. name is the
+// alias name, used only for user-facing messages and must be non-empty. A load
+// or save failure is reported via WarnStderrf and returns without error: the
+// caller has already completed the login, so persistence is best-effort. All
+// status messages go to stderr so they never corrupt structured stdout (e.g.
+// `-o json`). Overwriting an existing alias warns (and still updates); a fresh
+// alias reports success.
+func Persist(w *writer.Writer, configPath, name string, mutate Mutator) {
+	if w == nil || mutate == nil {
+		return
+	}
+	if strings.TrimSpace(name) == "" {
+		w.WarnStderrf("logged in, but could not save alias: no alias name was provided")
+		return
+	}
+	mgr := config.NewManager(configPath)
+	cfg, err := mgr.Load()
+	if err != nil {
+		w.WarnStderrf("logged in, but could not load config to save alias %q: %v", name, err)
+		return
+	}
+	overwrote := mutate(cfg)
+	if err := mgr.Save(); err != nil {
+		w.WarnStderrf("logged in, but could not save alias %q: %v", name, err)
+		return
+	}
+	if overwrote {
+		w.WarnStderrf("alias %q already existed and was updated", name)
+		return
+	}
+	w.SuccessStderrf("Saved alias %q", name)
+}

--- a/pkg/cmd/scafctl/aliassave/aliassave_test.go
+++ b/pkg/cmd/scafctl/aliassave/aliassave_test.go
@@ -1,0 +1,125 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package aliassave
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/adrg/xdg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+)
+
+func newWriter(t *testing.T) (*writer.Writer, *bytes.Buffer) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	io := terminal.NewIOStreams(nil, buf, buf, false)
+	return writer.New(io, settings.NewCliParams()), buf
+}
+
+func isolateConfig(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	// xdg caches env-derived paths globally. Register the reload before Setenv so
+	// the cleanup runs after t.Setenv restores the original env, preventing temp
+	// paths from leaking into later tests in this package.
+	t.Cleanup(func() { xdg.Reload() })
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_STATE_HOME", tmp)
+	xdg.Reload()
+}
+
+// setKubeAlias is a reusable mutator that upserts the "prod" kube cluster alias.
+func setKubeAlias(server string) Mutator {
+	return func(cfg *config.Config) bool {
+		if cfg.Kube.Clusters.Aliases == nil {
+			cfg.Kube.Clusters.Aliases = map[string]config.ClusterAlias{}
+		}
+		_, existed := cfg.Kube.Clusters.Aliases["prod"]
+		cfg.Kube.Clusters.Aliases["prod"] = config.ClusterAlias{Server: server}
+		return existed
+	}
+}
+
+func TestPersist_NewAlias(t *testing.T) {
+	isolateConfig(t)
+	w, buf := newWriter(t)
+
+	Persist(w, "", "prod", setKubeAlias("https://api.prod.example.com:6443"))
+
+	assert.Contains(t, buf.String(), `Saved alias "prod"`)
+	cfg, err := config.NewManager("").Load()
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.prod.example.com:6443", cfg.Kube.Clusters.Aliases["prod"].Server)
+}
+
+func TestPersist_OverwriteWarns(t *testing.T) {
+	isolateConfig(t)
+	w, buf := newWriter(t)
+
+	Persist(w, "", "prod", setKubeAlias("https://old.example.com:6443"))
+	buf.Reset()
+	Persist(w, "", "prod", setKubeAlias("https://new.example.com:6443"))
+
+	assert.Contains(t, buf.String(), "already existed and was updated")
+	cfg, err := config.NewManager("").Load()
+	require.NoError(t, err)
+	assert.Equal(t, "https://new.example.com:6443", cfg.Kube.Clusters.Aliases["prod"].Server)
+}
+
+func TestPersist_SaveFailureWarnsNeverPanics(t *testing.T) {
+	isolateConfig(t)
+	w, buf := newWriter(t)
+
+	// A directory path cannot be loaded/saved as a config file; Persist must
+	// degrade to a warning (the login already succeeded), not an error/panic.
+	dir := t.TempDir()
+	Persist(w, dir, "prod", setKubeAlias("https://x:6443"))
+
+	assert.Contains(t, buf.String(), `could not`)
+	assert.Contains(t, buf.String(), `"prod"`)
+}
+
+func TestPersist_NilGuards(t *testing.T) {
+	isolateConfig(t)
+	// Must not panic with a nil writer or nil mutator.
+	Persist(nil, "", "prod", setKubeAlias("https://x:6443"))
+	w, _ := newWriter(t)
+	Persist(w, "", "prod", nil)
+}
+
+func TestPersist_EmptyNameWarnsAndSkips(t *testing.T) {
+	isolateConfig(t)
+	w, buf := newWriter(t)
+
+	mutated := false
+	Persist(w, "", "   ", func(*config.Config) bool {
+		mutated = true
+		return false
+	})
+
+	assert.False(t, mutated, "mutate must not run for an empty alias name")
+	assert.Contains(t, buf.String(), "no alias name was provided")
+}
+
+// TestPersist_StatusGoesToStderr verifies the save status never lands on stdout,
+// so it cannot corrupt a command's structured output (e.g. kube login -o json).
+func TestPersist_StatusGoesToStderr(t *testing.T) {
+	isolateConfig(t)
+	var out, errOut bytes.Buffer
+	io := terminal.NewIOStreams(nil, &out, &errOut, false)
+	w := writer.New(io, settings.NewCliParams())
+
+	Persist(w, "", "prod", setKubeAlias("https://api.prod.example.com:6443"))
+
+	assert.Empty(t, out.String(), "success status must not be written to stdout")
+	assert.Contains(t, errOut.String(), `Saved alias "prod"`)
+}

--- a/pkg/cmd/scafctl/auth/login.go
+++ b/pkg/cmd/scafctl/auth/login.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/auth/loginui"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/aliassave"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
@@ -44,6 +45,7 @@ func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cob
 		registryScope             string
 		writeRegistryAuth         bool
 		profile                   string
+		saveAlias                 string
 	)
 
 	cmd := &cobra.Command{
@@ -256,6 +258,25 @@ func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cob
 				}
 				hostname = resolved
 			}
+			// --save-alias persists the resolved hostname URL as a static alias,
+			// so it needs the hostname capability and a resolved hostname to save.
+			// Gate it here (after resolution) rather than deep in the login path.
+			if cmd.Flags().Changed("save-alias") {
+				switch {
+				case !auth.HasCapability(caps, auth.CapHostname):
+					err := fmt.Errorf("--save-alias is not supported by the %q auth handler (it does not support hostname aliases)", handlerName)
+					w.Errorf("%v", err)
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				case strings.TrimSpace(saveAlias) == "":
+					err := fmt.Errorf("--save-alias requires a non-empty alias name")
+					w.Errorf("%v", err)
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				case hostname == "":
+					err := fmt.Errorf("--save-alias requires --hostname (the resolved host is saved under the alias)")
+					w.Errorf("%v", err)
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
+			}
 			if federatedToken != "" && !auth.HasCapability(caps, auth.CapFederatedToken) {
 				err := fmt.Errorf("--federated-token is not supported by the %q auth handler", handlerName)
 				w.Errorf("%v", err)
@@ -356,6 +377,24 @@ func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cob
 				}
 			}
 
+			// --save-alias: persist the resolved hostname URL as a static alias
+			// under auth.handlers.<handler>.hostname.aliases so future logins can
+			// reference it by the short name (and `auth token --server <alias>`
+			// resolves it). The login already succeeded, so a save failure only
+			// warns.
+			if saveAlias != "" {
+				resolvedURL := hostname
+				aliassave.Persist(w, configPathFromCmd(cmd), saveAlias, func(cfg *config.Config) bool {
+					hn := ensureHostnameConfig(cfg, handlerName)
+					if hn.Aliases == nil {
+						hn.Aliases = map[string]string{}
+					}
+					_, existed := hn.Aliases[saveAlias]
+					hn.Aliases[saveAlias] = resolvedURL
+					return existed
+				})
+			}
+
 			// Post-login registry bridge.
 			// Re-create the handler with the same overrides used during login so that
 			// token retrieval uses the correct clientID fingerprint and refresh token.
@@ -408,6 +447,7 @@ func CommandLogin(cliParams *settings.Run, _ *terminal.IOStreams, _ string) *cob
 	cmd.Flags().StringVar(&registryScope, "registry-scope", "", "OAuth scope for registry credential bridging")
 	cmd.Flags().BoolVar(&writeRegistryAuth, "write-registry-auth", false, "Also write bridged credentials to container auth file (Docker/Podman interop)")
 	cmd.Flags().StringVar(&profile, "profile", "", "Named profile for isolated credential storage (e.g. work, personal)")
+	cmd.Flags().StringVar(&saveAlias, "save-alias", "", "After login, save the resolved --hostname as a static alias under this name (requires hostname capability)")
 
 	return cmd
 }

--- a/pkg/cmd/scafctl/auth/login_extra_test.go
+++ b/pkg/cmd/scafctl/auth/login_extra_test.go
@@ -64,6 +64,66 @@ func TestCommandLogin_HostnameNotSupported(t *testing.T) {
 	assert.Contains(t, err.Error(), "--hostname is not supported")
 }
 
+// TestCommandLogin_SaveAliasRequiresHostname verifies --save-alias errors when
+// no --hostname was given (there is no resolved host to save under the alias).
+func TestCommandLogin_SaveAliasRequiresHostname(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockHandler("openshift")
+	mock.CapabilitiesValue = []auth.Capability{auth.CapHostname}
+	mock.SetNotAuthenticated()
+	ctx = withTestHandler(ctx, mock)
+
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	cmd := CommandLogin(settings.NewCliParams(), ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"openshift", "--save-alias", "prod"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--save-alias requires --hostname")
+}
+
+// TestCommandLogin_SaveAliasUnsupportedHandler verifies --save-alias is rejected
+// when the handler does not advertise CapHostname (aliases are hostname-scoped).
+func TestCommandLogin_SaveAliasUnsupportedHandler(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockHandler("entra")
+	mock.CapabilitiesValue = []auth.Capability{} // no CapHostname
+	mock.SetNotAuthenticated()
+	ctx = withTestHandler(ctx, mock)
+
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	cmd := CommandLogin(settings.NewCliParams(), ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"entra", "--save-alias", "prod"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--save-alias is not supported")
+}
+
+// TestCommandLogin_SaveAliasEmptyName verifies a blank --save-alias value is
+// rejected before login (there is no usable alias key).
+func TestCommandLogin_SaveAliasEmptyName(t *testing.T) {
+	ctx, buf := newTestContext(t)
+
+	mock := auth.NewMockHandler("openshift")
+	mock.CapabilitiesValue = []auth.Capability{auth.CapHostname}
+	mock.SetNotAuthenticated()
+	ctx = withTestHandler(ctx, mock)
+
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	cmd := CommandLogin(settings.NewCliParams(), ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"openshift", "--hostname", "https://api.x:6443", "--save-alias", "   "})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-empty alias name")
+}
+
 // TestCommandLogin_FederatedTokenNotSupported verifies that --federated-token
 // is rejected when the handler doesn't declare CapFederatedToken.
 func TestCommandLogin_FederatedTokenNotSupported(t *testing.T) {

--- a/pkg/cmd/scafctl/auth/login_hostname_test.go
+++ b/pkg/cmd/scafctl/auth/login_hostname_test.go
@@ -105,7 +105,34 @@ func TestCommandLogin_HostnameConcreteURLPassthrough(t *testing.T) {
 	assert.Equal(t, "https://api.custom.example.com:6443", mock.LoginCalls[0].Hostname)
 }
 
-// hostnameTokenFixture builds a CapTokenHostname mock handler that returns a
+// TestCommandLogin_SaveAliasPersists verifies that a successful login with
+// --save-alias persists the resolved hostname URL under the handler's
+// hostname.aliases so future logins can reference it by the short name.
+func TestCommandLogin_SaveAliasPersists(t *testing.T) {
+	ctx, mock := hostnameLoginFixture(t, nil)
+
+	buf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	cmd := CommandLogin(settings.NewCliParams(), ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{
+		"openshift",
+		"--hostname", "https://api.prod.example.com:6443",
+		"--save-alias", "prod",
+	})
+
+	require.NoError(t, cmd.Execute())
+	require.Len(t, mock.LoginCalls, 1)
+
+	// hostnameLoginFixture isolates XDG to a temp dir, so the alias is persisted
+	// to the temp config and can be read back with a default-path manager.
+	cfg, err := config.NewManager("").Load()
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Auth.Handlers["openshift"].Hostname)
+	assert.Equal(t, "https://api.prod.example.com:6443",
+		cfg.Auth.Handlers["openshift"].Hostname.Aliases["prod"])
+}
+
 // token, seeded with the given hostname config for that handler, for exercising
 // `auth token --server <selector>` resolution.
 func hostnameTokenFixture(t *testing.T, hn *config.HostnameConfig) (context.Context, *auth.MockHandler) {

--- a/pkg/cmd/scafctl/kube/login.go
+++ b/pkg/cmd/scafctl/kube/login.go
@@ -18,8 +18,11 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/auth/loginui"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/aliassave"
+	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	kubeapi "github.com/oakwood-commons/scafctl/pkg/kube"
+	"github.com/oakwood-commons/scafctl/pkg/kube/clusterconfig"
 	kubelogin "github.com/oakwood-commons/scafctl/pkg/kube/login"
 	"github.com/oakwood-commons/scafctl/pkg/kubeconfig"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -45,6 +48,7 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 		insecure       bool
 		verify         bool
 		refresh        bool
+		saveAlias      string
 		timeout        time.Duration
 		outputFlags    flags.KvxOutputFlags
 	)
@@ -92,6 +96,15 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			var cluster string
 			if len(args) == 1 {
 				cluster = args[0]
+			}
+
+			// --save-alias needs a non-empty name to key the persisted alias.
+			// Fail fast, before login, so the user isn't logged in only to have
+			// the alias silently dropped.
+			if cmd.Flags().Changed("save-alias") && strings.TrimSpace(saveAlias) == "" {
+				err := fmt.Errorf("--save-alias requires a non-empty alias name")
+				w.Errorf("%v", err)
+				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
 
 			mgr := kubeconfig.NewManager(cliParams.BinaryName)
@@ -154,6 +167,12 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				)
 			}
 
+			// --save-alias: remember this cluster under a short name by persisting
+			// a static ClusterAlias built from the resolved connection details.
+			if saveAlias != "" {
+				saveClusterAlias(cmd, w, saveAlias, res)
+			}
+
 			return renderLoginResult(ioStreams, &outputFlags, w, res)
 		},
 	}
@@ -171,6 +190,7 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 	cmd.Flags().BoolVar(&insecure, "insecure-skip-tls-verify", false, "Disable API server TLS verification (development only)")
 	cmd.Flags().BoolVar(&verify, "verify", false, "Verify the authenticated identity via a post-login whoami (requires the kubeconfig provider)")
 	cmd.Flags().BoolVar(&refresh, "refresh", false, "Re-apply resolved cluster details (CA, server, namespace) without a fresh interactive login when a valid token is cached")
+	cmd.Flags().StringVar(&saveAlias, "save-alias", "", "After login, remember this cluster under this short name (persists a kube.clusters alias)")
 	cmd.Flags().DurationVar(&timeout, "timeout", 0, "Login timeout (e.g. 5m); zero uses the handler default")
 	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
 
@@ -207,6 +227,30 @@ func renderLoginResult(ioStreams *terminal.IOStreams, outputFlags *flags.KvxOutp
 		w.Warningf("kubeconfig provider unavailable; wrote a static kubeconfig entry")
 	}
 	return nil
+}
+
+// saveClusterAlias persists the resolved cluster as a static alias under
+// kube.clusters.aliases so a later `kube login <alias>` resolves it. The login
+// already succeeded, so any problem here only warns.
+func saveClusterAlias(cmd *cobra.Command, w *writer.Writer, name string, res *kubelogin.Result) {
+	alias := clusterconfig.InfoToAlias(res.ResolvedCluster)
+	if alias.Server == "" {
+		w.WarnStderrf("could not save alias %q: the login produced no resolved server", name)
+		return
+	}
+	// Persist the handler actually used so `kube login <alias>` works without
+	// --handler, even when the resolver supplied no default.
+	if alias.DefaultHandler == "" {
+		alias.DefaultHandler = res.Handler
+	}
+	aliassave.Persist(w, configPathFromCmd(cmd), name, func(cfg *config.Config) bool {
+		if cfg.Kube.Clusters.Aliases == nil {
+			cfg.Kube.Clusters.Aliases = map[string]config.ClusterAlias{}
+		}
+		_, existed := cfg.Kube.Clusters.Aliases[name]
+		cfg.Kube.Clusters.Aliases[name] = alias
+		return existed
+	})
 }
 
 // loginTUIEligibleFormat reports whether the requested output format permits the

--- a/pkg/cmd/scafctl/kube/login_savealias_test.go
+++ b/pkg/cmd/scafctl/kube/login_savealias_test.go
@@ -1,0 +1,105 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kube
+
+import (
+	"testing"
+
+	"github.com/adrg/xdg"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/oakwood-commons/scafctl/pkg/config"
+	kubeapi "github.com/oakwood-commons/scafctl/pkg/kube"
+	kubelogin "github.com/oakwood-commons/scafctl/pkg/kube/login"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+)
+
+// isolateKubeConfig points the config dir at a temp location so save-alias
+// writes never touch the developer's real config.
+func isolateKubeConfig(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	// xdg caches env-derived paths globally. Register the reload before Setenv so
+	// the cleanup runs after t.Setenv restores the original env, preventing temp
+	// paths from leaking into later tests in this package.
+	t.Cleanup(func() { xdg.Reload() })
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_STATE_HOME", tmp)
+	xdg.Reload()
+}
+
+func TestSaveClusterAlias_PersistsResolvedCluster(t *testing.T) {
+	isolateKubeConfig(t)
+	ctx, buf := newTestContext(t)
+	w := writer.FromContext(ctx)
+	cmd := &cobra.Command{Use: "login"}
+	cmd.SetContext(ctx)
+
+	res := &kubelogin.Result{
+		Handler: "openshift",
+		ResolvedCluster: kubeapi.ClusterInfo{
+			Name:           "prod",
+			APIServerURL:   "https://api.prod.example.com:6443",
+			AuthType:       kubeapi.AuthTypeOIDC,
+			DefaultHandler: "openshift",
+			OIDCAudience:   "api://aud",
+		},
+	}
+
+	saveClusterAlias(cmd, w, "prod", res)
+
+	assert.Contains(t, buf.String(), `Saved alias "prod"`)
+	cfg, err := config.NewManager("").Load()
+	require.NoError(t, err)
+	al, ok := cfg.Kube.Clusters.Aliases["prod"]
+	require.True(t, ok, "the resolved cluster must be persisted as an alias")
+	assert.Equal(t, "https://api.prod.example.com:6443", al.Server)
+	assert.Equal(t, "openshift", al.DefaultHandler)
+	assert.Equal(t, "oidc", al.AuthType)
+	assert.Equal(t, "api://aud", al.OIDCAudience)
+}
+
+func TestSaveClusterAlias_FallsBackToUsedHandler(t *testing.T) {
+	isolateKubeConfig(t)
+	ctx, _ := newTestContext(t)
+	w := writer.FromContext(ctx)
+	cmd := &cobra.Command{Use: "login"}
+	cmd.SetContext(ctx)
+
+	// The resolver supplied no default handler; the alias must record the
+	// handler actually used so `kube login <alias>` works without --handler.
+	res := &kubelogin.Result{
+		Handler: "oidc",
+		ResolvedCluster: kubeapi.ClusterInfo{
+			Name:         "lab",
+			APIServerURL: "https://api.lab.example.com:6443",
+		},
+	}
+
+	saveClusterAlias(cmd, w, "lab", res)
+
+	cfg, err := config.NewManager("").Load()
+	require.NoError(t, err)
+	assert.Equal(t, "oidc", cfg.Kube.Clusters.Aliases["lab"].DefaultHandler)
+}
+
+func TestSaveClusterAlias_NoServerWarnsAndSkips(t *testing.T) {
+	isolateKubeConfig(t)
+	ctx, buf := newTestContext(t)
+	w := writer.FromContext(ctx)
+	cmd := &cobra.Command{Use: "login"}
+	cmd.SetContext(ctx)
+
+	res := &kubelogin.Result{Handler: "oidc", ResolvedCluster: kubeapi.ClusterInfo{Name: "x"}}
+	saveClusterAlias(cmd, w, "x", res)
+
+	assert.Contains(t, buf.String(), "no resolved server")
+	cfg, err := config.NewManager("").Load()
+	require.NoError(t, err)
+	_, ok := cfg.Kube.Clusters.Aliases["x"]
+	assert.False(t, ok, "nothing is persisted without a resolved server")
+}

--- a/pkg/cmd/scafctl/kube/login_test.go
+++ b/pkg/cmd/scafctl/kube/login_test.go
@@ -96,6 +96,19 @@ func TestCommandLogin_UnknownHandler(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestCommandLogin_SaveAliasEmptyName verifies a blank --save-alias value is
+// rejected before login (fail fast, no login side effects).
+func TestCommandLogin_SaveAliasEmptyName(t *testing.T) {
+	t.Parallel()
+	ctx, _ := newTestContext(t)
+
+	cmd := CommandLogin(embedderParams(), terminal.NewIOStreams(nil, nil, nil, false), "mycli")
+	err := runCmd(t, cmd, ctx, "prod", "--save-alias", "  ")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "non-empty alias name")
+	assert.Equal(t, exitcode.InvalidInput, exitcode.GetCode(err))
+}
+
 func TestCommandLogin_FallbackWritesKubeconfig(t *testing.T) {
 	t.Parallel()
 	ctx, buf := newTestContext(t)

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -837,7 +837,11 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 	cCmd.PersistentFlags().BoolVar(&cliParams.Verbose, "verbose", false, "Enable verbose output across all commands")
 	cCmd.PersistentFlags().BoolVar(&cliParams.NoColor, "no-color", false, "Disable color output")
 	cCmd.PersistentFlags().StringVarP(&cwdFlag, "cwd", "C", "", "Change the working directory before executing the command (similar to git -C)")
-	cCmd.PersistentFlags().StringVar(&configPath, "config", "", fmt.Sprintf("Path to config file (default: $XDG_CONFIG_HOME/%s/config.yaml or ~/.config/%s/config.yaml)", binaryName, binaryName))
+	// Use configPath (seeded from opts.ConfigPath) as the flag default so an
+	// embedder-provided ConfigPath is honored. StringVar would otherwise reset
+	// configPath to "" here, silently discarding RootOptions.ConfigPath and
+	// falling back to the global XDG path. An explicit --config still overrides.
+	cCmd.PersistentFlags().StringVar(&configPath, "config", configPath, fmt.Sprintf("Path to config file (default: $XDG_CONFIG_HOME/%s/config.yaml or ~/.config/%s/config.yaml)", binaryName, binaryName))
 	cCmd.PersistentFlags().String("pprof", "", "Enable profiling (options: memory, cpu)")
 	cCmd.PersistentFlags().String("pprof-output-dir", "./", "directory path to save the profiler.prof file (default: current working directory)")
 	cCmd.PersistentFlags().String("otel-endpoint", "", "OpenTelemetry OTLP exporter endpoint (e.g. localhost:4317). Overrides OTEL_EXPORTER_OTLP_ENDPOINT")

--- a/pkg/cmd/scafctl/root_test.go
+++ b/pkg/cmd/scafctl/root_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -354,11 +356,18 @@ func TestRoot_WithoutClusterResolver_Execution(t *testing.T) {
 	t.Parallel()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 
+	// Isolate from the developer's real config (which may declare clusters) by
+	// pointing at an empty config file. This keeps the test deterministic
+	// regardless of the machine's ~/.config/scafctl/config.yaml.
+	emptyCfg := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(emptyCfg, []byte("{}\n"), 0o600))
+
 	capturedSet := false
 	var captured kube.ClusterResolver
 	cmd, cleanup := Root(&RootOptions{
 		IOStreams:  ioStreams,
 		BinaryName: "mycli",
+		ConfigPath: emptyCfg,
 		PreRunHook: func(c *cobra.Command, _ []string) error {
 			captured = kube.ResolverFromContext(c.Context())
 			capturedSet = true
@@ -372,4 +381,43 @@ func TestRoot_WithoutClusterResolver_Execution(t *testing.T) {
 	// With no resolver configured, the context must not carry one.
 	assert.True(t, capturedSet, "PreRunHook should have run")
 	assert.Nil(t, captured)
+}
+
+// TestRoot_ConfigPathHonored verifies that RootOptions.ConfigPath is actually
+// read: a config file declaring a kube cluster alias must drive the attached
+// resolver. Regression guard for the flag-default bug where StringVar reset
+// configPath to "" and silently fell back to the global XDG path.
+func TestRoot_ConfigPathHonored(t *testing.T) {
+	t.Parallel()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cfgPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfgPath, []byte(
+		"kube:\n"+
+			"  clusters:\n"+
+			"    aliases:\n"+
+			"      lab:\n"+
+			"        server: https://api.lab.example.com:6443\n"+
+			"        defaultHandler: oidc\n"), 0o600))
+
+	var captured kube.ClusterResolver
+	cmd, cleanup := Root(&RootOptions{
+		IOStreams:  ioStreams,
+		BinaryName: "mycli",
+		ConfigPath: cfgPath,
+		PreRunHook: func(c *cobra.Command, _ []string) error {
+			captured = kube.ResolverFromContext(c.Context())
+			return nil
+		},
+	})
+	defer cleanup()
+	cmd.SetArgs([]string{"auth", "handlers", "-o", "json"})
+	require.NoError(t, cmd.Execute())
+
+	// A resolver built from the ConfigPath file must be attached and resolve the
+	// alias declared there, proving the embedder-provided ConfigPath was honored.
+	require.NotNil(t, captured, "ConfigPath config must drive the cluster resolver")
+	info, err := captured.Resolve(context.Background(), "lab")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.lab.example.com:6443", info.APIServerURL)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -578,6 +578,7 @@ func (m *Manager) Save() error {
 	m.v.Set("resolver", m.config.Resolver)
 	m.v.Set("action", m.config.Action)
 	m.v.Set("auth", m.config.Auth)
+	m.v.Set("kube", m.config.Kube)
 	m.v.Set("build", m.config.Build)
 
 	return m.writeConfig(m.v, "")
@@ -606,6 +607,7 @@ func (m *Manager) SaveAs(path string) error {
 	m.v.Set("resolver", m.config.Resolver)
 	m.v.Set("action", m.config.Action)
 	m.v.Set("auth", m.config.Auth)
+	m.v.Set("kube", m.config.Kube)
 	m.v.Set("build", m.config.Build)
 
 	return m.writeConfig(m.v, path)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -327,6 +327,45 @@ func TestManager_SaveAs(t *testing.T) {
 	assert.Equal(t, "test", cfg2.Catalogs[2].Name)
 }
 
+// TestManager_Save_PersistsKubeClusters is a regression guard: Save() and
+// SaveAs() must sync the kube section to viper. Without it, kube.clusters edits
+// (e.g. aliases written by `kube login --save-alias`) are silently dropped.
+func TestManager_Save_PersistsKubeClusters(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	mgr := NewManager(configPath)
+	cfg, err := mgr.Load()
+	require.NoError(t, err)
+	cfg.Kube.Clusters.Aliases = map[string]ClusterAlias{
+		"prod": {
+			Server:         "https://api.prod.example.com:6443",
+			DefaultHandler: "openshift",
+			AuthType:       "oidc",
+		},
+	}
+
+	// Save() must persist the kube section.
+	require.NoError(t, mgr.Save())
+	cfg2, err := NewManager(configPath).Load()
+	require.NoError(t, err)
+	got, ok := cfg2.Kube.Clusters.Aliases["prod"]
+	require.True(t, ok, "kube cluster alias must survive Save/Load")
+	assert.Equal(t, "https://api.prod.example.com:6443", got.Server)
+	assert.Equal(t, "openshift", got.DefaultHandler)
+	assert.Equal(t, "oidc", got.AuthType)
+
+	// SaveAs() must persist it too.
+	savePath := filepath.Join(tmpDir, "saved", "config.yaml")
+	require.NoError(t, mgr.SaveAs(savePath))
+	cfg3, err := NewManager(savePath).Load()
+	require.NoError(t, err)
+	_, ok = cfg3.Kube.Clusters.Aliases["prod"]
+	assert.True(t, ok, "kube cluster alias must survive SaveAs/Load")
+}
+
 func TestManager_GetSet(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/kube/clusterconfig/resolver.go
+++ b/pkg/kube/clusterconfig/resolver.go
@@ -182,6 +182,21 @@ func aliasToInfo(name string, a config.ClusterAlias) *kube.ClusterInfo {
 	}
 }
 
+// InfoToAlias maps a resolved ClusterInfo to a static ClusterAlias suitable for
+// persisting under kube.clusters.aliases. It is the inverse of aliasToInfo, used
+// by `kube login --save-alias` to remember a cluster by a short name.
+func InfoToAlias(info kube.ClusterInfo) config.ClusterAlias {
+	return config.ClusterAlias{
+		Server:          info.APIServerURL,
+		DefaultHandler:  info.DefaultHandler,
+		AuthType:        string(info.AuthType),
+		OIDCAudience:    info.OIDCAudience,
+		CAData:          info.CAData,
+		ConsoleURL:      info.ConsoleURL,
+		InsecureSkipTLS: info.InsecureSkipTLS,
+	}
+}
+
 // entryToInfo maps a resolved inventory Entry to a ClusterInfo.
 func entryToInfo(e *hostname.Entry) *kube.ClusterInfo {
 	return &kube.ClusterInfo{

--- a/pkg/kube/clusterconfig/resolver_test.go
+++ b/pkg/kube/clusterconfig/resolver_test.go
@@ -301,3 +301,30 @@ func TestResolver_List_InventoryErrorReturnsAliases(t *testing.T) {
 	require.Len(t, list, 1, "static aliases must still be returned when inventory fetch fails")
 	assert.Equal(t, "lab", list[0].Name)
 }
+
+func TestInfoToAlias_RoundTrip(t *testing.T) {
+	t.Parallel()
+	info := kube.ClusterInfo{
+		Name:            "prod",
+		APIServerURL:    "https://api.prod.example.com:6443",
+		ConsoleURL:      "https://console.prod.example.com",
+		AuthType:        kube.AuthTypeOIDC,
+		OIDCAudience:    "api://cluster-aud",
+		DefaultHandler:  "openshift",
+		CAData:          "-----BEGIN CERTIFICATE-----X",
+		InsecureSkipTLS: true,
+	}
+
+	alias := InfoToAlias(info)
+	assert.Equal(t, "https://api.prod.example.com:6443", alias.Server)
+	assert.Equal(t, "openshift", alias.DefaultHandler)
+	assert.Equal(t, "oidc", alias.AuthType)
+	assert.Equal(t, "api://cluster-aud", alias.OIDCAudience)
+	assert.Equal(t, "-----BEGIN CERTIFICATE-----X", alias.CAData)
+	assert.Equal(t, "https://console.prod.example.com", alias.ConsoleURL)
+	assert.True(t, alias.InsecureSkipTLS)
+
+	// InfoToAlias is the inverse of aliasToInfo (name is carried separately).
+	back := aliasToInfo(info.Name, alias)
+	assert.Equal(t, info, *back)
+}

--- a/pkg/kube/login/login.go
+++ b/pkg/kube/login/login.go
@@ -186,6 +186,11 @@ type Result struct {
 	// AuthType is the resolved (or detected) authentication method.
 	AuthType kube.AuthType
 
+	// ResolvedCluster is the fully resolved cluster connection detail used for
+	// the login (server, auth type, audience, CA, etc.). It lets callers persist
+	// a static alias via "kube login --save-alias" without re-resolving.
+	ResolvedCluster kube.ClusterInfo
+
 	// Username and Groups come from a best-effort whoami; empty when whoami did
 	// not run or did not succeed.
 	Username string
@@ -313,6 +318,7 @@ func Login(ctx context.Context, deps Deps, req Request) (*Result, error) {
 		Handler:                  handler.Name(),
 		Server:                   info.APIServerURL,
 		AuthType:                 info.AuthType,
+		ResolvedCluster:          info,
 		SupportsPerClusterTokens: auth.HasCapability(handler.Capabilities(), auth.CapTokenHostname),
 	}
 

--- a/pkg/kube/login/login_test.go
+++ b/pkg/kube/login/login_test.go
@@ -405,6 +405,33 @@ func TestLogin_NamespaceFromResolverWhenNoFlag(t *testing.T) {
 	assert.Equal(t, "from-resolver", kc.writeIn.Namespace)
 }
 
+// TestLogin_PopulatesResolvedCluster verifies Login surfaces the fully resolved
+// cluster on the Result so callers (e.g. `kube login --save-alias`) can persist
+// it without re-resolving.
+func TestLogin_PopulatesResolvedCluster(t *testing.T) {
+	t.Parallel()
+
+	handler := &stubAuth{name: "oidc"}
+	kc := &stubKube{writeRes: kubeconfig.WriteResult{Success: true}}
+	resolver := &kube.MockResolver{ResolveResult: &kube.ClusterInfo{
+		Name:           "prod",
+		APIServerURL:   "https://api.example.com:6443",
+		AuthType:       kube.AuthTypeOIDC,
+		OIDCAudience:   "api://aud",
+		DefaultHandler: "oidc",
+		CAData:         "-----BEGIN CERTIFICATE-----X",
+	}}
+	deps := Deps{Handler: handler, Kubeconfig: kc, Resolver: resolver}
+
+	res, err := Login(context.Background(), deps, Request{Cluster: "prod"})
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.example.com:6443", res.ResolvedCluster.APIServerURL)
+	assert.Equal(t, kube.AuthTypeOIDC, res.ResolvedCluster.AuthType)
+	assert.Equal(t, "api://aud", res.ResolvedCluster.OIDCAudience)
+	assert.Equal(t, "oidc", res.ResolvedCluster.DefaultHandler)
+	assert.Equal(t, "-----BEGIN CERTIFICATE-----X", res.ResolvedCluster.CAData)
+}
+
 func TestLogin_RefreshSkipsInteractiveLoginWithValidToken(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/terminal/writer/writer.go
+++ b/pkg/terminal/writer/writer.go
@@ -52,6 +52,23 @@ func (w *Writer) Successf(format string, args ...any) {
 	w.Success(fmt.Sprintf(format, args...))
 }
 
+// SuccessStderr writes a success message to stderr instead of stdout.
+// Use this for status confirmations that must not corrupt structured command
+// output (e.g., -o json). Respects --quiet and --no-color flags.
+func (w *Writer) SuccessStderr(msg string) {
+	if w.cliParams.IsQuiet {
+		return
+	}
+	fmt.Fprintln(w.ioStreams.ErrOut, output.SuccessMessage(msg, w.cliParams.NoColor))
+}
+
+// SuccessStderrf writes a formatted success message to stderr.
+// Use this for status confirmations that must not corrupt structured command
+// output (e.g., -o json). Respects --quiet and --no-color flags.
+func (w *Writer) SuccessStderrf(format string, args ...any) {
+	w.SuccessStderr(fmt.Sprintf(format, args...))
+}
+
 // Warning writes a warning message to stdout.
 // Respects --quiet and --no-color flags.
 func (w *Writer) Warning(msg string) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2238,6 +2238,22 @@ func TestIntegration_LoginHelp_NamespaceAndRefresh(t *testing.T) {
 	assert.Contains(t, stdout, "--refresh")
 }
 
+func TestIntegration_KubeLoginHelp_SaveAlias(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "kube", "login", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "--save-alias")
+}
+
+func TestIntegration_AuthLoginHelp_SaveAlias(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "auth", "login", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "--save-alias")
+}
+
 func TestIntegration_LogoutHelp_All(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "kube", "logout", "--help")
@@ -2256,9 +2272,13 @@ func TestIntegration_KubeListHelp(t *testing.T) {
 
 func TestIntegration_KubeListNoResolver(t *testing.T) {
 	t.Parallel()
-	// scafctl ships no cluster data; with no resolver configured, list reports
-	// that clearly instead of erroring.
-	stdout, stderr, exitCode := runScafctl(t, "kube", "list")
+	// Isolate from the developer's real config (which may declare clusters) by
+	// pointing at an empty config file. scafctl ships no cluster data, so with no
+	// resolver configured, list reports that clearly instead of erroring.
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte("{}\n"), 0o600))
+
+	stdout, stderr, exitCode := runScafctl(t, "--config", configPath, "kube", "list")
 
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout+stderr, "No cluster resolver configured")


### PR DESCRIPTION
Persist a login target as a reusable alias so a one-off login by URL becomes a short, resolver-known name.

- auth login --save-alias <name>: save the resolved --hostname as a hostname.aliases entry under the handler (resolvable by `auth login <name>` and `auth token --server <name>`)
- kube login --save-alias <name>: save the resolved cluster as a kube.clusters alias (resolvable by `kube login <name>`)
- add shared aliassave package: best-effort load/mutate/save that warns (never errors) on failure since the login already succeeded; rejects empty alias names and, for auth, requires hostname capability
- add clusterconfig.InfoToAlias (inverse of aliasToInfo) and surface the resolved cluster on kube/login Result.ResolvedCluster
- docs: document --save-alias in the hostname-resolution and kube-login examples

fix(config): sync the kube section in Save/SaveAs

kube.clusters edits (including aliases written by --save-alias) were silently dropped because Save/SaveAs never wrote the kube key to viper.

fix(cli): honor RootOptions.ConfigPath

The --config flag registration reset configPath to "", discarding an embedder-provided ConfigPath and falling back to the global XDG path (racy under parallel tests). Seed the flag default from configPath so an explicit --config still overrides.

Closes #591