### PR TITLE
feat(state)!: separate runtime engine version from invoking CLI version

### DIFF
--- a/docs/design/mcp-server-enhancements.md
+++ b/docs/design/mcp-server-enhancements.md
@@ -636,7 +636,10 @@ mcp.NewTool("show_snapshot",
   "solution": "my-solution",
   "version": "1.0.0",
   "timestamp": "2026-02-20T15:30:00Z",
-  "scafctlVersion": "0.15.0",
+  "runtime": {
+    "engine": { "name": "scafctl", "version": "0.15.0" },
+    "cli": { "name": "scafctl", "version": "0.15.0" }
+  },
   "duration": "2.3s",
   "status": "success",
   "resolverCount": { "total": 10, "success": 9, "failed": 1, "skipped": 0 },

--- a/docs/design/state/parameter-replay-design.md
+++ b/docs/design/state/parameter-replay-design.md
@@ -87,7 +87,10 @@ outputs.
     "version": "1.0.0",
     "createdAt": "2026-02-12T10:00:00Z",
     "lastUpdatedAt": "2026-05-27T14:30:00Z",
-    "scafctlVersion": "1.8.0"
+    "runtime": {
+      "engine": { "name": "scafctl", "version": "1.8.0" },
+      "cli": { "name": "scafctl", "version": "1.8.0" }
+    }
   },
   "command": {
     "subcommand": "run solution",

--- a/docs/design/state/state.md
+++ b/docs/design/state/state.md
@@ -224,13 +224,16 @@ State is persisted as JSON. The schema includes a `schemaVersion` field for forw
 
 ~~~json
 {
-  "schemaVersion": 1,
+  "schemaVersion": 3,
   "metadata": {
     "solution": "deploy-app",
     "version": "1.0.0",
     "createdAt": "2026-02-12T10:00:00Z",
     "lastUpdatedAt": "2026-02-12T11:30:00Z",
-    "scafctlVersion": "1.8.0"
+    "runtime": {
+      "engine": { "name": "scafctl", "version": "1.8.0" },
+      "cli": { "name": "mycli", "version": "3.2.0" }
+    }
   },
   "command": {
     "subcommand": "run solution",
@@ -261,7 +264,10 @@ State is persisted as JSON. The schema includes a `schemaVersion` field for forw
 | `metadata.version` | Solution version from `metadata.version` |
 | `metadata.createdAt` | Timestamp of first state file creation |
 | `metadata.lastUpdatedAt` | Timestamp of most recent state save |
-| `metadata.scafctlVersion` | Version of scafctl that last wrote the state |
+| `metadata.runtime.engine.name` | Execution engine (scafctl library) name -- always `scafctl` |
+| `metadata.runtime.engine.version` | Execution engine (scafctl library) build version |
+| `metadata.runtime.cli.name` | Invoking CLI/frontend binary name. Equals the engine name for direct scafctl use; differs for embedded runners |
+| `metadata.runtime.cli.version` | Invoking CLI/frontend version. Equals the engine version when not embedded or when the embedder supplies no version |
 | `command.subcommand` | CLI subcommand used (e.g., `run solution`) |
 | `command.parameters` | Key-value pairs from the most recent invocation's `-r/--resolver` flags |
 | `parameters` | Merged set of all CLI parameters across runs (drives replay) |

--- a/pkg/cmd/scafctl/render/solution.go
+++ b/pkg/cmd/scafctl/render/solution.go
@@ -781,7 +781,7 @@ func (o *SolutionOptions) loadStateIntoContext(ctx context.Context, sol *solutio
 		}
 	}
 
-	stateMgr := state.NewManager(sol.State, reg, settings.VersionInformation.BuildVersion)
+	stateMgr := state.NewManager(sol.State, reg, state.RuntimeProvenanceFromContext(ctx))
 	cmdInfo := state.CommandInfo{
 		Subcommand: "render solution",
 		Parameters: formatParams(params),

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -257,6 +257,12 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 	cliParams.BinaryName = binaryName
 	paths.SetAppName(binaryName)
 
+	// Record the embedder's version (if supplied) so state metadata can capture
+	// the invoking CLI/frontend provenance distinctly from the engine version.
+	if opts.VersionExtra != nil && opts.VersionExtra.BuildVersion != "" {
+		cliParams.EmbedderVersion = opts.VersionExtra.BuildVersion
+	}
+
 	// Update package-level solution discovery lists so any code reading them
 	// directly (e.g., PossibleSolutionPaths, MCP capabilities) reflects the
 	// embedder's binary name rather than the hardcoded default.

--- a/pkg/cmd/scafctl/root_coverage_test.go
+++ b/pkg/cmd/scafctl/root_coverage_test.go
@@ -370,6 +370,62 @@ func TestRoot_VersionExtra(t *testing.T) {
 	assert.Contains(t, output, "v2.0.0")
 }
 
+// TestRoot_EmbedderVersion_WiredFromVersionExtra verifies that a non-default
+// embedder supplying VersionExtra has its build version recorded in the ambient
+// settings as EmbedderVersion, so state/snapshot provenance can distinguish the
+// invoking CLI from the scafctl engine.
+func TestRoot_EmbedderVersion_WiredFromVersionExtra(t *testing.T) {
+	t.Parallel()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	var captured *settings.Run
+	cmd, _ := Root(&RootOptions{
+		IOStreams:  ioStreams,
+		BinaryName: "mycli",
+		VersionExtra: &settings.VersionInfo{
+			BuildVersion: "v2.0.0",
+		},
+		PreRunHook: func(c *cobra.Command, _ []string) error {
+			captured, _ = settings.FromContext(c.Context())
+			return nil
+		},
+	})
+	cmd.SetArgs([]string{"version"})
+	require.NoError(t, cmd.Execute())
+
+	require.NotNil(t, captured)
+	assert.Equal(t, "mycli", captured.BinaryName)
+	assert.Equal(t, "v2.0.0", captured.EmbedderVersion)
+}
+
+// TestRoot_EmbedderVersion_UnsetWhenNoVersionExtra verifies that without
+// VersionExtra (or with an empty build version) EmbedderVersion stays empty, so
+// CLI provenance falls back to mirroring the engine.
+func TestRoot_EmbedderVersion_UnsetWhenNoVersionExtra(t *testing.T) {
+	t.Parallel()
+
+	capture := func(opts *RootOptions) *settings.Run {
+		ioStreams, _, _ := terminal.NewTestIOStreams()
+		opts.IOStreams = ioStreams
+		var captured *settings.Run
+		opts.PreRunHook = func(c *cobra.Command, _ []string) error {
+			captured, _ = settings.FromContext(c.Context())
+			return nil
+		}
+		cmd, _ := Root(opts)
+		cmd.SetArgs([]string{"version"})
+		require.NoError(t, cmd.Execute())
+		require.NotNil(t, captured)
+		return captured
+	}
+
+	assert.Equal(t, "", capture(&RootOptions{BinaryName: "mycli"}).EmbedderVersion)
+	assert.Equal(t, "", capture(&RootOptions{
+		BinaryName:   "mycli",
+		VersionExtra: &settings.VersionInfo{BuildVersion: ""},
+	}).EmbedderVersion)
+}
+
 // TestNewRootOptions_NewFields verifies new fields have correct zero values.
 func TestNewRootOptions_NewFields(t *testing.T) {
 	t.Parallel()

--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -381,7 +381,7 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 	var stateMgr *state.Manager
 	var stateData *state.Data
 	if sol.State != nil {
-		stateMgr = state.NewManager(sol.State, reg, settings.VersionInformation.BuildVersion)
+		stateMgr = state.NewManager(sol.State, reg, state.RuntimeProvenanceFromContext(ctx))
 		cmdInfo := buildCommandInfo("run action", params)
 		loadResult, loadErr := stateMgr.Load(ctx, params, cmdInfo)
 		if loadErr != nil {

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -597,7 +597,7 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 	var stateMgr *state.Manager
 	var stateData *state.Data
 	if sol.State != nil {
-		stateMgr = state.NewManager(sol.State, reg, settings.VersionInformation.BuildVersion)
+		stateMgr = state.NewManager(sol.State, reg, state.RuntimeProvenanceFromContext(ctx))
 		cmdInfo := buildCommandInfo("run resolver", params)
 		loadResult, loadErr := stateMgr.Load(ctx, params, cmdInfo)
 		if loadErr != nil {

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -494,7 +494,7 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	var stateMgr *state.Manager
 	var stateData *state.Data
 	if sol.State != nil {
-		stateMgr = state.NewManager(sol.State, reg, settings.VersionInformation.BuildVersion)
+		stateMgr = state.NewManager(sol.State, reg, state.RuntimeProvenanceFromContext(ctx))
 		cmdInfo := buildCommandInfo("run solution", params)
 		loadResult, loadErr := stateMgr.Load(ctx, params, cmdInfo)
 		if loadErr != nil {

--- a/pkg/cmd/scafctl/snapshot/diff_test.go
+++ b/pkg/cmd/scafctl/snapshot/diff_test.go
@@ -264,12 +264,12 @@ func TestRunDiff_OutputToFile(t *testing.T) {
 func createTestSnapshotForDiff() *resolver.Snapshot {
 	return &resolver.Snapshot{
 		Metadata: resolver.SnapshotMetadata{
-			Solution:       "test-solution",
-			Version:        "1.0.0",
-			Timestamp:      time.Now(),
-			ScafctlVersion: "dev",
-			TotalDuration:  "1s",
-			Status:         "success",
+			Solution:      "test-solution",
+			Version:       "1.0.0",
+			Timestamp:     time.Now(),
+			Runtime:       resolver.SnapshotRuntime{Engine: resolver.SnapshotRuntimeComponent{Name: "scafctl", Version: "dev"}, CLI: resolver.SnapshotRuntimeComponent{Name: "scafctl", Version: "dev"}},
+			TotalDuration: "1s",
+			Status:        "success",
 		},
 		Resolvers: map[string]*resolver.SnapshotResolver{
 			"test_resolver": {
@@ -289,12 +289,12 @@ func createTestSnapshotPair(t *testing.T, dir string) (beforeFile, afterFile str
 	beforeFile = filepath.Join(dir, "before.json")
 	before := &resolver.Snapshot{
 		Metadata: resolver.SnapshotMetadata{
-			Solution:       "test-solution",
-			Version:        "1.0.0",
-			Timestamp:      time.Now().Add(-time.Hour),
-			ScafctlVersion: "dev",
-			TotalDuration:  "1s",
-			Status:         "success",
+			Solution:      "test-solution",
+			Version:       "1.0.0",
+			Timestamp:     time.Now().Add(-time.Hour),
+			Runtime:       resolver.SnapshotRuntime{Engine: resolver.SnapshotRuntimeComponent{Name: "scafctl", Version: "dev"}, CLI: resolver.SnapshotRuntimeComponent{Name: "scafctl", Version: "dev"}},
+			TotalDuration: "1s",
+			Status:        "success",
 		},
 		Resolvers: map[string]*resolver.SnapshotResolver{
 			"test_resolver": {
@@ -312,12 +312,12 @@ func createTestSnapshotPair(t *testing.T, dir string) (beforeFile, afterFile str
 	afterFile = filepath.Join(dir, "after.json")
 	after := &resolver.Snapshot{
 		Metadata: resolver.SnapshotMetadata{
-			Solution:       "test-solution",
-			Version:        "1.0.0",
-			Timestamp:      time.Now(),
-			ScafctlVersion: "dev",
-			TotalDuration:  "1s",
-			Status:         "success",
+			Solution:      "test-solution",
+			Version:       "1.0.0",
+			Timestamp:     time.Now(),
+			Runtime:       resolver.SnapshotRuntime{Engine: resolver.SnapshotRuntimeComponent{Name: "scafctl", Version: "dev"}, CLI: resolver.SnapshotRuntimeComponent{Name: "scafctl", Version: "dev"}},
+			TotalDuration: "1s",
+			Status:        "success",
 		},
 		Resolvers: map[string]*resolver.SnapshotResolver{
 			"test_resolver": {

--- a/pkg/cmd/scafctl/snapshot/show.go
+++ b/pkg/cmd/scafctl/snapshot/show.go
@@ -134,7 +134,8 @@ func showSummary(snapshot *resolver.Snapshot, opts *ShowOptions, w *writer.Write
 	// Metadata
 	w.Plainlnf("Solution:        %s (v%s)", snapshot.Metadata.Solution, snapshot.Metadata.Version)
 	w.Plainlnf("Timestamp:       %s", snapshot.Metadata.Timestamp.Format("2006-01-02 15:04:05"))
-	w.Plainlnf("%s Version: %s", opts.BinaryName, snapshot.Metadata.ScafctlVersion)
+	w.Plainlnf("Engine:          %s %s", snapshot.Metadata.Runtime.Engine.Name, snapshot.Metadata.Runtime.Engine.Version)
+	w.Plainlnf("CLI:             %s %s", snapshot.Metadata.Runtime.CLI.Name, snapshot.Metadata.Runtime.CLI.Version)
 	w.Plainlnf("Total Duration:  %s", snapshot.Metadata.TotalDuration)
 	w.Plainlnf("Overall Status:  %s\n", snapshot.Metadata.Status)
 

--- a/pkg/cmd/scafctl/snapshot/show_test.go
+++ b/pkg/cmd/scafctl/snapshot/show_test.go
@@ -335,12 +335,12 @@ func TestShowSummary_StatusCounting(t *testing.T) {
 func createTestSnapshot() *resolver.Snapshot {
 	return &resolver.Snapshot{
 		Metadata: resolver.SnapshotMetadata{
-			Solution:       "test-solution",
-			Version:        "1.0.0",
-			Timestamp:      time.Now(),
-			ScafctlVersion: "dev",
-			TotalDuration:  "1s",
-			Status:         "success",
+			Solution:      "test-solution",
+			Version:       "1.0.0",
+			Timestamp:     time.Now(),
+			Runtime:       resolver.SnapshotRuntime{Engine: resolver.SnapshotRuntimeComponent{Name: "scafctl", Version: "dev"}, CLI: resolver.SnapshotRuntimeComponent{Name: "scafctl", Version: "dev"}},
+			TotalDuration: "1s",
+			Status:        "success",
 		},
 		Resolvers: map[string]*resolver.SnapshotResolver{
 			"test_resolver": {
@@ -423,12 +423,12 @@ func TestRunShow_Integration(t *testing.T) {
 	snapshotFile := filepath.Join(tmpDir, "snapshot.json")
 	snapshot := &resolver.Snapshot{
 		Metadata: resolver.SnapshotMetadata{
-			Solution:       "my-app",
-			Version:        "2.3.1",
-			Timestamp:      time.Now(),
-			ScafctlVersion: "0.1.0",
-			TotalDuration:  "5s",
-			Status:         "success",
+			Solution:      "my-app",
+			Version:       "2.3.1",
+			Timestamp:     time.Now(),
+			Runtime:       resolver.SnapshotRuntime{Engine: resolver.SnapshotRuntimeComponent{Name: "scafctl", Version: "0.1.0"}, CLI: resolver.SnapshotRuntimeComponent{Name: "scafctl", Version: "0.1.0"}},
+			TotalDuration: "5s",
+			Status:        "success",
 		},
 		Resolvers: map[string]*resolver.SnapshotResolver{
 			"db_password": {

--- a/pkg/mcp/tools_snapshot.go
+++ b/pkg/mcp/tools_snapshot.go
@@ -122,15 +122,15 @@ func (s *Server) handleShowSnapshot(_ context.Context, request mcp.CallToolReque
 	}
 
 	result := map[string]any{
-		"solution":       snapshot.Metadata.Solution,
-		"version":        snapshot.Metadata.Version,
-		"timestamp":      snapshot.Metadata.Timestamp,
-		"scafctlVersion": snapshot.Metadata.ScafctlVersion,
-		"duration":       snapshot.Metadata.TotalDuration,
-		"status":         snapshot.Metadata.Status,
-		"resolverCount":  counts,
-		"phases":         len(snapshot.Phases),
-		"parameters":     snapshot.Parameters,
+		"solution":      snapshot.Metadata.Solution,
+		"version":       snapshot.Metadata.Version,
+		"timestamp":     snapshot.Metadata.Timestamp,
+		"runtime":       snapshot.Metadata.Runtime,
+		"duration":      snapshot.Metadata.TotalDuration,
+		"status":        snapshot.Metadata.Status,
+		"resolverCount": counts,
+		"phases":        len(snapshot.Phases),
+		"parameters":    snapshot.Parameters,
 	}
 
 	if format == "resolvers" || format == "full" {

--- a/pkg/mcp/tools_snapshot_test.go
+++ b/pkg/mcp/tools_snapshot_test.go
@@ -30,12 +30,12 @@ func writeTestSnapshot(t *testing.T, dir, name string, snap *resolver.Snapshot) 
 func TestHandleShowSnapshot(t *testing.T) {
 	baseSnap := &resolver.Snapshot{
 		Metadata: resolver.SnapshotMetadata{
-			Solution:       "my-solution",
-			Version:        "1.0.0",
-			Timestamp:      time.Date(2026, 2, 20, 15, 30, 0, 0, time.UTC),
-			ScafctlVersion: "0.15.0",
-			TotalDuration:  "2.3s",
-			Status:         "success",
+			Solution:      "my-solution",
+			Version:       "1.0.0",
+			Timestamp:     time.Date(2026, 2, 20, 15, 30, 0, 0, time.UTC),
+			Runtime:       resolver.SnapshotRuntime{Engine: resolver.SnapshotRuntimeComponent{Name: "scafctl", Version: "0.15.0"}, CLI: resolver.SnapshotRuntimeComponent{Name: "scafctl", Version: "0.15.0"}},
+			TotalDuration: "2.3s",
+			Status:        "success",
 		},
 		Parameters: map[string]any{"env": "prod", "region": "us-east1"},
 		Resolvers: map[string]*resolver.SnapshotResolver{

--- a/pkg/resolver/snapshot.go
+++ b/pkg/resolver/snapshot.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/format"
 )
 
@@ -23,12 +24,26 @@ type Snapshot struct {
 
 // SnapshotMetadata contains metadata about the snapshot
 type SnapshotMetadata struct {
-	Solution       string    `json:"solution" yaml:"solution" doc:"Solution name" maxLength:"512" example:"my-solution"`
-	Version        string    `json:"version,omitempty" yaml:"version,omitempty" doc:"Solution version" maxLength:"64" example:"1.0.0"`
-	Timestamp      time.Time `json:"timestamp" yaml:"timestamp" doc:"When snapshot was captured"`
-	ScafctlVersion string    `json:"scafctlVersion" yaml:"scafctlVersion" doc:"scafctl version" maxLength:"64" example:"0.5.0"`
-	TotalDuration  string    `json:"totalDuration" yaml:"totalDuration" doc:"Total execution duration" maxLength:"32" example:"1.5s"`
-	Status         string    `json:"status" yaml:"status" doc:"Overall execution status (success, failed)" maxLength:"32" example:"success"`
+	Solution      string          `json:"solution" yaml:"solution" doc:"Solution name" maxLength:"512" example:"my-solution"`
+	Version       string          `json:"version,omitempty" yaml:"version,omitempty" doc:"Solution version" maxLength:"64" example:"1.0.0"`
+	Timestamp     time.Time       `json:"timestamp" yaml:"timestamp" doc:"When snapshot was captured"`
+	Runtime       SnapshotRuntime `json:"runtime" yaml:"runtime" doc:"Execution provenance (engine vs invoking CLI)"`
+	TotalDuration string          `json:"totalDuration" yaml:"totalDuration" doc:"Total execution duration" maxLength:"32" example:"1.5s"`
+	Status        string          `json:"status" yaml:"status" doc:"Overall execution status (success, failed)" maxLength:"32" example:"success"`
+}
+
+// SnapshotRuntime records execution provenance, separating the engine (scafctl
+// library) identity from the invoking CLI/frontend identity. When scafctl runs
+// directly (not embedded), CLI mirrors Engine.
+type SnapshotRuntime struct {
+	Engine SnapshotRuntimeComponent `json:"engine" yaml:"engine" doc:"Execution engine (scafctl library) identity"`
+	CLI    SnapshotRuntimeComponent `json:"cli" yaml:"cli" doc:"Invoking CLI/frontend identity"`
+}
+
+// SnapshotRuntimeComponent identifies a named, versioned runtime participant.
+type SnapshotRuntimeComponent struct {
+	Name    string `json:"name" yaml:"name" doc:"Component name" maxLength:"64" example:"scafctl"`
+	Version string `json:"version" yaml:"version" doc:"Component version" maxLength:"64" example:"0.5.0"`
 }
 
 // SnapshotResolver contains execution result for a single resolver
@@ -60,6 +75,18 @@ type SnapshotPhase struct {
 	Resolvers []string `json:"resolvers" yaml:"resolvers" doc:"Resolver names in this phase" maxItems:"500"`
 }
 
+// snapshotRuntime builds execution provenance for a snapshot from the shared
+// settings primitive, applying the CLI-mirrors-engine fallback. The engine is
+// always scafctl at buildVersion; the CLI is the configured binary name and
+// embedder version (from context), defaulting to the engine when not embedded.
+func snapshotRuntime(ctx context.Context, buildVersion string) SnapshotRuntime {
+	p := settings.RuntimeProvenanceFromContext(ctx, buildVersion)
+	return SnapshotRuntime{
+		Engine: SnapshotRuntimeComponent{Name: p.EngineName, Version: p.EngineVersion},
+		CLI:    SnapshotRuntimeComponent{Name: p.ResolvedCLIName(), Version: p.ResolvedCLIVersion()},
+	}
+}
+
 // CaptureSnapshot creates a snapshot from execution context and results
 func CaptureSnapshot(
 	ctx context.Context,
@@ -80,12 +107,12 @@ func CaptureSnapshot(
 
 	snapshot := &Snapshot{
 		Metadata: SnapshotMetadata{
-			Solution:       solutionName,
-			Version:        solutionVersion,
-			Timestamp:      time.Now().UTC(),
-			ScafctlVersion: buildVersion,
-			TotalDuration:  format.Duration(totalDuration),
-			Status:         string(overallStatus),
+			Solution:      solutionName,
+			Version:       solutionVersion,
+			Timestamp:     time.Now().UTC(),
+			Runtime:       snapshotRuntime(ctx, buildVersion),
+			TotalDuration: format.Duration(totalDuration),
+			Status:        string(overallStatus),
 		},
 		Parameters: parameters,
 		Resolvers:  make(map[string]*SnapshotResolver),

--- a/pkg/resolver/snapshot_test.go
+++ b/pkg/resolver/snapshot_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -192,7 +193,7 @@ func TestCaptureSnapshot(t *testing.T) {
 			// Verify metadata
 			assert.Equal(t, tt.solutionName, snapshot.Metadata.Solution)
 			assert.Equal(t, tt.solutionVersion, snapshot.Metadata.Version)
-			assert.Equal(t, tt.buildVersion, snapshot.Metadata.ScafctlVersion)
+			assert.Equal(t, tt.buildVersion, snapshot.Metadata.Runtime.Engine.Version)
 			assert.Equal(t, string(tt.overallStatus), snapshot.Metadata.Status)
 			assert.NotZero(t, snapshot.Metadata.Timestamp)
 
@@ -226,6 +227,57 @@ func TestCaptureSnapshot(t *testing.T) {
 
 			// Verify phases
 			assert.NotEmpty(t, snapshot.Phases)
+		})
+	}
+}
+
+// TestCaptureSnapshot_Runtime verifies the runtime provenance block: the engine
+// is always scafctl at the build version, while the CLI mirrors the engine for
+// direct use and reflects the embedder identity when embedded.
+func TestCaptureSnapshot_Runtime(t *testing.T) {
+	tests := []struct {
+		name        string
+		ctxSettings *settings.Run
+		wantCLIName string
+		wantCLIVer  string
+	}{
+		{
+			name:        "direct use mirrors engine",
+			ctxSettings: nil,
+			wantCLIName: settings.CliBinaryName,
+			wantCLIVer:  "0.1.0",
+		},
+		{
+			name:        "embedder identity distinct from engine",
+			ctxSettings: &settings.Run{BinaryName: "mycli", EmbedderVersion: "9.9.9"},
+			wantCLIName: "mycli",
+			wantCLIVer:  "9.9.9",
+		},
+		{
+			name:        "embedder name without version falls back to engine version",
+			ctxSettings: &settings.Run{BinaryName: "mycli"},
+			wantCLIName: "mycli",
+			wantCLIVer:  "0.1.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithContext(context.Background(), NewContext())
+			if tt.ctxSettings != nil {
+				ctx = settings.IntoContext(ctx, tt.ctxSettings)
+			}
+
+			snapshot, err := CaptureSnapshot(
+				ctx, "sol", "1.0.0", "0.1.0", map[string]any{}, 0, ExecutionStatusSuccess,
+			)
+			require.NoError(t, err)
+
+			rt := snapshot.Metadata.Runtime
+			assert.Equal(t, settings.CliBinaryName, rt.Engine.Name)
+			assert.Equal(t, "0.1.0", rt.Engine.Version)
+			assert.Equal(t, tt.wantCLIName, rt.CLI.Name)
+			assert.Equal(t, tt.wantCLIVer, rt.CLI.Version)
 		})
 	}
 }
@@ -306,12 +358,15 @@ func TestSaveAndLoadSnapshot(t *testing.T) {
 	// Create a snapshot
 	originalSnapshot := &Snapshot{
 		Metadata: SnapshotMetadata{
-			Solution:       "test-solution",
-			Version:        "1.0.0",
-			Timestamp:      time.Date(2026, 1, 14, 10, 0, 0, 0, time.UTC),
-			ScafctlVersion: "0.1.0",
-			TotalDuration:  "1.234s",
-			Status:         "success",
+			Solution:  "test-solution",
+			Version:   "1.0.0",
+			Timestamp: time.Date(2026, 1, 14, 10, 0, 0, 0, time.UTC),
+			Runtime: SnapshotRuntime{
+				Engine: SnapshotRuntimeComponent{Name: "scafctl", Version: "0.1.0"},
+				CLI:    SnapshotRuntimeComponent{Name: "scafctl", Version: "0.1.0"},
+			},
+			TotalDuration: "1.234s",
+			Status:        "success",
 		},
 		Parameters: map[string]any{
 			"env":    "production",
@@ -365,7 +420,7 @@ func TestSaveAndLoadSnapshot(t *testing.T) {
 	// Verify loaded snapshot matches original
 	assert.Equal(t, originalSnapshot.Metadata.Solution, loadedSnapshot.Metadata.Solution)
 	assert.Equal(t, originalSnapshot.Metadata.Version, loadedSnapshot.Metadata.Version)
-	assert.Equal(t, originalSnapshot.Metadata.ScafctlVersion, loadedSnapshot.Metadata.ScafctlVersion)
+	assert.Equal(t, originalSnapshot.Metadata.Runtime, loadedSnapshot.Metadata.Runtime)
 	assert.Equal(t, originalSnapshot.Metadata.Status, loadedSnapshot.Metadata.Status)
 
 	assert.Equal(t, originalSnapshot.Parameters, loadedSnapshot.Parameters)

--- a/pkg/resolver/testdata/snapshots/diamond_pattern_expected.json
+++ b/pkg/resolver/testdata/snapshots/diamond_pattern_expected.json
@@ -2,7 +2,10 @@
   "metadata": {
     "solution": "diamond-pattern-snapshot",
     "version": "1.0.0",
-    "scafctlVersion": "test",
+    "runtime": {
+      "engine": { "name": "scafctl", "version": "test" },
+      "cli": { "name": "scafctl", "version": "test" }
+    },
     "timestamp": "2024-01-01T00:00:00Z",
     "status": "success",
     "totalDuration": "150ms"

--- a/pkg/resolver/testdata/snapshots/error_handling_expected.json
+++ b/pkg/resolver/testdata/snapshots/error_handling_expected.json
@@ -2,7 +2,10 @@
   "metadata": {
     "solution": "error-handling-snapshot",
     "version": "1.0.0",
-    "scafctlVersion": "test",
+    "runtime": {
+      "engine": { "name": "scafctl", "version": "test" },
+      "cli": { "name": "scafctl", "version": "test" }
+    },
     "timestamp": "2024-01-01T00:00:00Z",
     "status": "failed",
     "totalDuration": "50ms"

--- a/pkg/resolver/testdata/snapshots/simple_chain_expected.json
+++ b/pkg/resolver/testdata/snapshots/simple_chain_expected.json
@@ -2,7 +2,10 @@
   "metadata": {
     "solution": "simple-chain-snapshot",
     "version": "1.0.0",
-    "scafctlVersion": "test",
+    "runtime": {
+      "engine": { "name": "scafctl", "version": "test" },
+      "cli": { "name": "scafctl", "version": "test" }
+    },
     "timestamp": "2024-01-01T00:00:00Z",
     "status": "success",
     "totalDuration": "100ms"

--- a/pkg/settings/provenance.go
+++ b/pkg/settings/provenance.go
@@ -1,0 +1,68 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package settings
+
+import "context"
+
+// RuntimeProvenance is the primitive, dependency-free description of who
+// performed a run: the execution engine (the scafctl library) and the invoking
+// CLI/frontend. It is the single source of truth for provenance fallback
+// semantics -- the state and resolver-snapshot packages adapt it into their own
+// struct families rather than reimplementing the "default CLI to engine" logic.
+//
+// When the CLI fields are empty they mirror the engine fields, which is the
+// case for direct (non-embedded) scafctl use.
+type RuntimeProvenance struct {
+	// EngineName is the execution engine name (typically CliBinaryName).
+	EngineName string
+	// EngineVersion is the engine build version.
+	EngineVersion string
+	// CLIName is the invoking CLI/frontend binary name. Empty mirrors EngineName.
+	CLIName string
+	// CLIVersion is the invoking CLI/frontend version. Empty mirrors EngineVersion.
+	CLIVersion string
+}
+
+// ResolvedCLIName returns the effective CLI name, falling back to the engine
+// name when no distinct invoker is set.
+func (p RuntimeProvenance) ResolvedCLIName() string {
+	if p.CLIName != "" {
+		return p.CLIName
+	}
+	return p.EngineName
+}
+
+// ResolvedCLIVersion returns the effective CLI version, falling back to the
+// engine version when no distinct invoker version is set.
+func (p RuntimeProvenance) ResolvedCLIVersion() string {
+	if p.CLIVersion != "" {
+		return p.CLIVersion
+	}
+	return p.EngineVersion
+}
+
+// RuntimeProvenanceFromContext builds provenance from the ambient CLI settings.
+// The engine identity is always scafctl at its build version. The CLI identity
+// is the configured binary name and (when embedded) the embedder version;
+// otherwise it defaults to the engine via the Resolved* accessors.
+//
+// engineVersion is passed explicitly so callers that already hold a build
+// version string (e.g. snapshot capture) stay authoritative; when empty it
+// falls back to VersionInformation.BuildVersion.
+func RuntimeProvenanceFromContext(ctx context.Context, engineVersion string) RuntimeProvenance {
+	if engineVersion == "" {
+		engineVersion = VersionInformation.BuildVersion
+	}
+	p := RuntimeProvenance{
+		EngineName:    CliBinaryName,
+		EngineVersion: engineVersion,
+	}
+	if s, ok := FromContext(ctx); ok {
+		if s.BinaryName != "" {
+			p.CLIName = s.BinaryName
+		}
+		p.CLIVersion = s.EmbedderVersion
+	}
+	return p
+}

--- a/pkg/settings/provenance_test.go
+++ b/pkg/settings/provenance_test.go
@@ -1,0 +1,86 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package settings
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRuntimeProvenance_Resolved(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		prov        RuntimeProvenance
+		wantCLIName string
+		wantCLIVer  string
+	}{
+		{
+			name:        "cli mirrors engine when empty",
+			prov:        RuntimeProvenance{EngineName: "scafctl", EngineVersion: "1.2.3"},
+			wantCLIName: "scafctl",
+			wantCLIVer:  "1.2.3",
+		},
+		{
+			name:        "cli overrides both",
+			prov:        RuntimeProvenance{EngineName: "scafctl", EngineVersion: "1.2.3", CLIName: "mycli", CLIVersion: "9.9.9"},
+			wantCLIName: "mycli",
+			wantCLIVer:  "9.9.9",
+		},
+		{
+			name:        "cli name only, version falls back",
+			prov:        RuntimeProvenance{EngineName: "scafctl", EngineVersion: "1.2.3", CLIName: "mycli"},
+			wantCLIName: "mycli",
+			wantCLIVer:  "1.2.3",
+		},
+		{
+			name:        "zero value yields empty",
+			prov:        RuntimeProvenance{},
+			wantCLIName: "",
+			wantCLIVer:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.wantCLIName, tt.prov.ResolvedCLIName())
+			assert.Equal(t, tt.wantCLIVer, tt.prov.ResolvedCLIVersion())
+		})
+	}
+}
+
+func TestRuntimeProvenanceFromContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("embedder identity from settings", func(t *testing.T) {
+		t.Parallel()
+		ctx := IntoContext(context.Background(), &Run{BinaryName: "mycli", EmbedderVersion: "4.5.6"})
+		p := RuntimeProvenanceFromContext(ctx, "0.1.0")
+
+		assert.Equal(t, CliBinaryName, p.EngineName)
+		assert.Equal(t, "0.1.0", p.EngineVersion)
+		assert.Equal(t, "mycli", p.ResolvedCLIName())
+		assert.Equal(t, "4.5.6", p.ResolvedCLIVersion())
+	})
+
+	t.Run("direct use mirrors engine", func(t *testing.T) {
+		t.Parallel()
+		p := RuntimeProvenanceFromContext(context.Background(), "0.1.0")
+
+		assert.Equal(t, CliBinaryName, p.EngineName)
+		assert.Equal(t, "0.1.0", p.EngineVersion)
+		assert.Equal(t, CliBinaryName, p.ResolvedCLIName())
+		assert.Equal(t, "0.1.0", p.ResolvedCLIVersion())
+	})
+
+	t.Run("empty engine version falls back to build version", func(t *testing.T) {
+		t.Parallel()
+		p := RuntimeProvenanceFromContext(context.Background(), "")
+		assert.Equal(t, VersionInformation.BuildVersion, p.EngineVersion)
+	})
+}

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -477,6 +477,12 @@ type Run struct {
 	ExitOnError        bool               `json:"exitOnError" yaml:"exitOnError" doc:"Whether to exit on error"`
 	BinaryName         string             `json:"binaryName" yaml:"binaryName" doc:"Runtime binary name for the CLI" maxLength:"64" example:"scafctl"`
 
+	// EmbedderVersion is the version string of the embedding CLI/frontend, when
+	// scafctl is used as a library. Empty when scafctl runs directly. It is used
+	// to record invoking-CLI provenance (distinct from the engine version) in
+	// state metadata.
+	EmbedderVersion string `json:"embedderVersion,omitempty" yaml:"embedderVersion,omitempty" doc:"Version of the embedding CLI/frontend" maxLength:"64" example:"1.2.3"`
+
 	// ActionDiscoveryFileNames overrides the file names used by "run action"
 	// auto-discovery. When empty, defaults from ActionFileNamesFor are used.
 	ActionDiscoveryFileNames []string `json:"-" yaml:"-"`

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -211,6 +211,11 @@ func (m *Manager) SaveParams(ctx context.Context, stateData *Data, mergedParams,
 func (m *Manager) commit(ctx context.Context, stateData *Data, resolverData, mergedParams map[string]any, solMeta SolutionMeta) error {
 	// Update metadata
 	now := time.Now().UTC()
+	// Stamp the current schema version so a state file loaded under an older
+	// (still-supported) schema is re-persisted under the format this build
+	// actually writes -- otherwise the on-disk schemaVersion would understate
+	// the content (e.g. a v2 file re-saved with the v3 runtime block).
+	stateData.SchemaVersion = SchemaVersionCurrent
 	if stateData.Metadata.CreatedAt.IsZero() {
 		stateData.Metadata.CreatedAt = now
 	}

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
 )
 
@@ -23,16 +24,34 @@ import (
 type Manager struct {
 	registry *provider.Registry
 	config   *Config
-	version  string // scafctl build version for metadata
+	runtime  settings.RuntimeProvenance // execution provenance for metadata
 }
 
-// NewManager creates a state manager for the given state configuration.
-func NewManager(config *Config, registry *provider.Registry, version string) *Manager {
+// NewManager creates a state manager for the given state configuration. The
+// provenance records both the engine (scafctl library) and invoking
+// CLI/frontend identities; see settings.RuntimeProvenance.
+func NewManager(config *Config, registry *provider.Registry, runtime settings.RuntimeProvenance) *Manager {
 	return &Manager{
 		config:   config,
 		registry: registry,
-		version:  version,
+		runtime:  runtime,
 	}
+}
+
+// runtimeMetadata adapts the shared provenance primitive into the state
+// Runtime metadata block, applying the CLI-mirrors-engine fallback.
+func runtimeMetadata(p settings.RuntimeProvenance) Runtime {
+	return Runtime{
+		Engine: RuntimeComponent{Name: p.EngineName, Version: p.EngineVersion},
+		CLI:    RuntimeComponent{Name: p.ResolvedCLIName(), Version: p.ResolvedCLIVersion()},
+	}
+}
+
+// RuntimeProvenanceFromContext builds execution provenance from the ambient CLI
+// settings. It is a thin wrapper over settings.RuntimeProvenanceFromContext so
+// callers in the command layer need not import settings directly.
+func RuntimeProvenanceFromContext(ctx context.Context) settings.RuntimeProvenance {
+	return settings.RuntimeProvenanceFromContext(ctx, "")
 }
 
 // LoadResult is returned by Load with the loaded state and merged parameters.
@@ -198,7 +217,7 @@ func (m *Manager) commit(ctx context.Context, stateData *Data, resolverData, mer
 	stateData.Metadata.LastUpdatedAt = now
 	stateData.Metadata.Solution = solMeta.Name
 	stateData.Metadata.Version = solMeta.Version
-	stateData.Metadata.ScafctlVersion = m.version
+	stateData.Metadata.Runtime = runtimeMetadata(m.runtime)
 
 	// Resolve backend inputs for save -- resolver outputs are available as _
 	// and CLI params as __params in backend input expressions.

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -314,6 +314,36 @@ func TestManagerSave(t *testing.T) {
 			},
 		},
 		{
+			name: "upgrades schema version on save",
+			config: &Config{
+				Enabled: literalValueRef(true),
+				Backend: Backend{
+					Provider: "mock-state",
+					Inputs:   map[string]*spec.ValueRef{},
+				},
+			},
+			backend: &mockBackendProvider{},
+			// Simulate a state file loaded under an older, still-supported
+			// schema. Saving must re-stamp it with the current schema version so
+			// the on-disk format matches the content actually written.
+			state: func() *Data {
+				d := NewData()
+				d.SchemaVersion = SchemaVersionMinimum
+				return d
+			}(),
+			setup: func() (*resolver.Context, []*resolver.Resolver) {
+				return resolver.NewContext(), nil
+			},
+			check: func(t *testing.T, sd *Data, backend *mockBackendProvider) {
+				assert.Equal(t, SchemaVersionCurrent, sd.SchemaVersion)
+				// The persisted document must carry the upgraded version too.
+				require.Len(t, backend.saveCalls, 1)
+				data, ok := backend.saveCalls[0]["data"].(map[string]any)
+				require.True(t, ok, "save inputs must include the state data map")
+				assert.EqualValues(t, SchemaVersionCurrent, data["schemaVersion"])
+			},
+		},
+		{
 			name: "preserves existing createdAt",
 			config: &Config{
 				Enabled: literalValueRef(true),

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -216,7 +217,7 @@ func TestManagerLoad(t *testing.T) {
 				reg = provider.NewRegistry()
 			}
 
-			mgr := NewManager(tt.config, reg, "test-version")
+			mgr := NewManager(tt.config, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 			cmd := CommandInfo{
 				Subcommand: "run solution",
 				Parameters: map[string]string{"foo": "bar"},
@@ -306,7 +307,8 @@ func TestManagerSave(t *testing.T) {
 			check: func(t *testing.T, sd *Data, _ *mockBackendProvider) {
 				assert.Equal(t, "my-app", sd.Metadata.Solution)
 				assert.Equal(t, "2.0.0", sd.Metadata.Version)
-				assert.Equal(t, "test-version", sd.Metadata.ScafctlVersion)
+				assert.Equal(t, "test-version", sd.Metadata.Runtime.Engine.Version)
+				assert.Equal(t, "scafctl", sd.Metadata.Runtime.Engine.Name)
 				assert.False(t, sd.Metadata.CreatedAt.IsZero())
 				assert.False(t, sd.Metadata.LastUpdatedAt.IsZero())
 			},
@@ -360,7 +362,7 @@ func TestManagerSave(t *testing.T) {
 				reg = provider.NewRegistry()
 			}
 
-			mgr := NewManager(tt.config, reg, "test-version")
+			mgr := NewManager(tt.config, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 			rctx, resolvers := tt.setup()
 			solMeta := SolutionMeta{Name: "my-app", Version: "2.0.0"}
 
@@ -390,7 +392,7 @@ func TestManagerSaveImmutablesAndParams(t *testing.T) {
 	t.Run("SaveImmutables locks immutable without persisting parameters", func(t *testing.T) {
 		backend := &mockBackendProvider{}
 		reg := newTestRegistry(t, backend)
-		mgr := NewManager(baseConfig, reg, "test-version")
+		mgr := NewManager(baseConfig, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 
 		rctx := resolver.NewContext()
 		rctx.SetResult("cluster_id", &resolver.ExecutionResult{
@@ -415,7 +417,7 @@ func TestManagerSaveImmutablesAndParams(t *testing.T) {
 	t.Run("SaveImmutables skips resolvers whose deferred validation failed", func(t *testing.T) {
 		backend := &mockBackendProvider{}
 		reg := newTestRegistry(t, backend)
-		mgr := NewManager(baseConfig, reg, "test-version")
+		mgr := NewManager(baseConfig, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 
 		rctx := resolver.NewContext()
 		rctx.SetResult("cluster_id", &resolver.ExecutionResult{
@@ -438,7 +440,7 @@ func TestManagerSaveImmutablesAndParams(t *testing.T) {
 	t.Run("SaveParams persists the merged parameter set", func(t *testing.T) {
 		backend := &mockBackendProvider{}
 		reg := newTestRegistry(t, backend)
-		mgr := NewManager(baseConfig, reg, "test-version")
+		mgr := NewManager(baseConfig, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 
 		sd := NewData()
 		params := map[string]any{"appName": "demo", "region": "us-east1"}
@@ -451,7 +453,7 @@ func TestManagerSaveImmutablesAndParams(t *testing.T) {
 	})
 
 	t.Run("nil config is a no-op", func(t *testing.T) {
-		mgr := NewManager(nil, provider.NewRegistry(), "test-version")
+		mgr := NewManager(nil, provider.NewRegistry(), settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 		sd := NewData()
 
 		require.NoError(t, mgr.SaveImmutables(context.Background(), sd, resolver.NewContext(), nil, nil, nil, solMeta, nil))
@@ -471,7 +473,7 @@ func TestManagerSave_Immutable(t *testing.T) {
 	t.Run("first write saves immutable entry", func(t *testing.T) {
 		backend := &mockBackendProvider{}
 		reg := newTestRegistry(t, backend)
-		mgr := NewManager(baseConfig, reg, "test-version")
+		mgr := NewManager(baseConfig, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 
 		rctx := resolver.NewContext()
 		rctx.SetResult("cluster_id", &resolver.ExecutionResult{
@@ -494,7 +496,7 @@ func TestManagerSave_Immutable(t *testing.T) {
 	t.Run("same value is no-op", func(t *testing.T) {
 		backend := &mockBackendProvider{}
 		reg := newTestRegistry(t, backend)
-		mgr := NewManager(baseConfig, reg, "test-version")
+		mgr := NewManager(baseConfig, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 
 		rctx := resolver.NewContext()
 		rctx.SetResult("cluster_id", &resolver.ExecutionResult{
@@ -524,7 +526,7 @@ func TestManagerSave_Immutable(t *testing.T) {
 	t.Run("different value errors", func(t *testing.T) {
 		backend := &mockBackendProvider{}
 		reg := newTestRegistry(t, backend)
-		mgr := NewManager(baseConfig, reg, "test-version")
+		mgr := NewManager(baseConfig, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 
 		rctx := resolver.NewContext()
 		rctx.SetResult("cluster_id", &resolver.ExecutionResult{
@@ -558,7 +560,7 @@ func TestManagerSave_Immutable(t *testing.T) {
 	t.Run("non-immutable resolver does not create entry", func(t *testing.T) {
 		backend := &mockBackendProvider{}
 		reg := newTestRegistry(t, backend)
-		mgr := NewManager(baseConfig, reg, "test-version")
+		mgr := NewManager(baseConfig, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 
 		rctx := resolver.NewContext()
 		rctx.SetResult("env", &resolver.ExecutionResult{
@@ -684,11 +686,14 @@ func TestExtractStateData(t *testing.T) {
 		dataMap := map[string]any{
 			"schemaVersion": float64(1),
 			"metadata": map[string]any{
-				"solution":       "test-app",
-				"version":        "1.0.0",
-				"scafctlVersion": "dev",
-				"createdAt":      "2025-01-01T00:00:00Z",
-				"lastUpdatedAt":  "2025-01-01T00:00:00Z",
+				"solution": "test-app",
+				"version":  "1.0.0",
+				"runtime": map[string]any{
+					"engine": map[string]any{"name": "scafctl", "version": "dev"},
+					"cli":    map[string]any{"name": "scafctl", "version": "dev"},
+				},
+				"createdAt":     "2025-01-01T00:00:00Z",
+				"lastUpdatedAt": "2025-01-01T00:00:00Z",
 			},
 			"command": map[string]any{
 				"subcommand": "run solution",
@@ -739,7 +744,7 @@ func TestManagerLoad_ParamsAsParams(t *testing.T) {
 				Inputs:   map[string]*spec.ValueRef{"path": {Expr: &expr}},
 			},
 		}
-		mgr := NewManager(cfg, reg, "v")
+		mgr := NewManager(cfg, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "v"})
 		params := map[string]any{"project": "my-proj"}
 		result, err := mgr.Load(context.Background(), params, CommandInfo{Subcommand: "run solution"})
 		assert.NoError(t, err)
@@ -758,7 +763,7 @@ func TestManagerLoad_ParamsAsParams(t *testing.T) {
 				Inputs:   map[string]*spec.ValueRef{},
 			},
 		}
-		mgr := NewManager(cfg, reg, "v")
+		mgr := NewManager(cfg, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "v"})
 
 		// enabled=true
 		result, err := mgr.Load(context.Background(), map[string]any{"state_enabled": true}, CommandInfo{})
@@ -783,7 +788,7 @@ func TestManagerLoad_ParamsAsParams(t *testing.T) {
 				Inputs:   map[string]*spec.ValueRef{"path": {Tmpl: &tmpl}},
 			},
 		}
-		mgr := NewManager(cfg, reg, "v")
+		mgr := NewManager(cfg, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "v"})
 		params := map[string]any{"project": "my-proj"}
 		result, err := mgr.Load(context.Background(), params, CommandInfo{})
 		assert.NoError(t, err)
@@ -801,7 +806,7 @@ func TestManagerLoad_ParamsAsParams(t *testing.T) {
 				Inputs:   map[string]*spec.ValueRef{"path": literalValueRef("default.json")},
 			},
 		}
-		mgr := NewManager(cfg, reg, "v")
+		mgr := NewManager(cfg, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "v"})
 		result, err := mgr.Load(context.Background(), nil, CommandInfo{})
 		assert.NoError(t, err)
 		assert.False(t, result.Skipped)
@@ -870,7 +875,7 @@ func TestManagerSave_SaveOverrides(t *testing.T) {
 				Inputs:   map[string]*spec.ValueRef{"path": literalValueRef("state.json")},
 			},
 		}
-		mgr := NewManager(cfg, reg, "test-version")
+		mgr := NewManager(cfg, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 		sd := NewData()
 		rctx := resolver.NewContext()
 		err := mgr.Save(context.Background(), sd, rctx, nil, nil, nil, SolutionMeta{Name: "app", Version: "1.0.0"})
@@ -893,7 +898,7 @@ func TestManagerSave_SaveOverrides(t *testing.T) {
 				},
 			},
 		}
-		mgr := NewManager(cfg, reg, "test-version")
+		mgr := NewManager(cfg, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 		sd := NewData()
 		rctx := resolver.NewContext()
 		err := mgr.Save(context.Background(), sd, rctx, nil, nil, nil, SolutionMeta{Name: "app", Version: "1.0.0"})
@@ -918,7 +923,7 @@ func TestManagerSave_SaveOverrides(t *testing.T) {
 				},
 			},
 		}
-		mgr := NewManager(cfg, reg, "test-version")
+		mgr := NewManager(cfg, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 		sd := NewData()
 		rctx := resolver.NewContext()
 		resolverData := map[string]any{"featureBranch": "feat/my-feature"}
@@ -943,7 +948,7 @@ func TestManagerSave_SaveOverrides(t *testing.T) {
 				},
 			},
 		}
-		mgr := NewManager(cfg, reg, "test-version")
+		mgr := NewManager(cfg, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 		sd := NewData()
 		rctx := resolver.NewContext()
 		resolverData := map[string]any{"appName": "my-app"}
@@ -970,7 +975,7 @@ func TestManagerSave_SaveOverrides(t *testing.T) {
 				},
 			},
 		}
-		mgr := NewManager(cfg, reg, "test-version")
+		mgr := NewManager(cfg, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 		sd := NewData()
 		rctx := resolver.NewContext()
 		err := mgr.Save(context.Background(), sd, rctx, nil, nil, nil, SolutionMeta{Name: "app", Version: "1.0.0"})
@@ -998,7 +1003,7 @@ func TestManagerSave_SaveOverrides(t *testing.T) {
 				},
 			},
 		}
-		mgr := NewManager(cfg, reg, "test-version")
+		mgr := NewManager(cfg, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 		// Load should succeed -- saveOverrides are not resolved
 		result, err := mgr.Load(context.Background(), nil, CommandInfo{Subcommand: "run solution"})
 		assert.NoError(t, err)
@@ -1020,7 +1025,7 @@ func TestManagerSave_SaveOverrides(t *testing.T) {
 				},
 			},
 		}
-		mgr := NewManager(cfg, reg, "test-version")
+		mgr := NewManager(cfg, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 		sd := NewData()
 		rctx := resolver.NewContext()
 		err := mgr.Save(context.Background(), sd, rctx, nil, nil, nil, SolutionMeta{Name: "app", Version: "1.0.0"})
@@ -1042,7 +1047,7 @@ func TestManagerSave_SaveOverrides(t *testing.T) {
 				},
 			},
 		}
-		mgr := NewManager(cfg, reg, "test-version")
+		mgr := NewManager(cfg, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 		sd := NewData()
 		rctx := resolver.NewContext()
 		err := mgr.Save(context.Background(), sd, rctx, nil, nil, nil, SolutionMeta{Name: "app", Version: "1.0.0"})
@@ -1203,7 +1208,7 @@ func TestLoad_MissingParamsError(t *testing.T) {
 
 	backend := &mockBackendProvider{}
 	reg := newTestRegistry(t, backend)
-	mgr := NewManager(cfg, reg, "test-version")
+	mgr := NewManager(cfg, reg, settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "test-version"})
 
 	t.Run("returns MissingParamsError when params missing", func(t *testing.T) {
 		// No params supplied -- template will fail on .__params.project

--- a/pkg/state/mock.go
+++ b/pkg/state/mock.go
@@ -11,11 +11,14 @@ func NewMockData(solution, version string, params map[string]any) *Data {
 	now := time.Now().UTC()
 	data := NewData()
 	data.Metadata = Metadata{
-		Solution:       solution,
-		Version:        version,
-		CreatedAt:      now,
-		LastUpdatedAt:  now,
-		ScafctlVersion: "test",
+		Solution:      solution,
+		Version:       version,
+		CreatedAt:     now,
+		LastUpdatedAt: now,
+		Runtime: Runtime{
+			Engine: RuntimeComponent{Name: "scafctl", Version: "test"},
+			CLI:    RuntimeComponent{Name: "scafctl", Version: "test"},
+		},
 	}
 	if params != nil {
 		data.Parameters = params

--- a/pkg/state/runtime_test.go
+++ b/pkg/state/runtime_test.go
@@ -1,0 +1,96 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRuntimeMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		prov        settings.RuntimeProvenance
+		wantEngine  RuntimeComponent
+		wantCLIName string
+		wantCLIVer  string
+	}{
+		{
+			name:        "cli fields mirror engine when empty",
+			prov:        settings.RuntimeProvenance{EngineName: "scafctl", EngineVersion: "1.2.3"},
+			wantEngine:  RuntimeComponent{Name: "scafctl", Version: "1.2.3"},
+			wantCLIName: "scafctl",
+			wantCLIVer:  "1.2.3",
+		},
+		{
+			name: "embedder cli distinct from engine",
+			prov: settings.RuntimeProvenance{
+				EngineName:    "scafctl",
+				EngineVersion: "1.2.3",
+				CLIName:       "mycli",
+				CLIVersion:    "9.9.9",
+			},
+			wantEngine:  RuntimeComponent{Name: "scafctl", Version: "1.2.3"},
+			wantCLIName: "mycli",
+			wantCLIVer:  "9.9.9",
+		},
+		{
+			name: "embedder name but no version falls back to engine version",
+			prov: settings.RuntimeProvenance{
+				EngineName:    "scafctl",
+				EngineVersion: "1.2.3",
+				CLIName:       "mycli",
+			},
+			wantEngine:  RuntimeComponent{Name: "scafctl", Version: "1.2.3"},
+			wantCLIName: "mycli",
+			wantCLIVer:  "1.2.3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := runtimeMetadata(tt.prov)
+			assert.Equal(t, tt.wantEngine, got.Engine)
+			assert.Equal(t, tt.wantCLIName, got.CLI.Name)
+			assert.Equal(t, tt.wantCLIVer, got.CLI.Version)
+		})
+	}
+}
+
+func TestRuntimeProvenanceFromContext_Embedder(t *testing.T) {
+	t.Parallel()
+
+	ctx := settings.IntoContext(context.Background(), &settings.Run{
+		BinaryName:      "mycli",
+		EmbedderVersion: "4.5.6",
+	})
+
+	rt := runtimeMetadata(RuntimeProvenanceFromContext(ctx))
+
+	// Engine is always scafctl at its build version.
+	assert.Equal(t, settings.CliBinaryName, rt.Engine.Name)
+	assert.Equal(t, settings.VersionInformation.BuildVersion, rt.Engine.Version)
+
+	// CLI reflects the embedder identity, distinct from the engine.
+	assert.Equal(t, "mycli", rt.CLI.Name)
+	assert.Equal(t, "4.5.6", rt.CLI.Version)
+	assert.NotEqual(t, rt.Engine.Name, rt.CLI.Name)
+}
+
+func TestRuntimeProvenanceFromContext_DirectUse(t *testing.T) {
+	t.Parallel()
+
+	// No settings in context: CLI mirrors the engine.
+	rt := runtimeMetadata(RuntimeProvenanceFromContext(context.Background()))
+
+	assert.Equal(t, settings.CliBinaryName, rt.Engine.Name)
+	assert.Equal(t, rt.Engine.Name, rt.CLI.Name)
+	assert.Equal(t, rt.Engine.Version, rt.CLI.Version)
+}

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -11,7 +11,13 @@ import (
 
 const (
 	// SchemaVersionCurrent is the state file schema version written by this build.
-	SchemaVersionCurrent = 2
+	// v3 replaced the single-purpose metadata.scafctlVersion field with a
+	// metadata.runtime block that separates the execution engine identity
+	// (runtime.engine) from the invoking CLI/frontend identity (runtime.cli).
+	// Legacy v2 files still load (SchemaVersionMinimum stays 2) but their old
+	// scafctlVersion value is intentionally NOT migrated into runtime -- the
+	// runtime block is re-stamped from the current invocation on the next save.
+	SchemaVersionCurrent = 3
 
 	// SchemaVersionMinimum is the oldest state file schema version this build can
 	// safely load. Bump this ONLY when a breaking change makes older files unsafe
@@ -115,8 +121,32 @@ type Metadata struct {
 	// LastUpdatedAt is when the state file was most recently saved.
 	LastUpdatedAt time.Time `json:"lastUpdatedAt" doc:"Most recent save"`
 
-	// ScafctlVersion is the version of scafctl that last wrote the state.
-	ScafctlVersion string `json:"scafctlVersion" doc:"Version of scafctl that last wrote" maxLength:"30"`
+	// Runtime records the execution provenance that last wrote the state,
+	// separating the engine (library) identity from the invoking CLI/frontend.
+	Runtime Runtime `json:"runtime" doc:"Execution provenance that last wrote the state"`
+}
+
+// Runtime records execution provenance: which engine performed the run and
+// which CLI/frontend invoked it. When scafctl is run directly (not embedded),
+// CLI mirrors Engine.
+type Runtime struct {
+	// Engine identifies the execution engine (the scafctl library) that
+	// performed the run.
+	Engine RuntimeComponent `json:"engine" doc:"Execution engine (scafctl library) identity"`
+
+	// CLI identifies the CLI/frontend that invoked execution. For embedded
+	// runners this is the wrapper binary; for direct scafctl use it mirrors
+	// Engine.
+	CLI RuntimeComponent `json:"cli" doc:"Invoking CLI/frontend identity"`
+}
+
+// RuntimeComponent identifies a named, versioned runtime participant.
+type RuntimeComponent struct {
+	// Name is the component's binary/identifier name.
+	Name string `json:"name" doc:"Component name" maxLength:"64" example:"scafctl"`
+
+	// Version is the component's version string. May be empty when unknown.
+	Version string `json:"version" doc:"Component version" maxLength:"64" example:"0.5.0"`
 }
 
 // CommandInfo captures the most recent invocation for validation replay.

--- a/pkg/state/types_test.go
+++ b/pkg/state/types_test.go
@@ -31,11 +31,14 @@ func TestStateData_JSONRoundTrip(t *testing.T) {
 	original := &Data{
 		SchemaVersion: 1,
 		Metadata: Metadata{
-			Solution:       "deploy-app",
-			Version:        "1.0.0",
-			CreatedAt:      now,
-			LastUpdatedAt:  now,
-			ScafctlVersion: "0.9.0",
+			Solution:      "deploy-app",
+			Version:       "1.0.0",
+			CreatedAt:     now,
+			LastUpdatedAt: now,
+			Runtime: Runtime{
+				Engine: RuntimeComponent{Name: "scafctl", Version: "0.9.0"},
+				CLI:    RuntimeComponent{Name: "mycli", Version: "2.3.4"},
+			},
 		},
 		Command: CommandInfo{
 			Subcommand: "run solution",
@@ -73,7 +76,7 @@ func TestStateData_JSONRoundTrip(t *testing.T) {
 	assert.Equal(t, original.SchemaVersion, restored.SchemaVersion)
 	assert.Equal(t, original.Metadata.Solution, restored.Metadata.Solution)
 	assert.Equal(t, original.Metadata.Version, restored.Metadata.Version)
-	assert.Equal(t, original.Metadata.ScafctlVersion, restored.Metadata.ScafctlVersion)
+	assert.Equal(t, original.Metadata.Runtime, restored.Metadata.Runtime)
 	assert.Equal(t, original.Command.Subcommand, restored.Command.Subcommand)
 	assert.Equal(t, original.Command.Parameters, restored.Command.Parameters)
 	assert.Len(t, restored.Parameters, 2)
@@ -109,7 +112,7 @@ func TestNewMockStateData(t *testing.T) {
 	assert.Equal(t, SchemaVersionCurrent, data.SchemaVersion)
 	assert.Equal(t, "test-sol", data.Metadata.Solution)
 	assert.Equal(t, "2.0.0", data.Metadata.Version)
-	assert.Equal(t, "test", data.Metadata.ScafctlVersion)
+	assert.Equal(t, "test", data.Metadata.Runtime.Engine.Version)
 	assert.False(t, data.Metadata.CreatedAt.IsZero())
 	assert.Len(t, data.Parameters, 1)
 	assert.Equal(t, "prod", data.Parameters["env"])

--- a/pkg/state/view_test.go
+++ b/pkg/state/view_test.go
@@ -44,11 +44,14 @@ func TestBuildListView_GroupsSections(t *testing.T) {
 
 	sd := NewData()
 	sd.Metadata = Metadata{
-		Solution:       "demo",
-		Version:        "1.2.3",
-		ScafctlVersion: "dev",
-		CreatedAt:      created,
-		LastUpdatedAt:  updated,
+		Solution: "demo",
+		Version:  "1.2.3",
+		Runtime: Runtime{
+			Engine: RuntimeComponent{Name: "scafctl", Version: "dev"},
+			CLI:    RuntimeComponent{Name: "scafctl", Version: "dev"},
+		},
+		CreatedAt:     created,
+		LastUpdatedAt: updated,
 	}
 	sd.Command = CommandInfo{
 		Subcommand: "run resolver",
@@ -80,7 +83,7 @@ func TestBuildListView_GroupsSections(t *testing.T) {
 	meta := view.SectionByName("metadata").Fields
 	assert.Equal(t, "demo", meta["solution"])
 	assert.Equal(t, "1.2.3", meta["version"])
-	assert.Equal(t, "dev", meta["scafctlVersion"])
+	assert.NotNil(t, meta["runtime"])
 	assert.Equal(t, "2025-01-02T03:04:05Z", meta["createdAt"])
 	assert.Equal(t, "2025-06-07T08:09:10Z", meta["lastUpdatedAt"])
 

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -10721,7 +10721,7 @@ func TestIntegration_StateListResolversJSON(t *testing.T) {
 
 	// Seed a state file exercising every section: a parameter, a persisted
 	// resolver, an immutable resolver, and a fingerprint.
-	content := `{"schemaVersion":2,` +
+	content := `{"schemaVersion":3,` +
 		`"metadata":{"solution":"grouped-demo","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-02-02T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},` +
 		`"command":{"subcommand":"run resolver","parameters":{"token":"alpha"}},` +
 		`"parameters":{"env":"prod"},` +
@@ -10763,7 +10763,7 @@ func TestIntegration_StateListResolversTable(t *testing.T) {
 	t.Parallel()
 	stateFile := filepath.Join(t.TempDir(), "test-state.json")
 
-	content := `{"schemaVersion":2,` +
+	content := `{"schemaVersion":3,` +
 		`"metadata":{"solution":"grouped-demo","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-02-02T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},` +
 		`"command":{"subcommand":"run resolver","parameters":{}},` +
 		`"parameters":{"env":"prod"},` +
@@ -10793,7 +10793,7 @@ func TestIntegration_StateShowGrouped(t *testing.T) {
 
 	// Seed a state file exercising every section: a parameter, a persisted
 	// resolver, an immutable resolver, and a fingerprint.
-	content := `{"schemaVersion":2,` +
+	content := `{"schemaVersion":3,` +
 		`"metadata":{"solution":"grouped-demo","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-02-02T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},` +
 		`"command":{"subcommand":"run resolver","parameters":{"token":"alpha"}},` +
 		`"parameters":{"env":"prod"},` +
@@ -10825,7 +10825,7 @@ func TestIntegration_StateShowGrouped(t *testing.T) {
 	}
 	require.NoError(t, json.Unmarshal([]byte(stdout), &view), "output must be valid JSON")
 
-	assert.Equal(t, 2, view.SchemaVersion)
+	assert.Equal(t, 3, view.SchemaVersion)
 	assert.Equal(t, "grouped-demo", view.Metadata["solution"])
 	assert.Equal(t, "run resolver", view.Command["subcommand"])
 
@@ -10850,7 +10850,7 @@ func TestIntegration_StateShowGroupedTable(t *testing.T) {
 	t.Parallel()
 	stateFile := filepath.Join(t.TempDir(), "test-state.json")
 
-	content := `{"schemaVersion":2,` +
+	content := `{"schemaVersion":3,` +
 		`"metadata":{"solution":"grouped-demo","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-02-02T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},` +
 		`"command":{"subcommand":"run resolver","parameters":{}},` +
 		`"parameters":{"env":"prod"},` +
@@ -10928,7 +10928,7 @@ func TestIntegration_StateClearPreservesMetadata(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "test-state.json")
 
 	// Seed state with metadata and parameters
-	content := `{"schemaVersion":2,"metadata":{"solution":"my-sol","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-03-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"1.0.0"},"cli":{"name":"scafctl","version":"1.0.0"}}},"command":{"subcommand":"run solution","parameters":{"env":"prod"}},"parameters":{"k1":"v1","k2":"v2"},"resolvers":{},"fingerprints":{}}`
+	content := `{"schemaVersion":3,"metadata":{"solution":"my-sol","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-03-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"1.0.0"},"cli":{"name":"scafctl","version":"1.0.0"}}},"command":{"subcommand":"run solution","parameters":{"env":"prod"}},"parameters":{"k1":"v1","k2":"v2"},"resolvers":{},"fingerprints":{}}`
 	require.NoError(t, os.WriteFile(stateFile, []byte(content), 0o600))
 
 	// Clear

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -10722,7 +10722,7 @@ func TestIntegration_StateListResolversJSON(t *testing.T) {
 	// Seed a state file exercising every section: a parameter, a persisted
 	// resolver, an immutable resolver, and a fingerprint.
 	content := `{"schemaVersion":2,` +
-		`"metadata":{"solution":"grouped-demo","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-02-02T00:00:00Z","scafctlVersion":"dev"},` +
+		`"metadata":{"solution":"grouped-demo","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-02-02T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},` +
 		`"command":{"subcommand":"run resolver","parameters":{"token":"alpha"}},` +
 		`"parameters":{"env":"prod"},` +
 		`"resolvers":{` +
@@ -10764,7 +10764,7 @@ func TestIntegration_StateListResolversTable(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "test-state.json")
 
 	content := `{"schemaVersion":2,` +
-		`"metadata":{"solution":"grouped-demo","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-02-02T00:00:00Z","scafctlVersion":"dev"},` +
+		`"metadata":{"solution":"grouped-demo","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-02-02T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},` +
 		`"command":{"subcommand":"run resolver","parameters":{}},` +
 		`"parameters":{"env":"prod"},` +
 		`"resolvers":{"current_token":{"value":"alpha","type":"string","createdAt":"2025-01-01T00:00:00Z","updatedAt":"2025-02-02T00:00:00Z"}},` +
@@ -10794,7 +10794,7 @@ func TestIntegration_StateShowGrouped(t *testing.T) {
 	// Seed a state file exercising every section: a parameter, a persisted
 	// resolver, an immutable resolver, and a fingerprint.
 	content := `{"schemaVersion":2,` +
-		`"metadata":{"solution":"grouped-demo","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-02-02T00:00:00Z","scafctlVersion":"dev"},` +
+		`"metadata":{"solution":"grouped-demo","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-02-02T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},` +
 		`"command":{"subcommand":"run resolver","parameters":{"token":"alpha"}},` +
 		`"parameters":{"env":"prod"},` +
 		`"resolvers":{` +
@@ -10851,7 +10851,7 @@ func TestIntegration_StateShowGroupedTable(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "test-state.json")
 
 	content := `{"schemaVersion":2,` +
-		`"metadata":{"solution":"grouped-demo","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-02-02T00:00:00Z","scafctlVersion":"dev"},` +
+		`"metadata":{"solution":"grouped-demo","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-02-02T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},` +
 		`"command":{"subcommand":"run resolver","parameters":{}},` +
 		`"parameters":{"env":"prod"},` +
 		`"resolvers":{"current_token":{"value":"alpha","type":"string","createdAt":"2025-01-01T00:00:00Z","updatedAt":"2025-02-02T00:00:00Z"}},` +
@@ -10928,7 +10928,7 @@ func TestIntegration_StateClearPreservesMetadata(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "test-state.json")
 
 	// Seed state with metadata and parameters
-	content := `{"schemaVersion":2,"metadata":{"solution":"my-sol","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-03-01T00:00:00Z","scafctlVersion":"1.0.0"},"command":{"subcommand":"run solution","parameters":{"env":"prod"}},"parameters":{"k1":"v1","k2":"v2"},"resolvers":{},"fingerprints":{}}`
+	content := `{"schemaVersion":2,"metadata":{"solution":"my-sol","version":"2.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-03-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"1.0.0"},"cli":{"name":"scafctl","version":"1.0.0"}}},"command":{"subcommand":"run solution","parameters":{"env":"prod"}},"parameters":{"k1":"v1","k2":"v2"},"resolvers":{},"fingerprints":{}}`
 	require.NoError(t, os.WriteFile(stateFile, []byte(content), 0o600))
 
 	// Clear

--- a/tests/integration/solutions/state/dynamic-enabled/solution.yaml
+++ b/tests/integration/solutions/state/dynamic-enabled/solution.yaml
@@ -58,7 +58,7 @@ spec:
         init:
           # Pre-seed state with greeting = from-state
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"from-state"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"from-state"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/dynamic-enabled-state.json
         assertions:
           - expression: __exitCode == 0
@@ -75,7 +75,7 @@ spec:
         tags: [state, dynamic-enabled]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"from-state"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"from-state"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/dynamic-enabled-state.json
         assertions:
           - expression: __exitCode == 0
@@ -92,7 +92,7 @@ spec:
         tags: [state, dynamic-enabled]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"saved-hello"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"saved-hello"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/dynamic-enabled-state.json
         assertions:
           - expression: __exitCode == 0
@@ -122,7 +122,7 @@ spec:
         tags: [state, dynamic-enabled]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"from-state"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-dynamic-enabled","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"from-state"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/dynamic-enabled-state.json
         assertions:
           - expression: __exitCode == 0

--- a/tests/integration/solutions/state/dynamic-path-multi/solution.yaml
+++ b/tests/integration/solutions/state/dynamic-path-multi/solution.yaml
@@ -144,7 +144,7 @@ spec:
         init:
           - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/state/acme/staging"
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-dynamic-path-multi","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"config_value":"staging-config"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-dynamic-path-multi","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"config_value":"staging-config"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state/acme/staging/web.json
         assertions:
           - expression: __exitCode == 0

--- a/tests/integration/solutions/state/dynamic-path/solution.yaml
+++ b/tests/integration/solutions/state/dynamic-path/solution.yaml
@@ -73,7 +73,7 @@ spec:
         init:
           - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/dynamic"
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-dynamic-path","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"config_value":"beta-config"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-dynamic-path","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"config_value":"beta-config"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/dynamic/beta.json
         assertions:
           - expression: __exitCode == 0
@@ -92,7 +92,7 @@ spec:
           - command: "mkdir -p $SCAFCTL_SANDBOX_DIR/dynamic"
           # Pre-seed for project "beta" only
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-dynamic-path","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"config_value":"beta-only"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-dynamic-path","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"config_value":"beta-only"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/dynamic/beta.json
         assertions:
           - expression: __exitCode == 0

--- a/tests/integration/solutions/state/immutable-overwrite/solution.yaml
+++ b/tests/integration/solutions/state/immutable-overwrite/solution.yaml
@@ -61,7 +61,7 @@ spec:
         tags: [state, immutable]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-immutable-overwrite","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"resolvers":{"value":{"value":"fixed-value","type":"string","immutable":true,"createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-immutable-overwrite","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"resolvers":{"value":{"value":"fixed-value","type":"string","immutable":true,"createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __exitCode == 0
@@ -79,7 +79,7 @@ spec:
         tags: [state, immutable, negative]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-immutable-overwrite","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"resolvers":{"value":{"value":"original-locked","type":"string","immutable":true,"createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-immutable-overwrite","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"resolvers":{"value":{"value":"original-locked","type":"string","immutable":true,"createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __exitCode != 0
@@ -99,7 +99,7 @@ spec:
         tags: [state, immutable]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-immutable-overwrite","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-immutable-overwrite","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __exitCode == 0

--- a/tests/integration/solutions/state/immutable/solution.yaml
+++ b/tests/integration/solutions/state/immutable/solution.yaml
@@ -81,7 +81,7 @@ spec:
         extends: [_base]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"resolvers":{"locked_id":{"value":"generated-id-001","type":"string","immutable":true,"createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"resolvers":{"locked_id":{"value":"generated-id-001","type":"string","immutable":true,"createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __output.locked_id == "generated-id-001"
@@ -95,7 +95,7 @@ spec:
         extends: [_base]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"locked_id":"locked-from-state"},"resolvers":{"locked_id":{"value":"locked-from-state","type":"string","immutable":true,"createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"locked_id":"locked-from-state"},"resolvers":{"locked_id":{"value":"locked-from-state","type":"string","immutable":true,"createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __output.locked_id == "locked-from-state"
@@ -111,7 +111,7 @@ spec:
         tags: [state, immutable]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"locked_id":"locked-from-state"},"resolvers":{"locked_id":{"value":"locked-from-state","type":"string","immutable":true,"createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"locked_id":"locked-from-state"},"resolvers":{"locked_id":{"value":"locked-from-state","type":"string","immutable":true,"createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __exitCode != 0
@@ -128,7 +128,7 @@ spec:
         args: ["-o", "json", "-r", "mutable_value=updated-value"]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"mutable_value":"old-value"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"mutable_value":"old-value"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __output.mutable_value == "updated-value"
@@ -143,7 +143,7 @@ spec:
         args: ["-o", "json", "-r", "locked_id=permanent-id", "-r", "mutable_value=fresh-value"]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"locked_id":"permanent-id","mutable_value":"old-mutable"},"resolvers":{"locked_id":{"value":"permanent-id","type":"string","immutable":true,"createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-immutable","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"locked_id":"permanent-id","mutable_value":"old-mutable"},"resolvers":{"locked_id":{"value":"permanent-id","type":"string","immutable":true,"createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __output.locked_id == "permanent-id"

--- a/tests/integration/solutions/state/persist-provider/solution.yaml
+++ b/tests/integration/solutions/state/persist-provider/solution.yaml
@@ -161,7 +161,7 @@ spec:
         tags: [state, persist, provider]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-persist-provider","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"resolvers":{"current_token":{"value":"seeded-alpha","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-persist-provider","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"resolvers":{"current_token":{"value":"seeded-alpha","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __exitCode == 0
@@ -209,7 +209,7 @@ spec:
         tags: [state, workflow, provider]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-persist-provider","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run solution","parameters":{}},"parameters":{},"resolvers":{"current_token":{"value":"seeded-prior","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-persist-provider","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run solution","parameters":{}},"parameters":{},"resolvers":{"current_token":{"value":"seeded-prior","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __exitCode == 0

--- a/tests/integration/solutions/state/persist-provider/state.json
+++ b/tests/integration/solutions/state/persist-provider/state.json
@@ -7,7 +7,10 @@
   "metadata": {
     "createdAt": "2026-07-08T18:03:33.734263Z",
     "lastUpdatedAt": "2026-07-08T20:06:07.647078Z",
-    "scafctlVersion": "0.32.0-alpha20260708",
+    "runtime": {
+      "engine": { "name": "scafctl", "version": "0.32.0-alpha20260708" },
+      "cli": { "name": "scafctl", "version": "0.32.0-alpha20260708" }
+    },
     "solution": "test-state-persist-provider",
     "version": "1.0.0"
   },
@@ -22,5 +25,5 @@
       "value": "delta"
     }
   },
-  "schemaVersion": 2
+  "schemaVersion": 3
 }

--- a/tests/integration/solutions/state/persistence/solution.yaml
+++ b/tests/integration/solutions/state/persistence/solution.yaml
@@ -68,7 +68,7 @@ spec:
         extends: [_base]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-persistence","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"hello-from-state","counter":"99"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-persistence","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"greeting":"hello-from-state","counter":"99"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __output.greeting == "hello-from-state"

--- a/tests/integration/solutions/state/render-solution/solution.yaml
+++ b/tests/integration/solutions/state/render-solution/solution.yaml
@@ -80,7 +80,7 @@ spec:
         tags: [state, render]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-render-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"render solution","parameters":{}},"parameters":{"target":"prod-cluster","app_version":"3.2.1"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-render-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"render solution","parameters":{}},"parameters":{"target":"prod-cluster","app_version":"3.2.1"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/render-state.json
         assertions:
           - expression: __exitCode == 0
@@ -110,7 +110,7 @@ spec:
         tags: [state, render]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-render-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"render solution","parameters":{}},"parameters":{"target":"cached-target"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-render-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"render solution","parameters":{}},"parameters":{"target":"cached-target"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/render-state.json
         assertions:
           - expression: __exitCode == 0

--- a/tests/integration/solutions/state/render/solution.yaml
+++ b/tests/integration/solutions/state/render/solution.yaml
@@ -69,7 +69,7 @@ spec:
         tags: [state, render]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-render","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"cached_name":"cached-from-state"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-render","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"cached_name":"cached-from-state"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __exitCode == 0
@@ -88,7 +88,7 @@ spec:
         tags: [state, render, immutable]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-render","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"cached_name":"immutable-cached"},"resolvers":{"cached_name":{"value":"immutable-cached","type":"string","immutable":true,"createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-render","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"cached_name":"immutable-cached"},"resolvers":{"cached_name":{"value":"immutable-cached","type":"string","immutable":true,"createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __exitCode == 0

--- a/tests/integration/solutions/state/run-action/solution.yaml
+++ b/tests/integration/solutions/state/run-action/solution.yaml
@@ -95,7 +95,7 @@ spec:
         tags: [state, run-action]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-run-action","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run action","parameters":{}},"parameters":{"env":"production","version":"2.5.0"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-run-action","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run action","parameters":{}},"parameters":{"env":"production","version":"2.5.0"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/run-action-state.json
         assertions:
           - expression: __exitCode == 0
@@ -116,7 +116,7 @@ spec:
         tags: [state, run-action]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-run-action","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run action","parameters":{}},"parameters":{"env":"production"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-run-action","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run action","parameters":{}},"parameters":{"env":"production"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/run-action-state.json
         assertions:
           - expression: __exitCode == 0

--- a/tests/integration/solutions/state/run-solution/solution.yaml
+++ b/tests/integration/solutions/state/run-solution/solution.yaml
@@ -81,7 +81,7 @@ spec:
         tags: [state, run-solution]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-run-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run solution","parameters":{}},"parameters":{"target":"production","build_id":"build-042"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-run-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run solution","parameters":{}},"parameters":{"target":"production","build_id":"build-042"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/run-solution-state.json
         assertions:
           - expression: __exitCode == 0
@@ -101,7 +101,7 @@ spec:
         tags: [state, run-solution]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-run-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run solution","parameters":{}},"parameters":{"target":"production"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-run-solution","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run solution","parameters":{}},"parameters":{"target":"production"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/run-solution-state.json
         assertions:
           - expression: __exitCode == 0

--- a/tests/integration/solutions/state/save-overrides/solution.yaml
+++ b/tests/integration/solutions/state/save-overrides/solution.yaml
@@ -82,7 +82,7 @@ spec:
         init:
           # Pre-seed at inputs.path -- this should be found at load time
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-save-overrides","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"app_name":"from-default-path"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-save-overrides","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"app_name":"from-default-path"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/default-state.json
         assertions:
           - expression: __output.app_name == "from-default-path"

--- a/tests/integration/solutions/state/save-verify/solution.yaml
+++ b/tests/integration/solutions/state/save-verify/solution.yaml
@@ -88,7 +88,7 @@ spec:
         extends: [_base]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-save-verify","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"name":"saved-name","count":"42","enabled_flag":"false"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-save-verify","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"name":"saved-name","count":"42","enabled_flag":"false"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __output.name == "saved-name"
@@ -120,7 +120,7 @@ spec:
         args: ["-o", "json", "-r", "name=new-name"]
         init:
           - command: >-
-              printf '{"schemaVersion":2,"metadata":{"solution":"test-state-save-verify","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","scafctlVersion":"dev"},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"name":"old-name"},"resolvers":{},"fingerprints":{}}'
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-save-verify","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{"name":"old-name"},"resolvers":{},"fingerprints":{}}'
               > $SCAFCTL_SANDBOX_DIR/state.json
         assertions:
           - expression: __output.name == "new-name"


### PR DESCRIPTION
## Summary

Closes #524.

State and resolver-snapshot metadata recorded a single `scafctlVersion` string, which is ambiguous when execution is triggered through an embedding CLI/frontend -- it conflates the scafctl **engine** (library) with the **invoking CLI**. This replaces it with a structured `runtime` block that separates the two:

~~~json
"runtime": {
  "engine": { "name": "scafctl", "version": "..." },
  "cli":    { "name": "mycli",   "version": "..." }
}
~~~

When scafctl runs directly (not embedded), `runtime.cli` mirrors `runtime.engine`.

## Changes

- **State schema v2 -> v3.** `SchemaVersionMinimum` stays 2 so legacy v2 files still load; their old `scafctlVersion` is intentionally not migrated (runtime is re-stamped on next save).
- **Single source of truth for provenance fallback.** New dependency-free `settings.RuntimeProvenance` primitive encodes the "CLI mirrors engine when unset" rule once; the `state` and `resolver` packages adapt it into their own struct families (which carry package-specific Huma tags), so the semantics can't drift.
- **Embedder version plumbing.** `RootOptions.VersionExtra` -> `settings.Run.EmbedderVersion` -> `runtime.cli.version`, so embedded runners get real invoker provenance.
- **Snapshot + MCP alignment.** The resolver snapshot metadata and the MCP snapshot tool use the same `runtime` block.
- Docs (`docs/design/state/*.md`, `mcp-server-enhancements.md`) and all integration/unit fixtures updated.

## Breaking changes

- State schema is now **v3**; `metadata.scafctlVersion` is **removed** in favor of `metadata.runtime`.
- `state.NewManager` takes a `settings.RuntimeProvenance` instead of a version `string`.

Breaking changes are allowed (pre-production).

## Acceptance criteria (issue #524)

- [x] State metadata includes `runtime.engine` and `runtime.cli`
- [x] `runtime.cli` is populated for all official entrypoints (run/render commands)
- [x] State docs define exact semantics for each runtime field
- [x] Existing tests updated for new schema

## Testing

- `go build ./...`, `go vet`, and `go test -race` on changed packages: pass.
- New-code coverage: `settings.RuntimeProvenance` 100%; `snapshotRuntime` 100%; direct `root.go` embedder-wiring tests (non-default binary name + `VersionExtra`).
- `task integration`: 890 passed, 0 failed.
- `task lint`: only pre-existing gosec/revive findings in untouched files (catalog/plugin/version); none in this diff.