### PR TITLE
feat(auth)!: OpenShift login routing and openshift official handler

### DIFF
--- a/docs/design/kubernetes-auth.md
+++ b/docs/design/kubernetes-auth.md
@@ -21,7 +21,7 @@ The design is layered by dependency weight so each phase ships independently:
 | 2a | Kubeconfig provider capability contract + host-side manager | core (`pkg/kubeconfig`, `CapabilityKubeconfig`) | Shipped |
 | 2b | Kubeconfig provider plugin implementation (`client-go`/`clientcmd`) | plugin | Planned |
 | 3 | Thin `kube login` / `kube logout` commands | core (`pkg/kube/login`, `pkg/cmd/scafctl/kube`) | Shipped |
-| 4 | OpenShift OAuth auth-handler plugin | plugin | Planned |
+| 4 | OpenShift OAuth auth-handler plugin + two-path routing | plugin + core (`pkg/kube/login`, `pkg/catalog`, `pkg/auth/official`) | Shipped |
 | 5 | Multi-cluster per-cluster token routing on the exec-credential path | core (`pkg/auth/execcredential`, `pkg/cmd/scafctl/auth`, `pkg/kube/login`) + SDK `CapTokenHostname` | Shipped |
 
 Phases 1-3 add no OpenShift- or vendor-specific code and already deliver
@@ -202,9 +202,45 @@ with no resolver involved.
   resolver supplies `ClusterInfo.DefaultHandler`). When the kubeconfig provider
   plugin cannot be fetched, it degrades gracefully to writing a minimal static
   exec-credential kubeconfig directly. `client-go` never enters core.
-- **Phase 4 -- OpenShift OAuth handler plugin.** The one genuinely
-  OpenShift-specific credential source: localhost-callback implicit-grant flow,
-  plus `ListProjects` / MOTD behind graceful degradation.
+- **Phase 4 -- OpenShift OAuth handler plugin + two-path routing (Shipped).**
+  The one genuinely OpenShift-specific credential source: the
+  `openshift` auth-handler plugin runs a localhost-callback implicit-grant flow
+  (OAuth server discovered from the cluster's
+  `.well-known/oauth-authorization-server` endpoint), enriches the username via
+  `user.openshift.io`, and mints service-account tokens through the Kubernetes
+  TokenRequest API -- all over raw HTTP, so no `client-go` enters core. The
+  plugin is registered in `pkg/auth/official` so `kube login` auto-fetches it
+  from `ghcr.io/oakwood-commons/auth-handlers/openshift`.
+
+  **Two-path routing.** `kube login` auto-detects the cluster's auth method via
+  the kubeconfig provider's `DetectAuthType` (`pkg/kube/login`) and, when the
+  caller supplies neither `--handler` nor a resolved
+  `ClusterInfo.DefaultHandler`, routes on the detected `AuthType`:
+
+  - `oauth` (OpenShift bundled OAuth) -> the `openshift` handler's browser
+    web-login flow.
+  - `oidc` (structured / external identity, e.g. Entra) -> the existing `entra`
+    handler with the cluster's audience. The audience comes from the resolver's
+    `oidcAudience`, a `--audience` flag, or a static alias -- never a hardcoded
+    tenant or client ID. When the OIDC route is auto-selected but no audience is
+    resolvable, login fails fast (`ErrNoAudience`) rather than writing a
+    kubeconfig entry that cannot authenticate.
+
+  The policy is data, not a hardcoded switch: `login.Deps.AuthTypeHandlers`
+  (defaulted by `login.DefaultAuthTypeHandlers`) maps an `AuthType` to a handler
+  name and is consulted only as a last resort -- an explicit `--handler` and a
+  resolver-supplied `DefaultHandler` both take precedence, so embedders that ship
+  different handlers (or stamp `defaultHandler` in their cluster inventory)
+  override the fallback without touching core. An undetected `AuthType` (auto)
+  still requires an explicit handler.
+
+  **Credential-helper use.** Once logged in, the OpenShift integrated image
+  registry is served through the Docker credential-helper protocol
+  (`pkg/credentialhelper`): `pkg/catalog` infers the `openshift` handler for the
+  registry route (`default-route-openshift-image-registry.*`) and in-cluster
+  service (`image-registry.openshift-image-registry.svc*`) host forms, so
+  `docker`/`podman` pulls fetch fresh tokens from scafctl. Custom or renamed
+  registry routes are supported via a `customOAuth2` registry mapping.
 
 ## Phase 5: Multi-Cluster Token Routing (Shipped)
 

--- a/docs/tutorials/auth-tutorial.md
+++ b/docs/tutorials/auth-tutorial.md
@@ -2364,6 +2364,86 @@ Both commands support structured output (`-o json`, `-o yaml`) for automation.
 For a complete walkthrough see the
 [Kubernetes login / logout example](../../examples/auth/kube-login.md).
 
+### OpenShift: One Command, OAuth or Entra (auto-routing)
+
+OpenShift clusters authenticate one of two ways, and `kube login` picks the
+right path for you. It probes the API server's
+`/.well-known/oauth-authorization-server` endpoint to detect the cluster's auth
+type, then -- when you supply neither `--handler` nor a resolver default --
+routes automatically:
+
+- **OAuth cluster** (OpenShift's bundled OAuth server) -> the `openshift`
+  handler runs a browser web-login (the `oc login --web` experience) and holds
+  the token.
+- **OIDC / structured-auth cluster** (delegated to Entra / Azure AD) -> the
+  existing `entra` handler mints a cluster-scoped token. The cluster's audience
+  comes from your resolver (`oidcAudience`), a static alias, or `--audience` --
+  never a hardcoded tenant or client ID.
+
+The same command works for either cluster; scafctl holds the credential and
+serves it back to `kubectl`/`oc` on every call:
+
+{{< tabs "auth-tutorial-openshift-login" >}}
+{{% tab "Bash" %}}
+```bash
+# One command regardless of auth type -- scafctl detects and routes
+scafctl kube login mycluster --server https://api.mycluster.example.com:6443
+#   oauth cluster   -> browser web login via the openshift handler
+#   oidc cluster    -> entra handler, cluster-scoped token
+
+# OIDC cluster reached directly needs an audience to scope the token
+scafctl kube login --server https://api.mycluster.example.com:6443 \
+  --audience api://mycluster-client-id/.default
+
+kubectl get pods   # kubectl calls scafctl for a fresh token
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# One command regardless of auth type -- scafctl detects and routes
+scafctl kube login mycluster --server https://api.mycluster.example.com:6443
+
+# OIDC cluster reached directly needs an audience to scope the token
+scafctl kube login --server https://api.mycluster.example.com:6443 `
+  --audience api://mycluster-client-id/.default
+
+kubectl get pods   # kubectl calls scafctl for a fresh token
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+The routing is a fallback only: an explicit `--handler` and a resolver-supplied
+`defaultHandler` both win over the detected auth type, so a fleet inventory can
+stamp `defaultHandler` / `authType` / `audience` on every entry and users just
+run `kube login <cluster>`. When an OIDC cluster is auto-routed to `entra` but
+no audience is available, login fails fast asking for `--audience` rather than
+writing a kubeconfig entry that cannot authenticate.
+
+Once logged in, the OpenShift integrated image registry is served through
+scafctl's credential helper, so `docker`/`podman` pulls fetch fresh tokens
+without a separate `docker login`:
+
+{{< tabs "auth-tutorial-openshift-registry" >}}
+{{% tab "Bash" %}}
+```bash
+# Pull from the OpenShift integrated registry via the credential helper
+podman pull default-route-openshift-image-registry.mycluster/myns/myimage
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Pull from the OpenShift integrated registry via the credential helper
+podman pull default-route-openshift-image-registry.mycluster/myns/myimage
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+scafctl infers the `openshift` handler for the default registry route
+(`default-route-openshift-image-registry.*`) and the in-cluster service host
+(`image-registry.openshift-image-registry.svc*`). For a custom or renamed
+registry route, add a `customOAuth2` registry mapping (see
+[Custom OAuth2 registries](gcp-custom-oauth-tutorial.md)).
+
 ### Decoding the JWT (Header + Payload)
 
 Use `--decode` to inspect the full JWT structure -- both the **header** and the **payload** -- without needing an external decoder tool. Signature validation is intentionally skipped; this is for debugging only:
@@ -3113,13 +3193,64 @@ Custom handlers support all three OAuth2 flows:
 For advanced configurations including token exchange and identity
 verification, see [examples/auth/custom-oauth2-config.md](https://github.com/oakwood-commons/scafctl/blob/main/examples/auth/custom-oauth2-config.md).
 
+### Pinning an External Plugin Handler (`auth.handlers.<name>.plugin`)
+
+The `customOAuth2` block above adds a handler using scafctl's built-in generic
+OAuth2 engine -- no plugin binary required. When you instead need a *plugin* auth
+handler (a standalone gRPC binary -- e.g. written in another language, or with
+logic the generic engine can't express), pin it to a name under
+`auth.handlers.<name>.plugin`. scafctl auto-fetches the plugin from a configured
+catalog on first use. Neither approach requires recompiling scafctl:
+
+```yaml
+catalogs:
+  - name: acme
+    type: oci
+    url: oci://ghcr.io/acme/scafctl-handlers
+
+auth:
+  handlers:
+    acme:
+      plugin:
+        ref: acme-auth        # catalog artifact name (defaults to the handler name)
+        version: ">=1.0.0"    # semver constraint or "latest" (the default)
+      # Third-party handlers do not inherit the official trusted domains, so
+      # declare any device-code verification domains explicitly:
+      trustedVerificationDomains:
+        - login.acme.example.com
+      # Any other keys are forwarded opaquely to the plugin as its settings:
+      tenantId: "..."
+```
+
+Then it behaves like any other handler:
+
+```bash
+scafctl auth login acme
+scafctl auth status acme
+```
+
+Notes:
+
+- **Precedence.** A config pin wins over the built-in official manifest, so
+  `auth.handlers.github.plugin` repoints the `github` name at your own artifact.
+  (Unlike a `customOAuth2` entry -- which may not reuse a reserved official name
+  such as `github`, `gcp`, `entra`, or `openshift` -- a deliberate plugin pin is
+  allowed to override one.)
+- **Bare names work too.** If the artifact name matches the handler name, you can
+  skip the pin and just reference the name; scafctl auto-fetches it from your
+  configured catalogs. The pin is only needed to fix a `ref`/`version` or to
+  alias a differently named artifact.
+- **Policy switches.** `settings.disableThirdPartyAuthHandlers` blocks catalog
+  and config-pin resolution; `settings.disableOfficialAuthHandlers` blocks the
+  built-in official manifest.
+
 ---
 
 ## Handler Lifecycle Management
 
-Official auth handlers (github, gcp, entra) are delivered as plugin binaries and
-downloaded automatically on first use (e.g., during `scafctl auth login github`).
-You can also manage them explicitly.
+Official auth handlers (github, gcp, entra, openshift) are delivered as plugin
+binaries and downloaded automatically on first use (e.g., during `scafctl auth
+login github`). You can also manage them explicitly.
 
 ### Listing Available Handlers
 

--- a/docs/tutorials/extension-concepts.md
+++ b/docs/tutorials/extension-concepts.md
@@ -25,7 +25,7 @@ This page defines the core terminology and links to the detailed development gui
 | | **Builtin** | **Plugin** |
 |---|---|---|
 | **Provider** | Compiled into scafctl; 11 built-in providers (http, cel, static, parameter...) | Standalone gRPC binary; auto-fetched from OCI catalogs (10 official: exec, git, env...) |
-| **Auth Handler** | Compiled into scafctl; 3 built-in handlers (entra, github, gcp) | Standalone gRPC binary; auto-fetched from OCI catalogs |
+| **Auth Handler** | Only the generic OAuth2 handler, which backs user-defined `customOAuth2` configs (no first-party handlers are compiled in) | Standalone gRPC binary; auto-fetched from OCI catalogs (4 official: entra, gcp, github, openshift) |
 
 ## When to Choose Builtin vs Plugin
 

--- a/examples/auth/kube-login.md
+++ b/examples/auth/kube-login.md
@@ -205,6 +205,42 @@ scafctl kube login prod --handler oidc -o json
 scafctl kube logout prod -o json
 ```
 
+## OpenShift: OAuth or Entra, One Command
+
+For OpenShift clusters, `kube login` detects the cluster's auth method (probing
+`/.well-known/oauth-authorization-server`) and, when you pass neither `--handler`
+nor a resolver default, routes automatically:
+
+- **OAuth cluster** (OpenShift bundled OAuth) uses the `openshift` handler's
+  browser web-login.
+- **OIDC / structured-auth cluster** (Entra) uses the `entra` handler with the
+  cluster's audience from the resolver, a static alias, or `--audience`.
+
+```bash
+# Same command for either cluster type -- scafctl detects and routes
+scafctl kube login mycluster --server https://api.mycluster.example.com:6443
+
+# Reaching an OIDC cluster directly needs an audience to scope the token
+scafctl kube login --server https://api.mycluster.example.com:6443 \
+  --audience api://mycluster-client-id/.default
+```
+
+An explicit `--handler` and a resolver-supplied `defaultHandler` both take
+precedence over the detected auth type. When an OIDC cluster is auto-routed to
+`entra` with no audience available, login fails fast asking for `--audience`.
+
+After login, the OpenShift integrated image registry is served through scafctl's
+credential helper -- `docker`/`podman` pulls fetch fresh tokens automatically:
+
+```bash
+podman pull default-route-openshift-image-registry.mycluster/myns/myimage
+```
+
+The `openshift` handler is inferred for the default registry route
+(`default-route-openshift-image-registry.*`) and the in-cluster service host
+(`image-registry.openshift-image-registry.svc*`). Custom routes use a
+`customOAuth2` registry mapping.
+
 ## Limitations
 
 For OpenShift-style OAuth (implicit-grant) clusters, the kubeconfig `exec` block

--- a/pkg/auth/handlerdep/handlerdep_test.go
+++ b/pkg/auth/handlerdep/handlerdep_test.go
@@ -103,11 +103,21 @@ func TestResolve_ConfigPinDefaults(t *testing.T) {
 }
 
 func TestResolve_NoConfigNoOfficial(t *testing.T) {
-	// Nil config and no official registry: any name resolves as a bare catalog
-	// name (third-party enabled by default).
-	dep, source, err := Resolve(context.Background(), "openshift")
+	// Nil config and no official registry: a non-official name resolves as a
+	// bare catalog name (third-party enabled by default).
+	dep, source, err := Resolve(context.Background(), "acme")
 	require.NoError(t, err)
 	assert.Equal(t, SourceCatalog, source)
+	assert.Equal(t, "acme", dep.Name)
+}
+
+func TestResolve_NoRegistryFallsBackToDefaultOfficial(t *testing.T) {
+	// With no official registry attached, Resolve falls back to the canonical
+	// default official names so an official handler (e.g. openshift) is still
+	// classified as official rather than a bare catalog artifact.
+	dep, source, err := Resolve(context.Background(), "openshift")
+	require.NoError(t, err)
+	assert.Equal(t, SourceOfficial, source)
 	assert.Equal(t, "openshift", dep.Name)
 }
 
@@ -197,7 +207,7 @@ func TestResolve_ErrorsHaveNoBinaryName(t *testing.T) {
 	ctx := config.WithConfig(context.Background(), &config.Config{
 		Settings: config.Settings{DisableThirdPartyAuthHandlers: true},
 	})
-	_, _, err := Resolve(ctx, "openshift")
+	_, _, err := Resolve(ctx, "acme")
 	require.Error(t, err)
 	assert.NotContains(t, strings.ToLower(err.Error()), "scafctl")
 }

--- a/pkg/auth/official/official.go
+++ b/pkg/auth/official/official.go
@@ -1,11 +1,18 @@
 // Copyright 2025-2026 Oakwood Commons
 // SPDX-License-Identifier: Apache-2.0
 
-// Package official defines the registry of first-party auth handlers that will
-// be extracted from scafctl's built-in set into standalone plugin repos. The
-// registry drives auto-resolution: when a CLI command or solution references an
-// auth handler that isn't registered (built-in, config-defined, or plugin), the
-// runtime checks this list and auto-fetches from the official OCI catalog.
+// Package official defines the manifest of first-party auth handlers that scafctl
+// distributes as standalone gRPC plugins (published to
+// ghcr.io/oakwood-commons/auth-handlers/<name>), NOT compiled into the binary.
+// Each entry is a pointer -- name, OCI catalog ref, version constraint, and
+// minimum plugin SDK version -- and carries no handler logic. The manifest
+// drives zero-config auto-resolution: when a CLI command or solution references
+// an auth handler that isn't already registered (an embedder builtin, a
+// config-defined handler, or an installed plugin), the runtime consults this
+// manifest and auto-fetches the matching plugin from the official OCI catalog.
+// It also acts as a trust allowlist -- only these names auto-resolve to the
+// official catalog. Embedders override the set via
+// RootOptions.OfficialAuthHandlers.
 package official
 
 import (
@@ -54,8 +61,8 @@ type AuthHandler struct {
 	TrustedVerificationDomains []string
 }
 
-// defaultAuthHandlers is the canonical list of all 3 auth handlers planned for
-// extraction. Sorted alphabetically by name.
+// defaultAuthHandlers is the canonical list of the 4 official first-party auth
+// handlers, distributed as standalone plugins. Sorted alphabetically by name.
 //
 // DefaultVersion is "latest" so the catalog resolver picks the newest
 // available version. This avoids hard-coding a concrete semver that must
@@ -89,6 +96,18 @@ var defaultAuthHandlers = []AuthHandler{
 			"github.com",
 		},
 	},
+	{
+		Name:           "openshift",
+		CatalogRef:     "openshift",
+		DefaultVersion: "latest",
+		MinSDKVersion:  "0.2.0",
+		// No TrustedVerificationDomains: the OpenShift OAuth server host is
+		// per-cluster and discovered at login from the API server's
+		// .well-known/oauth-authorization-server endpoint, so there is no fixed
+		// identity-provider domain to pin. Host verification for this handler is
+		// config-driven per cluster rather than hardcoded here.
+		TrustedVerificationDomains: nil,
+	},
 }
 
 // Registry holds the set of known official auth handlers.
@@ -97,7 +116,7 @@ type Registry struct {
 }
 
 // NewRegistry returns the default official auth handler registry containing
-// all 3 auth handlers planned for extraction.
+// the 4 official first-party auth handlers.
 func NewRegistry() *Registry {
 	return NewRegistryFrom(defaultAuthHandlers)
 }
@@ -113,7 +132,7 @@ func NewRegistryFrom(handlers []AuthHandler) *Registry {
 	return &Registry{handlers: m}
 }
 
-// DefaultAuthHandlers returns a copy of the 3 official auth handler entries.
+// DefaultAuthHandlers returns a copy of the 4 official auth handler entries.
 // Embedders can append their own entries and pass the result to
 // NewRegistryFrom to extend rather than replace the defaults.
 func DefaultAuthHandlers() []AuthHandler {

--- a/pkg/auth/official/official_test.go
+++ b/pkg/auth/official/official_test.go
@@ -12,15 +12,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewRegistry_Contains3Handlers(t *testing.T) {
+func TestNewRegistry_Contains4Handlers(t *testing.T) {
 	r := NewRegistry()
-	assert.Equal(t, 3, r.Len())
+	assert.Equal(t, 4, r.Len())
 }
 
 func TestNewRegistry_AllNamesPresent(t *testing.T) {
 	r := NewRegistry()
 
-	expected := []string{"entra", "gcp", "github"}
+	expected := []string{"entra", "gcp", "github", "openshift"}
 	assert.Equal(t, expected, r.Names())
 }
 
@@ -30,10 +30,15 @@ func TestRegistry_Get(t *testing.T) {
 		query     string
 		wantFound bool
 		wantName  string
+		// wantTrustedDomains is false for handlers whose OAuth host is
+		// per-cluster/config-driven (e.g. openshift), which intentionally
+		// carry no pinned identity-provider domains.
+		wantTrustedDomains bool
 	}{
-		{name: "known handler github", query: "github", wantFound: true, wantName: "github"},
-		{name: "known handler entra", query: "entra", wantFound: true, wantName: "entra"},
-		{name: "known handler gcp", query: "gcp", wantFound: true, wantName: "gcp"},
+		{name: "known handler github", query: "github", wantFound: true, wantName: "github", wantTrustedDomains: true},
+		{name: "known handler entra", query: "entra", wantFound: true, wantName: "entra", wantTrustedDomains: true},
+		{name: "known handler gcp", query: "gcp", wantFound: true, wantName: "gcp", wantTrustedDomains: true},
+		{name: "known handler openshift", query: "openshift", wantFound: true, wantName: "openshift", wantTrustedDomains: false},
 		{name: "unknown handler", query: "nonexistent", wantFound: false},
 		{name: "empty string", query: "", wantFound: false},
 		{name: "builtin handler not extracted", query: "oauth2", wantFound: false},
@@ -49,7 +54,11 @@ func TestRegistry_Get(t *testing.T) {
 				assert.NotEmpty(t, h.CatalogRef)
 				assert.NotEmpty(t, h.DefaultVersion)
 				assert.NotEmpty(t, h.MinSDKVersion)
-				assert.NotEmpty(t, h.TrustedVerificationDomains)
+				if tt.wantTrustedDomains {
+					assert.NotEmpty(t, h.TrustedVerificationDomains)
+				} else {
+					assert.Empty(t, h.TrustedVerificationDomains)
+				}
 			}
 		})
 	}
@@ -64,6 +73,7 @@ func TestRegistry_Has(t *testing.T) {
 		{name: "known github", query: "github", want: true},
 		{name: "known entra", query: "entra", want: true},
 		{name: "known gcp", query: "gcp", want: true},
+		{name: "known openshift", query: "openshift", want: true},
 		{name: "unknown", query: "aws", want: false},
 		{name: "builtin not extracted", query: "oauth2", want: false},
 	}
@@ -132,7 +142,7 @@ func TestDefaultAuthHandlers_ReturnsCopy(t *testing.T) {
 }
 
 func TestDefaultAuthHandlers_Count(t *testing.T) {
-	assert.Equal(t, 3, len(DefaultAuthHandlers()))
+	assert.Equal(t, 4, len(DefaultAuthHandlers()))
 }
 
 func TestDefaultAuthHandlers_ExtendPattern(t *testing.T) {
@@ -141,7 +151,7 @@ func TestDefaultAuthHandlers_ExtendPattern(t *testing.T) {
 	)
 
 	r := NewRegistryFrom(extended)
-	assert.Equal(t, 4, r.Len())
+	assert.Equal(t, 5, r.Len())
 	assert.True(t, r.Has("github"))
 	assert.True(t, r.Has("okta"))
 }
@@ -200,7 +210,7 @@ func TestRegistry_Len(t *testing.T) {
 		handlers []AuthHandler
 		want     int
 	}{
-		{name: "default", handlers: defaultAuthHandlers, want: 3},
+		{name: "default", handlers: defaultAuthHandlers, want: 4},
 		{name: "empty", handlers: nil, want: 0},
 		{name: "one", handlers: []AuthHandler{{Name: "x"}}, want: 1},
 	}
@@ -232,7 +242,7 @@ func TestWithRegistry_ContextRoundTrip(t *testing.T) {
 
 	got := RegistryFromContext(ctx)
 	require.NotNil(t, got)
-	assert.Equal(t, 3, got.Len())
+	assert.Equal(t, 4, got.Len())
 }
 
 func TestRegistryFromContext_NilWhenNotSet(t *testing.T) {

--- a/pkg/catalog/auth_bridge.go
+++ b/pkg/catalog/auth_bridge.go
@@ -19,16 +19,25 @@ const RegistryUsernameDefault = "oauth2accesstoken"
 // ACR uses a zero-GUID as the username when authenticating with an Entra token.
 const RegistryUsernameACR = "00000000-0000-0000-0000-000000000000"
 
+// OpenShift integrated image-registry host patterns. The registry is exposed
+// either through a default route (external) or the in-cluster service DNS
+// (internal). Custom/renamed registry routes are not matched here; they are
+// handled via config.CustomOAuth2Config.Registry exact-host mappings.
+const (
+	// openshiftRegistryRoutePrefix matches the default exposed route form,
+	// e.g. default-route-openshift-image-registry.apps.<cluster-domain>.
+	openshiftRegistryRoutePrefix = "default-route-openshift-image-registry."
+	// openshiftRegistrySvcPrefix matches the in-cluster service form,
+	// e.g. image-registry.openshift-image-registry.svc(.cluster.local)(:5000).
+	openshiftRegistrySvcPrefix = "image-registry.openshift-image-registry.svc"
+)
+
 // RegistryUsernameProvider is an optional interface for auth handlers that declare
 // a custom registry username convention. BridgeAuthToRegistry checks for this
 // interface via type assertion on the default (non-built-in) path.
 type RegistryUsernameProvider interface {
 	RegistryUsername() string
 }
-
-// builtinHandlerNames contains the names of built-in auth handlers.
-// Used for name conflict detection when registering custom OAuth2 handlers.
-var builtinHandlerNames = []string{"github", "gcp", "entra"}
 
 // BridgeAuthToRegistry converts an auth handler's token into OCI registry credentials.
 // Each registry type expects a specific username/password convention:
@@ -66,16 +75,9 @@ func BridgeAuthToRegistry(ctx context.Context, handler auth.Handler, registryHos
 func RegistryUsername(ctx context.Context, handler auth.Handler, _ string) (string, error) {
 	switch handler.Name() {
 	case "github":
-		// GHCR expects the GitHub username as the registry username.
-		// Falls back to default if Status is unavailable or claims are empty.
-		status, err := handler.Status(ctx)
-		if err != nil {
-			return RegistryUsernameDefault, nil //nolint:nilerr // intentional fallback to default username
-		}
-		if status.Claims != nil && status.Claims.Username != "" {
-			return status.Claims.Username, nil
-		}
-		return RegistryUsernameDefault, nil
+		// GHCR expects the GitHub username as the registry username, falling
+		// back to the default when Status/claims are unavailable.
+		return claimsUsernameOrDefault(ctx, handler), nil
 
 	case "entra":
 		// ACR expects the zero-GUID as username
@@ -84,6 +86,12 @@ func RegistryUsername(ctx context.Context, handler auth.Handler, _ string) (stri
 	case "gcp":
 		// GCR/Artifact Registry expects "oauth2accesstoken"
 		return RegistryUsernameDefault, nil
+
+	case "openshift":
+		// The OpenShift integrated registry accepts the user's token as the
+		// password with the OpenShift username as the docker username (like the
+		// GitHub case), falling back to the default when unavailable.
+		return claimsUsernameOrDefault(ctx, handler), nil
 
 	default:
 		// Check if the handler provides a custom registry username override
@@ -96,6 +104,21 @@ func RegistryUsername(ctx context.Context, handler auth.Handler, _ string) (stri
 		// Generic OAuth2 handlers default to oauth2accesstoken
 		return RegistryUsernameDefault, nil
 	}
+}
+
+// claimsUsernameOrDefault returns the handler's authenticated username from its
+// Status claims, falling back to RegistryUsernameDefault when Status is
+// unavailable or the claim is empty. Used by registries (GHCR, the OpenShift
+// integrated registry) that expect the user's own name as the docker username.
+func claimsUsernameOrDefault(ctx context.Context, handler auth.Handler) string {
+	status, err := handler.Status(ctx)
+	if err != nil {
+		return RegistryUsernameDefault
+	}
+	if status.Claims != nil && status.Claims.Username != "" {
+		return status.Claims.Username
+	}
+	return RegistryUsernameDefault
 }
 
 // InferAuthHandler maps a registry host to a built-in or custom auth handler name.
@@ -111,6 +134,8 @@ func InferAuthHandler(registryHost string, customHandlers []config.CustomOAuth2C
 		return "gcp"
 	case strings.HasSuffix(registryHost, ".azurecr.io"):
 		return "entra"
+	case isOpenShiftRegistryHost(registryHost):
+		return "openshift"
 	}
 
 	// Check custom OAuth2 handler registry mappings
@@ -123,6 +148,23 @@ func InferAuthHandler(registryHost string, customHandlers []config.CustomOAuth2C
 	return ""
 }
 
+// isOpenShiftRegistryHost reports whether host is an OpenShift integrated
+// image-registry host: the exposed default route or the in-cluster service DNS.
+// The service-form match enforces a boundary after the ".svc" segment (end of
+// host, ":" for a port, or "." for a domain suffix) so look-alike hosts such as
+// "image-registry.openshift-image-registry.svcevil.example" are not matched and
+// cannot be sent an OpenShift token.
+func isOpenShiftRegistryHost(host string) bool {
+	if strings.HasPrefix(host, openshiftRegistryRoutePrefix) {
+		return true
+	}
+	rest, ok := strings.CutPrefix(host, openshiftRegistrySvcPrefix)
+	if !ok {
+		return false
+	}
+	return rest == "" || rest[0] == ':' || rest[0] == '.'
+}
+
 // InferDefaultScope returns the default OAuth scope for a known registry host.
 // Returns empty string if no default scope is known for the registry.
 func InferDefaultScope(registryHost string) string {
@@ -133,14 +175,4 @@ func InferDefaultScope(registryHost string) string {
 		return "https://www.googleapis.com/auth/cloud-platform"
 	}
 	return ""
-}
-
-// IsBuiltinHandlerName returns true if the name conflicts with a built-in handler.
-func IsBuiltinHandlerName(name string) bool {
-	for _, builtin := range builtinHandlerNames {
-		if name == builtin {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/catalog/auth_bridge_test.go
+++ b/pkg/catalog/auth_bridge_test.go
@@ -73,6 +73,24 @@ func TestBridgeAuthToRegistry(t *testing.T) {
 			wantPassword: "eyJ0entra-token",
 		},
 		{
+			name:         "openshift handler uses cluster username",
+			handlerName:  "openshift",
+			registryHost: "default-route-openshift-image-registry.apps.example.com",
+			token:        "sha256~openshift-token",
+			claims:       &auth.Claims{Username: "developer"},
+			wantUsername: "developer",
+			wantPassword: "sha256~openshift-token",
+		},
+		{
+			name:         "openshift handler falls back to default username",
+			handlerName:  "openshift",
+			registryHost: "image-registry.openshift-image-registry.svc:5000",
+			token:        "sha256~openshift-token",
+			claims:       &auth.Claims{},
+			wantUsername: RegistryUsernameDefault,
+			wantPassword: "sha256~openshift-token",
+		},
+		{
 			name:         "generic handler uses oauth2accesstoken",
 			handlerName:  "quay",
 			registryHost: "quay.io",
@@ -200,6 +218,14 @@ func TestInferAuthHandler(t *testing.T) {
 		{"gcr.io", "gcp"},
 		{"us.gcr.io", "gcp"},
 		{"myacr.azurecr.io", "entra"},
+		{"default-route-openshift-image-registry.apps.example.com", "openshift"},
+		{"image-registry.openshift-image-registry.svc", "openshift"},
+		{"image-registry.openshift-image-registry.svc:5000", "openshift"},
+		{"image-registry.openshift-image-registry.svc.cluster.local:5000", "openshift"},
+		// Look-alike hosts must NOT match: the ".svc" segment requires a
+		// boundary (end, ":", or ".") so a token is never sent to an impostor.
+		{"image-registry.openshift-image-registry.svcevil.example", ""},
+		{"image-registry.openshift-image-registry.svc-evil.example", ""},
 		{"quay.io", "quay"},
 		{"registry.gitlab.com", "gitlab"},
 		{"registry-1.docker.io", ""},
@@ -217,26 +243,6 @@ func TestInferAuthHandler(t *testing.T) {
 func TestInferAuthHandler_NoCustomHandlers(t *testing.T) {
 	assert.Equal(t, "github", InferAuthHandler("ghcr.io", nil))
 	assert.Equal(t, "", InferAuthHandler("quay.io", nil))
-}
-
-func TestIsBuiltinHandlerName(t *testing.T) {
-	tests := []struct {
-		name string
-		want bool
-	}{
-		{"github", true},
-		{"gcp", true},
-		{"entra", true},
-		{"quay", false},
-		{"custom", false},
-		{"", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, IsBuiltinHandlerName(tt.name))
-		})
-	}
 }
 
 // Benchmarks

--- a/pkg/cmd/scafctl/auth/handlers_install_test.go
+++ b/pkg/cmd/scafctl/auth/handlers_install_test.go
@@ -33,11 +33,11 @@ func TestCommandHandlersInstall_ThirdPartyDisabledNoOfficial(t *testing.T) {
 
 	cmd := commandHandlersInstall(cliParams, ioStreams)
 	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"openshift"})
+	cmd.SetArgs([]string{"notarealhandler"})
 
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "openshift")
+	assert.Contains(t, err.Error(), "notarealhandler")
 	assert.Contains(t, err.Error(), "disabled")
 }
 

--- a/pkg/cmd/scafctl/kube/login.go
+++ b/pkg/cmd/scafctl/kube/login.go
@@ -113,6 +113,12 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 				Kubeconfig: mgr,
 				Resolver:   kubeapi.ResolverFromContext(ctx),
 				BinaryName: cliParams.BinaryName,
+				// Route a detected cluster AuthType to a default handler when the
+				// caller supplies neither --handler nor a cluster DefaultHandler:
+				// OpenShift OAuth clusters -> "openshift", OIDC clusters -> "entra".
+				// Embedders override this by setting DefaultHandler/AuthType on their
+				// resolved clusters (which take precedence over this fallback).
+				AuthTypeHandlers: kubelogin.DefaultAuthTypeHandlers(),
 				HandlerLookup: func(ctx context.Context, name string) (kubelogin.Authenticator, error) {
 					return auth.GetHandler(ctx, name)
 				},
@@ -150,7 +156,7 @@ func CommandLogin(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			res, err := kubelogin.Login(ctx, deps, req)
 			if err != nil {
 				w.Errorf("%v", err)
-				if errors.Is(err, kubelogin.ErrNoHandler) || errors.Is(err, kubelogin.ErrNoServer) {
+				if errors.Is(err, kubelogin.ErrNoHandler) || errors.Is(err, kubelogin.ErrNoServer) || errors.Is(err, kubelogin.ErrNoAudience) {
 					return exitcode.WithCode(err, exitcode.InvalidInput)
 				}
 				if errors.Is(err, kubelogin.ErrVerificationFailed) && res != nil {

--- a/pkg/cmd/scafctl/kube/login_test.go
+++ b/pkg/cmd/scafctl/kube/login_test.go
@@ -47,6 +47,19 @@ func withMockHandler(t *testing.T, ctx context.Context) (context.Context, *auth.
 	return auth.WithRegistry(ctx, reg), mock
 }
 
+// withNamedMockHandler registers a mock auth handler under the given name in the
+// context's auth registry. Used to exercise AuthType-based auto-routing, where
+// the handler name is chosen by the detected cluster auth type rather than by
+// --handler.
+func withNamedMockHandler(t *testing.T, ctx context.Context, name string) (context.Context, *auth.MockHandler) {
+	t.Helper()
+	mock := auth.NewMockHandler(name)
+	mock.LoginResult = &auth.Result{}
+	reg := auth.NewRegistry()
+	require.NoError(t, reg.Register(mock))
+	return auth.WithRegistry(ctx, reg), mock
+}
+
 // embedderParams returns CLI params with a non-default binary name to exercise
 // the embedder contract.
 func embedderParams() *settings.Run {
@@ -198,6 +211,86 @@ func TestCommandLogin_HandlerFromResolverDefault(t *testing.T) {
 	assert.FileExists(t, path)
 	assert.Len(t, mock.LoginCalls, 1)
 	assert.Contains(t, buf.String(), "Logged in")
+}
+
+// TestCommandLogin_AutoRoutesOAuthToOpenshift verifies the CLI wires
+// DefaultAuthTypeHandlers so a detected OAuth cluster with no --handler and no
+// resolver DefaultHandler routes to the "openshift" handler. Only the openshift
+// mock is registered, so a successful login proves the routing selected it.
+func TestCommandLogin_AutoRoutesOAuthToOpenshift(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx, mock := withNamedMockHandler(t, ctx, "openshift")
+	mock.GetTokenResult = &auth.Token{AccessToken: "tok"}
+
+	resolver := &kubeapi.MockResolver{ResolveResult: &kubeapi.ClusterInfo{
+		Name:         "prod",
+		APIServerURL: "https://api.example.com:6443",
+		AuthType:     kubeapi.AuthTypeOAuth,
+	}}
+	ctx = kubeapi.WithResolver(ctx, resolver)
+
+	path := filepath.Join(t.TempDir(), "config")
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(embedderParams(), ioStreams, "mycli")
+	err := runCmd(t, cmd, ctx, "prod", "--kubeconfig", path)
+	require.NoError(t, err)
+	assert.Len(t, mock.LoginCalls, 1, "oauth cluster must auto-route to the openshift handler")
+	assert.Contains(t, buf.String(), "Logged in")
+}
+
+// TestCommandLogin_AutoRoutesOIDCToEntra verifies a detected OIDC cluster with a
+// resolved audience and no --handler routes to the "entra" handler.
+func TestCommandLogin_AutoRoutesOIDCToEntra(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx, mock := withNamedMockHandler(t, ctx, "entra")
+	mock.GetTokenResult = &auth.Token{AccessToken: "tok"}
+
+	resolver := &kubeapi.MockResolver{ResolveResult: &kubeapi.ClusterInfo{
+		Name:         "prod",
+		APIServerURL: "https://api.example.com:6443",
+		AuthType:     kubeapi.AuthTypeOIDC,
+		OIDCAudience: "api://cluster-client-id",
+	}}
+	ctx = kubeapi.WithResolver(ctx, resolver)
+
+	path := filepath.Join(t.TempDir(), "config")
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(embedderParams(), ioStreams, "mycli")
+	err := runCmd(t, cmd, ctx, "prod", "--kubeconfig", path)
+	require.NoError(t, err)
+	assert.Len(t, mock.LoginCalls, 1, "oidc cluster must auto-route to the entra handler")
+	assert.Contains(t, buf.String(), "Logged in")
+}
+
+// TestCommandLogin_AutoRouteOIDCNoAudienceErrors verifies that auto-routing an
+// OIDC cluster with no resolvable audience fails fast with ErrNoAudience mapped
+// to the InvalidInput exit code, before any kubeconfig is written.
+func TestCommandLogin_AutoRouteOIDCNoAudienceErrors(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx, _ = withNamedMockHandler(t, ctx, "entra")
+
+	resolver := &kubeapi.MockResolver{ResolveResult: &kubeapi.ClusterInfo{
+		Name:         "prod",
+		APIServerURL: "https://api.example.com:6443",
+		AuthType:     kubeapi.AuthTypeOIDC,
+		// No OIDCAudience: the entra route cannot scope the token.
+	}}
+	ctx = kubeapi.WithResolver(ctx, resolver)
+
+	path := filepath.Join(t.TempDir(), "config")
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+
+	cmd := CommandLogin(embedderParams(), ioStreams, "mycli")
+	err := runCmd(t, cmd, ctx, "prod", "--kubeconfig", path)
+	require.Error(t, err)
+	assert.Equal(t, exitcode.InvalidInput, exitcode.GetCode(err))
+	assert.Contains(t, err.Error(), "audience")
+	assert.NoFileExists(t, path, "login must fail before writing a kubeconfig entry")
 }
 
 func TestCommandLogin_VerifyFailsWithoutProvider(t *testing.T) {

--- a/pkg/cmd/scafctl/kube/logout.go
+++ b/pkg/cmd/scafctl/kube/logout.go
@@ -81,6 +81,10 @@ func CommandLogout(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ str
 				Kubeconfig: mgr,
 				Resolver:   kubeapi.ResolverFromContext(ctx),
 				BinaryName: cliParams.BinaryName,
+				// Mirror the login auto-routing policy so logout revokes the same
+				// handler an auto-routed login selected when the resolved cluster
+				// carries an AuthType but no explicit DefaultHandler.
+				AuthTypeHandlers: kubelogin.DefaultAuthTypeHandlers(),
 				HandlerLookup: func(ctx context.Context, name string) (kubelogin.Authenticator, error) {
 					return auth.GetHandler(ctx, name)
 				},

--- a/pkg/cmd/scafctl/kube/logout_test.go
+++ b/pkg/cmd/scafctl/kube/logout_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	kubeapi "github.com/oakwood-commons/scafctl/pkg/kube"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -93,6 +94,35 @@ func TestCommandLogout_RevokesResolverDefaultHandler(t *testing.T) {
 	logoutCmd := CommandLogout(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
 	require.NoError(t, runCmd(t, logoutCmd, ctx, "prod", "--kubeconfig", path))
 	assert.Equal(t, 1, mock.LogoutCalls, "resolver default handler must be revoked without --handler")
+}
+
+// TestCommandLogout_RevokesAuthTypeFallbackHandler verifies the logout CLI wires
+// DefaultAuthTypeHandlers so a cluster with an AuthType but no DefaultHandler is
+// revoked via the same auto-routing login used. Only the openshift mock is
+// registered, so a revoke proves the AuthType fallback selected it.
+func TestCommandLogout_RevokesAuthTypeFallbackHandler(t *testing.T) {
+	t.Parallel()
+	ctx, buf := newTestContext(t)
+	ctx, mock := withNamedMockHandler(t, ctx, "openshift")
+	mock.GetTokenResult = &auth.Token{AccessToken: "tok"}
+
+	// The resolver carries an OAuth AuthType but no DefaultHandler, mirroring an
+	// inventory that stamps authType only. Login auto-routes to openshift.
+	resolver := &kubeapi.MockResolver{ResolveResult: &kubeapi.ClusterInfo{
+		Name:         "prod",
+		APIServerURL: "https://api.example.com:6443",
+		AuthType:     kubeapi.AuthTypeOAuth,
+	}}
+	ctx = kubeapi.WithResolver(ctx, resolver)
+
+	path := filepath.Join(t.TempDir(), "config")
+	loginCmd := CommandLogin(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, loginCmd, ctx, "prod", "--kubeconfig", path))
+
+	buf.Reset()
+	logoutCmd := CommandLogout(embedderParams(), terminal.NewIOStreams(nil, buf, buf, false), "mycli")
+	require.NoError(t, runCmd(t, logoutCmd, ctx, "prod", "--kubeconfig", path))
+	assert.Equal(t, 1, mock.LogoutCalls, "AuthType fallback must revoke the auto-routed handler without --handler")
 }
 
 func TestCommandLogout_OutputUsesEffectiveClusterFromFlag(t *testing.T) {

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -187,7 +187,7 @@ type RootOptions struct {
 
 	// OfficialAuthHandlers overrides the default official auth handler registry
 	// used for auto-resolution. When nil and DisableOfficialAuthHandlers is
-	// false, the default registry (3 extracted first-party auth handlers) is
+	// false, the default registry (4 extracted first-party auth handlers) is
 	// used. Embedders can supply a custom registry via
 	// authofficial.NewRegistryFrom to extend or replace the default set.
 	OfficialAuthHandlers *authofficial.Registry
@@ -497,14 +497,44 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 				}
 			}
 
+			// ── Wire official auth handler registry for auto-resolution ──
+			// Same pattern as official providers. When the embedder provides a
+			// custom registry, use it. Otherwise, use the default registry
+			// unless disabled in config.
+			// NOTE: Resolved before custom OAuth2 handlers so their names can be
+			// reserved (a customOAuth2 must not shadow an official first-party
+			// handler), and before RegisterAuthHandlerPlugins so that
+			// configureAndRegisterAuthHandlers can read per-handler
+			// TrustedVerificationDomains.
+			var officialAuthReg *authofficial.Registry
+			if !cfg.Settings.DisableOfficialAuthHandlers {
+				officialAuthReg = opts.OfficialAuthHandlers
+				if officialAuthReg == nil {
+					officialAuthReg = authofficial.NewRegistry()
+				}
+				source := "default"
+				if opts.OfficialAuthHandlers != nil {
+					source = "embedder"
+				}
+				lgr.V(1).Info("official auth handler registry enabled", "count", officialAuthReg.Len(), "source", source)
+				ctx = authofficial.WithRegistry(ctx, officialAuthReg)
+			} else {
+				lgr.V(1).Info("official auth handler registry disabled via config")
+			}
+
 			// Register custom OAuth2 handlers from config
 			for _, customCfg := range cfg.Auth.CustomOAuth2 {
 				if validateErr := customoauth2.ValidateConfig(customCfg); validateErr != nil {
 					lgr.V(1).Info("warning: skipping invalid custom OAuth2 handler", "name", customCfg.Name, "error", validateErr)
 					continue
 				}
-				if authRegistry.Has(customCfg.Name) {
-					lgr.V(1).Info("warning: custom OAuth2 handler name conflicts with built-in handler, skipping", "name", customCfg.Name)
+				// Skip names already registered (an embedder builtin) or reserved
+				// by an official first-party handler, so user config cannot shadow
+				// a first-party handler name (github, gcp, entra, openshift, ...).
+				// When official handlers are disabled, officialAuthReg is nil and
+				// user configs are free to use those names.
+				if authRegistry.Has(customCfg.Name) || (officialAuthReg != nil && officialAuthReg.Has(customCfg.Name)) {
+					lgr.V(1).Info("warning: custom OAuth2 handler name conflicts with a reserved first-party handler, skipping", "name", customCfg.Name)
 					continue
 				}
 				var customOpts []customoauth2.Option
@@ -520,27 +550,6 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 						lgr.V(1).Info("warning: failed to register custom OAuth2 handler", "name", customCfg.Name, "error", regErr)
 					}
 				}
-			}
-
-			// ── Wire official auth handler registry for auto-resolution ──
-			// Same pattern as official providers. When the embedder provides a
-			// custom registry, use it. Otherwise, use the default registry
-			// unless disabled in config.
-			// NOTE: This must be wired before RegisterAuthHandlerPlugins so that
-			// configureAndRegisterAuthHandlers can read per-handler TrustedVerificationDomains.
-			if !cfg.Settings.DisableOfficialAuthHandlers {
-				officialAuthReg := opts.OfficialAuthHandlers
-				if officialAuthReg == nil {
-					officialAuthReg = authofficial.NewRegistry()
-				}
-				source := "default"
-				if opts.OfficialAuthHandlers != nil {
-					source = "embedder"
-				}
-				lgr.V(1).Info("official auth handler registry enabled", "count", officialAuthReg.Len(), "source", source)
-				ctx = authofficial.WithRegistry(ctx, officialAuthReg)
-			} else {
-				lgr.V(1).Info("official auth handler registry disabled via config")
 			}
 
 			// Register auth handler plugins if directories are configured

--- a/pkg/cmd/scafctl/root_coverage_test.go
+++ b/pkg/cmd/scafctl/root_coverage_test.go
@@ -430,7 +430,7 @@ func TestRoot_OfficialAuthHandlerRegistry_Enabled(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 	require.NotNil(t, registryFromCtx, "official auth handler registry should be set in context")
-	assert.Equal(t, 3, registryFromCtx.Len(), "default registry should contain 3 handlers")
+	assert.Equal(t, 4, registryFromCtx.Len(), "default registry should contain 4 handlers")
 }
 
 // TestRoot_OfficialAuthHandlerRegistry_CustomEmbedder verifies that an
@@ -509,7 +509,7 @@ func TestRoot_OfficialAuthHandlerRegistry_Enabled_NonDefaultBinary(t *testing.T)
 	err := cmd.Execute()
 	require.NoError(t, err)
 	require.NotNil(t, registryFromCtx, "official auth handler registry should be set for custom binary")
-	assert.Equal(t, 3, registryFromCtx.Len())
+	assert.Equal(t, 4, registryFromCtx.Len())
 }
 
 // TestRoot_PluginSignaturePolicy_Wired verifies that PluginSignaturePolicy is

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -982,7 +982,8 @@ type APITracingConfig struct {
 // (OCI registries, APIs, providers, etc.).
 type CustomOAuth2Config struct {
 	// Name is the handler identifier, used as: scafctl auth login <name>
-	// Must not conflict with built-in handler names (github, gcp, entra).
+	// Must not conflict with a reserved first-party (official) handler name
+	// (github, gcp, entra, openshift, ...); such configs are skipped at startup.
 	Name        string `json:"name" yaml:"name" mapstructure:"name" doc:"Handler name (used as CLI argument)" maxLength:"64" example:"quay"`
 	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty" mapstructure:"displayName" doc:"Human-readable display name" maxLength:"128" example:"Quay.io"`
 

--- a/pkg/credentialhelper/resolver_test.go
+++ b/pkg/credentialhelper/resolver_test.go
@@ -285,6 +285,21 @@ func TestAuthTokenResolver_Resolve(t *testing.T) {
 		assert.Contains(t, err.Error(), "not available")
 	})
 
+	t.Run("openshift integrated registry infers openshift handler", func(t *testing.T) {
+		t.Parallel()
+		handler := &mockAuthHandler{
+			name:   "openshift",
+			claims: &auth.Claims{Username: "developer"},
+		}
+		ctx, registry := configureAuthRegistry(t, context.Background(), handler)
+
+		resolver := NewAuthTokenResolver(registry)
+		cred, err := resolver.Resolve(ctx, "default-route-openshift-image-registry.apps.example.com")
+		require.NoError(t, err)
+		assert.Equal(t, "developer", cred.Username)
+		assert.Equal(t, "fresh-access-token", cred.Secret)
+	})
+
 	t.Run("handler token error returns error", func(t *testing.T) {
 		t.Parallel()
 		handler := &mockAuthHandler{

--- a/pkg/kube/login/login.go
+++ b/pkg/kube/login/login.go
@@ -58,7 +58,34 @@ var (
 	// authenticated identity via a post-login whoami. The kubeconfig entry is
 	// still written; only the verification step failed.
 	ErrVerificationFailed = errors.New("login: post-login identity verification failed")
+
+	// ErrNoAudience indicates the auth handler was auto-selected for an OIDC
+	// cluster (via the AuthType fallback) but no audience could be resolved to
+	// scope the minted token. An OIDC token without the cluster's audience
+	// cannot authenticate to the API server, so login fails fast rather than
+	// writing a kubeconfig entry that would reject every subsequent request.
+	ErrNoAudience = errors.New("login: OIDC cluster requires an audience; pass --audience or configure the cluster's oidcAudience")
 )
+
+// Default auth handler names used by DefaultAuthTypeHandlers to route a detected
+// cluster AuthType to a handler when the caller supplies none. Embedders that
+// ship different handlers override the policy by populating Deps.AuthTypeHandlers
+// themselves (or by setting DefaultHandler on their resolved clusters).
+const (
+	defaultOAuthHandler = "openshift"
+	defaultOIDCHandler  = "entra"
+)
+
+// DefaultAuthTypeHandlers returns the built-in policy that maps a detected
+// cluster AuthType to a fallback auth handler name: OpenShift OAuth clusters
+// route to the "openshift" handler and OIDC clusters to "entra". The CLI wires
+// this into Deps.AuthTypeHandlers; embedders may supply their own map instead.
+func DefaultAuthTypeHandlers() map[kube.AuthType]string {
+	return map[kube.AuthType]string{
+		kube.AuthTypeOAuth: defaultOAuthHandler,
+		kube.AuthTypeOIDC:  defaultOIDCHandler,
+	}
+}
 
 // Authenticator is the subset of auth.Handler the login orchestration needs.
 // *auth.Handler implementations satisfy it; tests supply a stub.
@@ -100,6 +127,16 @@ type Deps struct {
 
 	// Resolver resolves cluster names to connection details. Optional.
 	Resolver kube.ClusterResolver
+
+	// AuthTypeHandlers maps a detected cluster AuthType to a fallback auth
+	// handler name, consulted only when neither an explicit --handler nor the
+	// resolved cluster's DefaultHandler is set. It powers zero-config
+	// `login <cluster>`: an auto-detected OpenShift OAuth cluster routes to the
+	// "openshift" handler, an OIDC cluster to "entra". Nil disables the
+	// AuthType fallback (undetected clusters then require an explicit handler).
+	// The CLI populates this from DefaultAuthTypeHandlers; embedders may supply
+	// their own policy.
+	AuthTypeHandlers map[kube.AuthType]string
 
 	// LoginRunner, when set, performs the interactive handler login. It lets the
 	// caller wrap the login with a progress UI (e.g. the shared kvx status TUI
@@ -354,8 +391,29 @@ func resolveHandler(ctx context.Context, deps Deps, req Request, info kube.Clust
 		return deps.Handler, nil
 	}
 	name := firstNonEmpty(req.Handler, info.DefaultHandler)
+	// When neither an explicit --handler nor the cluster's DefaultHandler is
+	// set, fall back to the detected auth type's default handler (e.g. an
+	// auto-detected OpenShift OAuth cluster routes to "openshift", an OIDC
+	// cluster to "entra"). This powers zero-config `login <cluster>`. An
+	// undetected AuthType (AuthTypeAuto) has no mapping and still errors below.
+	usedAuthTypeFallback := false
+	if name == "" && deps.AuthTypeHandlers != nil {
+		if mapped := deps.AuthTypeHandlers[info.AuthType]; mapped != "" {
+			name = mapped
+			usedAuthTypeFallback = true
+		}
+	}
 	if name == "" {
 		return nil, ErrNoHandler
+	}
+	// The OIDC route mints a cluster-scoped token, which needs the cluster's
+	// audience (its client ID). When the handler was auto-selected for an OIDC
+	// cluster but no audience was resolved (from the inventory/alias, --audience,
+	// or the resolver), fail fast before the interactive login rather than write
+	// a kubeconfig entry that cannot authenticate. An explicitly requested
+	// handler is left to the caller's intent and skips this guard.
+	if usedAuthTypeFallback && info.AuthType == kube.AuthTypeOIDC && info.OIDCAudience == "" {
+		return nil, ErrNoAudience
 	}
 	if deps.HandlerLookup == nil {
 		return nil, ErrNoHandler

--- a/pkg/kube/login/login_test.go
+++ b/pkg/kube/login/login_test.go
@@ -890,3 +890,114 @@ func TestLogin_VerifyFailure(t *testing.T) {
 	require.NotNil(t, res)
 	assert.Equal(t, "prod", res.ContextName)
 }
+
+func TestDefaultAuthTypeHandlers(t *testing.T) {
+	t.Parallel()
+
+	m := DefaultAuthTypeHandlers()
+	assert.Equal(t, "openshift", m[kube.AuthTypeOAuth])
+	assert.Equal(t, "entra", m[kube.AuthTypeOIDC])
+	// Auto has no default mapping: an undetected cluster must require an
+	// explicit handler rather than guess.
+	_, ok := m[kube.AuthTypeAuto]
+	assert.False(t, ok)
+}
+
+func TestResolveHandler_AuthTypeFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		req         Request
+		info        kube.ClusterInfo
+		authMap     map[kube.AuthType]string
+		wantHandler string
+		wantErr     error
+	}{
+		{
+			name:        "oauth detected routes to openshift",
+			info:        kube.ClusterInfo{AuthType: kube.AuthTypeOAuth},
+			authMap:     DefaultAuthTypeHandlers(),
+			wantHandler: "openshift",
+		},
+		{
+			name:        "oidc detected with audience routes to entra",
+			info:        kube.ClusterInfo{AuthType: kube.AuthTypeOIDC, OIDCAudience: "aud"},
+			authMap:     DefaultAuthTypeHandlers(),
+			wantHandler: "entra",
+		},
+		{
+			name:    "oidc detected without audience errors",
+			info:    kube.ClusterInfo{AuthType: kube.AuthTypeOIDC},
+			authMap: DefaultAuthTypeHandlers(),
+			wantErr: ErrNoAudience,
+		},
+		{
+			name:    "auto undetected still errors",
+			info:    kube.ClusterInfo{AuthType: kube.AuthTypeAuto},
+			authMap: DefaultAuthTypeHandlers(),
+			wantErr: ErrNoHandler,
+		},
+		{
+			name:        "explicit handler wins over fallback map",
+			req:         Request{Handler: "github"},
+			info:        kube.ClusterInfo{AuthType: kube.AuthTypeOAuth},
+			authMap:     DefaultAuthTypeHandlers(),
+			wantHandler: "github",
+		},
+		{
+			name:        "cluster default handler wins over fallback map",
+			info:        kube.ClusterInfo{AuthType: kube.AuthTypeOAuth, DefaultHandler: "entra"},
+			authMap:     DefaultAuthTypeHandlers(),
+			wantHandler: "entra",
+		},
+		{
+			name:    "nil map disables the fallback",
+			info:    kube.ClusterInfo{AuthType: kube.AuthTypeOAuth},
+			authMap: nil,
+			wantErr: ErrNoHandler,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotName string
+			deps := Deps{
+				AuthTypeHandlers: tt.authMap,
+				HandlerLookup: func(_ context.Context, name string) (Authenticator, error) {
+					gotName = name
+					return &stubAuth{name: name}, nil
+				},
+			}
+			h, err := resolveHandler(context.Background(), deps, tt.req, tt.info)
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, h)
+			assert.Equal(t, tt.wantHandler, h.Name())
+			assert.Equal(t, tt.wantHandler, gotName)
+		})
+	}
+}
+
+func TestResolveHandler_ExplicitHandlerSkipsAudienceGuard(t *testing.T) {
+	t.Parallel()
+
+	// An explicitly requested handler on an OIDC cluster with no audience must
+	// NOT trip ErrNoAudience: the guard applies only to the auto-routed path.
+	deps := Deps{
+		AuthTypeHandlers: DefaultAuthTypeHandlers(),
+		HandlerLookup: func(_ context.Context, name string) (Authenticator, error) {
+			return &stubAuth{name: name}, nil
+		},
+	}
+	h, err := resolveHandler(context.Background(), deps,
+		Request{Handler: "entra"},
+		kube.ClusterInfo{AuthType: kube.AuthTypeOIDC})
+	require.NoError(t, err)
+	assert.Equal(t, "entra", h.Name())
+}

--- a/pkg/kube/login/logout.go
+++ b/pkg/kube/login/logout.go
@@ -162,8 +162,12 @@ func LogoutAll(ctx context.Context, deps Deps, req LogoutAllRequest) (*LogoutAll
 // logoutHandler returns the handler whose cached credentials should be revoked.
 // An explicit Deps.Handler wins; otherwise the resolved cluster's DefaultHandler
 // is looked up best-effort so "logout <cluster>" revokes the same handler that
-// "login <cluster>" used. Returns nil when no handler can be determined; the
-// caller treats credential revocation as optional.
+// "login <cluster>" used. When the cluster carries no DefaultHandler but does
+// carry an AuthType, the same AuthTypeHandlers fallback that login uses is
+// applied, so an auto-routed login can be cleanly revoked. A pure --server
+// login with no resolver cannot be re-detected here and still needs an explicit
+// --handler. Returns nil when no handler can be determined; the caller treats
+// credential revocation as optional.
 func logoutHandler(ctx context.Context, deps Deps, req LogoutRequest) Authenticator {
 	if deps.Handler != nil {
 		return deps.Handler
@@ -172,10 +176,17 @@ func logoutHandler(ctx context.Context, deps Deps, req LogoutRequest) Authentica
 		return nil
 	}
 	resolved, err := deps.Resolver.Resolve(ctx, req.Cluster)
-	if err != nil || resolved == nil || resolved.DefaultHandler == "" {
+	if err != nil || resolved == nil {
 		return nil
 	}
-	handler, err := deps.HandlerLookup(ctx, resolved.DefaultHandler)
+	name := resolved.DefaultHandler
+	if name == "" && deps.AuthTypeHandlers != nil {
+		name = deps.AuthTypeHandlers[resolved.AuthType]
+	}
+	if name == "" {
+		return nil
+	}
+	handler, err := deps.HandlerLookup(ctx, name)
 	if err != nil {
 		return nil
 	}

--- a/pkg/kube/login/logout_test.go
+++ b/pkg/kube/login/logout_test.go
@@ -169,6 +169,78 @@ func TestLogout_NoDefaultHandlerSkipsRevoke(t *testing.T) {
 	assert.False(t, lookupCalled, "no DefaultHandler means no handler lookup")
 }
 
+func TestLogout_RevokesAuthTypeFallbackHandler(t *testing.T) {
+	t.Parallel()
+
+	// The resolved cluster carries an AuthType but no DefaultHandler (e.g. an
+	// inventory that stamps authType only). Logout applies the same
+	// AuthTypeHandlers fallback that login used, revoking the auto-routed handler.
+	handler := &stubAuth{name: "openshift"}
+	var lookupName string
+	kc := &stubKube{removeRes: kubeconfig.RemoveResult{Removed: true}}
+	deps := Deps{
+		Kubeconfig:       kc,
+		Resolver:         &kube.MockResolver{ResolveResult: &kube.ClusterInfo{Name: "prod", AuthType: kube.AuthTypeOAuth}},
+		AuthTypeHandlers: DefaultAuthTypeHandlers(),
+		HandlerLookup: func(_ context.Context, name string) (Authenticator, error) {
+			lookupName = name
+			return handler, nil
+		},
+	}
+
+	res, err := Logout(context.Background(), deps, LogoutRequest{Cluster: "prod"})
+	require.NoError(t, err)
+	assert.True(t, res.Removed)
+	assert.Equal(t, "openshift", lookupName, "AuthType fallback must drive the revoke when DefaultHandler is empty")
+	assert.Equal(t, 1, handler.logoutCalls)
+}
+
+func TestLogout_DefaultHandlerWinsOverAuthTypeFallback(t *testing.T) {
+	t.Parallel()
+
+	// When both are present, the explicit DefaultHandler wins over the AuthType
+	// fallback map.
+	var lookupName string
+	kc := &stubKube{removeRes: kubeconfig.RemoveResult{Removed: true}}
+	deps := Deps{
+		Kubeconfig:       kc,
+		Resolver:         &kube.MockResolver{ResolveResult: &kube.ClusterInfo{Name: "prod", DefaultHandler: "github", AuthType: kube.AuthTypeOAuth}},
+		AuthTypeHandlers: DefaultAuthTypeHandlers(),
+		HandlerLookup: func(_ context.Context, name string) (Authenticator, error) {
+			lookupName = name
+			return &stubAuth{name: name}, nil
+		},
+	}
+
+	_, err := Logout(context.Background(), deps, LogoutRequest{Cluster: "prod"})
+	require.NoError(t, err)
+	assert.Equal(t, "github", lookupName, "DefaultHandler must win over the AuthType fallback")
+}
+
+func TestLogout_AuthTypeFallbackUndetectedSkipsRevoke(t *testing.T) {
+	t.Parallel()
+
+	// AuthType is unset (auto/undetected) with no DefaultHandler: the fallback
+	// map has no entry for auto, so no handler is revoked (the entry is still
+	// removed).
+	lookupCalled := false
+	kc := &stubKube{removeRes: kubeconfig.RemoveResult{Removed: true}}
+	deps := Deps{
+		Kubeconfig:       kc,
+		Resolver:         &kube.MockResolver{ResolveResult: &kube.ClusterInfo{Name: "prod"}},
+		AuthTypeHandlers: DefaultAuthTypeHandlers(),
+		HandlerLookup: func(_ context.Context, _ string) (Authenticator, error) {
+			lookupCalled = true
+			return &stubAuth{name: "x"}, nil
+		},
+	}
+
+	res, err := Logout(context.Background(), deps, LogoutRequest{Cluster: "prod"})
+	require.NoError(t, err)
+	assert.True(t, res.Removed)
+	assert.False(t, lookupCalled, "undetected AuthType has no fallback mapping")
+}
+
 func TestLogout_DefaultHandlerLookupErrorIsNonFatal(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/plugin/auth_grpc_client_test.go
+++ b/pkg/plugin/auth_grpc_client_test.go
@@ -1371,6 +1371,114 @@ func TestConfigureAndRegisterAuthHandlers_SetsTrustedDomains(t *testing.T) {
 	assert.Equal(t, []string{"github.com"}, wrapper.trustedDomains)
 }
 
+func TestApplyTrustedDomains(t *testing.T) {
+	t.Parallel()
+
+	officialWithDomains := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "github", CatalogRef: "github", TrustedVerificationDomains: []string{"github.com"}},
+	})
+	// openshift is official but carries no hardcoded domains (per-cluster host).
+	officialEmpty := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "openshift", CatalogRef: "openshift"},
+	})
+
+	tests := []struct {
+		name           string
+		handler        string
+		officialReg    *authofficial.Registry
+		cfgDomains     []string
+		handlerDomains []string
+		wantTrusted    []string
+		wantRequire    bool
+	}{
+		{
+			name:        "official with hardcoded domains is validated, not fail-closed",
+			handler:     "github",
+			officialReg: officialWithDomains,
+			wantTrusted: []string{"github.com"},
+			wantRequire: false,
+		},
+		{
+			name:        "official without hardcoded domains fails closed (e.g. openshift)",
+			handler:     "openshift",
+			officialReg: officialEmpty,
+			wantRequire: true,
+		},
+		{
+			name:           "official without domains but operator config is validated",
+			handler:        "openshift",
+			officialReg:    officialEmpty,
+			handlerDomains: []string{"oauth.mycluster.example.com"},
+			wantTrusted:    []string{"oauth.mycluster.example.com"},
+			wantRequire:    false,
+		},
+		{
+			name:        "third-party handler with no config fails closed",
+			handler:     "acme",
+			officialReg: officialEmpty, // acme absent
+			wantRequire: true,
+		},
+		{
+			name:        "nil registry with global config is validated",
+			handler:     "acme",
+			officialReg: nil,
+			cfgDomains:  []string{"login.acme.example.com"},
+			wantTrusted: []string{"login.acme.example.com"},
+			wantRequire: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			w := &AuthHandlerWrapper{
+				client:      &AuthHandlerClient{plugin: &MockAuthHandlerPlugin{}, name: "p"},
+				handlerName: tt.handler,
+				info:        AuthHandlerInfo{Name: tt.handler},
+			}
+			applyTrustedDomains(w, tt.handler, tt.officialReg, tt.cfgDomains, tt.handlerDomains)
+
+			w.mu.RLock()
+			defer w.mu.RUnlock()
+			assert.Equal(t, tt.wantRequire, w.requireTrustedDomains)
+			if tt.wantTrusted == nil {
+				assert.Empty(t, w.trustedDomains)
+			} else {
+				assert.Equal(t, tt.wantTrusted, w.trustedDomains)
+			}
+		})
+	}
+}
+
+// TestConfigureAndRegisterAuthHandlers_FailsClosedOnEmptyTrusted verifies the
+// eager registration path fails closed for an official handler that carries no
+// hardcoded trusted domains (e.g. openshift), so device-code verification cannot
+// be phished via an arbitrary HTTPS URL.
+func TestConfigureAndRegisterAuthHandlers_FailsClosedOnEmptyTrusted(t *testing.T) {
+	t.Parallel()
+
+	reg := authofficial.NewRegistryFrom([]authofficial.AuthHandler{
+		{Name: "openshift", CatalogRef: "openshift"}, // no hardcoded domains
+	})
+	ctx := authofficial.WithRegistry(context.Background(), reg)
+
+	registry := auth.NewRegistry()
+	ahClient := &AuthHandlerClient{plugin: &MockAuthHandlerPlugin{}, name: "test-plugin"}
+	handlers := []AuthHandlerInfo{{Name: "openshift", DisplayName: "OpenShift"}}
+
+	configureAndRegisterAuthHandlers(ctx, registry, ahClient, handlers, nil)
+
+	h, err := registry.Get("openshift")
+	require.NoError(t, err)
+	wrapper, ok := h.(*AuthHandlerWrapper)
+	require.True(t, ok)
+	wrapper.mu.RLock()
+	defer wrapper.mu.RUnlock()
+	assert.True(t, wrapper.requireTrustedDomains, "official handler with empty trusted domains must fail closed")
+	assert.Empty(t, wrapper.trustedDomains)
+}
+
 // =====================================================================
 // KillAll / KillAllAuthHandlers additional tests
 // =====================================================================

--- a/pkg/plugin/wrapper_auth.go
+++ b/pkg/plugin/wrapper_auth.go
@@ -416,21 +416,9 @@ func configureAndRegisterAuthHandlers(ctx context.Context, registry *auth.Regist
 
 		wrapper := NewAuthHandlerWrapper(client, info)
 
-		// Set trusted domains: merge per-handler official domains + global config
-		// domains + per-handler config domains. Non-official handlers do not
-		// inherit the hardcoded official domains; their trust comes from config.
-		trusted := buildTrustedDomains(info.Name, officialReg, cfgDomains, handlerCfgs[info.Name].TrustedVerificationDomains)
-		if len(trusted) > 0 {
-			wrapper.SetTrustedDomains(trusted)
-		}
-
-		// Fail closed on device-code verification for non-official handlers: a
-		// catalog-resolved third-party handler must not display arbitrary
-		// verification URLs without configured trusted domains. Official
-		// handlers carry hardcoded trust domains and are exempt.
-		if officialReg == nil || !officialReg.Has(info.Name) {
-			wrapper.SetRequireTrustedDomains(true)
-		}
+		// Resolve trusted verification domains (official + config) onto the
+		// wrapper and fail closed on device-code verification when none resolve.
+		applyTrustedDomains(wrapper, info.Name, officialReg, cfgDomains, handlerCfgs[info.Name].TrustedVerificationDomains)
 
 		if err := registry.Register(wrapper); err != nil {
 			lgr.V(1).Info("failed to register auth handler", "handler", info.Name, "error", err)
@@ -498,6 +486,22 @@ func buildTrustedDomains(handlerName string, officialReg *authofficial.Registry,
 	domains = append(domains, cfgDomains...)
 	domains = append(domains, handlerDomains...)
 	return domains
+}
+
+// applyTrustedDomains resolves a handler's trusted device-code verification
+// domains (official hardcoded + operator config) onto the wrapper. When none
+// resolve it fails closed by requiring trusted domains, so a plugin cannot phish
+// via an arbitrary HTTPS verification URL. This uniformly covers catalog-resolved
+// third-party handlers (no hardcoded domains) and official handlers whose OAuth
+// host is per-cluster and thus carry no hardcoded domains (e.g. openshift);
+// operators supply trust via auth.handlers.<name>.trustedVerificationDomains.
+func applyTrustedDomains(wrapper *AuthHandlerWrapper, handlerName string, officialReg *authofficial.Registry, cfgDomains, handlerDomains []string) {
+	trusted := buildTrustedDomains(handlerName, officialReg, cfgDomains, handlerDomains)
+	if len(trusted) > 0 {
+		wrapper.SetTrustedDomains(trusted)
+		return
+	}
+	wrapper.SetRequireTrustedDomains(true)
 }
 
 // injectAuthHandlerSettings reads per-handler auth configuration from the app

--- a/pkg/plugin/wrapper_auth_lazy.go
+++ b/pkg/plugin/wrapper_auth_lazy.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	authofficial "github.com/oakwood-commons/scafctl/pkg/auth/official"
+	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 )
 
@@ -99,12 +100,17 @@ func NewLazyAuthHandlerWrapper(cfg LazyAuthHandlerConfig) *LazyAuthHandlerWrappe
 				if info.Name == cfg.Name {
 					wrapper := NewAuthHandlerWrapper(client, info)
 
-					// Set trusted domains from official registry + config.
-					if cfg.OfficialRegistry != nil {
-						if official, ok := cfg.OfficialRegistry.Get(cfg.Name); ok {
-							wrapper.SetTrustedDomains(official.TrustedVerificationDomains)
-						}
+					// Resolve trusted domains (official + operator config) and fail
+					// closed on device-code verification when none resolve. Official
+					// handlers whose OAuth host is per-cluster (e.g. openshift) carry
+					// no hardcoded domains and rely on this until
+					// auth.handlers.<name>.trustedVerificationDomains is set.
+					var cfgDomains, handlerDomains []string
+					if appCfg := config.FromContext(ctx); appCfg != nil {
+						cfgDomains = appCfg.Auth.TrustedVerificationDomains
+						handlerDomains = appCfg.Auth.Handlers[cfg.Name].TrustedVerificationDomains
 					}
+					applyTrustedDomains(wrapper, cfg.Name, cfg.OfficialRegistry, cfgDomains, handlerDomains)
 
 					// Configure the handler.
 					if cfg.PluginCfg != nil {

--- a/pkg/solution/prepare/prepare_test.go
+++ b/pkg/solution/prepare/prepare_test.go
@@ -1352,6 +1352,7 @@ func TestResolveOfficialAuthHandlers_AllRegistered(t *testing.T) {
 	_ = authReg.Register(auth.NewMockHandler("github"))
 	_ = authReg.Register(auth.NewMockHandler("entra"))
 	_ = authReg.Register(auth.NewMockHandler("gcp"))
+	_ = authReg.Register(auth.NewMockHandler("openshift"))
 
 	officialReg := authofficial.NewRegistry()
 	lgr := logr.Discard()

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -3441,23 +3441,36 @@ func TestIntegration_CustomOAuth2Handler_AuthStatus(t *testing.T) {
 func TestIntegration_CustomOAuth2Handler_NameConflict(t *testing.T) {
 	t.Parallel()
 
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "config.yaml")
-	configContent := `auth:
+	// A customOAuth2 config must not shadow a reserved first-party (official)
+	// handler name. The reserved set is derived from the official registry, so
+	// both the long-standing handlers (github) and newer ones (openshift) are
+	// protected. Such configs are skipped at startup without crashing.
+	for _, name := range []string{"github", "openshift"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "config.yaml")
+			configContent := `auth:
   customOAuth2:
-    - name: github
+    - name: ` + name + `
       displayName: "Conflict"
       tokenURL: "https://example.com/oauth/token"
       clientID: "test-client"
       clientSecret: "test-secret"
       defaultFlow: client_credentials
 `
-	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o600))
+			require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0o600))
 
-	// The handler should be skipped (name conflicts with built-in)
-	// but the CLI should not crash
-	_, _, exitCode := runScafctl(t, "--config", configPath, "auth", "list")
-	assert.Equal(t, 0, exitCode)
+			// With debug logging on, the startup skip is observable. The CLI
+			// must not crash, and the conflicting handler must be skipped.
+			_, stderr, exitCode := runScafctl(t, "--config", configPath, "--log-level", "debug", "auth", "list")
+			assert.Equal(t, 0, exitCode)
+			assert.Containsf(t, stderr, "skipping", "reserved first-party name %q must be skipped", name)
+			assert.Contains(t, stderr, name)
+		})
+	}
 }
 
 func TestIntegration_CatalogListHelp(t *testing.T) {
@@ -5714,21 +5727,21 @@ settings:
 	}
 
 	binDir := t.TempDir()
-	binPath := filepath.Join(binDir, "scafctl-plugin-auth-openshift")
+	binPath := filepath.Join(binDir, "scafctl-plugin-auth-acme")
 	require.NoError(t, os.WriteFile(binPath, []byte("dummy-auth-handler"), 0o755))
 	platform := runtime.GOOS + "/" + runtime.GOARCH
 
 	_, buildErr, buildExit := runScafctlWithEnv(t, env, "build", "plugin",
-		"--name", "openshift",
+		"--name", "acme",
 		"--kind", "auth-handler",
 		"--version", "0.1.0",
 		"--platform", platform+"="+binPath)
 	require.Equal(t, 0, buildExit, "build plugin failed: %s", buildErr)
 
 	// Policy blocks resolution of the third-party handler.
-	_, stderr, exitCode := runScafctlWithEnv(t, env, "auth", "handlers", "install", "openshift")
+	_, stderr, exitCode := runScafctlWithEnv(t, env, "auth", "handlers", "install", "acme")
 	assert.NotEqual(t, 0, exitCode)
-	assert.Contains(t, stderr, "openshift")
+	assert.Contains(t, stderr, "acme")
 	assert.Contains(t, stderr, "disabled")
 }
 


### PR DESCRIPTION
Implement the in-core Phase 4 wiring for OpenShift/Kubernetes auth so a single `kube login` works for both OpenShift OAuth and Entra clusters and serves the held credential back to kubectl/oc, docker/podman.

- Register `openshift` in the official auth-handler registry so it is auto-fetched from the OCI catalog like the other first-party handlers.
- Add two-path routing to `kube login`/`kube logout`: an auto-detected OpenShift OAuth cluster routes to the `openshift` handler and an OIDC cluster to `entra`, via a data-driven `Deps.AuthTypeHandlers` policy (embedder-overridable). An OIDC route with no resolvable audience now fails fast with a new `ErrNoAudience` instead of writing an unusable kubeconfig entry.
- Infer the `openshift` handler for the OpenShift integrated image registry (default route + in-cluster service hosts) in the credential helper, so docker/podman pulls fetch fresh tokens.
- Derive reserved auth-handler names from the official registry at startup and remove the stale static `builtinHandlerNames` / `IsBuiltinHandlerName`.
- Docs: mark Phase 4 shipped, document auto-routing and the `auth.handlers.<name>.plugin` config pin, add OpenShift login and credential-helper examples.

BREAKING CHANGE: removes the exported `catalog.IsBuiltinHandlerName` (reserved handler names are now derived from the official registry). A `customOAuth2` config whose name matches an official handler (github, gcp, entra, openshift) is now skipped at startup rather than registered.

closes #565