### PR TITLE
feat(inspect): complete solution usage view for authored help

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -651,9 +651,15 @@ scafctl inspect solution -f solution.yaml --usage
 scafctl inspect solution -f solution.yaml --usage -o json
 ~~~
 
-Authors can enrich the view with an optional `metadata.usage` block (synopsis
-and curated examples). When absent, the view is generated from parameters and
-actions.
+Authors can enrich the view with an optional `metadata.usage` block:
+
+- `synopsis` -- a one-line usage summary (overrides the metadata description)
+- `details` -- long-form prose about how the solution works and when to use it
+- `examples` -- curated `description`/`command` pairs
+
+Along with the auto-projected `displayName`, `tags`, `links`, per-parameter
+`description`/`example`, and per-action `description`. When `metadata.usage` is
+absent, the view is generated entirely from parameters and actions.
 
 ### Explain Schema Kinds
 

--- a/examples/inspect/usage-view.yaml
+++ b/examples/inspect/usage-view.yaml
@@ -11,10 +11,19 @@ kind: Solution
 
 metadata:
   name: registry-index
+  displayName: Registry Index
   version: 1.0.0
   description: Query and refresh a small registry index.
+  tags: [registry, discovery]
+  links:
+    - name: Documentation
+      url: https://example.com/registry-index/docs
   usage:
     synopsis: Query and refresh a registry index of modules and providers
+    details: |
+      This solution maintains a local index of Terraform modules and
+      providers. Use the 'action' parameter to choose what to do: show the
+      cached summary, refresh from live data, or emit the raw JSON index.
     examples:
       - description: Show the registry summary (default)
         command: scafctl run solution
@@ -26,6 +35,7 @@ spec:
     action:
       description: What the solution should do
       type: string
+      example: refresh
       resolve:
         with:
           - provider: parameter

--- a/pkg/cmd/scafctl/inspect/solution.go
+++ b/pkg/cmd/scafctl/inspect/solution.go
@@ -227,15 +227,31 @@ func (o *SolutionOptions) renderUsageText(ctx context.Context, u *inspect.UsageI
 		return nil
 	}
 
-	// Header: name (version) + synopsis.
-	title := u.Name
+	// Header: display name / name (version) + synopsis.
+	displayTitle := u.Name
+	if u.DisplayName != "" {
+		displayTitle = u.DisplayName
+	}
+	title := displayTitle
 	if u.Version != "" {
-		title = fmt.Sprintf("%s (%s)", u.Name, u.Version)
+		title = fmt.Sprintf("%s (%s)", displayTitle, u.Version)
 	}
 	w.Plainlnf("%s", title)
 	if u.Synopsis != "" {
 		w.Plainlnf("%s", u.Synopsis)
 	}
+	if len(u.Tags) > 0 {
+		w.Plainlnf("Tags: %s", strings.Join(u.Tags, ", "))
+	}
+
+	// Long-form details (author prose), if provided.
+	if u.Details != "" {
+		w.Plainln("")
+		for _, line := range strings.Split(strings.TrimRight(u.Details, "\n"), "\n") {
+			w.Plainlnf("%s", line)
+		}
+	}
+
 	if u.Run != "" {
 		w.Plainln("")
 		w.Plainlnf("Run: %s", u.Run)
@@ -261,6 +277,9 @@ func (o *SolutionOptions) renderUsageText(ctx context.Context, u *inspect.UsageI
 			}
 			if len(p.AllowedValues) > 0 {
 				w.Plainlnf("      values: %s", joinAny(p.AllowedValues))
+			}
+			if p.Example != nil {
+				w.Plainlnf("      example: %v", p.Example)
 			}
 		}
 	}
@@ -291,6 +310,19 @@ func (o *SolutionOptions) renderUsageText(ctx context.Context, u *inspect.UsageI
 				w.Plainlnf("  # %s", ex.Description)
 			}
 			w.Plainlnf("  %s", ex.Command)
+		}
+	}
+
+	// Links.
+	if len(u.Links) > 0 {
+		w.Plainln("")
+		w.Plainln("LINKS")
+		for _, l := range u.Links {
+			if l.Name != "" {
+				w.Plainlnf("  %s: %s", l.Name, l.URL)
+			} else {
+				w.Plainlnf("  %s", l.URL)
+			}
 		}
 	}
 

--- a/pkg/cmd/scafctl/inspect/solution_test.go
+++ b/pkg/cmd/scafctl/inspect/solution_test.go
@@ -310,10 +310,18 @@ const usageInspectSolution = `apiVersion: scafctl.io/v1
 kind: Solution
 metadata:
   name: usage-test
+  displayName: Usage Test Solution
   version: 2.0.0
   description: Fallback description
+  tags: [demo, usage]
+  links:
+    - name: Docs
+      url: https://example.com/docs
+    - url: https://example.com/nameless
   usage:
     synopsis: Do useful things with this solution
+    details: |
+      Extended prose describing the solution.
     examples:
       - description: Refresh
         command: scafctl run solution -r action=refresh
@@ -321,6 +329,7 @@ spec:
   resolvers:
     action:
       type: string
+      example: refresh
       resolve:
         with:
           - provider: parameter
@@ -365,12 +374,18 @@ func TestCommandInspectSolution_UsageJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(out.Bytes(), &usage))
 
 	assert.Equal(t, "usage-test", usage.Name)
+	assert.Equal(t, "Usage Test Solution", usage.DisplayName)
 	assert.Equal(t, "2.0.0", usage.Version)
 	assert.Equal(t, "Do useful things with this solution", usage.Synopsis)
+	assert.Contains(t, usage.Details, "Extended prose describing the solution.")
 	assert.Equal(t, "scafctl run solution", usage.Run)
+	assert.Equal(t, []string{"demo", "usage"}, usage.Tags)
+	require.Len(t, usage.Links, 2)
+	assert.Equal(t, "https://example.com/docs", usage.Links[0].URL)
 	require.Len(t, usage.Params, 1)
 	assert.Equal(t, "action", usage.Params[0].Name)
 	assert.Equal(t, "show", usage.Params[0].Default)
+	assert.Equal(t, "refresh", usage.Params[0].Example)
 	assert.ElementsMatch(t, []any{"refresh", "show"}, usage.Params[0].AllowedValues)
 	assert.Len(t, usage.Actions, 2)
 	assert.Len(t, usage.Examples, 1)
@@ -395,13 +410,20 @@ func TestCommandInspectSolution_UsageText(t *testing.T) {
 	require.NoError(t, cmd.Execute())
 
 	got := out.String()
-	assert.Contains(t, got, "usage-test (2.0.0)")
+	assert.Contains(t, got, "Usage Test Solution (2.0.0)")
 	assert.Contains(t, got, "Do useful things with this solution")
+	assert.Contains(t, got, "Extended prose describing the solution.")
+	assert.Contains(t, got, "Tags: demo, usage")
 	assert.Contains(t, got, "PARAMETERS")
 	assert.Contains(t, got, "values: refresh, show")
+	assert.Contains(t, got, "example: refresh")
 	assert.Contains(t, got, "ACTIONS")
 	assert.Contains(t, got, "scafctl run solution -r action=refresh")
 	assert.Contains(t, got, "EXAMPLES")
+	assert.Contains(t, got, "LINKS")
+	assert.Contains(t, got, "Docs: https://example.com/docs")
+	// Nameless link renders as a bare URL.
+	assert.Contains(t, got, "  https://example.com/nameless")
 }
 
 func TestCommandInspect(t *testing.T) {

--- a/pkg/solution/inspect/usage.go
+++ b/pkg/solution/inspect/usage.go
@@ -19,14 +19,18 @@ import (
 // projection over a solution's metadata, parameters, and actions, rendered via
 // the kvx pipeline (table/json/yaml/tui).
 type UsageInfo struct {
-	Name     string              `json:"name" yaml:"name" doc:"Solution name" maxLength:"256"`
-	Version  string              `json:"version,omitempty" yaml:"version,omitempty" doc:"Solution version" maxLength:"64"`
-	Synopsis string              `json:"synopsis,omitempty" yaml:"synopsis,omitempty" doc:"How to consume this solution" maxLength:"5000"`
-	Source   string              `json:"source,omitempty" yaml:"source,omitempty" doc:"Resolved solution path" maxLength:"1024"`
-	Run      string              `json:"run,omitempty" yaml:"run,omitempty" doc:"Base command to run the solution" maxLength:"2048"`
-	Params   []ParamUsage        `json:"parameters,omitempty" yaml:"parameters,omitempty" doc:"User-supplied parameters" maxItems:"100"`
-	Actions  []ActionUsage       `json:"actions,omitempty" yaml:"actions,omitempty" doc:"Runnable actions with commands" maxItems:"200"`
-	Examples []spec.UsageExample `json:"examples,omitempty" yaml:"examples,omitempty" doc:"Curated usage examples" maxItems:"50"`
+	Name        string              `json:"name" yaml:"name" doc:"Solution name" maxLength:"256"`
+	DisplayName string              `json:"displayName,omitempty" yaml:"displayName,omitempty" doc:"Human-readable display name" maxLength:"256"`
+	Version     string              `json:"version,omitempty" yaml:"version,omitempty" doc:"Solution version" maxLength:"64"`
+	Synopsis    string              `json:"synopsis,omitempty" yaml:"synopsis,omitempty" doc:"How to consume this solution" maxLength:"5000"`
+	Details     string              `json:"details,omitempty" yaml:"details,omitempty" doc:"Long-form description of how the solution works and when to use it" maxLength:"20000"`
+	Source      string              `json:"source,omitempty" yaml:"source,omitempty" doc:"Resolved solution path" maxLength:"1024"`
+	Run         string              `json:"run,omitempty" yaml:"run,omitempty" doc:"Base command to run the solution" maxLength:"2048"`
+	Tags        []string            `json:"tags,omitempty" yaml:"tags,omitempty" doc:"Searchable tags" maxItems:"100"`
+	Links       []LinkInfo          `json:"links,omitempty" yaml:"links,omitempty" doc:"Related documentation and resources" maxItems:"10"`
+	Params      []ParamUsage        `json:"parameters,omitempty" yaml:"parameters,omitempty" doc:"User-supplied parameters" maxItems:"100"`
+	Actions     []ActionUsage       `json:"actions,omitempty" yaml:"actions,omitempty" doc:"Runnable actions with commands" maxItems:"200"`
+	Examples    []spec.UsageExample `json:"examples,omitempty" yaml:"examples,omitempty" doc:"Curated usage examples" maxItems:"50"`
 }
 
 // ParamUsage describes a single user-supplied parameter in the usage view.
@@ -34,6 +38,7 @@ type ParamUsage struct {
 	Name          string `json:"name" yaml:"name" doc:"Parameter name" maxLength:"256"`
 	Type          string `json:"type,omitempty" yaml:"type,omitempty" doc:"Parameter type" maxLength:"64"`
 	Description   string `json:"description,omitempty" yaml:"description,omitempty" doc:"Parameter description" maxLength:"512"`
+	Example       any    `json:"example,omitempty" yaml:"example,omitempty" doc:"Example value for the parameter"`
 	Default       any    `json:"default,omitempty" yaml:"default,omitempty" doc:"Default value when omitted"`
 	Required      bool   `json:"required,omitempty" yaml:"required,omitempty" doc:"Whether the parameter must be supplied"`
 	AllowedValues []any  `json:"allowedValues,omitempty" yaml:"allowedValues,omitempty" doc:"Discovered allowed values (best-effort)" maxItems:"100"`
@@ -64,15 +69,19 @@ func BuildUsage(ctx context.Context, sol *solution.Solution, path, binaryName st
 	}
 
 	info := &UsageInfo{
-		Name:     sol.Metadata.Name,
-		Synopsis: usageSynopsis(sol),
-		Source:   sol.Metadata.Source,
-		Run:      runInfo.Subcommand,
+		Name:        sol.Metadata.Name,
+		DisplayName: sol.Metadata.DisplayName,
+		Synopsis:    usageSynopsis(sol),
+		Source:      sol.Metadata.Source,
+		Run:         runInfo.Subcommand,
+		Tags:        sol.Metadata.Tags,
+		Links:       usageLinks(sol.Metadata.Links),
 	}
 	if sol.Metadata.Version != nil {
 		info.Version = sol.Metadata.Version.String()
 	}
 	if sol.Metadata.Usage != nil {
+		info.Details = sol.Metadata.Usage.Details
 		info.Examples = sol.Metadata.Usage.Examples
 	}
 
@@ -141,6 +150,18 @@ func discoverAllowedValues(ctx context.Context, sol *solution.Solution) map[stri
 	return agg
 }
 
+// usageLinks converts solution metadata links into the inspect view's link shape.
+func usageLinks(links []solution.Link) []LinkInfo {
+	if len(links) == 0 {
+		return nil
+	}
+	out := make([]LinkInfo, 0, len(links))
+	for _, l := range links {
+		out = append(out, LinkInfo{Name: l.Name, URL: l.URL})
+	}
+	return out
+}
+
 // buildParamUsage merges run-command parameter info with discovered allowed
 // values. Allowed values are discovered keyed by RESOLVER name (what a
 // when-clause references), so they are looked up by ParamInfo.ResolverName; the
@@ -155,6 +176,7 @@ func buildParamUsage(params []ParamInfo, allowedByResolver map[string][]any) []P
 			Name:          p.Name,
 			Type:          p.Type,
 			Description:   p.Description,
+			Example:       p.Example,
 			Default:       p.Default,
 			Required:      p.Required,
 			AllowedValues: allowedByResolver[p.ResolverName],

--- a/pkg/solution/inspect/usage_test.go
+++ b/pkg/solution/inspect/usage_test.go
@@ -330,3 +330,65 @@ func TestBuildUsage_ShellQuotesValues(t *testing.T) {
 	require.Len(t, usage.Actions, 1)
 	assert.Equal(t, "scafctl run solution -f ./solution.yaml -r mode='dry run'", usage.Actions[0].Command)
 }
+
+// #345 completeness: the usage view surfaces displayName, tags, links, and
+// per-parameter example.
+func TestBuildUsage_MetadataFields(t *testing.T) {
+	t.Parallel()
+
+	// parameter resolver with an example.
+	actionResolver := &resolver.Resolver{
+		Type:        "string",
+		Description: "What to do",
+		Example:     "refresh",
+		Resolve: &resolver.ResolvePhase{
+			With: []resolver.ProviderSource{
+				{Provider: "parameter", Inputs: map[string]*resolver.ValueRef{
+					"key":     {Literal: "action"},
+					"default": {Literal: "show"},
+				}},
+			},
+		},
+	}
+	sol := &solution.Solution{
+		Metadata: solution.Metadata{
+			Name:        "tf-registry",
+			DisplayName: "Terraform Registry",
+			Description: "Discovers modules",
+			Tags:        []string{"terraform", "registry"},
+			Links: []solution.Link{
+				{Name: "Docs", URL: "https://example.com/docs"},
+				{Name: "Source", URL: "https://github.com/example/tf"},
+				{URL: "https://example.com/nameless"}, // nameless link
+			},
+			Usage: &spec.Usage{
+				Details: "Long-form prose about how this works.",
+			},
+		},
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{"action": actionResolver},
+			Workflow: &action.Workflow{
+				Actions: map[string]*action.Action{
+					"go": {Description: "Go", When: whenCondition(`_.action == "go"`)},
+				},
+			},
+		},
+	}
+
+	usage, err := BuildUsage(context.Background(), sol, "solution.yaml", "scafctl")
+	require.NoError(t, err)
+
+	assert.Equal(t, "Terraform Registry", usage.DisplayName)
+	assert.Equal(t, []string{"terraform", "registry"}, usage.Tags)
+	require.Len(t, usage.Links, 3)
+	assert.Equal(t, "Docs", usage.Links[0].Name)
+	assert.Equal(t, "https://example.com/docs", usage.Links[0].URL)
+	// Nameless link is preserved with an empty name.
+	assert.Empty(t, usage.Links[2].Name)
+	assert.Equal(t, "https://example.com/nameless", usage.Links[2].URL)
+
+	require.Len(t, usage.Params, 1)
+	assert.Equal(t, "refresh", usage.Params[0].Example)
+
+	assert.Equal(t, "Long-form prose about how this works.", usage.Details)
+}

--- a/pkg/spec/usage.go
+++ b/pkg/spec/usage.go
@@ -12,6 +12,11 @@ type Usage struct {
 	// When set it takes precedence over the metadata description in the usage view.
 	Synopsis string `json:"synopsis,omitempty" yaml:"synopsis,omitempty" doc:"One-line description of how to consume the solution" maxLength:"500" example:"Registry index for Terraform modules and providers"`
 
+	// Details is free-form, multi-paragraph prose describing how the solution
+	// works and when to use it -- the long-form counterpart to the one-line
+	// description/synopsis (analogous to a command's long help or a README body).
+	Details string `json:"details,omitempty" yaml:"details,omitempty" doc:"Long-form description of how the solution works and when to use it" maxLength:"20000"`
+
 	// Examples are curated command examples shown in the usage view.
 	Examples []UsageExample `json:"examples,omitempty" yaml:"examples,omitempty" doc:"Curated usage examples" maxItems:"50"`
 }

--- a/tests/integration/solutions/inspect-usage/solution.yaml
+++ b/tests/integration/solutions/inspect-usage/solution.yaml
@@ -3,8 +3,13 @@ kind: Solution
 
 metadata:
   name: test-inspect-usage
+  displayName: Inspect Usage Test
   version: 1.0.0
   description: A registry-style solution routed by an 'action' parameter.
+  tags: [registry, test]
+  links:
+    - name: Docs
+      url: https://example.com/docs
   usage:
     synopsis: Query and refresh a small registry index
     examples:
@@ -53,6 +58,11 @@ spec:
           - expression: __exitCode == 0
           - expression: __output.synopsis == "Query and refresh a small registry index"
             message: "Synopsis should come from metadata.usage"
+          - expression: __output.displayName == "Inspect Usage Test"
+          - expression: __output.tags.exists(tg, tg == "registry")
+            message: "Tags should be surfaced"
+          - expression: __output.links[0].url == "https://example.com/docs"
+            message: "Links should be surfaced"
           - expression: __output.parameters[0].name == "action"
           - expression: __output.parameters[0].default == "show"
           - expression: __output.parameters[0].allowedValues.exists(v, v == "refresh")
@@ -69,6 +79,8 @@ spec:
         tags: [inspect, usage]
         assertions:
           - expression: __exitCode == 0
+          - expression: '__stdout.contains("Tags: registry, test")'
           - expression: __stdout.contains("PARAMETERS")
           - expression: __stdout.contains("ACTIONS")
           - expression: __stdout.contains("-r action=refresh")
+          - expression: __stdout.contains("LINKS")


### PR DESCRIPTION
## Description

Completes issue #345 (built-in structured help surface for solutions). The `inspect solution --usage` view shipped in #646 covered most of it; this fills the remaining gaps so the view surfaces **everything #345 asked for** and lets solution authors provide their own help content that flows through to the CLI (human + `-o json`/`-o yaml`) and MCP -- retiring the old hand-rolled `help`-action pattern.

### Auto-projected from existing metadata
- `displayName` (header; falls back to `name`)
- `tags`
- `links` (reusing the package's existing `LinkInfo` type)
- per-parameter `example` (was computed in `ParamInfo` but dropped from the usage projection)

### Author-curated via `metadata.usage`
- `synopsis` -- one-line usage summary (overrides the plain description)
- **`details`** -- NEW long-form, multi-paragraph prose ("about / how it works"), the long-description counterpart to `synopsis` (mirrors Cobra `Short`/`Long`)
- `examples` -- curated `description`/`command` pairs

Authors now have a full spectrum: zero-effort auto-generation, light-touch per-field descriptions, or full control via `metadata.usage`.

### Example output

```
App Deployer (1.0.0)
Deploy an app to an environment.

This solution provisions and deploys the application to a target
environment. It reads the environment from the "env" parameter.

Run: scafctl run solution

PARAMETERS
  env (string) [default: dev]
      Target environment
      values: prod
      example: prod

ACTIONS
  deploy
      Deploy the application
      scafctl run solution -f ./solution.yaml -r env=prod

EXAMPLES
  # Deploy to production
  scafctl run solution -r env=prod

LINKS
  Docs: https://example.com/docs
```

## Related Issues

Closes #345

## Type of Change

- [x] New feature
- [ ] Breaking change
- [x] Documentation update

Additive only -- no breaking changes. `metadata.usage.details` and the new `UsageInfo` fields are optional.

## Checklist

- [x] Read CONTRIBUTING
- [x] Commits follow conventional commit format
- [x] Tests added/updated
- [x] `go test ./...` passes
- [x] `task lint:changed` passes (0 new issues)
- [x] Commits signed (`-S`) and DCO signed-off (`-s`)

## Testing

- Unit: `TestBuildUsage_MetadataFields` (displayName/tags/links incl. nameless link/param example/details); `inspect solution --usage` CLI tests (json + text) assert all fields.
- Integration: `tests/integration/solutions/inspect-usage/` fixture asserts displayName, tags, links, and text sections (Tags/LINKS).
- Reviewed by go-reviewer (APPROVE); resolved the finding to reuse `LinkInfo` instead of a duplicate type.

## Notes

Builds directly on #646. Prior art for the `synopsis` + `details` split: Cobra `Short`/`Long`, Helm `description`+README, npm/cargo. Kept to a single long-form field to avoid author confusion / metadata drift.