### PR TITLE
feat(file): add parse option to file provider read operation

### DIFF
--- a/docs/tutorials/file-provider-tutorial.md
+++ b/docs/tutorials/file-provider-tutorial.md
@@ -78,6 +78,79 @@ Output:
 }
 ```
 
+### Parsing Structured Content
+
+By default `read` returns the file body as a raw string in `content`. To work with
+the data as a structured object, set the `parse` input. The parsed value is
+returned in an additional `object` field, so you do not need a separate CEL
+`json.unmarshal` / `yaml.unmarshal` resolver.
+
+Reach for `parse: auto` in most cases -- it picks the decoder from the file
+extension (`.json`, `.yaml`, `.yml`), so you never hand-pick the format:
+
+```yaml
+spec:
+  resolvers:
+    config:
+      type: any
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: config.yaml
+              parse: auto   # decoder chosen from the .yaml extension
+```
+
+Output (raw `content` is still present alongside the parsed `object`):
+
+```json
+{
+  "config": {
+    "content": "name: my-project\nversion: 1.0.0\n",
+    "object": { "name": "my-project", "version": "1.0.0" },
+    "path": "/abs/path/to/config.yaml"
+  }
+}
+```
+
+Downstream resolvers then read fields directly, e.g. `_.config.object.version`.
+
+#### Forcing a decoder
+
+Use an explicit `parse: yaml` (or `parse: json`) when the extension cannot be
+trusted -- for example a file with no data extension, or one named `.conf`,
+`.txt`, or similar that actually holds YAML:
+
+```yaml
+spec:
+  resolvers:
+    settings:
+      type: any
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: settings.conf   # holds YAML, but the extension won't reveal it
+              parse: yaml
+```
+
+Accepted `parse` values:
+
+| Value | Behavior |
+|-------|----------|
+| `json` | Parse content as JSON. |
+| `yaml` | Parse content as YAML. |
+| `auto` | Pick the decoder from the file extension (`.json`, `.yaml`, `.yml`); fall back to content sniffing (YAML then JSON) for other extensions. |
+| (omitted) | Return raw string `content` only (default). |
+
+Parsing fails loudly: malformed content returns an error rather than a silent
+`nil`. `parse` is ignored when `encoding` is `binary`. Note that `json` decodes
+numbers as floating point while `yaml` decodes integers as integers; in `auto`
+mode the winning decoder (chosen by extension) determines the numeric type --
+relevant for exact numeric comparisons in CEL.
+
 ---
 
 ## Writing Files

--- a/docs/tutorials/provider-output-shapes.md
+++ b/docs/tutorials/provider-output-shapes.md
@@ -159,7 +159,8 @@ Returns file content, or for `write-tree`, information about written files.
 
 | Capability | Fields | Type | Description |
 |-----------|--------|------|-------------|
-| from | `content` | string | Raw file content |
+| from / transform | `content` | string | Raw file content |
+| | `object` | any | Parsed content (only when the `parse` input is set to `json`, `yaml`, or `auto`) |
 | | `path` | string | Resolved file path |
 | | `size` | int | File size in bytes |
 | action (`write-tree`) | `success` | bool | Whether all files were written |

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -447,6 +447,7 @@ a tree of files.
 | `content` | string | ❌ | Content to write (required for `write`) |
 | `createDirs` | bool | ❌ | Create parent directories if missing (for `write`) |
 | `encoding` | string | ❌ | File encoding: `utf-8`, `binary` (default: `utf-8`) |
+| `parse` | string | ❌ | Parse file content into a structured `object` (for `read`): `json`, `yaml`, or `auto` (decoder chosen by file extension `.json`/`.yaml`/`.yml`, else content-sniffed). Malformed content errors. Omitted returns raw `content` only. Ignored when `encoding` is `binary`. |
 | `basePath` | string | ❌ | Destination root directory (required for `write-tree`) |
 | `entries` | array | ❌ | Array of `{path, content}` objects (required for `write-tree`) |
 | `outputPath` | string | ❌ | Go template to transform each entry's path before writing (`write-tree` only). Available variables: `__filePath`, `__fileName`, `__fileStem`, `__fileExtension`, `__fileDir`. Sprig functions supported. |
@@ -456,6 +457,7 @@ a tree of files.
 | Field | Type | Description |
 |-------|------|-------------|
 | `content` | string | File content (for `read`) |
+| `object` | any | Parsed content (for `read`, only when `parse` is set) |
 | `exists` | bool | Whether file exists |
 | `size` | int | File size in bytes |
 | `success` | bool | Operation success (action only) |

--- a/docs/tutorials/reference-data-lookups.md
+++ b/docs/tutorials/reference-data-lookups.md
@@ -108,7 +108,7 @@ Given `regions.json`:
 }
 ~~~
 
-Read it, then parse and query with CEL:
+Read and parse it in one step, then query with CEL:
 
 ~~~yaml
 spec:
@@ -124,7 +124,7 @@ spec:
             inputs:
               value: us-east
 
-    # `file` read returns an object; access the file body via `.content`.
+    # `file` read with `parse: json` returns the parsed value in `.object`.
     regionsFile:
       type: any
       resolve:
@@ -133,8 +133,9 @@ spec:
             inputs:
               operation: read
               path: regions.json
+              parse: json
 
-    # Parse once with cel.bind, then look up the key with a safe default.
+    # Bind the parsed object once, then look up the key with a safe default.
     quota:
       type: number
       resolve:
@@ -142,13 +143,14 @@ spec:
           - provider: cel
             inputs:
               expression: >
-                cel.bind(t, json.unmarshal(_.regionsFile.content),
+                cel.bind(t, _.regionsFile.object,
                   _.region in t ? t[_.region].quota : 0
                 )
 ~~~
 
-For a YAML dataset, swap `json.unmarshal` for `yaml.unmarshal`. The `file` read
-returns `{ content, path, size }`, so the payload is always at `.content`.
+For a YAML dataset, use `parse: yaml` instead. The `file` read returns
+`{ content, path, size }`, plus `object` (the parsed value) when `parse` is set;
+the raw text is always available at `.content`.
 
 ## Pattern 3: Remote Dataset
 
@@ -206,11 +208,11 @@ _.region in _.regionTable
   : {"code": "unknown", "quota": 0, "tier": "unknown"}
 ~~~
 
-When the source is a parsed file or HTTP body, bind the parsed value once with
-`cel.bind` so you do not unmarshal it twice:
+When the source is an already-parsed file object or an HTTP body, bind the
+value once with `cel.bind` so you do not unmarshal or re-reference it twice:
 
 ~~~cel
-cel.bind(t, json.unmarshal(_.regionsFile.content),
+cel.bind(t, _.regionsFile.object,
   _.region in t ? t[_.region].quota : 0
 )
 ~~~

--- a/examples/solutions/reference-data-lookup/README.md
+++ b/examples/solutions/reference-data-lookup/README.md
@@ -2,8 +2,7 @@
 
 Resolve values from curated reference data (a region/quota taxonomy) by
 composing existing providers. There is no dedicated "dataset" provider -- and
-you do not need one. `static`/`file`/`http` supply the data, CEL parses and
-queries it.
+you do not need one. `static`/`file`/`http` supply the data, CEL queries it.
 
 ## What It Does
 
@@ -12,9 +11,9 @@ queries it.
 2. **Pattern 1 -- inline table**: embeds the taxonomy with `static`
    (`regionTable`) and looks up the record with a safe default (`regionRecord`),
    then derives a scalar (`regionCode`).
-3. **Pattern 2 -- local dataset file**: reads `regions.json` with the `file`
-   provider (`regionsFile`), parses it with `json.unmarshal`, and looks up the
-   `quota` for the key (`quota`).
+3. **Pattern 2 -- local dataset file**: reads and parses `regions.json` with the
+   `file` provider (`regionsFile`, using `parse: json`), then looks up the
+   `quota` for the key (`quota`) directly from `_.regionsFile.object`.
 
 A remote dataset uses the same shape with `provider: http` in place of `file`;
 that snippet lives in the tutorial so this example stays hermetic.
@@ -48,8 +47,8 @@ scafctl run resolver -f examples/solutions/reference-data-lookup/solution.yaml -
 | `regionTable` | `static` | Inline taxonomy (name -> attributes) |
 | `regionRecord` | `cel` | Keyed lookup with `in` guard + fallback record |
 | `regionCode` | `cel` | Derive a scalar from the record |
-| `regionsFile` | `file` (`read`) | Load an on-disk dataset |
-| `quota` | `cel` | `json.unmarshal` + `cel.bind` + guarded lookup |
+| `regionsFile` | `file` (`read`, `parse: json`) | Load and parse an on-disk dataset |
+| `quota` | `cel` | `cel.bind` + guarded lookup on the parsed object |
 
 ## Safe Lookups
 
@@ -61,10 +60,10 @@ _.region in _.regionTable
   : {"code": "unknown", "quota": 0, "tier": "unknown"}
 ```
 
-For a parsed file, bind the parsed value once to avoid re-parsing:
+For a parsed file, bind the parsed object once for a clean guarded lookup:
 
 ```cel
-cel.bind(t, json.unmarshal(_.regionsFile.content),
+cel.bind(t, _.regionsFile.object,
   _.region in t ? t[_.region].quota : 0
 )
 ```

--- a/examples/solutions/reference-data-lookup/solution.yaml
+++ b/examples/solutions/reference-data-lookup/solution.yaml
@@ -20,7 +20,7 @@ metadata:
 
     Demonstrates the three canonical source patterns:
       1. Inline table via the `static` provider + keyed CEL lookup.
-      2. Local dataset file via the `file` provider (`read`) + `json.unmarshal`.
+      2. Local dataset file via the `file` provider (`read` with `parse: json`).
       3. Safe lookups that fall back to a default when the key is absent.
 
     A remote/HTTP dataset follows the same shape with `provider: http` in place
@@ -85,12 +85,13 @@ spec:
               expression: _.regionRecord.code
 
     # ─────────────────────────────────────────────
-    # Pattern 2: Local dataset file (file read + json.unmarshal)
+    # Pattern 2: Local dataset file (file read with parse)
     # ─────────────────────────────────────────────
-    # Read a curated JSON file, then parse and query it with CEL. Best when the
-    # taxonomy is large, shared across solutions, or maintained separately.
+    # Read a curated JSON file and parse it in one step via the file provider's
+    # parse input. Best when the taxonomy is large, shared across solutions, or
+    # maintained separately.
     regionsFile:
-      description: Raw contents of the curated regions.json dataset
+      description: Parsed contents of the curated regions.json dataset
       type: any
       resolve:
         with:
@@ -98,8 +99,11 @@ spec:
             inputs:
               operation: read
               path: regions.json
+              parse: json
 
-    # Parse the file content, then look up the same key with a safe default.
+    # Look up the key with a safe default. The dataset is already parsed by the
+    # file provider (available as _.regionsFile.object), so no separate
+    # json.unmarshal resolver is needed.
     quota:
       description: Quota for `region`, read from the on-disk dataset
       type: number
@@ -108,6 +112,6 @@ spec:
           - provider: cel
             inputs:
               expression: >
-                cel.bind(t, json.unmarshal(_.regionsFile.content),
+                cel.bind(t, _.regionsFile.object,
                   _.region in t ? t[_.region].quota : 0
                 )

--- a/pkg/provider/builtin/fileprovider/file.go
+++ b/pkg/provider/builtin/fileprovider/file.go
@@ -20,12 +20,25 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
+	yaml "gopkg.in/yaml.v3"
 
 	scafpath "github.com/oakwood-commons/scafctl/pkg/filepath"
 )
 
 // ProviderName is the name of this provider.
 const ProviderName = "file"
+
+// Parse modes for the read operation's optional parse input. These constants
+// back both the input schema enum and the parseContent switch so the two
+// cannot drift apart.
+const (
+	parseModeJSON = "json"
+	parseModeYAML = "yaml"
+	parseModeAuto = "auto"
+)
+
+// encodingBinary is the encoding value for which structured parsing is skipped.
+const encodingBinary = "binary"
 
 // FileProvider provides filesystem operations.
 type FileProvider struct {
@@ -97,6 +110,14 @@ func NewFileProvider() *FileProvider {
 					schemahelper.WithExample("utf-8"),
 					schemahelper.WithDefault("utf-8"),
 					schemahelper.WithEnum("utf-8", "binary")),
+				"parse": schemahelper.StringProp("Parse the file content into a structured object (read operation). "+
+					"When set, the parsed value is returned in the 'object' output field alongside the raw 'content'. "+
+					"json: parse as JSON. yaml: parse as YAML. auto: pick the decoder from the file extension "+
+					"(.json, .yaml, .yml), falling back to content sniffing (YAML then JSON) for other extensions. "+
+					"Malformed content returns an error. When omitted, only the raw string 'content' is returned. "+
+					"Ignored when encoding is binary.",
+					schemahelper.WithExample(parseModeAuto),
+					schemahelper.WithEnum(parseModeJSON, parseModeYAML, parseModeAuto)),
 				"basePath": schemahelper.StringProp("Destination root directory (required for write-tree operation). Entries are written relative to this path.",
 					schemahelper.WithExample("./output"),
 					schemahelper.WithMaxLength(4096)),
@@ -169,12 +190,14 @@ func NewFileProvider() *FileProvider {
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
 				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"content": schemahelper.StringProp("File content (for read operation)"),
+					"object":  schemahelper.AnyProp("Parsed content as a structured object (read operation, only present when the parse input is set)"),
 					"exists":  schemahelper.BoolProp("Whether the file exists (for exists operation)"),
 					"path":    schemahelper.StringProp("Absolute path to the file"),
 					"size":    schemahelper.IntProp("File size in bytes (for read operation)"),
 				}),
 				provider.CapabilityTransform: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"content": schemahelper.StringProp("File content (for read operation)"),
+					"object":  schemahelper.AnyProp("Parsed content as a structured object (read operation, only present when the parse input is set)"),
 					"path":    schemahelper.StringProp("Absolute path to the file"),
 					"size":    schemahelper.IntProp("File size in bytes"),
 				}),
@@ -217,6 +240,16 @@ provider: file
 inputs:
   operation: read
   path: ./config.yaml`,
+				},
+				{
+					Name:        "Read and parse structured data",
+					Description: "Read a file and parse its content into a structured object. The parsed value is available in the 'object' output field (e.g. _.read-config.object), removing the need for a separate CEL json.unmarshal/yaml.unmarshal resolver. Use parse: json, yaml, or auto.",
+					YAML: `name: read-config
+provider: file
+inputs:
+  operation: read
+  path: ./config.yaml
+  parse: yaml`,
 				},
 				{
 					Name:        "Write file",
@@ -397,7 +430,7 @@ func (p *FileProvider) Execute(ctx context.Context, input any) (*provider.Output
 	var result *provider.Output
 	switch operation {
 	case "read":
-		result, err = p.executeRead(absPath)
+		result, err = p.executeRead(absPath, inputs)
 	case "write":
 		result, err = p.executeWrite(ctx, absPath, inputs)
 	case "exists":
@@ -416,7 +449,7 @@ func (p *FileProvider) Execute(ctx context.Context, input any) (*provider.Output
 	return result, nil
 }
 
-func (p *FileProvider) executeRead(absPath string) (*provider.Output, error) {
+func (p *FileProvider) executeRead(absPath string, inputs map[string]any) (*provider.Output, error) {
 	// Check if file exists
 	info, err := os.Stat(absPath)
 	if err != nil {
@@ -436,13 +469,76 @@ func (p *FileProvider) executeRead(absPath string) (*provider.Output, error) {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
 
-	return &provider.Output{
-		Data: map[string]any{
-			"content": string(content),
-			"path":    absPath,
-			"size":    info.Size(),
-		},
-	}, nil
+	data := map[string]any{
+		"content": string(content),
+		"path":    absPath,
+		"size":    info.Size(),
+	}
+
+	// Optionally parse the content into a structured object. Parsing is
+	// opt-in via the parse input and fails loudly on malformed content.
+	// It is skipped for binary encoding, where structured parsing is meaningless.
+	parseMode, _ := inputs["parse"].(string)
+	encoding, _ := inputs["encoding"].(string)
+	if parseMode != "" && encoding != encodingBinary {
+		ext := strings.ToLower(filepath.Ext(absPath))
+		object, err := parseContent(content, parseMode, ext)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse file %s as %s: %w", absPath, parseMode, err)
+		}
+		data["object"] = object
+	}
+
+	return &provider.Output{Data: data}, nil
+}
+
+// parseContent decodes raw file content into a structured value according to
+// the requested parse mode: "json", "yaml", or "auto". In auto mode the file
+// extension selects the preferred decoder (.json -> JSON, .yaml/.yml -> YAML)
+// and the other decoder is tried as a fallback, so mislabeled or extensionless
+// files still parse when possible.
+func parseContent(content []byte, mode, ext string) (any, error) {
+	switch mode {
+	case parseModeJSON:
+		var object any
+		if err := json.Unmarshal(content, &object); err != nil {
+			return nil, err
+		}
+		return object, nil
+	case parseModeYAML:
+		var object any
+		if err := yaml.Unmarshal(content, &object); err != nil {
+			return nil, err
+		}
+		return object, nil
+	case parseModeAuto:
+		return parseAuto(content, ext)
+	default:
+		return nil, fmt.Errorf("unsupported parse mode: %q (expected json, yaml, or auto)", mode)
+	}
+}
+
+// unmarshalFunc matches the signature of json.Unmarshal and yaml.Unmarshal.
+type unmarshalFunc func([]byte, any) error
+
+// parseAuto parses content with the decoder preferred by the file extension,
+// falling back to the other decoder. Unknown or absent extensions try YAML
+// first (a superset of JSON), matching the parameter-file loader convention.
+func parseAuto(content []byte, ext string) (any, error) {
+	decoders := []unmarshalFunc{yaml.Unmarshal, json.Unmarshal}
+	if ext == ".json" {
+		decoders = []unmarshalFunc{json.Unmarshal, yaml.Unmarshal}
+	}
+	var lastErr error
+	for _, decode := range decoders {
+		var object any
+		err := decode(content, &object)
+		if err == nil {
+			return object, nil
+		}
+		lastErr = err
+	}
+	return nil, fmt.Errorf("content is neither valid JSON nor YAML: %w", lastErr)
 }
 
 func (p *FileProvider) executeWrite(ctx context.Context, absPath string, inputs map[string]any) (*provider.Output, error) {
@@ -1154,15 +1250,21 @@ func (p *FileProvider) executeDryRunWriteTree(ctx context.Context, absBasePath s
 func (p *FileProvider) executeDryRun(ctx context.Context, operation, absPath string, inputs map[string]any) (*provider.Output, error) {
 	switch operation {
 	case "read":
-		return &provider.Output{
-			Data: map[string]any{
-				"content":  "[DRY RUN] Would read file content",
-				"path":     absPath,
-				"size":     0,
-				"_dryRun":  true,
-				"_message": fmt.Sprintf("Would read file: %s", absPath),
-			},
-		}, nil
+		data := map[string]any{
+			"content":  "[DRY RUN] Would read file content",
+			"path":     absPath,
+			"size":     0,
+			"_dryRun":  true,
+			"_message": fmt.Sprintf("Would read file: %s", absPath),
+		}
+		// Mirror executeRead: parsing (and thus the object field) is skipped for
+		// binary encoding, so dry-run output stays consistent with real output.
+		parseMode, _ := inputs["parse"].(string)
+		encoding, _ := inputs["encoding"].(string)
+		if parseMode != "" && encoding != encodingBinary {
+			data["object"] = nil
+		}
+		return &provider.Output{Data: data}, nil
 
 	case "write":
 		content, ok := inputs["content"].(string)

--- a/pkg/provider/builtin/fileprovider/file_benchmark_test.go
+++ b/pkg/provider/builtin/fileprovider/file_benchmark_test.go
@@ -34,6 +34,40 @@ func BenchmarkFileProvider_Execute_Read(b *testing.B) {
 	}
 }
 
+func BenchmarkFileProvider_Execute_Read_Parse(b *testing.B) {
+	yamlContent := []byte("name: John\nage: 30\ntags:\n  - a\n  - b\n  - c\n")
+
+	for _, mode := range []string{"json", "yaml", "auto"} {
+		b.Run(mode, func(b *testing.B) {
+			p := NewFileProvider()
+			tmpDir := b.TempDir()
+			testFile := filepath.Join(tmpDir, "bench-parse.yaml")
+			content := yamlContent
+			if mode == "json" {
+				content = []byte(`{"name":"John","age":30,"tags":["a","b","c"]}`)
+			}
+			if err := os.WriteFile(testFile, content, 0o600); err != nil {
+				b.Fatal(err)
+			}
+
+			ctx := provider.WithWorkingDirectory(context.Background(), tmpDir)
+			inputs := map[string]any{
+				"operation": "read",
+				"path":      testFile,
+				"parse":     mode,
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				if _, err := p.Execute(ctx, inputs); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
 func BenchmarkFileProvider_Execute_Exists(b *testing.B) {
 	p := NewFileProvider()
 

--- a/pkg/provider/builtin/fileprovider/file_test.go
+++ b/pkg/provider/builtin/fileprovider/file_test.go
@@ -113,6 +113,332 @@ func TestFileProvider_Execute_Read_Directory(t *testing.T) {
 	assert.Contains(t, err.Error(), "is a directory")
 }
 
+func TestFileProvider_Execute_Read_Parse(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		parse   string
+		assert  func(t *testing.T, object any)
+	}{
+		{
+			name:    "yaml object",
+			content: "name: John\nage: 30\n",
+			parse:   "yaml",
+			assert: func(t *testing.T, object any) {
+				m, ok := object.(map[string]any)
+				require.True(t, ok, "expected map, got %T", object)
+				assert.Equal(t, "John", m["name"])
+				assert.Equal(t, 30, m["age"])
+			},
+		},
+		{
+			name:    "json object",
+			content: `{"name":"John","age":30}`,
+			parse:   "json",
+			assert: func(t *testing.T, object any) {
+				m, ok := object.(map[string]any)
+				require.True(t, ok, "expected map, got %T", object)
+				assert.Equal(t, "John", m["name"])
+				assert.InEpsilon(t, 30.0, m["age"], 0.0001)
+			},
+		},
+		{
+			name:    "yaml array",
+			content: "- apple\n- banana\n- cherry\n",
+			parse:   "yaml",
+			assert: func(t *testing.T, object any) {
+				arr, ok := object.([]any)
+				require.True(t, ok, "expected slice, got %T", object)
+				assert.Equal(t, []any{"apple", "banana", "cherry"}, arr)
+			},
+		},
+		{
+			name:    "auto parses json content with unknown extension",
+			content: `{"key":"value"}`,
+			parse:   "auto",
+			assert: func(t *testing.T, object any) {
+				m, ok := object.(map[string]any)
+				require.True(t, ok, "expected map, got %T", object)
+				assert.Equal(t, "value", m["key"])
+			},
+		},
+		{
+			name:    "auto parses yaml content with unknown extension",
+			content: "key: value\n",
+			parse:   "auto",
+			assert: func(t *testing.T, object any) {
+				m, ok := object.(map[string]any)
+				require.True(t, ok, "expected map, got %T", object)
+				assert.Equal(t, "value", m["key"])
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewFileProvider()
+			tmpFile, err := os.CreateTemp("", "test-parse-*.txt")
+			require.NoError(t, err)
+			defer os.Remove(tmpFile.Name())
+			_, err = tmpFile.WriteString(tt.content)
+			require.NoError(t, err)
+			require.NoError(t, tmpFile.Close())
+
+			result, err := p.Execute(context.Background(), map[string]any{
+				"operation": "read",
+				"path":      tmpFile.Name(),
+				"parse":     tt.parse,
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			data := result.Data.(map[string]any)
+			// Raw content is always preserved alongside the parsed object.
+			assert.Equal(t, tt.content, data["content"])
+			tt.assert(t, data["object"])
+		})
+	}
+}
+
+func TestFileProvider_Execute_Read_Parse_MalformedFailsLoud(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		parse   string
+	}{
+		{name: "invalid json", content: "{not json", parse: "json"},
+		{name: "invalid yaml", content: "key: value\n\t- bad: indent", parse: "yaml"},
+		{name: "auto neither", content: "{not: valid: json: or: yaml", parse: "auto"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewFileProvider()
+			tmpFile, err := os.CreateTemp("", "test-parse-bad-*.txt")
+			require.NoError(t, err)
+			defer os.Remove(tmpFile.Name())
+			_, err = tmpFile.WriteString(tt.content)
+			require.NoError(t, err)
+			require.NoError(t, tmpFile.Close())
+
+			result, err := p.Execute(context.Background(), map[string]any{
+				"operation": "read",
+				"path":      tmpFile.Name(),
+				"parse":     tt.parse,
+			})
+
+			require.Error(t, err)
+			assert.Nil(t, result)
+			assert.Contains(t, err.Error(), "failed to parse file")
+		})
+	}
+}
+
+func TestFileProvider_Execute_Read_Parse_OmittedReturnsRawOnly(t *testing.T) {
+	p := NewFileProvider()
+	tmpFile, err := os.CreateTemp("", "test-noparse-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	content := "name: John\n"
+	_, err = tmpFile.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	result, err := p.Execute(context.Background(), map[string]any{
+		"operation": "read",
+		"path":      tmpFile.Name(),
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	data := result.Data.(map[string]any)
+	assert.Equal(t, content, data["content"])
+	_, hasObject := data["object"]
+	assert.False(t, hasObject, "object should be absent when parse is omitted")
+}
+
+func TestFileProvider_Execute_Read_Parse_SkippedForBinary(t *testing.T) {
+	p := NewFileProvider()
+	tmpFile, err := os.CreateTemp("", "test-binary-*.bin")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	content := "name: John\n"
+	_, err = tmpFile.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	result, err := p.Execute(context.Background(), map[string]any{
+		"operation": "read",
+		"path":      tmpFile.Name(),
+		"parse":     "yaml",
+		"encoding":  "binary",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	data := result.Data.(map[string]any)
+	_, hasObject := data["object"]
+	assert.False(t, hasObject, "object should be absent for binary encoding")
+}
+
+func TestFileProvider_Execute_Read_Parse_TransformMode(t *testing.T) {
+	// executeRead runs for both From and Transform capabilities, so the parsed
+	// object must be produced (and is schema-declared) in transform mode too.
+	p := NewFileProvider()
+	tmpFile, err := os.CreateTemp("", "test-parse-transform-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	_, err = tmpFile.WriteString("name: John\n")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	ctx := provider.WithExecutionMode(context.Background(), provider.CapabilityTransform)
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "read",
+		"path":      tmpFile.Name(),
+		"parse":     "yaml",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	data := result.Data.(map[string]any)
+	m, ok := data["object"].(map[string]any)
+	require.True(t, ok, "expected parsed object in transform mode, got %T", data["object"])
+	assert.Equal(t, "John", m["name"])
+
+	// The transform output schema must declare the object field it can return.
+	transformSchema := p.Descriptor().OutputSchemas[provider.CapabilityTransform]
+	require.NotNil(t, transformSchema)
+	assert.Contains(t, transformSchema.Properties, "object")
+}
+
+func TestFileProvider_Execute_DryRun_Read_Parse(t *testing.T) {
+	p := NewFileProvider()
+	ctx := provider.WithDryRun(context.Background(), true)
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "read",
+		"path":      "/some/path.yaml",
+		"parse":     "yaml",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["_dryRun"].(bool))
+	object, hasObject := data["object"]
+	assert.True(t, hasObject, "object key should be present in dry-run when parse is set")
+	assert.Nil(t, object)
+}
+
+func TestFileProvider_Execute_DryRun_Read_Parse_SkippedForBinary(t *testing.T) {
+	// Dry-run must match real read: parsing is skipped for binary encoding, so
+	// the object key is omitted rather than set to nil.
+	p := NewFileProvider()
+	ctx := provider.WithDryRun(context.Background(), true)
+
+	result, err := p.Execute(ctx, map[string]any{
+		"operation": "read",
+		"path":      "/some/path.bin",
+		"parse":     "yaml",
+		"encoding":  "binary",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	data := result.Data.(map[string]any)
+	assert.True(t, data["_dryRun"].(bool))
+	_, hasObject := data["object"]
+	assert.False(t, hasObject, "object should be absent in dry-run for binary encoding")
+}
+
+func TestParseContent(t *testing.T) {
+	t.Run("unsupported mode returns error", func(t *testing.T) {
+		object, err := parseContent([]byte("anything"), "xml", "")
+		require.Error(t, err)
+		assert.Nil(t, object)
+		assert.Contains(t, err.Error(), "unsupported parse mode")
+	})
+
+	t.Run("empty mode returns error", func(t *testing.T) {
+		_, err := parseContent([]byte("anything"), "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported parse mode")
+	})
+}
+
+func TestParseContent_AutoExtensionAware(t *testing.T) {
+	// A file whose content is valid in both formats: the extension decides which
+	// decoder wins, which affects numeric typing (JSON -> float64, YAML -> int).
+	jsonish := []byte(`{"age": 30}`)
+
+	t.Run(".json extension uses JSON decoder", func(t *testing.T) {
+		object, err := parseContent(jsonish, "auto", ".json")
+		require.NoError(t, err)
+		m := object.(map[string]any)
+		assert.IsType(t, float64(0), m["age"], "JSON decoder yields float64")
+	})
+
+	t.Run(".yaml extension uses YAML decoder", func(t *testing.T) {
+		object, err := parseContent([]byte("age: 30\n"), "auto", ".yaml")
+		require.NoError(t, err)
+		m := object.(map[string]any)
+		assert.Equal(t, 30, m["age"], "YAML decoder yields int")
+	})
+
+	t.Run(".yml extension uses YAML decoder", func(t *testing.T) {
+		object, err := parseContent([]byte("age: 30\n"), "auto", ".yml")
+		require.NoError(t, err)
+		m := object.(map[string]any)
+		assert.Equal(t, 30, m["age"])
+	})
+
+	t.Run("unknown extension sniffs YAML first", func(t *testing.T) {
+		// JSON content with an unrecognized extension: YAML (a JSON superset)
+		// parses it, decoding the integer as int.
+		object, err := parseContent(jsonish, "auto", ".txt")
+		require.NoError(t, err)
+		m := object.(map[string]any)
+		assert.Equal(t, 30, m["age"])
+	})
+
+	t.Run("mislabeled extension falls back to other decoder", func(t *testing.T) {
+		// A .json file that actually contains YAML still parses via the fallback.
+		object, err := parseContent([]byte("age: 30\n"), "auto", ".json")
+		require.NoError(t, err)
+		m := object.(map[string]any)
+		assert.Equal(t, 30, m["age"])
+	})
+
+	t.Run("invalid in both formats returns error", func(t *testing.T) {
+		_, err := parseContent([]byte("{not: valid: json: or: yaml"), "auto", ".json")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "neither valid JSON nor YAML")
+	})
+}
+
+func TestFileProvider_Execute_Read_Parse_AutoUsesExtension(t *testing.T) {
+	// End-to-end: executeRead derives the extension from the file path.
+	p := NewFileProvider()
+	tmpFile, err := os.CreateTemp("", "test-auto-*.yaml")
+	require.NoError(t, err)
+	defer os.Remove(tmpFile.Name())
+	_, err = tmpFile.WriteString("age: 30\n")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+
+	result, err := p.Execute(context.Background(), map[string]any{
+		"operation": "read",
+		"path":      tmpFile.Name(),
+		"parse":     "auto",
+	})
+
+	require.NoError(t, err)
+	data := result.Data.(map[string]any)
+	m := data["object"].(map[string]any)
+	assert.Equal(t, 30, m["age"], "auto should use the .yaml extension's YAML decoder")
+}
+
 func TestFileProvider_Execute_Write_Success(t *testing.T) {
 	p := NewFileProvider()
 

--- a/tests/integration/solutions/providers/file/solution.yaml
+++ b/tests/integration/solutions/providers/file/solution.yaml
@@ -44,6 +44,36 @@ spec:
               operation: read
               path: ./test-data.json
 
+    parseJson:
+      description: Read and parse a JSON fixture file into a structured object
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: ./test-data.json
+              parse: json
+
+    parseYaml:
+      description: Read and parse a YAML fixture into a structured object (JSON is valid YAML)
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: ./test-data.json
+              parse: yaml
+
+    parseAuto:
+      description: Read and auto-parse a fixture, selecting the decoder by file extension
+      resolve:
+        with:
+          - provider: file
+            inputs:
+              operation: read
+              path: ./test-data.json
+              parse: auto
+
   testing:
     config:
       # resolve-defaults: resolvers read fixture files that only exist via test init steps
@@ -106,3 +136,50 @@ spec:
         assertions:
           - expression: '__output.readJson.content.contains("key")'
           - expression: '__output.readJson.content.contains("value")'
+
+      parse-json-object:
+        description: Verify parse:json returns a structured object alongside raw content
+        extends: [_base]
+        init:
+          - command: "echo -n 'dummy' > test-fixture.txt"
+          - command: 'echo -n ''{"key":"value","count":42}'' > test-data.json'
+        cleanup:
+          - command: "rm -f test-fixture.txt test-data.json"
+        assertions:
+          - expression: '__output.parseJson.object.key == "value"'
+            message: "Parsed object should expose nested fields"
+          - expression: '__output.parseJson.object.count == 42'
+            message: "Parsed object should preserve numeric values"
+          - expression: '__output.parseJson.content.contains("key")'
+            message: "Raw content should still be present alongside object"
+
+      parse-yaml-object:
+        description: Verify parse:yaml returns a structured object
+        extends: [_base]
+        init:
+          - command: "echo -n 'dummy' > test-fixture.txt"
+          - command: 'echo -n ''{"key":"value","count":42}'' > test-data.json'
+        cleanup:
+          - command: "rm -f test-fixture.txt test-data.json"
+        assertions:
+          - expression: '__output.parseYaml.object.key == "value"'
+            message: "Parsed YAML object should expose mapping fields"
+          - expression: '__output.parseYaml.object.count == 42'
+            message: "Parsed YAML object should preserve numeric values"
+
+      parse-auto-by-extension:
+        description: Verify parse:auto selects the decoder from the .json extension
+        extends: [_base]
+        init:
+          - command: "echo -n 'dummy' > test-fixture.txt"
+          - command: 'echo -n ''{"key":"value","count":42}'' > test-data.json'
+        cleanup:
+          - command: "rm -f test-fixture.txt test-data.json"
+        assertions:
+          - expression: '__output.parseAuto.object.key == "value"'
+            message: "auto should parse the .json fixture into an object"
+          - expression: '__output.parseAuto.object.count == 42'
+            message: "auto should expose numeric fields"
+
+
+


### PR DESCRIPTION
Add an optional `parse` input to the file provider's `read` operation so solutions can consume structured data without a separate CEL unmarshal resolver. The parsed value is returned in a new `object` output field alongside the raw `content`.

- `parse` accepts `json`, `yaml`, or `auto`; when omitted, `read` returns the raw string `content` only (unchanged, opt-in behavior)
- `auto` selects the decoder from the file extension (.json, .yaml, .yml), falling back to content sniffing (YAML then JSON) for other extensions, matching the parameter-file loader convention
- malformed content fails loudly with an error rather than a silent nil; parsing is skipped when encoding is binary
- declare `object` on both the `from` and `transform` output schemas
- add unit tests, a parse benchmark, integration cases, and update the file provider tutorial, reference, output-shapes, and example docs

Closes #628