### PR TITLE
fix(state)!: don't silently cache when source globs match no files

### DIFF
--- a/.github/agents/planner.agent.md
+++ b/.github/agents/planner.agent.md
@@ -20,10 +20,82 @@ You are a senior Go architect and implementation planner for the **scafctl** pro
 
 ## Planning Process
 
+0. **Validate the issue** -- Before planning ANY solution, run the "Issue Triage & Solution Validation" gate below. Do not assume an issue is worth implementing or that its suggested approach is correct.
 1. **Understand** -- Analyze the request, identify constraints
 2. **Research** -- Use the `Explore` subagent for fast codebase searches when you need to find patterns, interfaces, or conventions across multiple packages
 3. **Design** -- Create the implementation blueprint
 4. **Review** -- Identify risks, edge cases, and dependencies
+
+## Issue Triage & Solution Validation (do this FIRST)
+
+An issue existing does not mean it should be implemented, and the reporter's
+suggested implementation is a hypothesis -- not a spec. Reporters often lack
+access to the codebase, so their file references and approach may be wrong,
+outdated, or already handled. Work through this gate before writing a blueprint.
+
+### 1. Is the issue legitimate and still relevant?
+
+- **Verify it is real, not assumed.** Reproduce the bug or confirm the gap
+  against the current code (cite `file:line`). Many issues are already
+  implemented, partially done, or fixed since filing -- check before planning.
+- **Confirm it is worth doing.** Ask whether it aligns with scafctl's purpose
+  and the embedder contract. If it adds narrow, ecosystem-specific surface area
+  to core (e.g. one-tool-specific behavior), that is a signal to push back or
+  scope it as a plugin/extension rather than core.
+- **Push back when warranted.** If the issue is invalid, redundant, better solved
+  another way, or not worth the maintenance cost, say so with evidence and
+  recommend closing or reshaping it. Do not implement something just because it
+  was requested.
+
+### 2. Treat the reporter's suggested implementation with skepticism
+
+- The issue's "Proposed Fix" / "Files to Modify" is a starting hint, **not** the
+  plan. Validate every referenced file, function, and line against the real code
+  -- they are frequently stale or wrong.
+- Independently derive where the change actually belongs using the codebase, the
+  layer rules (`.github/instructions/*`), and the domain-package boundaries
+  (business logic never in CLI/MCP/API layers).
+- If your validated approach diverges from the reporter's suggestion, state the
+  divergence and why.
+
+### 3. Find the BEST solution, not the easy one
+
+- **Breaking changes are allowed** -- scafctl is pre-production and does not keep
+  backward compatibility (see copilot-instructions). Do not contort the design to
+  avoid a break; choose the correct model and note the break explicitly.
+- Prefer the solution that is correct, maintainable, and consistent over the one
+  that is fastest to land. Call out any easy-but-inferior option you rejected and
+  why.
+
+### 4. Implement idiomatically to scafctl -- reuse before inventing
+
+- Search for existing patterns first and reuse them: `writer.FromContext`, `kvx`
+  output options, `celexp`, functional options, `settings`/`config` layering,
+  provider `Descriptor()`/`Execute()`, schema struct tags with Huma validation,
+  the struct-tag deprecation mechanism, etc. Match the conventions in
+  `.github/instructions/*` and the skills in `.github/skills/*`.
+- Only introduce a new pattern when the existing ones are genuinely unsuitable or
+  are not best practice -- and justify it in the blueprint.
+
+### 5. Learn from best-in-class CLIs
+
+- Consider how mature, well-regarded tools solve the same problem (e.g. `git`,
+  `docker`, `kubectl`, `gh`, `terraform`, `brew`, `cargo`, `npm`). Use `web`
+  research when a UX or architecture pattern is non-obvious.
+- Prefer established conventions (flag naming, subcommand shape, output modes,
+  config precedence, trust/verification models) over bespoke inventions, and note
+  which tool's precedent you are following.
+
+### Triage output
+
+Before the blueprint, produce a short **Validation** section recording:
+- Legitimacy verdict (implement / reshape / recommend-close) with `file:line` evidence.
+- Whether the reporter's suggested approach was confirmed or diverged from, and why.
+- The chosen approach vs. rejected alternatives (including any breaking-change decision).
+- The existing scafctl patterns being reused and any prior-art CLI precedent followed.
+
+If the verdict is recommend-close or reshape, STOP and surface that instead of
+producing an implementation blueprint.
 
 ## Blueprint Template
 
@@ -75,6 +147,11 @@ type SomeInterface interface {
 
 ## Principles
 
+- **Validate first** -- Never plan before confirming the issue is legitimate, still relevant, and worth doing (see triage gate)
+- **Escalate plan ambiguities** -- If the plan has an unresolved assumption, an ambiguity, a scope question, or anything that needs the user's attention, pause and ask (offer concrete options and a recommendation) rather than guessing
+- **Skeptical of suggestions** -- Treat the reporter's proposed implementation as an unverified hint; validate against the real code
+- **Best over easy** -- Choose the correct, maintainable solution; breaking changes are acceptable
+- **Prior art** -- Follow best-in-class CLI precedent and idiomatic scafctl patterns before inventing
 - **Read-only** -- This agent plans but does not modify code
 - **Interface-driven** -- Define contracts before implementations
 - **Incremental** -- Break work into small, independently testable pieces
@@ -84,3 +161,9 @@ type SomeInterface interface {
 ## Output
 
 Produce a structured blueprint following the template above. Each task should be small enough to implement and test independently.
+
+When a plan is implemented as issue-driven work, the implementer must run the
+"Issue Definition of Done" gate automatically as the final phase -- `go-reviewer`
+then `artifact-auditor` (the `/finish-issue` flow), resolving findings before any
+commit, without asking the user for permission. This is codified in
+`.github/copilot-instructions.md`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,11 +39,70 @@ The project uses `task` (go-task/task) for builds and linting. **Always use `tas
 
 ## Critical Rules
 
+- **Before implementing an issue, validate it first**: An open issue is not a mandate. Confirm the bug/gap is real against the current code (cite `file:line`) and worth doing before writing any solution. Treat the reporter's "Proposed Fix"/"Files to Modify" as an unverified hint -- reporters may lack codebase access, so validate the actual best location and approach in the code. Aim for the BEST solution, not the easy one (breaking changes are allowed -- see below). Reuse idiomatic scafctl patterns before inventing, and take cues from best-in-class CLIs (`git`, `docker`, `kubectl`, `gh`, `terraform`, `brew`). The `planner` agent codifies this triage gate -- use it for non-trivial issues.
 - **Business logic placement**: Never in CLI command packages (`pkg/cmd/scafctl/...`), MCP handler files (`pkg/mcp/tools_*.go`), or API packages -- put it in shared domain packages (`pkg/...`)
 - **After any change**: Run `task test:e2e` to ensure everything passes. E2E is slow -- run it **once**, redirect output to a file (`task test:e2e 2>&1 | tee /tmp/e2e-results.txt`), and grep the file to check results. Never re-run just to read output differently.
 - **Test coverage**: Every new or changed file must have tests. Target 70%+ patch coverage. Never submit a new file with 0% test coverage
 - **No magic values**: Always define constants or use settings for configuration values
 - **Git safety**: The AI may commit and push, but must **ask for approval first** every time (never commit or push without explicit per-action approval); `git commit --amend` is **denied** and run manually by the user. Before committing, verify a signing key is loaded (`ssh-add -l`); if none is loaded, prompt the user to run `ssh-add --apple-use-keychain ~/.ssh/id_ecdsa_public_github` (drop the flag on non-macOS; on Windows first `Start-Service ssh-agent` in PowerShell) rather than attempting a doomed commit. All commits must be signed (`-S`) and DCO signed-off (`-s`). See `AGENTS.md` for details.
+
+## Issue Definition of Done (automatic quality gate)
+
+When work originates from a GitHub issue (via `/issue`, the `planner`, or a
+direct "fix issue N" request), the following review gate runs **automatically**
+as the last phase -- do not ask the user whether to run it, and do not wait to
+be asked. Treat it as part of "done," equivalent to a pre-commit hook.
+
+**Checkpoint policy: one stop before commit.** After the plan is authorized,
+implement the change, run the automatic gate below, and apply fixes in one
+continuous pass. Do NOT pause between implementation, review, and fixing.
+Interrupt only to ask a genuine judgment-call question (see "Ask vs. proceed").
+Then present a **single consolidated summary** (what changed, review findings and
+how they were resolved, coverage, test results) and **ask once for approval to
+commit**. Commit and push remain separate approval-gated steps
+(`/pr-review` is run by the user afterward).
+
+Once the code changes for the issue are complete and local tests pass, and
+**before proposing a commit**:
+
+1. **Code review** -- Dispatch the `go-reviewer` agent (equivalent to the
+   `/go-review` command) over the current diff. Complete every phase; do not
+   stop at the first few findings.
+2. **Completeness/artifact audit** -- Dispatch the `artifact-auditor` agent
+   (equivalent to `/completeness-check`) to confirm the change has its required
+   tests, benchmarks, examples, docs, integration tests, and MCP/tool coverage.
+3. **Resolve findings** -- Address every CRITICAL/HIGH finding and any real
+   MEDIUM before proposing a commit (hand off to `go-fixer` if substantial).
+   Validate the fixes (build, `-race` tests, targeted integration) and note any
+   accepted LOW/INFO items with justification.
+4. **Summarize** -- Report the review outcome and what was fixed. Surface a
+   question to the user only if a finding requires a genuine product/design
+   decision -- never merely to ask permission to run the gate.
+
+**Ask vs. proceed.** The rule is about not asking *permission to run the gate* --
+it is NOT a rule to suppress genuine questions. Prompt the user whenever a real
+judgment call surfaces, for example:
+
+- The plan or issue has an ambiguity, an unresolved assumption, or something that
+  needs the user's attention before or during implementation.
+- A review or completeness finding does not have an obvious fix -- e.g. a design
+  tradeoff, a scope decision, a breaking-change choice, conflicting conventions,
+  or two reasonable approaches with different implications.
+- The correct behavior/UX is unclear, or the fix would expand scope beyond the
+  issue.
+
+In these cases, pause and ask (offer concrete options and a recommendation).
+Only routine, unambiguous findings should be fixed silently. When in doubt about
+whether something is "obvious," ask.
+
+`/pr-review` is **not** part of this local gate: it operates on an open GitHub
+PR (fetching review threads, CI status, and Codecov) and therefore runs only
+**after push**, once a PR exists. **The user runs `/pr-review` themselves** after
+the local gate is done and the branch is pushed -- do not auto-run it as part of
+issue work.
+
+The `/finish-issue` command wraps steps 1-4 as a single callable; the flow above
+must happen even if that command is never invoked explicitly.
 
 ## Embedder Contract
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -76,7 +76,16 @@ Once the code changes for the issue are complete and local tests pass, and
    MEDIUM before proposing a commit (hand off to `go-fixer` if substantial).
    Validate the fixes (build, `-race` tests, targeted integration) and note any
    accepted LOW/INFO items with justification.
-4. **Summarize** -- Report the review outcome and what was fixed. Surface a
+4. **Lint before commit (mandatory)** -- Immediately before proposing a commit,
+   run `task lint:changed` and confirm it reports **no new issues** in the
+   changed code. This is required on the FINAL diff every time -- a lint run from
+   earlier in the session does not count, since later edits (including test
+   changes) can introduce new findings. Note: plain `task lint` always exits
+   non-zero because of pre-existing issues in untouched files; `task lint:changed`
+   filters to only issues this branch introduced (vs. the merge base), so a
+   clean result there is the gate. If it reports anything, fix it before
+   committing -- never push a lint-failing change and rely on CI to catch it.
+5. **Summarize** -- Report the review outcome and what was fixed. Surface a
    question to the user only if a finding requires a genuine product/design
    decision -- never merely to ask permission to run the gate.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,6 +15,7 @@ Go-based CLI tool using CEL (Common Expression Language) for dynamic configurati
 ## Conventions
 
 - **Commits**: Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)
+- **Squash-merge**: PRs are squash-merged, so a PR becomes one commit on `main` built from the **PR title and body** (branch commit messages are discarded). Do not split a branch into multiple commits for history's sake, put the effort into the PR title/body, and keep unrelated concerns in **separate PRs** rather than separate commits. The PR title must be a valid conventional-commit subject. See `AGENTS.md` for detail.
 - **Signing**: All commits must be GPG/SSH signed (`-S`) and include DCO sign-off (`-s`)
 - **Errors**: Return errors with `fmt.Errorf("context: %w", err)`, don't panic
 - **Breaking changes**: Allowed -- this app is not in production. Note when doing so.

--- a/.github/issue-workflow.md
+++ b/.github/issue-workflow.md
@@ -1,0 +1,75 @@
+# Issue-to-PR Workflow
+
+This diagram shows how an issue is taken from evaluation to a pushed PR, and
+where the AI pauses for your input. It reflects the rules in
+[`.github/copilot-instructions.md`](./copilot-instructions.md) (the "Issue
+Definition of Done" gate and the "one stop before commit" checkpoint policy).
+
+## Key principles
+
+- **Validate before building** -- an open issue is not a mandate. The AI confirms
+  the bug/gap is real (`file:line`) and worth doing, and may recommend
+  closing/reshaping instead of implementing.
+- **Automatic quality gate** -- after implementation, `go-reviewer` and
+  `artifact-auditor` run automatically. The AI does not ask permission to run
+  them.
+- **One stop before commit** -- implementation, review, and fixes happen in a
+  single continuous pass. The AI interrupts only for genuine judgment-call
+  questions, then presents one summary and asks once to commit.
+- **Approval-gated git** -- commit and push are separate approvals. Commits are
+  signed (`-S`) and DCO signed-off (`-s`).
+- **`/pr-review` is user-run** -- it operates on the open GitHub PR (review
+  threads, CI, Codecov) and is run by you after push.
+
+## Flow
+
+```mermaid
+flowchart TD
+    A([You: evaluate issue #xxx for implementation]) --> B{Triage &#47; validation gate}
+    B -->|Not legit / redundant / better solved another way| C[AI recommends close or reshape]
+    C --> Z([Stop])
+    B -->|Legitimate| D[AI builds implementation plan]
+    D --> E{Plan ambiguity, assumption,<br/>or scope question?}
+    E -->|Yes| F[AI asks you: options + recommendation]
+    F --> G([You: answer, authorize implementation])
+    E -->|No| G
+
+    G --> H[AI implements plan]
+    H --> I[Build + race tests + targeted tests until green]
+
+    I --> J[[Auto Definition-of-Done gate]]
+    J --> K[go-reviewer: full multi-phase review]
+    K --> L[artifact-auditor: tests, docs,<br/>examples, integration, MCP]
+    L --> M[AI resolves CRITICAL / HIGH / real MEDIUM]
+
+    M --> N{Finding needs a judgment call?<br/>design tradeoff, breaking change, scope}
+    N -->|Yes| O[AI asks you: options + recommendation]
+    O --> P([You: answer])
+    P --> M
+    N -->|No, routine| Q[AI re-validates: build, race, integration]
+
+    Q --> R[/Single consolidated summary:<br/>changes, findings + resolutions,<br/>coverage, test results/]
+    R --> S{You: approve commit?}
+    S -->|No| Z
+    S -->|Yes| T[AI commits: signed -S + DCO -s]
+    T --> U{You: approve push?}
+    U -->|No| Z2([Stop: committed, not pushed])
+    U -->|Yes| V[AI pushes branch]
+    V --> W([You: run /pr-review on the open PR])
+    W --> X([PR review threads, CI, Codecov])
+```
+
+## Where the AI stops for you
+
+| Checkpoint | Who decides | Notes |
+|---|---|---|
+| Triage verdict | AI reports; you react | May recommend close/reshape instead of implementing |
+| Plan questions | You | Only when there is a real ambiguity/assumption/scope call |
+| Authorize implementation | You | Green-light to start coding |
+| Gate judgment calls | You | Only for non-obvious findings (design/scope/breaking) |
+| Approve commit | You | Single ask after one consolidated summary |
+| Approve push | You | Separate approval from commit |
+| `/pr-review` | You | Run manually after push, once the PR exists |
+
+Everything else -- running the review/completeness gate, fixing routine
+findings, re-validating -- happens automatically without asking permission.

--- a/.opencode/agent/go-fixer.md
+++ b/.opencode/agent/go-fixer.md
@@ -34,7 +34,9 @@ After all fixes are applied, run in this order:
 
 1. `go build ./...` -- must compile
 2. `go vet ./...` -- no warnings
-3. `task lint` -- no lint issues
+3. `task lint:changed` -- no NEW lint issues in changed code (plain `task lint`
+   always exits non-zero from pre-existing issues in untouched files, which hides
+   findings you introduced; `lint:changed` reports only what this branch added)
 4. `task test:e2e 2>&1 | tee /tmp/e2e-results.txt` -- all tests pass (run once, grep results)
 
 Fix any errors introduced by the changes before proceeding.

--- a/.opencode/agent/planner.md
+++ b/.opencode/agent/planner.md
@@ -13,10 +13,82 @@ You are a senior Go architect and implementation planner for the **scafctl** pro
 
 ## Planning Process
 
+0. **Validate the issue** -- Before planning ANY solution, run the "Issue Triage & Solution Validation" gate below. Do not assume an issue is worth implementing or that its suggested approach is correct.
 1. **Understand** -- Analyze the request, identify constraints
 2. **Research** -- Use the `Explore` subagent for fast codebase searches when you need to find patterns, interfaces, or conventions across multiple packages
 3. **Design** -- Create the implementation blueprint
 4. **Review** -- Identify risks, edge cases, and dependencies
+
+## Issue Triage & Solution Validation (do this FIRST)
+
+An issue existing does not mean it should be implemented, and the reporter's
+suggested implementation is a hypothesis -- not a spec. Reporters often lack
+access to the codebase, so their file references and approach may be wrong,
+outdated, or already handled. Work through this gate before writing a blueprint.
+
+### 1. Is the issue legitimate and still relevant?
+
+- **Verify it is real, not assumed.** Reproduce the bug or confirm the gap
+  against the current code (cite `file:line`). Many issues are already
+  implemented, partially done, or fixed since filing -- check before planning.
+- **Confirm it is worth doing.** Ask whether it aligns with scafctl's purpose
+  and the embedder contract. If it adds narrow, ecosystem-specific surface area
+  to core (e.g. one-tool-specific behavior), that is a signal to push back or
+  scope it as a plugin/extension rather than core.
+- **Push back when warranted.** If the issue is invalid, redundant, better solved
+  another way, or not worth the maintenance cost, say so with evidence and
+  recommend closing or reshaping it. Do not implement something just because it
+  was requested.
+
+### 2. Treat the reporter's suggested implementation with skepticism
+
+- The issue's "Proposed Fix" / "Files to Modify" is a starting hint, **not** the
+  plan. Validate every referenced file, function, and line against the real code
+  -- they are frequently stale or wrong.
+- Independently derive where the change actually belongs using the codebase, the
+  layer rules (`.github/instructions/*`), and the domain-package boundaries
+  (business logic never in CLI/MCP/API layers).
+- If your validated approach diverges from the reporter's suggestion, state the
+  divergence and why.
+
+### 3. Find the BEST solution, not the easy one
+
+- **Breaking changes are allowed** -- scafctl is pre-production and does not keep
+  backward compatibility. Do not contort the design to avoid a break; choose the
+  correct model and note the break explicitly.
+- Prefer the solution that is correct, maintainable, and consistent over the one
+  that is fastest to land. Call out any easy-but-inferior option you rejected and
+  why.
+
+### 4. Implement idiomatically to scafctl -- reuse before inventing
+
+- Search for existing patterns first and reuse them: `writer.FromContext`, `kvx`
+  output options, `celexp`, functional options, `settings`/`config` layering,
+  provider `Descriptor()`/`Execute()`, schema struct tags with Huma validation,
+  the struct-tag deprecation mechanism, etc. Match the conventions in
+  `.github/instructions/*` and the skills in `.github/skills/*`.
+- Only introduce a new pattern when the existing ones are genuinely unsuitable or
+  are not best practice -- and justify it in the blueprint.
+
+### 5. Learn from best-in-class CLIs
+
+- Consider how mature, well-regarded tools solve the same problem (e.g. `git`,
+  `docker`, `kubectl`, `gh`, `terraform`, `brew`, `cargo`, `npm`). Use `webfetch`
+  research when a UX or architecture pattern is non-obvious.
+- Prefer established conventions (flag naming, subcommand shape, output modes,
+  config precedence, trust/verification models) over bespoke inventions, and note
+  which tool's precedent you are following.
+
+### Triage output
+
+Before the blueprint, produce a short **Validation** section recording:
+- Legitimacy verdict (implement / reshape / recommend-close) with `file:line` evidence.
+- Whether the reporter's suggested approach was confirmed or diverged from, and why.
+- The chosen approach vs. rejected alternatives (including any breaking-change decision).
+- The existing scafctl patterns being reused and any prior-art CLI precedent followed.
+
+If the verdict is recommend-close or reshape, STOP and surface that instead of
+producing an implementation blueprint.
 
 ## Blueprint Template
 
@@ -68,6 +140,11 @@ type SomeInterface interface {
 
 ## Principles
 
+- **Validate first** -- Never plan before confirming the issue is legitimate, still relevant, and worth doing (see triage gate)
+- **Escalate plan ambiguities** -- If the plan has an unresolved assumption, an ambiguity, a scope question, or anything that needs the user's attention, pause and ask (offer concrete options and a recommendation) rather than guessing
+- **Skeptical of suggestions** -- Treat the reporter's proposed implementation as an unverified hint; validate against the real code
+- **Best over easy** -- Choose the correct, maintainable solution; breaking changes are acceptable
+- **Prior art** -- Follow best-in-class CLI precedent and idiomatic scafctl patterns before inventing
 - **Read-only** -- This agent plans but does not modify code
 - **Interface-driven** -- Define contracts before implementations
 - **Incremental** -- Break work into small, independently testable pieces
@@ -79,3 +156,9 @@ type SomeInterface interface {
 Produce a structured blueprint following the template above. Each task should be small enough to implement and test independently.
 
 When done, you may hand off to the `issue-creator` agent to file a GitHub issue from the plan, or to the default `build` agent to start implementing the plan or generate a markdown plan file.
+
+Whenever a plan is implemented as issue-driven work, the implementer must run the
+"Issue Definition of Done" gate automatically as the final phase -- `go-reviewer`
+then `artifact-auditor` (the `/finish-issue` flow), resolving findings before any
+commit, without asking the user for permission. This is codified in
+`.github/copilot-instructions.md`.

--- a/.opencode/command/finish-issue.md
+++ b/.opencode/command/finish-issue.md
@@ -50,6 +50,16 @@ flow) over the staged-or-changed set. Confirm the change has:
   concrete options and a recommendation. When in doubt whether it is "obvious,"
   ask.
 
+## Phase 4.5: Lint the final diff (mandatory before commit)
+
+Run `task lint:changed` on the FINAL diff and confirm **no new issues** in the
+changed code. Do this every time, right before proposing a commit -- an earlier
+lint run does not count, because the review/fix edits above can introduce new
+findings. `task lint` always exits non-zero due to pre-existing issues in
+untouched files; `task lint:changed` reports only issues this branch introduced
+(vs. the merge base), so a clean result there is the gate. Fix anything it
+reports before committing; never rely on CI to catch a lint failure.
+
 ## Phase 5: Summarize
 
 Report: review outcome (findings by severity), what was fixed, coverage status,

--- a/.opencode/command/finish-issue.md
+++ b/.opencode/command/finish-issue.md
@@ -1,0 +1,67 @@
+---
+description: "scafctl: Run the issue definition-of-done gate -- code review (go-reviewer) then completeness/artifact audit (artifact-auditor) over the current changes, resolve findings, and summarize. Runs automatically at the end of issue work; can also be invoked manually."
+agent: build
+---
+Run the local "Issue Definition of Done" quality gate over the current
+uncommitted changes. This wraps the steps that must run automatically at the end
+of any issue-driven change, before proposing a commit. Do NOT ask the user for
+permission to run these steps -- just run them and report.
+
+$ARGUMENTS
+
+## Phase 1: Preconditions
+
+1. Confirm code changes exist: `git status --short` and `git diff --stat`.
+   If there are no changes, report that and stop.
+2. Ensure the build and targeted tests pass before reviewing. Run
+   `go build ./...` and `go test -race` on the changed packages. If they fail,
+   fix them first (or hand off to `go-fixer`) before continuing.
+
+## Phase 2: Code review (go-reviewer)
+
+Dispatch the `go-reviewer` subagent over the current diff (this is the
+`/go-review` flow). Require it to complete ALL phases -- automated checks,
+systematic per-file review, adversarial analysis, cross-file consistency,
+coverage analysis, and self-review. Collect findings by severity.
+
+## Phase 3: Completeness / artifact audit (artifact-auditor)
+
+Dispatch the `artifact-auditor` subagent (this is the `/completeness-check`
+flow) over the staged-or-changed set. Confirm the change has:
+- Tests in the corresponding `*_test.go` files (70%+ patch coverage target)
+- Benchmarks for performance-sensitive code
+- Examples in `examples/` if user-facing
+- Updated docs / doc comments on exported types
+- Integration tests (CLI, solution, or API per the change type)
+- MCP tool / provider descriptor updates if applicable
+
+## Phase 4: Resolve findings
+
+- Address every CRITICAL and HIGH finding, and any real MEDIUM, before proposing
+  a commit. For substantial fixes, hand off to the `go-fixer` subagent.
+- After fixing, re-validate: `go build ./...`, `go test -race` on changed
+  packages, and any targeted integration tests. Run the full `task integration`
+  (or `task test:e2e`) once if the change is broad.
+- Note any accepted LOW/INFO items with a short justification.
+- **Ask when a fix is not obvious.** Fix routine, unambiguous findings silently,
+  but pause and prompt the user when a finding involves a real judgment call --
+  a design tradeoff, a scope decision, a breaking-change choice, conflicting
+  conventions, or two reasonable approaches with different implications. Offer
+  concrete options and a recommendation. When in doubt whether it is "obvious,"
+  ask.
+
+## Phase 5: Summarize
+
+Report: review outcome (findings by severity), what was fixed, coverage status,
+and test results.
+
+Prompt the user whenever a genuine judgment call surfaces -- an ambiguous or
+unresolved point in the plan/issue, or a review/completeness finding without an
+obvious fix (design tradeoff, scope, breaking change, conflicting conventions).
+The "no questions" rule applies ONLY to asking permission to run this gate; it
+does NOT suppress real decisions. Do not commit or push (that remains a separate,
+approval-gated step).
+
+Note: `/pr-review` is intentionally NOT part of this gate. The user runs it
+themselves after the branch is pushed and a GitHub PR exists, because it fetches
+PR review threads, CI status, and Codecov data. Do not auto-run it here.

--- a/.opencode/command/issue.md
+++ b/.opencode/command/issue.md
@@ -8,3 +8,8 @@ Create a GitHub issue for the described change. Follow this process:
 2. **Assess** feasibility, scope (XS/S/M/L/XL), risks, and affected areas
 3. **Wait** for user confirmation before creating anything
 4. **Create** the issue via `gh issue create` with appropriate title and structured body
+
+When an issue is later implemented, the "Issue Definition of Done" gate runs
+automatically before any commit: `go-reviewer` then `artifact-auditor` (the
+`/finish-issue` flow), resolving findings without asking the user for permission.
+See `.github/copilot-instructions.md`.

--- a/.opencode/command/plan.md
+++ b/.opencode/command/plan.md
@@ -14,3 +14,12 @@ Create a structured implementation blueprint for the described feature:
 8. **Risks & edge cases** -- What could go wrong
 
 Follow scafctl conventions: provider-based architecture, CEL/Go templates, Writer for output, kvx for data.
+
+Before planning, run the issue triage/validation gate (confirm the issue is
+legitimate and still relevant, treat the reporter's suggested implementation as
+an unverified hint, and choose the BEST solution -- breaking changes allowed).
+
+When the plan is implemented, the "Issue Definition of Done" gate runs
+automatically as the final phase: dispatch `go-reviewer` then `artifact-auditor`
+(the `/finish-issue` flow), resolve findings, and summarize -- without asking the
+user for permission. See `.github/copilot-instructions.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,26 @@ The AI **may** create commits and push (with approval), but must follow these ru
    (The `.opencode/plugins/git-signing-guard.ts` plugin enforces this by
    blocking commits when no key is loaded.)
 
+### This is a squash-merge repo
+
+PRs are merged with **squash**, so every PR becomes a single commit on `main`
+and the individual commit messages on the branch are discarded (GitHub uses the
+**PR title and body** as the final squash commit message). Commit accordingly:
+
+- **Do not split a branch into multiple commits for history's sake** -- it buys
+  nothing under squash and the messages are thrown away. Prefer a single,
+  well-formed commit per PR (or however many is convenient while working;
+  they collapse anyway).
+- **Put the real effort into the PR title and body**, not per-commit messages.
+  The PR title must be a valid conventional-commit subject (`feat:`, `fix:`,
+  `docs:`, `!` for breaking) because it becomes the squash subject.
+- **One logical change per PR.** Since everything in a PR squashes together,
+  keep unrelated concerns in **separate PRs** rather than separate commits --
+  e.g. a bug fix and unrelated tooling/docs changes should be two PRs, not one
+  PR with two commits.
+- The branch still must be signed and DCO signed-off (the checks run on the
+  branch commits, and the DCO trailer must survive into the squash).
+
 ### Identity for this worktree
 
 Repos under the `Public/` folder are signed as **abaker9@gmail.com** using
@@ -66,6 +86,8 @@ through the ssh-agent.
 ## Conventions (summary; see .github for full detail)
 
 - **Conventional commits** (`feat:`, `fix:`, `docs:`, `!` for breaking).
+- **Squash-merge repo:** PRs squash to one commit from the PR title/body -- don't
+  split for history, keep unrelated concerns in separate PRs (see Git section).
 - **Errors:** wrap with `fmt.Errorf("context: %w", err)`; never panic.
 - **Business logic** never in `pkg/cmd/scafctl/...`, `pkg/mcp/tools_*.go`, or API
   packages -- put it in shared domain packages.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,4 +93,7 @@ through the ssh-agent.
   packages -- put it in shared domain packages.
 - **Tests** for every new/changed file (target 70%+ patch coverage).
 - **Scratch files** go in the gitignored `temp/`; never commit them.
-- **Build/lint** via `task` (use `task lint`, not raw golangci-lint).
+- **Build/lint** via `task` (use `task lint`, not raw golangci-lint). Before
+  every commit, run `task lint:changed` and confirm no new issues -- it filters
+  out pre-existing findings in untouched files (which make plain `task lint`
+  always exit non-zero) and reports only what this branch introduced.

--- a/docs/design/state/fingerprinting.md
+++ b/docs/design/state/fingerprinting.md
@@ -138,6 +138,35 @@ func HashFiles(baseDir string, patterns []string) (string, error)
 func ExpandGlobs(baseDir string, patterns []string) ([]string, error)
 ~~~
 
+#### Empty source globs
+
+A `sources` pattern that matches no files (for example a typo, or a file that
+does not exist yet) is **tolerated** rather than fatal -- mirroring the
+`sources` semantics of build tools like go-task:
+
+- **Partial no-match** (some patterns match, some do not): the action is
+  fingerprinted on the files that *did* match. The non-matching patterns are
+  reported and surface as a low-key stderr hint (useful for catching typos),
+  but idempotency is preserved. This fixes the silent correctness bug where a
+  single bad pattern disabled caching for the whole action.
+- **Total no-match** (every source pattern matches nothing): there are no
+  trackable inputs, so the action is treated as **always stale** (reason
+  `no source files`) and re-runs on every invocation. A stderr warning is
+  emitted (`sources matched no files (fingerprint disabled)`). Caching is
+  effectively disabled for that action until at least one source pattern matches.
+- **Invalid or unsafe patterns** (malformed globs, absolute paths, `..`
+  traversal) remain a hard error (`ErrPatternInvalid`).
+
+Note that `generates` is stricter than `sources`: a declared output that does
+not exist (partial or total no-match) always marks the action stale, since a
+missing product means the action must run to produce it.
+
+`ExpandGlobs` returns `ErrNoMatches` only for the total no-match case; callers
+that need to distinguish partial from total (and warn accordingly) use
+`ExpandGlobsReport` / `HashFilesReport`, which never return `ErrNoMatches` and
+instead report `EmptyPatterns` and `AllEmpty`. All warnings are written to
+stderr so they never corrupt structured output (`-o json`).
+
 ### 4.5 State Helpers
 
 ~~~go

--- a/pkg/action/executor.go
+++ b/pkg/action/executor.go
@@ -671,7 +671,20 @@ func (e *Executor) executeAction(ctx context.Context, graph *Graph, actionName s
 	if e.fingerprintChecker != nil && !e.noCache && len(action.Sources) > 0 {
 		fpResult, fpErr := e.fingerprintChecker.CheckFiles(ctx, actionName, action.Sources, action.Generates, e.cwd)
 		if fpErr != nil {
-			// Log warning and continue execution (fail-open)
+			// A malformed, absolute, or path-traversing glob is a user/security
+			// error, not a transient miss -- fail the action hard rather than
+			// silently executing it (fail-open would defeat the pattern
+			// validation and its containment checks).
+			if errors.Is(fpErr, fingerprint.ErrPatternInvalid) {
+				e.actionContext.MarkFailed(actionName, fmt.Sprintf("invalid sources/generates pattern: %v", fpErr))
+				if e.progressCallback != nil {
+					e.progressCallback.OnActionFailed(actionName, fpErr)
+				}
+				span.RecordError(fpErr)
+				span.SetStatus(codes.Error, fpErr.Error())
+				return fpErr
+			}
+			// Other errors are non-fatal: log and continue execution (fail-open).
 			logger.FromContext(ctx).V(0).Info("fingerprint file check failed, executing action",
 				"action", actionName, "error", fpErr.Error())
 		} else {

--- a/pkg/action/executor.go
+++ b/pkg/action/executor.go
@@ -20,6 +20,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/spec"
 	"github.com/oakwood-commons/scafctl/pkg/telemetry"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -673,8 +674,11 @@ func (e *Executor) executeAction(ctx context.Context, graph *Graph, actionName s
 			// Log warning and continue execution (fail-open)
 			logger.FromContext(ctx).V(0).Info("fingerprint file check failed, executing action",
 				"action", actionName, "error", fpErr.Error())
-		} else if !fpResult.Stale {
-			filesFresh = true
+		} else {
+			e.warnEmptySources(ctx, actionName, fpResult.SourcesEmptyPatterns, fpResult.SourcesAllEmpty)
+			if !fpResult.Stale {
+				filesFresh = true
+			}
 		}
 	}
 
@@ -907,6 +911,31 @@ func (e *Executor) executeAction(ctx context.Context, graph *Graph, actionName s
 	}
 
 	return nil
+}
+
+// warnEmptySources surfaces user-visible warnings when an action's source globs
+// match no files. A total no-match (allEmpty) means the action cannot be
+// fingerprinted meaningfully, so caching is effectively disabled. A partial
+// no-match (some patterns matched) still fingerprints correctly and is a milder
+// typo hint. Both are written to stderr so they never corrupt structured
+// command output (e.g. -o json). It is a no-op when no writer is attached to the
+// context (e.g. embedded/library use) so domain behavior never depends on CLI
+// wiring.
+func (e *Executor) warnEmptySources(ctx context.Context, actionName string, emptyPatterns []string, allEmpty bool) {
+	if len(emptyPatterns) == 0 {
+		return
+	}
+	w := writer.FromContext(ctx)
+	if w == nil {
+		return
+	}
+	if allEmpty {
+		w.WarnStderrf("%s: sources matched no files (fingerprint disabled, action will always re-run): %v",
+			actionName, emptyPatterns)
+		return
+	}
+	w.WarnStderrf("%s: source pattern(s) matched no files (ignored): %v",
+		actionName, emptyPatterns)
 }
 
 // resolveInputs resolves all inputs including deferred values.

--- a/pkg/action/executor_test.go
+++ b/pkg/action/executor_test.go
@@ -1406,6 +1406,113 @@ func TestExecutor_Execute_FingerprintUpToDate(t *testing.T) {
 	assert.Equal(t, SkipReasonUpToDate, result.Actions["build"].SkipReason)
 }
 
+// Regression for #522: an action whose sources include a glob that matches no
+// files (e.g. a typo or a not-yet-created file) must still be fingerprinted on
+// its remaining sources -- it must NOT re-run on every invocation.
+func TestExecutor_Execute_FingerprintPartialMissingSource(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(dir+"/main.go", []byte("package main"), 0o644))
+
+	execCount := 0
+	registry := newExecMockRegistry()
+	registry.register(&execMockProvider{
+		name: "test-provider",
+		execute: func(_ context.Context, _ any) (*provider.Output, error) {
+			execCount++
+			return &provider.Output{Data: map[string]any{"result": "built"}}, nil
+		},
+	})
+
+	stateData := state.NewData()
+	fpChecker := fingerprint.NewChecker(stateData)
+
+	// One source glob matches (main.go), one references a non-existent file.
+	workflow := &Workflow{
+		Actions: map[string]*Action{
+			"build": {
+				Provider: "test-provider",
+				Sources:  []string{"*.go", "NonExistentFile.txt"},
+			},
+		},
+	}
+
+	// First execution: runs and records a fingerprint on the matched source.
+	executor := NewExecutor(
+		WithRegistry(registry),
+		WithFingerprintChecker(fpChecker),
+		WithCwd(dir),
+		WithDefaultTimeout(5*time.Second),
+	)
+	_, err := executor.Execute(context.Background(), workflow)
+	require.NoError(t, err)
+	assert.Equal(t, 1, execCount)
+
+	// Second execution: must skip as up-to-date despite the missing source glob.
+	executor2 := NewExecutor(
+		WithRegistry(registry),
+		WithFingerprintChecker(fpChecker),
+		WithCwd(dir),
+		WithDefaultTimeout(5*time.Second),
+	)
+	result, err := executor2.Execute(context.Background(), workflow)
+	require.NoError(t, err)
+	assert.Equal(t, 1, execCount, "action must not re-run when only a non-matching source glob is present")
+	assert.Equal(t, StatusSkipped, result.Actions["build"].Status)
+	assert.Equal(t, SkipReasonUpToDate, result.Actions["build"].SkipReason)
+}
+
+// Regression for #522: an action whose sources ALL match nothing has no
+// trackable inputs, so it must re-run on every invocation (never silently
+// skipped) rather than being cached on the deterministic empty-set hash.
+func TestExecutor_Execute_FingerprintAllMissingSourcesAlwaysRuns(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	execCount := 0
+	registry := newExecMockRegistry()
+	registry.register(&execMockProvider{
+		name: "test-provider",
+		execute: func(_ context.Context, _ any) (*provider.Output, error) {
+			execCount++
+			return &provider.Output{Data: map[string]any{"result": "built"}}, nil
+		},
+	})
+
+	stateData := state.NewData()
+	fpChecker := fingerprint.NewChecker(stateData)
+
+	workflow := &Workflow{
+		Actions: map[string]*Action{
+			"build": {
+				Provider: "test-provider",
+				Sources:  []string{"does-not-exist-a.txt", "does-not-exist-b.txt"},
+			},
+		},
+	}
+
+	newExec := func() *Executor {
+		return NewExecutor(
+			WithRegistry(registry),
+			WithFingerprintChecker(fpChecker),
+			WithCwd(dir),
+			WithDefaultTimeout(5*time.Second),
+		)
+	}
+
+	_, err := newExec().Execute(context.Background(), workflow)
+	require.NoError(t, err)
+	assert.Equal(t, 1, execCount)
+
+	// Second run: must execute again (no trackable inputs => always stale).
+	result, err := newExec().Execute(context.Background(), workflow)
+	require.NoError(t, err)
+	assert.Equal(t, 2, execCount, "action with no matching sources must re-run every time")
+	assert.Equal(t, StatusSucceeded, result.Actions["build"].Status)
+}
+
 func TestExecutor_Execute_FingerprintNoCache(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/action/executor_test.go
+++ b/pkg/action/executor_test.go
@@ -1519,20 +1519,6 @@ func TestExecutor_Execute_FingerprintAllMissingSourcesAlwaysRuns(t *testing.T) {
 func TestExecutor_Execute_FingerprintInvalidPatternHardFails(t *testing.T) {
 	t.Parallel()
 
-	dir := t.TempDir()
-
-	execCount := 0
-	registry := newExecMockRegistry()
-	registry.register(&execMockProvider{
-		name: "test-provider",
-		execute: func(_ context.Context, _ any) (*provider.Output, error) {
-			execCount++
-			return &provider.Output{Data: map[string]any{"result": "built"}}, nil
-		},
-	})
-
-	fpChecker := fingerprint.NewChecker(state.NewData())
-
 	for _, tc := range []struct {
 		name    string
 		pattern string
@@ -1542,7 +1528,21 @@ func TestExecutor_Execute_FingerprintInvalidPatternHardFails(t *testing.T) {
 		{"malformed glob", "[invalid"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			execCount = 0
+			t.Parallel()
+
+			dir := t.TempDir()
+
+			execCount := 0
+			registry := newExecMockRegistry()
+			registry.register(&execMockProvider{
+				name: "test-provider",
+				execute: func(_ context.Context, _ any) (*provider.Output, error) {
+					execCount++
+					return &provider.Output{Data: map[string]any{"result": "built"}}, nil
+				},
+			})
+			fpChecker := fingerprint.NewChecker(state.NewData())
+
 			workflow := &Workflow{
 				Actions: map[string]*Action{
 					"build": {

--- a/pkg/action/executor_test.go
+++ b/pkg/action/executor_test.go
@@ -1513,6 +1513,63 @@ func TestExecutor_Execute_FingerprintAllMissingSourcesAlwaysRuns(t *testing.T) {
 	assert.Equal(t, StatusSucceeded, result.Actions["build"].Status)
 }
 
+// A malformed, absolute, or path-traversing sources glob is a user/security
+// error and must fail the action hard rather than fail-open into execution
+// (PR #642 review: invalid patterns must not be silently ignored).
+func TestExecutor_Execute_FingerprintInvalidPatternHardFails(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	execCount := 0
+	registry := newExecMockRegistry()
+	registry.register(&execMockProvider{
+		name: "test-provider",
+		execute: func(_ context.Context, _ any) (*provider.Output, error) {
+			execCount++
+			return &provider.Output{Data: map[string]any{"result": "built"}}, nil
+		},
+	})
+
+	fpChecker := fingerprint.NewChecker(state.NewData())
+
+	for _, tc := range []struct {
+		name    string
+		pattern string
+	}{
+		{"absolute path", "/etc/passwd"},
+		{"path traversal", "../../../etc/passwd"},
+		{"malformed glob", "[invalid"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			execCount = 0
+			workflow := &Workflow{
+				Actions: map[string]*Action{
+					"build": {
+						Provider: "test-provider",
+						Sources:  []string{tc.pattern},
+					},
+				},
+			}
+
+			executor := NewExecutor(
+				WithRegistry(registry),
+				WithFingerprintChecker(fpChecker),
+				WithCwd(dir),
+				WithDefaultTimeout(5*time.Second),
+			)
+
+			result, err := executor.Execute(context.Background(), workflow)
+			require.Error(t, err, "invalid pattern must fail the action")
+			assert.ErrorIs(t, err, fingerprint.ErrPatternInvalid)
+			assert.Equal(t, 0, execCount, "action must NOT execute when its pattern is invalid")
+			if result != nil {
+				assert.Equal(t, StatusFailed, result.Actions["build"].Status)
+			}
+		})
+	}
+}
+
 func TestExecutor_Execute_FingerprintNoCache(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/action/executor_warn_test.go
+++ b/pkg/action/executor_warn_test.go
@@ -1,0 +1,76 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package action
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+)
+
+func TestExecutor_warnEmptySources(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		emptyPatterns []string
+		allEmpty      bool
+		wantStdout    string
+		wantStderr    string
+	}{
+		{
+			name:          "no empty patterns is silent",
+			emptyPatterns: nil,
+		},
+		{
+			name:          "total no-match warns on stderr",
+			emptyPatterns: []string{"*.go", "missing.txt"},
+			allEmpty:      true,
+			wantStderr:    "fingerprint disabled",
+		},
+		{
+			name:          "partial no-match hints on stderr",
+			emptyPatterns: []string{"missing.txt"},
+			allEmpty:      false,
+			wantStderr:    "matched no files (ignored)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ioStreams, out, errOut := terminal.NewTestIOStreams()
+			w := writer.New(ioStreams, &settings.Run{})
+			ctx := writer.WithWriter(context.Background(), w)
+
+			e := NewExecutor()
+			e.warnEmptySources(ctx, "build", tt.emptyPatterns, tt.allEmpty)
+
+			// Warnings must never pollute stdout (structured output safety).
+			assert.Empty(t, out.String())
+			if tt.wantStderr == "" {
+				assert.Empty(t, errOut.String())
+			} else {
+				assert.Contains(t, errOut.String(), tt.wantStderr)
+				assert.Contains(t, errOut.String(), "build")
+			}
+		})
+	}
+}
+
+// Embedder-safe: when no writer is attached to the context, warnEmptySources
+// must be a no-op and never panic.
+func TestExecutor_warnEmptySources_NoWriter(t *testing.T) {
+	t.Parallel()
+	e := NewExecutor()
+	assert.NotPanics(t, func() {
+		e.warnEmptySources(context.Background(), "build", []string{"missing.txt"}, true)
+	})
+}

--- a/pkg/dryrun/dryrun.go
+++ b/pkg/dryrun/dryrun.go
@@ -239,6 +239,9 @@ func checkFingerprintStatus(ctx context.Context, ea *action.ExpandedAction, sd *
 	if err != nil {
 		return "error", err.Error()
 	}
+	if result.SourcesAllEmpty {
+		return "no-sources", fmt.Sprintf("source pattern(s) matched no files: %v", result.SourcesEmptyPatterns)
+	}
 	if !result.Stale {
 		return "up-to-date", string(result.Reason)
 	}

--- a/pkg/dryrun/dryrun_test.go
+++ b/pkg/dryrun/dryrun_test.go
@@ -511,6 +511,32 @@ func TestGenerate_FingerprintStatus_FirstRun(t *testing.T) {
 	assert.Equal(t, "first run", report.ActionPlan[0].FingerprintReason)
 }
 
+// Regression for #522: an action whose source globs all match nothing reports
+// the dedicated "no-sources" status in dry-run output rather than "error".
+func TestGenerate_FingerprintStatus_AllSourcesMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	sol := minimalSolution("app")
+	sol.Spec.Workflow = &action.Workflow{
+		Actions: map[string]*action.Action{
+			"build": {
+				Provider: "shell",
+				Sources:  []string{"does-not-exist-a.txt", "does-not-exist-b.txt"},
+			},
+		},
+	}
+
+	sd := state.NewData()
+	report, err := Generate(context.Background(), sol, Options{
+		StateData: sd,
+		Cwd:       tmpDir,
+	})
+	require.NoError(t, err)
+	require.Len(t, report.ActionPlan, 1)
+	assert.Equal(t, "no-sources", report.ActionPlan[0].FingerprintStatus)
+	assert.Contains(t, report.ActionPlan[0].FingerprintReason, "matched no files")
+}
+
 func TestGenerate_FingerprintStatus_UpToDate(t *testing.T) {
 	tmpDir := t.TempDir()
 	srcFile := filepath.Join(tmpDir, "main.go")

--- a/pkg/fingerprint/fingerprint.go
+++ b/pkg/fingerprint/fingerprint.go
@@ -249,11 +249,15 @@ func (c *Checker) Check(ctx context.Context, actionName string, sources, generat
 		return nil, err
 	}
 
-	// Merge file hashes into input result for completeness
+	// Merge file-check results into the input result for completeness so the
+	// convenience API exposes the same diagnostics as CheckFiles, including the
+	// empty-source-glob signals.
 	inputResult.CurrentHash = fileResult.CurrentHash
 	inputResult.PreviousHash = fileResult.PreviousHash
 	inputResult.GeneratesHash = fileResult.GeneratesHash
 	inputResult.PreviousGeneratesHash = fileResult.PreviousGeneratesHash
+	inputResult.SourcesEmptyPatterns = fileResult.SourcesEmptyPatterns
+	inputResult.SourcesAllEmpty = fileResult.SourcesAllEmpty
 
 	return inputResult, nil
 }

--- a/pkg/fingerprint/fingerprint.go
+++ b/pkg/fingerprint/fingerprint.go
@@ -30,6 +30,11 @@ const (
 	// ReasonGeneratesMissing indicates one or more generated files don't exist.
 	ReasonGeneratesMissing Reason = "generates missing"
 
+	// ReasonNoSources indicates every declared source glob matched no files, so
+	// there is nothing to fingerprint. The action is treated as always stale
+	// (never cacheable) because it has no trackable inputs.
+	ReasonNoSources Reason = "no source files"
+
 	// ReasonInputsChanged indicates resolved action inputs have changed since last run.
 	ReasonInputsChanged Reason = "inputs changed"
 
@@ -60,6 +65,16 @@ type Result struct {
 	// PreviousInputsHash is the stored hash of inputs from last successful run.
 	PreviousInputsHash string
 
+	// SourcesEmptyPatterns lists source glob patterns that matched no files.
+	// Populated for both partial and total no-match so callers can warn about
+	// typos that would otherwise silently weaken idempotency.
+	SourcesEmptyPatterns []string
+
+	// SourcesAllEmpty is true when every source glob matched zero files, meaning
+	// there is nothing to fingerprint and caching is effectively disabled for
+	// the action.
+	SourcesAllEmpty bool
+
 	// Reason provides a human-readable explanation.
 	Reason Reason
 }
@@ -81,20 +96,41 @@ func NewChecker(stateData *state.Data) *Checker {
 // If Stale==false, the caller should resolve inputs and call CheckInputs.
 //
 // Staleness logic:
-//  1. No previous state -> stale (first run)
-//  2. Sources hash mismatch -> stale (sources changed)
-//  3. If generates declared: generated files missing -> stale
-//  4. If generates declared: generates hash mismatch -> stale (externally modified)
-//  5. All file hashes match -> not stale (proceed to CheckInputs)
+//  1. Every source glob matched no files -> stale (no source files to track)
+//  2. No previous state -> stale (first run)
+//  3. Sources hash mismatch -> stale (sources changed)
+//  4. If generates declared: any declared output missing -> stale
+//  5. If generates declared: generates hash mismatch -> stale (externally modified)
+//  6. All file hashes match -> not stale (proceed to CheckInputs)
+//
+// A partially-matching sources set (some patterns match, some do not) is
+// tolerated: the action is fingerprinted on the files that matched. Only a
+// total no-match forces staleness.
 func (c *Checker) CheckFiles(_ context.Context, actionName string, sources, generates []string, baseDir string) (*Result, error) {
 	result := &Result{}
 
-	// Compute current sources hash
-	currentHash, err := HashFiles(baseDir, sources)
+	// Compute current sources hash. Source globs that match no files are
+	// tolerated (hashed on whatever matched); the empty patterns are reported so
+	// the caller can warn. Only ErrPatternInvalid (malformed/unsafe) is fatal.
+	sourcesReport, err := HashFilesReport(baseDir, sources)
 	if err != nil {
 		return nil, err
 	}
+	currentHash := sourcesReport.Hash
 	result.CurrentHash = currentHash
+	result.SourcesEmptyPatterns = sourcesReport.EmptyPatterns
+	result.SourcesAllEmpty = sourcesReport.AllEmpty
+
+	// Every source glob matched nothing: there are no trackable inputs, so the
+	// action cannot be meaningfully fingerprinted. Treat it as always stale
+	// rather than skipping it on the deterministic empty-set hash -- an action
+	// with no inputs to compare should re-run, and this keeps behavior aligned
+	// with the "fingerprint disabled" warning surfaced to the user.
+	if sourcesReport.AllEmpty {
+		result.Stale = true
+		result.Reason = ReasonNoSources
+		return result, nil
+	}
 
 	// Load previous sources hash from state
 	result.PreviousHash = LoadSourcesHash(c.stateData, actionName)
@@ -113,19 +149,21 @@ func (c *Checker) CheckFiles(_ context.Context, actionName string, sources, gene
 		return result, nil
 	}
 
-	// If generates are declared, check them too
+	// If generates are declared, check them too. Unlike sources, a declared
+	// output that does not exist means the action's product is missing, so any
+	// non-matching generates pattern (partial or total) marks the action stale.
 	if len(generates) > 0 {
-		genHash, genErr := HashFiles(baseDir, generates)
+		genReport, genErr := HashFilesReport(baseDir, generates)
 		if genErr != nil {
-			// If generates don't exist (ErrNoMatches), they're missing
-			if isNoMatchError(genErr) {
-				result.Stale = true
-				result.Reason = ReasonGeneratesMissing
-				return result, nil
-			}
 			return nil, genErr
 		}
-		result.GeneratesHash = genHash
+		// Any declared output missing -> rebuild.
+		if len(genReport.EmptyPatterns) > 0 {
+			result.Stale = true
+			result.Reason = ReasonGeneratesMissing
+			return result, nil
+		}
+		result.GeneratesHash = genReport.Hash
 
 		// Load previous generates hash
 		result.PreviousGeneratesHash = LoadGeneratesHash(c.stateData, actionName)
@@ -138,7 +176,7 @@ func (c *Checker) CheckFiles(_ context.Context, actionName string, sources, gene
 		}
 
 		// Generates modified externally
-		if genHash != result.PreviousGeneratesHash {
+		if genReport.Hash != result.PreviousGeneratesHash {
 			result.Stale = true
 			result.Reason = ReasonGeneratesModified
 			return result, nil
@@ -223,10 +261,14 @@ func (c *Checker) Check(ctx context.Context, actionName string, sources, generat
 // Record stores the current fingerprints (sources + generates + inputs) after a
 // successful action. Call this after action execution to persist the new baseline.
 func (c *Checker) Record(_ context.Context, actionName string, sources, generates []string, baseDir string, resolvedInputs map[string]any) error {
-	sourcesHash, err := HashFiles(baseDir, sources)
+	// Source globs matching no files are tolerated: record the hash of whatever
+	// matched (or the empty-set hash when none matched) so idempotency is not
+	// silently disabled. Only ErrPatternInvalid is fatal.
+	sourcesReport, err := HashFilesReport(baseDir, sources)
 	if err != nil {
 		return err
 	}
+	sourcesHash := sourcesReport.Hash
 
 	var generatesHash string
 	if len(generates) > 0 {

--- a/pkg/fingerprint/fingerprint_test.go
+++ b/pkg/fingerprint/fingerprint_test.go
@@ -50,6 +50,29 @@ func TestChecker_Check(t *testing.T) {
 		assert.Equal(t, ReasonUpToDate, result.Reason)
 	})
 
+	// PR #642 review: the Check convenience method must propagate the empty-
+	// source-glob diagnostics from CheckFiles on the non-stale path, not just
+	// the hash fields.
+	t.Run("propagates empty-source diagnostics on up-to-date path", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		testWriteFile(t, dir, "main.go", "package main")
+
+		stateData := state.NewData()
+		checker := NewChecker(stateData)
+		sources := []string{"*.go", "NonExistentFile.txt"}
+
+		require.NoError(t, checker.Record(context.Background(), "build", sources, nil, dir, nil))
+
+		result, err := checker.Check(context.Background(), "build", sources, nil, dir, nil)
+		require.NoError(t, err)
+
+		assert.False(t, result.Stale)
+		assert.Equal(t, []string{"NonExistentFile.txt"}, result.SourcesEmptyPatterns,
+			"Check must surface the same empty-pattern diagnostics as CheckFiles")
+		assert.False(t, result.SourcesAllEmpty)
+	})
+
 	t.Run("sources changed - stale", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()

--- a/pkg/fingerprint/fingerprint_test.go
+++ b/pkg/fingerprint/fingerprint_test.go
@@ -310,6 +310,76 @@ func TestChecker_CheckFiles(t *testing.T) {
 		assert.True(t, result.Stale)
 		assert.Equal(t, ReasonSourcesChanged, result.Reason)
 	})
+
+	// Regression for #522: a source glob referencing a non-existent file must
+	// NOT disable fingerprinting. The action should still be fingerprinted on
+	// its other sources and report up-to-date on the second run.
+	t.Run("partial no-match preserves idempotency", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		testWriteFile(t, dir, "main.go", "package main")
+
+		stateData := state.NewData()
+		checker := NewChecker(stateData)
+		sources := []string{"*.go", "NonExistentFile.txt"}
+
+		err := checker.Record(context.Background(), "build", sources, nil, dir, nil)
+		require.NoError(t, err)
+
+		result, err := checker.CheckFiles(context.Background(), "build", sources, nil, dir)
+		require.NoError(t, err)
+
+		assert.False(t, result.Stale, "action must be treated as up-to-date despite the missing source")
+		assert.Equal(t, ReasonUpToDate, result.Reason)
+		assert.Equal(t, []string{"NonExistentFile.txt"}, result.SourcesEmptyPatterns)
+		assert.False(t, result.SourcesAllEmpty)
+	})
+
+	// Regression for #522: when every source glob matches nothing, CheckFiles
+	// must not return an error; it reports SourcesAllEmpty and marks the action
+	// stale (no trackable inputs) so it re-runs rather than being silently
+	// skipped on the deterministic empty-set hash.
+	t.Run("total no-match reports AllEmpty and forces stale", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		testWriteFile(t, dir, "a.txt", "text")
+
+		stateData := state.NewData()
+		checker := NewChecker(stateData)
+		sources := []string{"*.go", "missing.txt"}
+
+		// Record then check: an all-empty sources set must remain stale even
+		// after a prior run recorded the empty-set hash.
+		require.NoError(t, checker.Record(context.Background(), "build", sources, nil, dir, nil))
+
+		result, err := checker.CheckFiles(context.Background(), "build", sources, nil, dir)
+		require.NoError(t, err)
+		assert.True(t, result.SourcesAllEmpty)
+		assert.True(t, result.Stale, "no trackable sources must be treated as always stale")
+		assert.Equal(t, ReasonNoSources, result.Reason)
+		assert.Equal(t, sources, result.SourcesEmptyPatterns)
+	})
+
+	// A declared output that does not exist must mark the action stale even when
+	// other declared outputs are present (strict generates semantics).
+	t.Run("partial-missing generates marks stale", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		testWriteFile(t, dir, "main.go", "package main")
+		testWriteFile(t, dir, "app", "binary")
+
+		stateData := state.NewData()
+		checker := NewChecker(stateData)
+		sources := []string{"*.go"}
+		generates := []string{"app", "missing-output"}
+
+		require.NoError(t, checker.Record(context.Background(), "build", sources, generates, dir, nil))
+
+		result, err := checker.CheckFiles(context.Background(), "build", sources, generates, dir)
+		require.NoError(t, err)
+		assert.True(t, result.Stale, "a missing declared output must force a rebuild")
+		assert.Equal(t, ReasonGeneratesMissing, result.Reason)
+	})
 }
 
 func TestChecker_CheckInputs(t *testing.T) {

--- a/pkg/fingerprint/glob.go
+++ b/pkg/fingerprint/glob.go
@@ -12,62 +12,111 @@ import (
 	"github.com/bmatcuk/doublestar/v4"
 )
 
-// ExpandGlobs resolves glob patterns against the filesystem, returning
-// a sorted, deduplicated list of matching file paths (relative to baseDir).
-// Supports ** for recursive matching via doublestar.
-// Returns ErrPatternInvalid for malformed patterns and ErrNoMatches when
-// a pattern resolves to zero files.
-func ExpandGlobs(baseDir string, patterns []string) ([]string, error) {
+// ExpandResult reports the outcome of expanding a set of glob patterns.
+type ExpandResult struct {
+	// Files is the sorted, deduplicated list of matching file paths
+	// (relative to baseDir, slash-separated).
+	Files []string
+
+	// EmptyPatterns lists the input patterns that matched zero files, in
+	// input order. A non-empty EmptyPatterns with a non-empty Files means a
+	// partial match (some patterns matched, some did not).
+	EmptyPatterns []string
+}
+
+// AllEmpty reports whether every pattern matched zero files (i.e. there are no
+// files to track). It is false when there were no patterns to begin with.
+func (r ExpandResult) AllEmpty() bool {
+	return len(r.Files) == 0 && len(r.EmptyPatterns) > 0
+}
+
+// ExpandGlobsReport resolves glob patterns against the filesystem, tolerating
+// individual patterns that match no files. It returns the sorted, deduplicated
+// list of matching files together with the patterns that matched nothing, so
+// callers can decide how to surface partial or total no-match situations.
+//
+// Supports ** for recursive matching via doublestar. Malformed, absolute, or
+// path-traversing patterns return ErrPatternInvalid (these are user or security
+// errors, not "no files"). ExpandGlobsReport never returns ErrNoMatches -- an
+// all-empty result is reported via ExpandResult.AllEmpty instead.
+//
+// This mirrors the lenient sources handling of build tools like go-task, where
+// a glob matching nothing simply contributes no files to the checksum rather
+// than aborting the up-to-date check.
+func ExpandGlobsReport(baseDir string, patterns []string) (ExpandResult, error) {
 	if len(patterns) == 0 {
-		return nil, nil
+		return ExpandResult{}, nil
 	}
 
 	seen := make(map[string]struct{})
-	var result []string
+	result := ExpandResult{}
 
 	for _, pattern := range patterns {
 		if !doublestar.ValidatePattern(pattern) {
-			return nil, fmt.Errorf("%w: %q", ErrPatternInvalid, pattern)
+			return ExpandResult{}, fmt.Errorf("%w: %q", ErrPatternInvalid, pattern)
 		}
 
 		// Reject absolute patterns and path traversal to prevent
 		// fingerprinting files outside the solution tree.
 		if filepath.IsAbs(pattern) || strings.HasPrefix(pattern, "/") {
-			return nil, fmt.Errorf("%w: absolute patterns not allowed: %q", ErrPatternInvalid, pattern)
+			return ExpandResult{}, fmt.Errorf("%w: absolute patterns not allowed: %q", ErrPatternInvalid, pattern)
 		}
 		for _, seg := range strings.Split(filepath.Clean(pattern), string(filepath.Separator)) {
 			if seg == ".." {
-				return nil, fmt.Errorf("%w: path traversal not allowed: %q", ErrPatternInvalid, pattern)
+				return ExpandResult{}, fmt.Errorf("%w: path traversal not allowed: %q", ErrPatternInvalid, pattern)
 			}
 		}
 
 		absPattern := filepath.Join(baseDir, pattern)
 		matches, err := doublestar.FilepathGlob(absPattern, doublestar.WithFilesOnly())
 		if err != nil {
-			return nil, fmt.Errorf("%w: %q: %w", ErrPatternInvalid, pattern, err)
+			return ExpandResult{}, fmt.Errorf("%w: %q: %w", ErrPatternInvalid, pattern, err)
 		}
 
 		if len(matches) == 0 {
-			return nil, fmt.Errorf("%w: %q", ErrNoMatches, pattern)
+			// A pattern matching nothing is not fatal -- record it and move on.
+			result.EmptyPatterns = append(result.EmptyPatterns, pattern)
+			continue
 		}
 
 		for _, m := range matches {
 			rel, relErr := filepath.Rel(baseDir, m)
 			if relErr != nil {
-				return nil, fmt.Errorf("%w: match %q escapes base directory", ErrPatternInvalid, m)
+				return ExpandResult{}, fmt.Errorf("%w: match %q escapes base directory", ErrPatternInvalid, m)
 			}
 			// Ensure the match doesn't escape baseDir via ..
 			if rel == ".." || strings.HasPrefix(rel, "../") || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
-				return nil, fmt.Errorf("%w: match %q escapes base directory", ErrPatternInvalid, m)
+				return ExpandResult{}, fmt.Errorf("%w: match %q escapes base directory", ErrPatternInvalid, m)
 			}
 			normalized := filepath.ToSlash(rel)
 			if _, exists := seen[normalized]; !exists {
 				seen[normalized] = struct{}{}
-				result = append(result, normalized)
+				result.Files = append(result.Files, normalized)
 			}
 		}
 	}
 
-	sort.Strings(result)
+	sort.Strings(result.Files)
 	return result, nil
+}
+
+// ExpandGlobs resolves glob patterns against the filesystem, returning a sorted,
+// deduplicated list of matching file paths (relative to baseDir).
+//
+// Individual patterns that match no files are tolerated; ExpandGlobs only
+// returns ErrNoMatches when the combined result is empty (every pattern matched
+// nothing), i.e. there are genuinely no files to track. Malformed, absolute, or
+// path-traversing patterns return ErrPatternInvalid.
+//
+// Callers that need to distinguish partial from total no-match (e.g. to warn a
+// user about a typo'd source) should use ExpandGlobsReport instead.
+func ExpandGlobs(baseDir string, patterns []string) ([]string, error) {
+	report, err := ExpandGlobsReport(baseDir, patterns)
+	if err != nil {
+		return nil, err
+	}
+	if report.AllEmpty() {
+		return nil, fmt.Errorf("%w: %q", ErrNoMatches, strings.Join(report.EmptyPatterns, ", "))
+	}
+	return report.Files, nil
 }

--- a/pkg/fingerprint/glob_test.go
+++ b/pkg/fingerprint/glob_test.go
@@ -68,6 +68,15 @@ func TestExpandGlobs(t *testing.T) {
 			wantErr:  ErrNoMatches,
 		},
 		{
+			name: "partial match tolerated by ExpandGlobs",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				testWriteFile(t, dir, "a.go", "package a")
+			},
+			patterns: []string{"*.go", "does-not-exist.txt"},
+			want:     []string{"a.go"},
+		},
+		{
 			name:     "invalid pattern returns error",
 			patterns: []string{"[invalid"},
 			wantErr:  ErrPatternInvalid,
@@ -114,6 +123,86 @@ func TestExpandGlobs(t *testing.T) {
 			}
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestExpandGlobsReport(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		setup        func(t *testing.T, dir string)
+		patterns     []string
+		wantFiles    []string
+		wantEmpty    []string
+		wantAllEmpty bool
+		wantErr      error
+	}{
+		{
+			name:     "empty patterns yields zero-value result",
+			patterns: nil,
+		},
+		{
+			name: "all patterns match",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				testWriteFile(t, dir, "a.go", "package a")
+			},
+			patterns:  []string{"*.go"},
+			wantFiles: []string{"a.go"},
+		},
+		{
+			name: "partial match reports empty pattern but no error",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				testWriteFile(t, dir, "a.go", "package a")
+				testWriteFile(t, dir, "go.mod", "module x")
+			},
+			patterns:  []string{"*.go", "go.mod", "missing.txt"},
+			wantFiles: []string{"a.go", "go.mod"},
+			wantEmpty: []string{"missing.txt"},
+		},
+		{
+			name: "total no-match sets AllEmpty without error",
+			setup: func(t *testing.T, dir string) {
+				t.Helper()
+				testWriteFile(t, dir, "a.txt", "text")
+			},
+			patterns:     []string{"*.go", "missing.txt"},
+			wantEmpty:    []string{"*.go", "missing.txt"},
+			wantAllEmpty: true,
+		},
+		{
+			name:     "invalid pattern still errors",
+			patterns: []string{"[invalid"},
+			wantErr:  ErrPatternInvalid,
+		},
+		{
+			name:     "absolute pattern still errors",
+			patterns: []string{"/etc/passwd"},
+			wantErr:  ErrPatternInvalid,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			if tt.setup != nil {
+				tt.setup(t, dir)
+			}
+
+			got, err := ExpandGlobsReport(dir, tt.patterns)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFiles, got.Files)
+			assert.Equal(t, tt.wantEmpty, got.EmptyPatterns)
+			assert.Equal(t, tt.wantAllEmpty, got.AllEmpty())
 		})
 	}
 }

--- a/pkg/fingerprint/hash.go
+++ b/pkg/fingerprint/hash.go
@@ -13,11 +13,56 @@ import (
 	"path/filepath"
 )
 
+// HashResult carries a content hash plus diagnostics about glob patterns that
+// matched no files.
+type HashResult struct {
+	// Hash is the SHA-256 hash over the matched file set. For an all-empty
+	// pattern set it is the deterministic hash of zero files (empty string).
+	Hash string
+
+	// EmptyPatterns lists patterns that matched no files, in input order.
+	EmptyPatterns []string
+
+	// AllEmpty is true when every pattern matched zero files.
+	AllEmpty bool
+}
+
+// HashFilesReport computes a deterministic SHA-256 hash over the files matching
+// the given glob patterns, tolerating patterns that match nothing. Unlike
+// HashFiles it never returns ErrNoMatches; instead it reports which patterns
+// were empty via HashResult, so callers can warn without losing the hash of the
+// files that did match. Malformed/unsafe patterns still return ErrPatternInvalid.
+func HashFilesReport(baseDir string, patterns []string) (HashResult, error) {
+	if len(patterns) == 0 {
+		return HashResult{}, nil
+	}
+
+	report, err := ExpandGlobsReport(baseDir, patterns)
+	if err != nil {
+		return HashResult{}, err
+	}
+
+	hash, err := hashFileList(baseDir, report.Files)
+	if err != nil {
+		return HashResult{}, err
+	}
+
+	return HashResult{
+		Hash:          hash,
+		EmptyPatterns: report.EmptyPatterns,
+		AllEmpty:      report.AllEmpty(),
+	}, nil
+}
+
 // HashFiles computes a deterministic SHA-256 hash over the contents of all
 // files matching the given glob patterns, resolved relative to baseDir.
 // Files are sorted lexicographically before hashing for determinism.
 // The hash includes both file paths and contents so that renames are detected.
 // Returns empty string and nil error if patterns is empty.
+//
+// Individual patterns matching no files are tolerated; HashFiles only returns
+// ErrNoMatches when every pattern matches nothing. Callers that need to
+// distinguish partial from total no-match should use HashFilesReport.
 func HashFiles(baseDir string, patterns []string) (string, error) {
 	if len(patterns) == 0 {
 		return "", nil

--- a/pkg/fingerprint/hash.go
+++ b/pkg/fingerprint/hash.go
@@ -17,7 +17,8 @@ import (
 // matched no files.
 type HashResult struct {
 	// Hash is the SHA-256 hash over the matched file set. For an all-empty
-	// pattern set it is the deterministic hash of zero files (empty string).
+	// pattern set it is the deterministic SHA-256 digest of an empty file set
+	// (a stable non-empty hex string), not an empty string.
 	Hash string
 
 	// EmptyPatterns lists patterns that matched no files, in input order.

--- a/pkg/fingerprint/hash_test.go
+++ b/pkg/fingerprint/hash_test.go
@@ -209,3 +209,70 @@ func BenchmarkHashInputs(b *testing.B) {
 		_, _ = HashInputs(inputs)
 	}
 }
+
+func TestHashFilesReport(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty patterns returns zero-value result", func(t *testing.T) {
+		t.Parallel()
+		res, err := HashFilesReport(t.TempDir(), nil)
+		require.NoError(t, err)
+		assert.Empty(t, res.Hash)
+		assert.Empty(t, res.EmptyPatterns)
+		assert.False(t, res.AllEmpty)
+	})
+
+	t.Run("partial match hashes matched files and reports empty pattern", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		testWriteFile(t, dir, "a.go", "package a")
+
+		res, err := HashFilesReport(dir, []string{"*.go", "missing.txt"})
+		require.NoError(t, err)
+		assert.NotEmpty(t, res.Hash)
+		assert.Equal(t, []string{"missing.txt"}, res.EmptyPatterns)
+		assert.False(t, res.AllEmpty)
+
+		// The hash must equal hashing only the matched file, proving the empty
+		// pattern did not corrupt or disable hashing.
+		want, err := HashFiles(dir, []string{"*.go"})
+		require.NoError(t, err)
+		assert.Equal(t, want, res.Hash)
+	})
+
+	t.Run("total no-match sets AllEmpty with deterministic empty hash", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		testWriteFile(t, dir, "a.txt", "text")
+
+		res, err := HashFilesReport(dir, []string{"*.go", "missing.txt"})
+		require.NoError(t, err)
+		assert.True(t, res.AllEmpty)
+		assert.Equal(t, []string{"*.go", "missing.txt"}, res.EmptyPatterns)
+
+		// Deterministic across runs.
+		res2, err := HashFilesReport(dir, []string{"*.go"})
+		require.NoError(t, err)
+		assert.Equal(t, res.Hash, res2.Hash)
+	})
+
+	t.Run("invalid pattern still errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := HashFilesReport(t.TempDir(), []string{"/etc/passwd"})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrPatternInvalid)
+	})
+}
+
+func BenchmarkHashFilesReport(b *testing.B) {
+	dir := b.TempDir()
+	testWriteFile(b, dir, "a.go", "package a")
+	testWriteFile(b, dir, "b.go", "package b")
+	patterns := []string{"*.go", "missing.txt"}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = HashFilesReport(dir, patterns)
+	}
+}

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -433,6 +433,35 @@ tasks:
         golangci-lint run ./... --config .golangci.yml --timeout 10m0s
         echo "✅ No linting issues found"
 
+  lint:changed:
+    desc: "Lint ONLY issues introduced by this branch (vs. the merge base). Cuts through pre-existing findings in untouched files so you can verify your own changes are clean before committing."
+    aliases: [lc]
+    silent: true
+    deps: [install-tools]
+    vars:
+      # Branch to diff against; override with BASE=<ref>. Defaults to the
+      # tracked default branch, falling back to main.
+      BASE: '{{.BASE | default "main"}}'
+    cmds:
+      - |
+        set -e
+        export PATH="{{.TOOLS_PATH}}:$PATH"
+        mkdir -p "{{.GOLANGCI_LINT_CACHE}}"
+
+        # Resolve the merge base so only lines this branch changed are reported.
+        base_ref="{{.BASE}}"
+        if git rev-parse --verify --quiet "origin/${base_ref}" >/dev/null; then
+          base_ref="origin/${base_ref}"
+        fi
+
+        echo "Linting changes introduced since ${base_ref}..."
+        golangci-lint run ./... \
+          --config .golangci.yml \
+          --timeout 10m0s \
+          --new-from-merge-base "${base_ref}" \
+          --whole-files
+        echo "✅ No new linting issues in changed code"
+
   vet:
     desc: "Run go vet (static checks from the Go toolchain)"
     silent: true

--- a/tests/integration/solutions/actions/fingerprint-missing-source/solution.yaml
+++ b/tests/integration/solutions/actions/fingerprint-missing-source/solution.yaml
@@ -1,0 +1,73 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-fingerprint-missing-source
+  version: 1.0.0
+  description: |
+    Regression coverage for #522. A source glob that matches no files (a typo
+    or a not-yet-created file) must NOT hard-fail the action's fingerprint. The
+    action still runs and succeeds; a total no-match simply disables caching for
+    that action instead of erroring. Two-run idempotency (skip on the second run
+    with a partially-matching sources set) is covered by unit tests in
+    pkg/action/executor_test.go (TestExecutor_Execute_FingerprintPartialMissingSource).
+
+state:
+  enabled: true
+  backend:
+    provider: file
+    inputs:
+      path: fingerprint-missing-source-state.json
+
+spec:
+  workflow:
+    actions:
+      # 'partialMissing' has one matching source (the solution file) and one
+      # pattern that references a non-existent file. Prior to the #522 fix the
+      # missing pattern caused ErrNoMatches, which silently broke fingerprinting.
+      partialMissing:
+        description: Action with a partially-matching sources set
+        provider: exec
+        sources:
+          - "solution.yaml"
+          - "NonExistentFile.txt"
+        inputs:
+          command: "echo PARTIAL_OK"
+
+      # 'allMissing' has ONLY non-matching source patterns. This is the
+      # degenerate case: fingerprinting is effectively disabled, but the action
+      # must still execute and succeed rather than erroring out.
+      allMissing:
+        description: Action whose source globs all match nothing
+        provider: exec
+        sources:
+          - "does-not-exist-a.txt"
+          - "does-not-exist-b.txt"
+        inputs:
+          command: "echo ALL_MISSING_OK"
+
+  testing:
+    cases:
+      partial-missing-source-succeeds:
+        description: A missing source glob does not fail the action
+        command: [run, action]
+        args: ["partialMissing", "-o", "json"]
+        tags: [fingerprint, actions, smoke]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output.actions["partialMissing"].status == "succeeded"
+            message: "Action with a partially-matching sources set must succeed"
+          - expression: __output.actions["partialMissing"].results.stdout.contains("PARTIAL_OK")
+            message: "Action output should be produced"
+
+      all-missing-sources-still-runs:
+        description: An all-empty sources set disables caching but does not error
+        command: [run, action]
+        args: ["allMissing", "-o", "json"]
+        tags: [fingerprint, actions]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output.actions["allMissing"].status == "succeeded"
+            message: "Action must still run when every source glob matches nothing"
+          - expression: __output.actions["allMissing"].results.stdout.contains("ALL_MISSING_OK")
+            message: "Action output should be produced"


### PR DESCRIPTION
## Description

Fixes a silent correctness bug in action fingerprinting. When an action's `sources` glob matched no files (a typo, or a not-yet-created path), the empty file set produced a stable hash that cached successfully -- so the action was treated as up-to-date and never re-ran, even when it should have. The failure was only visible with `--debug`.

Behavior after this change:

- **Partial no-match** (some source globs match, some do not): the action is fingerprinted on the files that matched; a stderr hint flags the non-matching patterns. Idempotency is preserved. This mirrors go-task's `sources:` semantics (scafctl's action model is Taskfile-inspired).
- **Total no-match** (every source glob matches nothing): the action has no trackable inputs, so it is reported stale (new `ReasonNoSources`) and re-runs every time, with a stderr warning. It no longer silently caches on the empty-set hash.
- **Invalid/unsafe patterns** (malformed globs, absolute paths, `..` traversal) still hard-fail.
- **`generates` keeps strict semantics**: any missing declared output still forces a rebuild.
- Warnings go to **stderr** via `writer.FromContext` (embedder-safe no-op when absent), so `-o json` output is never corrupted.
- Dry-run reports a dedicated `no-sources` status instead of `error`.

Internals: new `ExpandGlobsReport`/`ExpandResult` and `HashFilesReport`/`HashResult` report matched files alongside empty patterns; `ExpandGlobs` now returns `ErrNoMatches` only when every pattern is empty.

The second commit (`docs(ai)`) adds AI-agent workflow tooling: an issue triage/validation gate and an automatic "definition of done" review+completeness gate, plus a `/finish-issue` command and a mermaid workflow diagram. No product code.

## Related Issues

Closes #522

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Documentation update
- [ ] Refactoring

Breaking: actions with `sources` globs that match no files are now reported stale and re-run every time, rather than caching as up-to-date.

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] My commits follow conventional commit format
- [x] I have added/updated tests for my changes
- [x] `go test ./...` passes (incl. `-race` on changed packages; full solution integration suite: 895 passed)
- [x] `task lint` passes (no findings in changed files)
- [x] I have signed off my commits (`git commit -s -S`)

## Testing

- Unit: glob (partial/total/invalid), hash report + `BenchmarkHashFilesReport`, checker idempotency + strict-generates, executor (partial-skip / all-missing-reruns / warn stderr / embedder no-writer), dryrun `no-sources`.
- Integration: new `tests/integration/solutions/actions/fingerprint-missing-source/` fixture; verified via the full `task integration` sweep.