### PR TITLE
feat(auth): add display schemas for diagnose and list interactive output

### DIFF
--- a/pkg/cmd/scafctl/auth/auth_diagnose_schema.json
+++ b/pkg/cmd/scafctl/auth/auth_diagnose_schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Auth Diagnostics",
+  "description": "Diagnostic check results for scafctl authentication",
+  "type": "array",
+
+  "x-kvx-icon": "🩺",
+  "x-kvx-collectionTitle": "Auth Diagnostics",
+
+  "x-kvx-list": {
+    "titleField": "check",
+    "subtitleField": "message",
+    "subtitleMaxLines": 2,
+    "badgeFields": ["status", "category"]
+  },
+
+  "x-kvx-detail": {
+    "titleField": "check",
+    "hiddenFields": [],
+    "sections": [
+      {
+        "title": "",
+        "fields": ["status", "category", "check"],
+        "layout": "inline"
+      },
+      {
+        "title": "Message",
+        "fields": ["message"],
+        "layout": "paragraph"
+      }
+    ]
+  },
+
+  "items": {
+    "type": "object",
+    "required": ["check", "status"],
+    "properties": {
+      "category": {
+        "type": "string",
+        "title": "Category",
+        "description": "Diagnostic category (registry, config, handler, cache, etc.)",
+        "maxLength": 10
+      },
+      "check": {
+        "type": "string",
+        "title": "Check",
+        "description": "Name of the diagnostic check"
+      },
+      "status": {
+        "type": "string",
+        "title": "Status",
+        "description": "Check result (ok, warn, fail, info)",
+        "maxLength": 6
+      },
+      "message": {
+        "type": "string",
+        "title": "Message",
+        "description": "Detailed check result message"
+      }
+    }
+  }
+}

--- a/pkg/cmd/scafctl/auth/auth_list_schema.json
+++ b/pkg/cmd/scafctl/auth/auth_list_schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Auth Tokens",
+  "description": "Cached token metadata for scafctl authentication handlers",
+  "type": "array",
+
+  "x-kvx-icon": "🔑",
+  "x-kvx-collectionTitle": "Cached Tokens",
+
+  "x-kvx-list": {
+    "titleField": "handler",
+    "subtitleField": "scope",
+    "subtitleMaxLines": 1,
+    "badgeFields": ["tokenKind", "expiresIn"]
+  },
+
+  "x-kvx-detail": {
+    "titleField": "handler",
+    "hiddenFields": [],
+    "sections": [
+      {
+        "title": "",
+        "fields": ["handler", "cluster", "tokenKind"],
+        "layout": "inline"
+      },
+      {
+        "title": "Expiry",
+        "fields": ["scope", "expiresIn", "isExpired", "expiresAt", "cachedAt"],
+        "layout": "table"
+      },
+      {
+        "title": "Details",
+        "fields": ["tokenType", "flow", "sessionId"],
+        "layout": "table"
+      },
+      {
+        "title": "Retrieve Token",
+        "fields": ["getTokenCommand"],
+        "layout": "paragraph"
+      }
+    ]
+  },
+
+  "items": {
+    "type": "object",
+    "required": ["handler", "tokenKind"],
+    "properties": {
+      "handler": {
+        "type": "string",
+        "title": "Handler",
+        "description": "Auth handler that owns this token",
+        "maxLength": 16
+      },
+      "cluster": {
+        "type": "string",
+        "title": "Cluster",
+        "description": "Instance alias or hostname for per-instance handlers",
+        "maxLength": 40
+      },
+      "tokenKind": {
+        "type": "string",
+        "title": "Kind",
+        "description": "Token kind (refresh or access)",
+        "maxLength": 10
+      },
+      "scope": {
+        "type": "string",
+        "title": "Scope",
+        "description": "OAuth scope or resource identifier",
+        "maxLength": 40
+      },
+      "expiresIn": {
+        "type": "string",
+        "title": "Expires",
+        "description": "Human-readable time until expiry",
+        "maxLength": 10
+      },
+      "isExpired": {
+        "type": "boolean",
+        "title": "Expired",
+        "description": "Whether the token has expired"
+      },
+      "tokenType": {
+        "type": "string",
+        "title": "Token Type",
+        "description": "OAuth token type (e.g., Bearer)"
+      },
+      "flow": {
+        "type": "string",
+        "title": "Flow",
+        "description": "Authentication flow used to obtain this token"
+      },
+      "sessionId": {
+        "type": "string",
+        "title": "Session ID",
+        "description": "Session identifier for the token"
+      },
+      "expiresAt": {
+        "type": "string",
+        "title": "Expires At",
+        "description": "Absolute expiry timestamp"
+      },
+      "cachedAt": {
+        "type": "string",
+        "title": "Cached At",
+        "description": "When the token was cached"
+      },
+      "getTokenCommand": {
+        "type": "string",
+        "title": "Retrieve Command",
+        "description": "CLI command to retrieve this token value"
+      }
+    }
+  }
+}

--- a/pkg/cmd/scafctl/auth/diagnose.go
+++ b/pkg/cmd/scafctl/auth/diagnose.go
@@ -4,6 +4,7 @@
 package auth
 
 import (
+	_ "embed"
 	"fmt"
 	"strings"
 	"time"
@@ -27,6 +28,9 @@ import (
 // pluginStartupWarnThreshold is the latency above which a plugin handler
 // startup is flagged as slow during 'auth diagnose'.
 const pluginStartupWarnThreshold = 2 * time.Second
+
+//go:embed auth_diagnose_schema.json
+var authDiagnoseDisplaySchema []byte
 
 // clockSkewCheckFunc is the function used to perform the clock skew check.
 // Tests can replace this to avoid real network calls.
@@ -403,15 +407,14 @@ func CommandDiagnose(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ s
 						"message":  c.Message,
 					})
 				}
-				outputOpts := flags.NewKvxOutputOptionsFromFlags(
-					outputFlags.Output,
-					outputFlags.Interactive,
-					outputFlags.Expression,
+				outputOpts := flags.ToKvxOutputOptions(&outputFlags,
+					kvx.WithIOStreams(ioStreams),
 					kvx.WithOutputContext(ctx),
 					kvx.WithOutputNoColor(cliParams.NoColor),
 					kvx.WithOutputAppName(cliParams.BinaryName+" auth diagnose"),
+					kvx.WithOutputDisplaySchemaJSON(authDiagnoseDisplaySchema),
+					kvx.WithOutputColumnOrder([]string{"status", "category", "check", "message"}),
 				)
-				outputOpts.IOStreams = ioStreams
 				return outputOpts.Write(results)
 			}
 

--- a/pkg/cmd/scafctl/auth/diagnose_test.go
+++ b/pkg/cmd/scafctl/auth/diagnose_test.go
@@ -6,11 +6,13 @@ package auth
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/adrg/xdg"
+	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/auth/diagnose"
 	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
@@ -682,4 +684,19 @@ func TestCommandDiagnose_NoHandlers_ShowsOfficialAvailable(t *testing.T) {
 	assert.Contains(t, output, "no handlers installed yet")
 	assert.Contains(t, output, "github")
 	assert.Contains(t, output, "entra")
+}
+
+// ── Display schema tests ─────────────────────────────────────────────────────
+
+func TestAuthDiagnoseDisplaySchema_IsValidJSON(t *testing.T) {
+	t.Parallel()
+	assert.True(t, json.Valid(authDiagnoseDisplaySchema), "auth_diagnose_schema.json must be valid JSON")
+}
+
+func TestAuthDiagnoseDisplaySchema_ParsesWithDisplay(t *testing.T) {
+	t.Parallel()
+	hints, ds, err := tui.ParseSchemaWithDisplay(authDiagnoseDisplaySchema)
+	require.NoError(t, err, "auth_diagnose_schema.json must parse without error")
+	assert.NotNil(t, hints, "should produce column hints")
+	assert.NotNil(t, ds, "should produce display schema")
 }

--- a/pkg/cmd/scafctl/auth/list.go
+++ b/pkg/cmd/scafctl/auth/list.go
@@ -4,12 +4,14 @@
 package auth
 
 import (
+	_ "embed"
 	"fmt"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/auth/hostname"
 	"github.com/oakwood-commons/scafctl/pkg/auth/statusrows"
@@ -21,6 +23,9 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
 )
+
+//go:embed auth_list_schema.json
+var authListDisplaySchema []byte
 
 // authListSchema controls table column display for 'auth list'. Columns in the
 // "required" array resist truncation; "deprecated" fields are hidden in table
@@ -185,15 +190,12 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 					return exitcode.WithCode(err, exitcode.GeneralError)
 				}
 				if outputFlags.Output == "json" || outputFlags.Output == "yaml" || outputFlags.Output == "quiet" {
-					opts := flags.NewKvxOutputOptionsFromFlags(
-						outputFlags.Output,
-						outputFlags.Interactive,
-						outputFlags.Expression,
+					opts := flags.ToKvxOutputOptions(&outputFlags,
+						kvx.WithIOStreams(ioStreams),
 						kvx.WithOutputContext(ctx),
 						kvx.WithOutputNoColor(cliParams.NoColor),
 						kvx.WithOutputAppName(cliParams.BinaryName+" auth list"),
 					)
-					opts.IOStreams = ioStreams
 					return opts.Write([]map[string]any{})
 				}
 				w.Infof("No active authentication sessions.")
@@ -248,17 +250,16 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 
 			results := make([]map[string]any, 0)
 
-			outputOpts := flags.NewKvxOutputOptionsFromFlags(
-				outputFlags.Output,
-				outputFlags.Interactive,
-				outputFlags.Expression,
+			outputOpts := flags.ToKvxOutputOptions(&outputFlags,
+				kvx.WithIOStreams(ioStreams),
 				kvx.WithOutputContext(ctx),
 				kvx.WithOutputNoColor(cliParams.NoColor),
 				kvx.WithOutputAppName(cliParams.BinaryName+" auth list"),
 				kvx.WithOutputColumnOrder([]string{"handler", "cluster", "tokenKind", "scope", "expiresIn", "isExpired"}),
+				kvx.WithOutputColumnarMode(tui.ColumnarModeAlways),
 				kvx.WithOutputSchemaJSON(authListSchema),
+				kvx.WithOutputDisplaySchemaJSON(authListDisplaySchema),
 			)
-			outputOpts.IOStreams = ioStreams
 
 			for _, name := range handlerNames {
 				handler, err := getHandler(ctx, name)

--- a/pkg/cmd/scafctl/auth/list_test.go
+++ b/pkg/cmd/scafctl/auth/list_test.go
@@ -6,10 +6,12 @@ package auth
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
@@ -411,4 +413,79 @@ func (m *minimalHandler) GetToken(_ context.Context, _ auth.TokenOptions) (*auth
 
 func (m *minimalHandler) InjectAuth(_ context.Context, _ *http.Request, _ auth.TokenOptions) error {
 	return nil
+}
+
+func TestCommandList_MultiHandler_ColumnarTable(t *testing.T) {
+	// When multiple handlers are registered, 'auth list -o text' must render
+	// as a multi-column table (not a key/value array) even when handlers
+	// produce heterogeneous key sets.
+	var stdout bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &stdout, &bytes.Buffer{}, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+	ctx := writer.WithWriter(context.Background(), w)
+	ctx = logger.WithLogger(ctx, logger.GetNoopLogger())
+
+	now := time.Now()
+	mockGCP := auth.NewMockHandler("gcp")
+	mockGCP.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{
+			Handler:   "gcp",
+			Hostname:  "https://gcp.example.com",
+			TokenKind: "access",
+			Scope:     "https://www.googleapis.com/auth/cloud-platform",
+			Flow:      auth.FlowInteractive,
+			ExpiresAt: now.Add(50 * time.Minute),
+			CachedAt:  now.Add(-10 * time.Minute),
+			IsExpired: false,
+		},
+	}
+
+	mockGitHub := auth.NewMockHandler("github")
+	mockGitHub.ListCachedTokensResult = []*auth.CachedTokenInfo{
+		{
+			Handler:   "github",
+			TokenKind: "access",
+			Scope:     "repo,user",
+			Flow:      auth.FlowDeviceCode,
+			ExpiresAt: now.Add(7 * 24 * time.Hour),
+			CachedAt:  now.Add(-1 * time.Hour),
+			IsExpired: false,
+		},
+	}
+
+	reg := auth.NewRegistry()
+	require.NoError(t, reg.Register(mockGCP))
+	require.NoError(t, reg.Register(mockGitHub))
+	ctx = auth.WithRegistry(ctx, reg)
+
+	cliParams := settings.NewCliParams()
+	cmd := CommandList(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{"-o", "text"})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	output := stdout.String()
+	// Multi-column table renders column headers and both handler rows.
+	assert.Contains(t, output, "gcp")
+	assert.Contains(t, output, "github")
+	// Must NOT render as a key/value array (index-based).
+	assert.NotContains(t, output, "[0]")
+	assert.NotContains(t, output, "[1]")
+}
+
+// ── Display schema tests ─────────────────────────────────────────────────────
+
+func TestAuthListDisplaySchema_IsValidJSON(t *testing.T) {
+	t.Parallel()
+	assert.True(t, json.Valid(authListDisplaySchema), "auth_list_schema.json must be valid JSON")
+}
+
+func TestAuthListDisplaySchema_ParsesWithDisplay(t *testing.T) {
+	t.Parallel()
+	hints, ds, err := tui.ParseSchemaWithDisplay(authListDisplaySchema)
+	require.NoError(t, err, "auth_list_schema.json must parse without error")
+	assert.NotNil(t, hints, "should produce column hints")
+	assert.NotNil(t, ds, "should produce display schema")
 }


### PR DESCRIPTION
## Description

Add `x-kvx` display schema JSON files for `auth diagnose` and `auth list` commands to enable rich interactive TUI rendering with card-list views, detail sections, and badge fields.

- `auth diagnose`: 🩺 icon, check/message/status/category layout
- `auth list`: 🔑 icon, handler/scope/tokenKind/expiresIn layout
- Switch both commands from `NewKvxOutputOptionsFromFlags` to `ToKvxOutputOptions` with `WithOutputDisplaySchemaJSON`
- Add schema validation tests (`IsValidJSON` + `ParsesWithDisplay`)
- Fix multi-handler display for `auth list -o table` to show detailed columns instead of key/value array

## Related Issues

Closes #

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My commits follow conventional commit format
- [x] I have added/updated tests for my changes
- [x] `go test ./...` passes
- [x] `task lint` passes
- [x] I have signed off my commits (`git commit -s -S`)
