### PR TITLE
fix: raise integration test suite timeout to 10m

### DIFF
--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -1049,7 +1049,7 @@ tasks:
       CGO_ENABLED: '{{ if eq .HAS_CC "true" }}1{{ else }}0{{ end }}'
     cmds:
       - go test {{.RACE_FLAG}} -count=1 ./tests/integration/ -run "TestAPI_"
-      - go test -count=1 -parallel 4 ./tests/integration/ -run "TestIntegration_" -timeout 5m
+      - go test -count=1 -parallel 4 ./tests/integration/ -run "TestIntegration_" -timeout 10m
       - '{{.DIST}}/{{.OUTPUT_FILE}} test functional --tests-path "{{.FIXED_ROOT}}/tests/integration/solutions" --no-color -q --concurrency 8'
 
   test:e2e:


### PR DESCRIPTION
## Summary

Fixes #373 -- the integration test suite hits the default `go test` timeout and panics, killing the run before all tests complete.

## Root cause

`taskfile.yaml` capped the entire `TestIntegration_` suite at `-timeout 5m` -- the only test task in the file below the standard `10m` (cf. lines 728, 757, 770). The suite now has 579 tests, 60 of which each spawn a real `build solution` subprocess (24-26s each observed) throttled to `-parallel 4`. Aggregate wall time exceeded the 5m budget, so `go test` panicked and killed all remaining tests, producing incomplete results.

## Fix

Raise `-timeout 5m` -> `-timeout 10m`, aligning the integration task with every other test task in the taskfile.

## Why not the issue's other suggestions

- **Per-test context timeouts:** already exist -- every subprocess runs under a 90s/180s `context.WithTimeout` (`tests/integration/cli_test.go:140,147`). The panic is the *aggregate* binary timeout, not a per-test hang, so this would not help.
- **Separate build tag for slow catalog tests:** adds permanent maintenance overhead and fights the repo's guidance of validating the full suite in a single run.

## Testing

One-line taskfile change; no Go code touched, so no test/coverage impact.