### PR TITLE
docs(cli): establish a consistent command grammar

### DIFF
--- a/docs/design/cli-command-grammar.md
+++ b/docs/design/cli-command-grammar.md
@@ -1,0 +1,191 @@
+---
+title: "CLI Command Grammar"
+weight: 10
+---
+
+# CLI Command Grammar Decision
+
+## Status
+
+Accepted (direction). Implementation is sequenced across phased PRs; see
+"Migration" below. This document is the ratified rule set that new commands must
+follow and that the seam fixes below will bring existing commands into line with.
+
+Tracks issue #649. Builds on the information-command taxonomy
+(`docs/design/information-command-taxonomy.md`, `get`/`explain`/`inspect`).
+
+## Problem
+
+scafctl's command surface mixes command shapes with no documented rule, so users
+cannot predict how to invoke a command, and new features have no obvious home.
+A full survey (issue #649) found:
+
+- **Two orderings coexist.** Workflow/inspection commands are verb-first
+  (`run solution`, `render solution`, `get solution`, `inspect solution`), while
+  subsystem-management commands are noun-first (`config get`, `auth login`,
+  `catalog list`, `secrets set`). This is not itself wrong -- best-in-class CLIs
+  do the same -- but it was never stated as an intentional rule, so the seams are
+  inconsistent.
+- **The `solution` noun straddles both lanes.** It is `<verb> solution` under six
+  verbs AND a top-level `solution` group (`solution diff`). A user cannot predict
+  whether `solution` comes first or second.
+- **Inconsistent verb ergonomics.** Some operation verbs act directly
+  (`lint [name]`), but others require an explicit sub-verb or noun, so a
+  developer cannot rely on "the verb does the obvious thing." `test` runs
+  functional tests when bare, which is good, but the surface around it is
+  uneven.
+- **A meta subcommand can collide with a target.** `lint rules`/`lint explain`
+  are auxiliary operations, but there is no stated rule for how a positional is
+  interpreted (target vs. subcommand), so behavior is implicit.
+- **Hyphenated command tokens** (`get cel-functions`,
+  `get go-template-functions`) pack two concepts into one token instead of
+  expressing hierarchy by nesting.
+- **Inconsistent no-args UX.** Some commands show help on bare invocation, some
+  error (`run provider`), some act on an implicit target.
+
+## Prior art
+
+The verb-first / noun-first split is standard and tracks command *class*:
+
+| Tool | Lifecycle / operations | Subsystem management |
+|------|------------------------|----------------------|
+| kubectl | `get`/`create`/`delete`/`describe`/`explain <resource>` (verb-first) | `config view`, `auth can-i` (noun-first) |
+| docker | `container run`, `image ls` (noun-first, migrated with aliases) | same |
+| gh | `pr create`, `repo view`, `issue list` (noun-first) | `auth login` |
+| helm | `install`/`upgrade` (verb-first) | `repo add` (noun-first) |
+| git | `commit`/`diff` (flat verbs) | `remote add`, `stash list` |
+
+The takeaway: a mixed grammar is fine **when the split is by command class and is
+consistent within each class**. scafctl already has a clean verb-first spine for
+the workflow nouns and a clean noun-first spine for admin subsystems; the fix is
+to codify that and repair the seams -- not to force a single global ordering
+(which would be massive, low-value churn).
+
+## Decision
+
+### Two lanes, chosen by command class
+
+**Lane 1 -- Operation verbs: `<verb> [target] [flags]` (verb acts by default)**
+
+Commands that *do something to a domain object* are verb-first, and the verb
+performs its action directly -- the way `go test`, `cargo build`, `git commit`,
+and `npm test` work. A developer types the verb and it does the obvious thing.
+
+- Verbs: `run`, `render`, `get`, `inspect`, `explain`, `validate`, `lint`,
+  `test`, `diff`, `new`, `package`.
+- The verb's **default target is the solution**, auto-discovered when not given:
+  `scafctl test` tests the solution, `scafctl lint` lints it, `scafctl run`
+  runs it. A positional names a specific target (`scafctl test my-app`), and
+  `-f` always points at a file (`scafctl lint -f ./sol.yaml`).
+- **A verb may also host closely-related sub-verbs** for auxiliary operations on
+  the same domain (e.g. `test list`, `test init`, `lint rules`). This mirrors
+  `git stash` / `git stash list`.
+- **Where a verb operates on more than one noun**, the noun is explicit:
+  `run solution` / `run resolver` / `run provider` / `run action`;
+  `validate solution` / `validate resolver` / `validate schema`. When there is a
+  single natural target (solution), the noun may be omitted.
+- A new operation slots in obviously. Validating arbitrary data against a schema
+  is `validate schema` -- a sibling of `validate solution`, not a new top-level
+  command.
+
+**Lane 2 -- Subsystem management: `<subsystem> <verb> [args] [flags]`**
+
+Commands that *manage a subsystem or a collection of resources* -- where there
+is no single "primary action," just a set of admin operations -- are noun-first.
+The subsystem is a group; its children are verbs.
+
+- Subsystems: `config`, `auth`, `catalog`, `secrets`, `state`, `plugins`,
+  `cache`, `mcp`, `kube`, `snapshot`, `bundle`, `vendor`, `credential-helper`.
+- Children are verbs: `list`, `get`, `set`, `delete`, `login`, `push`, `pull`, ...
+- A bare subsystem shows help (it has no default action).
+
+**Deciding the lane:** if there is one obvious primary action ("test it", "lint
+it", "run it"), it is an operation verb (Lane 1). If it is a bag of management
+operations with no primary action ("manage config", "manage auth"), it is a
+subsystem (Lane 2).
+
+### Rules that apply to both lanes
+
+1. **Verbs act; be natural and discoverable.** Prefer what a developer would
+   naturally type (`scafctl test`, not `scafctl test run`), following go / cargo
+   / git / npm conventions. When the exact command is not obvious, it must be
+   discoverable by walking the help tree (`scafctl --help` ->
+   `scafctl test --help` -> `scafctl test list --help`).
+2. **Ambiguity rule for sub-verbs.** A positional argument to an operation verb
+   is treated as a **target** unless it exactly matches a known subcommand name;
+   `-f` always forces a file target. So `scafctl test list` runs the `list`
+   sub-verb, while `scafctl test -f ./list` tests the file `./list`. Keep
+   sub-verb names short and unlikely to collide with real solution names, and
+   document them.
+3. **Do not hyphenate two separately-meaningful command tokens; nest instead.**
+   A hyphen that joins two concepts (a namespace + a thing, or a verb + an
+   object) is hiding a hierarchy -- express it by nesting: `get cel functions`,
+   not `get cel-functions`. A hyphen is acceptable only when it is part of a
+   single established compound term (`credential-helper`, `go-template`) -- the
+   same way git keeps `cherry-pick`. Hyphenated *flag* names are always fine.
+4. **Bare invocation never errors with a raw cobra message.** A subsystem or a
+   verb with no discoverable target shows help or a clear, actionable error
+   (see the silent-failure fix in `inspect solution`, PR #646) -- not
+   `requires at least 1 arg`.
+5. **Schema/kind documentation lives under `explain`.** The schema of a kind and
+   its field docs are `explain <kind>` (e.g. `explain solution`, `explain
+   provider`). Sub-verbs that are auxiliary operations of a *specific verb* stay
+   under that verb (e.g. `lint rules` lists the lint engine's rules; it belongs
+   to `lint`, not to `explain`).
+
+## Seam fixes (bringing existing commands into line)
+
+| Seam | Today | Target | Rationale |
+|------|-------|--------|-----------|
+| `solution` straddle | `solution diff <a> <b>` (top-level noun group) | `diff solution <a> <b>` | `diff` becomes an operation verb; retires the top-level `solution` group. |
+| lint ergonomics | `lint [name]` + `lint rules` + `lint explain <rule>` | `lint [solution]` (acts by default) + `lint rules` (list) + `lint rule <name>` (detail) | `lint` acts by default; its rule-metadata stay as natural sub-verbs under `lint` (git-stash-style). `lint explain <rule>` -> `lint rule <name>` (nested noun, no hyphen). Positional-vs-subcommand resolved by the ambiguity rule. |
+| test ergonomics | `test [ref]` (runs functional) + `test functional/init/list` | `test [solution]` (acts by default, runs functional tests) + `test list` + `test init` | `test` acts by default like `go test`/`cargo test`; `functional` folds into the default (aliased); `list`/`init` remain natural sub-verbs. |
+| `auth handlers` | `auth handlers [name]` (lists) + `install`/`remove` | `auth handlers list` / `auth handlers install <h>` / `auth handlers remove <h>` | `auth` is a subsystem (Lane 2), so `handlers` is a sub-subsystem whose children are verbs -- explicit, no bare-acts. |
+| `serve` + openapi | `serve` (starts server) + `serve openapi` | `serve` stays a pure leaf (starts the server); OpenAPI export moves to `get openapi`. | Starting the server is `serve`'s one obvious action (leaf); exporting the generated spec is a `get` of an artifact, not a sub-mode of the running server. |
+| Hyphenated `get cel-functions` / `get go-template-functions` | verb + hyphenated token | `get cel functions` / `get go-template functions` (nested) | Listing available functions is the `get` lane (like `get provider`, `get examples`). The hyphen joins a namespace (`cel`) and a thing (`functions`) -- nest it. `go-template` stays hyphenated as a single established term. |
+| `run provider` no-args | `requires at least 1 arg` | Show help (or a clear error) | Rule 4. |
+| New: schema/data validation | (does not exist) | `validate schema --schema <s> --data <d>` | The concrete driver for #649; lands cleanly in the operation-verb lane. |
+
+Note the two existing "validate" surfaces are reconciled by the lanes:
+`validate <noun>` (solution/resolver/schema) is the operation-verb form;
+`eval validate` (CEL/template syntax) stays under the `eval` sandbox subsystem
+because it validates ad-hoc expressions, not domain artifacts.
+
+## Consequences
+
+- **Breaking CLI-path changes** (pre-production, squash-merge -- acceptable, noted
+  per change). Each moved command ships with a **deprecated alias** forwarding to
+  the new path for one release where practical, so scripts and muscle memory get
+  a transition window; aliases are removed in a later major.
+- New commands have an unambiguous home: pick the lane by class, then the verb
+  (Lane 1) or subsystem+verb (Lane 2).
+- Operation verbs are natural to type -- `scafctl test`, `scafctl lint`,
+  `scafctl run` all do the obvious thing -- with auxiliary sub-verbs discoverable
+  in each verb's help.
+- The top-level `solution` group is retired (its sole child `diff` moves to
+  `diff solution`); this resolves the #648 placement question.
+
+## Migration (phased PRs)
+
+This is too large for one PR. Suggested sequence, each its own PR with aliases:
+
+1. **Grammar doc** (this document) -- ratify the rule set. No code.
+2. **`diff solution`** -- add the operation verb, alias `solution diff` -> it,
+   retire the top-level `solution` group. Resolves #648.
+3. **`validate schema`** -- implement the schema/data validation command (the
+   driver). Reconcile the `validate` lane.
+4. **Tidy `lint`** -- keep `lint [solution]` acting by default; rename
+   `lint explain <rule>` -> `lint rule <name>` and keep `lint rules` (list);
+   apply the ambiguity rule. Alias old paths.
+5. **Tidy `test`** -- keep `test [solution]` acting by default (running
+   functional tests), fold `test functional` into the default (alias), keep
+   `test list`/`test init`. De-dual-mode `auth handlers` (-> explicit verbs) and
+   move `serve openapi` -> `get openapi`. One PR or split as needed.
+6. **De-hyphenate** `get cel-functions` / `get go-template-functions` ->
+   `get cel functions` / `get go-template functions` (nested). Alias old paths.
+7. **No-args UX sweep** -- ensure every bare command shows help or acts on its
+   default target; fix `run provider` and audit the rest.
+
+Each PR updates `docs/design/cli.md`, integration tests, and MCP tool
+descriptions that reference the moved paths, and notes the breaking change and
+alias in its title/body.

--- a/docs/design/cli-command-grammar.md
+++ b/docs/design/cli-command-grammar.md
@@ -65,28 +65,40 @@ to codify that and repair the seams -- not to force a single global ordering
 
 ### Two lanes, chosen by command class
 
-**Lane 1 -- Operation verbs: `<verb> [target] [flags]` (verb acts by default)**
+**Lane 1 -- Operation verbs: `<verb> [noun] [name] [flags]`**
 
-Commands that *do something to a domain object* are verb-first, and the verb
-performs its action directly -- the way `go test`, `cargo build`, `git commit`,
-and `npm test` work. A developer types the verb and it does the obvious thing.
+Commands that *do something to a domain object* are verb-first. Within Lane 1
+there are two shapes, distinguished by how many nouns the verb operates on:
 
-- Verbs: `run`, `render`, `get`, `inspect`, `explain`, `validate`, `lint`,
-  `test`, `diff`, `new`, `package`.
-- The verb's **default target is the solution**, auto-discovered when not given:
-  `scafctl test` tests the solution, `scafctl lint` lints it, `scafctl run`
-  runs it. A positional names a specific target (`scafctl test my-app`), and
-  `-f` always points at a file (`scafctl lint -f ./sol.yaml`).
-- **A verb may also host closely-related sub-verbs** for auxiliary operations on
-  the same domain (e.g. `test list`, `test init`, `lint rules`). This mirrors
-  `git stash` / `git stash list`.
-- **Where a verb operates on more than one noun**, the noun is explicit:
-  `run solution` / `run resolver` / `run provider` / `run action`;
-  `validate solution` / `validate resolver` / `validate schema`. When there is a
-  single natural target (solution), the noun may be omitted.
-- A new operation slots in obviously. Validating arbitrary data against a schema
-  is `validate schema` -- a sibling of `validate solution`, not a new top-level
-  command.
+- **Single-target verbs** act directly, defaulting to the solution -- the way
+  `go test`, `cargo build`, `git commit`, and `npm test` work. A developer types
+  the verb and it does the obvious thing.
+  - Verbs: `lint`, `test`.
+  - `scafctl test` tests the solution, `scafctl lint` lints it. A positional
+    names a specific target (`scafctl test my-app`); `-f` always points at a
+    file (`scafctl lint -f ./sol.yaml`).
+  - A single-target verb **may also host closely-related sub-verbs** for
+    auxiliary operations on the same domain (e.g. `test list`, `test init`,
+    `lint rules`). This mirrors `git stash` / `git stash list`.
+
+- **Multi-noun verbs** operate on more than one kind of object, so the noun is
+  **explicit** -- these are parent dispatchers, not solution-defaulting verbs. A
+  bare invocation shows help (it lists the nouns), not a default action.
+  - Verbs and their nouns: `run solution|resolver|provider|action`,
+    `render solution`, `get solution|provider|example|...`,
+    `inspect solution`, `explain <kind>`, `validate solution|resolver|schema`,
+    `diff solution`, `new solution`, `package solution|plugin`.
+  - `scafctl run` shows help; `scafctl run solution` runs a solution.
+    `diff` takes an explicit noun (`diff solution <a> <b>`) so it can grow to
+    other diffable nouns (e.g. `diff snapshot`) later.
+
+A new operation slots in obviously: validating arbitrary data against a schema
+is `validate schema` -- a sibling of `validate solution` under the existing
+multi-noun `validate` verb, not a new top-level command.
+
+Note: some multi-noun verbs already accept a positional solution ref as a
+convenience on their solution subcommand (e.g. `inspect solution my-app`). That
+is the *noun's* argument, not a verb-level default; the noun is still required.
 
 **Lane 2 -- Subsystem management: `<subsystem> <verb> [args] [flags]`**
 
@@ -99,10 +111,13 @@ The subsystem is a group; its children are verbs.
 - Children are verbs: `list`, `get`, `set`, `delete`, `login`, `push`, `pull`, ...
 - A bare subsystem shows help (it has no default action).
 
-**Deciding the lane:** if there is one obvious primary action ("test it", "lint
-it", "run it"), it is an operation verb (Lane 1). If it is a bag of management
-operations with no primary action ("manage config", "manage auth"), it is a
-subsystem (Lane 2).
+**Deciding the lane:** if the command *does something to a domain object*
+("test it", "lint it", "run a solution", "diff two solutions"), it is an
+operation verb (Lane 1). If it is a bag of management operations with no single
+primary action ("manage config", "manage auth"), it is a subsystem (Lane 2).
+Within Lane 1, a verb that has a single natural target defaults to the solution
+(`lint`, `test`); a verb that spans several nouns (or is kept extensible)
+requires the noun explicitly (`run`, `get`, `validate`, `diff`, ...).
 
 ### Rules that apply to both lanes
 
@@ -123,9 +138,10 @@ subsystem (Lane 2).
    not `get cel-functions`. A hyphen is acceptable only when it is part of a
    single established compound term (`credential-helper`, `go-template`) -- the
    same way git keeps `cherry-pick`. Hyphenated *flag* names are always fine.
-4. **Bare invocation never errors with a raw cobra message.** A subsystem or a
-   verb with no discoverable target shows help or a clear, actionable error
-   (see the silent-failure fix in `inspect solution`, PR #646) -- not
+4. **Bare invocation never errors with a raw cobra message.** A subsystem, a
+   multi-noun verb (a parent that dispatches to nouns), or a single-target verb
+   with no discoverable target shows help or a clear, actionable error (see the
+   silent-failure fix in `inspect solution`, PR #646) -- not
    `requires at least 1 arg`.
 5. **Schema/kind documentation lives under `explain`.** The schema of a kind and
    its field docs are `explain <kind>` (e.g. `explain solution`, `explain

--- a/docs/design/cli-command-grammar.md
+++ b/docs/design/cli-command-grammar.md
@@ -63,7 +63,7 @@ to codify that and repair the seams -- not to force a single global ordering
 
 ## Decision
 
-### Two lanes, chosen by command class
+### Lanes, chosen by command class
 
 **Lane 1 -- Operation verbs: `<verb> [noun] [name] [flags]`**
 
@@ -111,13 +111,28 @@ The subsystem is a group; its children are verbs.
 - Children are verbs: `list`, `get`, `set`, `delete`, `login`, `push`, `pull`, ...
 - A bare subsystem shows help (it has no default action).
 
+**Lane 3 -- Meta / self commands: `<verb> [flags]` (flat, top-level)**
+
+Commands that operate on *the tool itself or the user's environment* -- not on a
+domain object (Lane 1) and not on a managed subsystem (Lane 2) -- are flat
+top-level verbs. They take no solution and have no noun.
+
+- Verbs: `version`, `update` (self-update), `completion`, `options`, and future
+  diagnostics such as `doctor` / `env` / `status`.
+- These are the "tool about the tool" commands every mature CLI has
+  (`brew doctor`, `gh extension upgrade`, `rustup update`, `kubectl completion`).
+- Keep this lane small and obvious; if a command starts needing sub-verbs or a
+  managed resource, it belongs in Lane 2 instead.
+
 **Deciding the lane:** if the command *does something to a domain object*
 ("test it", "lint it", "run a solution", "diff two solutions"), it is an
 operation verb (Lane 1). If it is a bag of management operations with no single
-primary action ("manage config", "manage auth"), it is a subsystem (Lane 2).
-Within Lane 1, a verb that has a single natural target defaults to the solution
-(`lint`, `test`); a verb that spans several nouns (or is kept extensible)
-requires the noun explicitly (`run`, `get`, `validate`, `diff`, ...).
+primary action ("manage config", "manage auth"), it is a subsystem (Lane 2). If
+it operates on the tool or the environment itself ("update scafctl", "print the
+version", "diagnose my setup"), it is a meta command (Lane 3). Within Lane 1,
+a verb that has a single natural target defaults to the solution (`lint`,
+`test`); a verb that spans several nouns (or is kept extensible) requires the
+noun explicitly (`run`, `get`, `validate`, `diff`, ...).
 
 ### Rules that apply to both lanes
 
@@ -166,6 +181,34 @@ Note the two existing "validate" surfaces are reconciled by the lanes:
 `validate <noun>` (solution/resolver/schema) is the operation-verb form;
 `eval validate` (CEL/template syntax) stays under the `eval` sandbox subsystem
 because it validates ad-hoc expressions, not domain artifacts.
+
+## Future fit
+
+A grammar is only useful if new commands slot in without debate. The
+capabilities scafctl is likely to grow -- several already requested -- map onto
+the three lanes as follows. This is illustrative, not a commitment to build.
+
+| Anticipated capability | Lane / form | Prior art |
+|------------------------|-------------|-----------|
+| Self-update (#239) | Lane 3: `update` (alias `upgrade`) | `brew upgrade`, `rustup update` |
+| Setup diagnostics | Lane 3: `doctor` / `env` | `brew doctor`, `npm doctor` |
+| Shell completion | Lane 3: `completion` (exists) | universal |
+| Inspect a provider (#319) | Lane 1 multi-noun: `inspect provider <name>` | `kubectl describe` |
+| Replay / verify / drift (#242) | Lane 1: `verify solution`, `replay solution` | `terraform plan` |
+| Format a solution file | Lane 1 single-target: `fmt` (defaults to solution) | `gofmt`, `terraform fmt` |
+| Edit in `$EDITOR` | Lane 1 single-target: `edit` | `kubectl edit` |
+| Live-follow output | Flag, not a verb: `-w`/`--watch` on operation verbs | `kubectl get -w` |
+| Execution logs / history | Lane 1 or `run` sub-verb: `logs` / `run logs` | `docker logs` |
+| Graph / visualize | Extend existing `render solution -o mermaid` | `terraform graph` |
+| Plugins search (#535) | Lane 2: `plugins search` | `brew search` |
+| MCP inspector (#419) | Lane 2: `mcp tools` / `mcp call` / `mcp ping` | -- |
+| Schema/UI generation (#243) | Lane 1 multi-noun: `get schema` / `generate schema` | -- |
+
+**Open question -- `pipeline` (#60):** catalog-regression testing does not fit
+cleanly. Options: a `test` sub-verb (`test catalog`), a Lane 2 subsystem
+(`pipeline run`/`test`), or fold into `catalog` (`catalog test`). Decide when
+that feature is designed; noting it here so the grammar is not assumed to have
+already answered it.
 
 ## Consequences
 

--- a/docs/design/cli-command-grammar.md
+++ b/docs/design/cli-command-grammar.md
@@ -12,7 +12,9 @@ Accepted (direction). Implementation is sequenced across phased PRs; see
 follow and that the seam fixes below will bring existing commands into line with.
 
 Tracks issue #649. Builds on the information-command taxonomy
-(`docs/design/information-command-taxonomy.md`, `get`/`explain`/`inspect`).
+(`docs/design/information-command-taxonomy.md`), which introduced
+`get`/`explain`/`inspect`; this document supersedes the `inspect` verb by
+folding instance detail into `get` (Rule 3).
 
 ## Problem
 
@@ -20,23 +22,25 @@ scafctl's command surface mixes command shapes with no documented rule, so users
 cannot predict how to invoke a command, and new features have no obvious home.
 A full survey (issue #649) found:
 
-- **Two orderings coexist.** Workflow/inspection commands are verb-first
-  (`run solution`, `render solution`, `get solution`, `inspect solution`), while
+- **Two orderings coexist with no stated rule.** Workflow/inspection commands are
+  verb-first (`run solution`, `render solution`, `get solution`), while
   subsystem-management commands are noun-first (`config get`, `auth login`,
-  `catalog list`, `secrets set`). This is not itself wrong -- best-in-class CLIs
-  do the same -- but it was never stated as an intentional rule, so the seams are
-  inconsistent.
-- **The `solution` noun straddles both lanes.** It is `<verb> solution` under six
-  verbs AND a top-level `solution` group (`solution diff`). A user cannot predict
-  whether `solution` comes first or second.
+  `catalog list`). A mixed grammar is fine -- best-in-class CLIs do it -- but the
+  split was never defined, so the seams are inconsistent.
+- **Artifact nouns straddle both lanes.** `solution`, `bundle`, and `snapshot`
+  are user artifacts, yet they appear inconsistently: `solution` is `<verb>
+  solution` under six verbs AND a top-level `solution diff` group; `bundle` and
+  `snapshot` are top-level noun groups (`bundle diff/verify/extract`,
+  `snapshot diff/show`). So `diff` is spelled three different ways
+  (`solution diff` vs `bundle diff` vs `snapshot diff`) and a user cannot predict
+  whether the artifact comes first or second.
+- **Overlapping check-verbs proliferate.** `validate` (root), `verify` (under
+  `bundle`), and `lint` all "check something" and read as synonyms, so a user
+  cannot tell which one gates their build; the surface was never rationalized.
+- **Inconsistent terminology.** Go templates are called `template` in one place
+  (`eval template`) and `go-template` in another (`get go-template-functions`).
 - **Inconsistent verb ergonomics.** Some operation verbs act directly
-  (`lint [name]`), but others require an explicit sub-verb or noun, so a
-  developer cannot rely on "the verb does the obvious thing." `test` runs
-  functional tests when bare, which is good, but the surface around it is
-  uneven.
-- **A meta subcommand can collide with a target.** `lint rules`/`lint explain`
-  are auxiliary operations, but there is no stated rule for how a positional is
-  interpreted (target vs. subcommand), so behavior is implicit.
+  (`lint [name]`); others require an explicit sub-verb or noun.
 - **Hyphenated command tokens** (`get cel-functions`,
   `get go-template-functions`) pack two concepts into one token instead of
   expressing hierarchy by nesting.
@@ -47,203 +51,284 @@ A full survey (issue #649) found:
 
 The verb-first / noun-first split is standard and tracks command *class*:
 
-| Tool | Lifecycle / operations | Subsystem management |
+| Tool | Operations on objects | Subsystem management |
 |------|------------------------|----------------------|
-| kubectl | `get`/`create`/`delete`/`describe`/`explain <resource>` (verb-first) | `config view`, `auth can-i` (noun-first) |
+| kubectl | `get`/`describe`/`explain`/`diff <resource>` (verb-first) | `config view`, `auth can-i` (noun-first) |
 | docker | `container run`, `image ls` (noun-first, migrated with aliases) | same |
-| gh | `pr create`, `repo view`, `issue list` (noun-first) | `auth login` |
+| gh | `pr create`, `repo view` (noun-first) | `auth login` |
 | helm | `install`/`upgrade` (verb-first) | `repo add` (noun-first) |
 | git | `commit`/`diff` (flat verbs) | `remote add`, `stash list` |
 
 The takeaway: a mixed grammar is fine **when the split is by command class and is
-consistent within each class**. scafctl already has a clean verb-first spine for
-the workflow nouns and a clean noun-first spine for admin subsystems; the fix is
-to codify that and repair the seams -- not to force a single global ordering
-(which would be massive, low-value churn).
+consistent within each class**. The fix is to codify the split with a test that
+predicts which lane any noun belongs in -- and repair the seams -- not to force a
+single global ordering (massive, low-value churn).
 
 ## Decision
 
-### Lanes, chosen by command class
+### The lane test: is the noun an OBJECT or a SUBSYSTEM?
 
-**Lane 1 -- Operation verbs: `<verb> [noun] [name] [flags]`**
+Every noun in the CLI is either an **object** you act on or a **subsystem** you
+operate within. This single distinction chooses the lane:
 
-Commands that *do something to a domain object* are verb-first. Within Lane 1
-there are two shapes, distinguished by how many nouns the verb operates on:
+- **Object -> verb-first.** A noun is an *object* when you *do things to it*: it
+  is typically an artifact the user made (a solution, a bundle, a snapshot, a
+  provider definition), usually a single instance, and the verbs that act on it
+  (`diff`, `validate`, `get`, `extract`) **generalize across several objects**.
+  The operation is the point; the object is its target. Read it as `<verb>
+  <object>` -- "diff solution", "validate solution", "get snapshot".
 
-- **Single-target verbs** act directly, defaulting to the solution -- the way
-  `go test`, `cargo build`, `git commit`, and `npm test` work. A developer types
-  the verb and it does the obvious thing.
-  - Verbs: `lint`, `test`.
-  - `scafctl test` tests the solution, `scafctl lint` lints it. A positional
-    names a specific target (`scafctl test my-app`); `-f` always points at a
-    file (`scafctl lint -f ./sol.yaml`).
-  - A single-target verb **may also host closely-related sub-verbs** for
-    auxiliary operations on the same domain (e.g. `test list`, `test init`,
-    `lint rules`). This mirrors `git stash` / `git stash list`.
+- **Subsystem -> noun-first.** A noun is a *subsystem* when it is a bounded
+  management context / a place with its own vocabulary: *the* catalog, *the*
+  cache, *the* config -- a standing store or service, not an artifact -- whose
+  verbs (`login`, `push`, `prune`, `set`) are **specific to it and do not
+  generalize** to other nouns. You are not "doing X to the config"; you are
+  "using config's own commands." Read it as `<subsystem> <verb>` -- "auth login",
+  "catalog push".
 
-- **Multi-noun verbs** operate on more than one kind of object, so the noun is
-  **explicit** -- these are parent dispatchers, not solution-defaulting verbs. A
-  bare invocation shows help (it lists the nouns), not a default action.
-  - Verbs and their nouns: `run solution|resolver|provider|action`,
-    `render solution`, `get solution|provider|example|...`,
-    `inspect solution`, `explain <kind>`, `validate solution|resolver|schema`,
-    `diff solution`, `new solution`, `package solution|plugin`.
-  - `scafctl run` shows help; `scafctl run solution` runs a solution.
-    `diff` takes an explicit noun (`diff solution <a> <b>`) so it can grow to
-    other diffable nouns (e.g. `diff snapshot`) later.
+**The tests, applied:**
 
-A new operation slots in obviously: validating arbitrary data against a schema
-is `validate schema` -- a sibling of `validate solution` under the existing
-multi-noun `validate` verb, not a new top-level command.
+| Test | Object (verb-first) | Subsystem (noun-first) |
+|------|---------------------|------------------------|
+| Is it a file/artifact the user made? | solution, bundle, snapshot -- yes | config, auth, catalog -- no |
+| One instance, or a standing store/service? | one bundle, one snapshot | *the* catalog, *the* cache, *the* config |
+| Do its verbs generalize to other nouns? | `diff`/`validate`/`get`/`extract` do | `catalog push`, `auth login` do not |
+| Does `<verb> <it>` read naturally? | "diff solution" yes | "login auth" no, "list catalog" no |
+| Fundamentally a management/admin surface? | no | yes |
 
-Note: some multi-noun verbs already accept a positional solution ref as a
-convenience on their solution subcommand (e.g. `inspect solution my-app`). That
-is the *noun's* argument, not a verb-level default; the noun is still required.
+`solution`, `bundle`, and `snapshot` all pass the object tests -- they are
+artifacts, single instances, and share the same verbs -- so they are **objects,
+verb-first**, and the top-level `solution`/`bundle`/`snapshot` groups are retired.
+`catalog`, `config`, `auth`, `kube`, `cache`, `secrets`, `state`, `plugins`,
+`mcp`, `eval`, and `vendor` all pass the subsystem tests -- standing surfaces with
+bespoke verbs -- so they stay **noun-first**. You would never say "diff catalog"
+or "login auth"; you *use* those subsystems, you do not act *on* them.
 
-**Lane 2 -- Subsystem management: `<subsystem> <verb> [args] [flags]`**
+### Lane 1 -- Operation verbs on objects: `<verb> <object> [name] [flags]`
 
-Commands that *manage a subsystem or a collection of resources* -- where there
-is no single "primary action," just a set of admin operations -- are noun-first.
-The subsystem is a group; its children are verbs.
+Verbs that *do something to an object* are verb-first. The same verb works across
+many objects (it is polymorphic), which is what makes the grammar predictable:
+learn the verb once, apply it to any object.
+
+- **Polymorphic operation verbs:** `run`, `render`, `get`, `explain`,
+  `validate`, `diff`, `extract`, `new`, `package`.
+- **Objects:** `solution`, `bundle`, `snapshot`, `provider`, `resolver`,
+  `action`, `schema`, `plugin`, ... A new object type slots straight in
+  (`diff <newthing>`, `validate <newthing>`).
+- **Single-target verbs** default to the solution -- the way `go test`,
+  `cargo build`, and `git commit` work. These are `lint` and `test`:
+  `scafctl test` tests the solution, `scafctl lint` lints it. A positional names
+  a specific target; `-f` always points at a file. A single-target verb may host
+  closely-related sub-verbs (`test list`, `lint rules`), git-stash-style.
+- **Multi-noun verbs** span several objects, so the object is **explicit** and a
+  bare invocation shows help (it lists the objects): `scafctl run` shows help;
+  `scafctl run solution` runs a solution; `scafctl diff snapshot <a> <b>` diffs
+  two snapshots.
+
+Examples of the polymorphism this buys:
+
+- `diff solution|bundle|snapshot` -- one verb, one spelling, every artifact.
+- `validate solution|bundle|schema` -- one gate verb; each object defines what
+  "correct" means for it (see Rule 2).
+- `get solution|snapshot|bundle` -- list many, or one in full via arg + `-o`/
+  `--detail`; a single verb for instances at any depth (see Rule 3).
+- `extract bundle` (and future `extract <object>`) -- pull contents out of any
+  extractable artifact.
+
+### Lane 2 -- Subsystem management: `<subsystem> <verb> [args] [flags]`
+
+Subsystems -- bounded management contexts with no single primary action -- are
+noun-first. The subsystem is a group; its children are verbs.
 
 - Subsystems: `config`, `auth`, `catalog`, `secrets`, `state`, `plugins`,
-  `cache`, `mcp`, `kube`, `snapshot`, `bundle`, `vendor`, `credential-helper`.
-- Children are verbs: `list`, `get`, `set`, `delete`, `login`, `push`, `pull`, ...
+  `cache`, `mcp`, `kube`, `eval`, `vendor`, `credential-helper`.
+- Children are verbs: `list`, `get`, `set`, `delete`, `login`, `push`, `pull`,
+  `install`, `update`, `prune`, ...
 - A bare subsystem shows help (it has no default action).
 
-**Lane 3 -- Meta / self commands: `<verb> [flags]` (flat, top-level)**
+### Lane 3 -- Meta / self commands: `<verb> [flags]` (flat, top-level)
 
-Commands that operate on *the tool itself or the user's environment* -- not on a
-domain object (Lane 1) and not on a managed subsystem (Lane 2) -- are flat
-top-level verbs. They take no solution and have no noun.
+Commands that operate on *the tool itself or the user's environment* -- not on an
+object (Lane 1), not on a subsystem (Lane 2) -- are flat top-level verbs.
 
 - Verbs: `version`, `update` (self-update), `completion`, `options`, and future
   diagnostics such as `doctor` / `env` / `status`.
-- These are the "tool about the tool" commands every mature CLI has
-  (`brew doctor`, `gh extension upgrade`, `rustup update`, `kubectl completion`).
-- Keep this lane small and obvious; if a command starts needing sub-verbs or a
-  managed resource, it belongs in Lane 2 instead.
+- Prior art: `brew doctor`, `gh extension upgrade`, `rustup update`,
+  `kubectl completion`.
+- Keep this lane small; if a command grows sub-verbs or a managed resource, it
+  belongs in Lane 2.
 
-**Deciding the lane:** if the command *does something to a domain object*
-("test it", "lint it", "run a solution", "diff two solutions"), it is an
-operation verb (Lane 1). If it is a bag of management operations with no single
-primary action ("manage config", "manage auth"), it is a subsystem (Lane 2). If
-it operates on the tool or the environment itself ("update scafctl", "print the
-version", "diagnose my setup"), it is a meta command (Lane 3). Within Lane 1,
-a verb that has a single natural target defaults to the solution (`lint`,
-`test`); a verb that spans several nouns (or is kept extensible) requires the
-noun explicitly (`run`, `get`, `validate`, `diff`, ...).
+**Deciding the lane:** run the object-vs-subsystem test. If the noun is an object
+you act on, it is Lane 1 (verb-first). If it is a subsystem you operate within, it
+is Lane 2 (noun-first). If the command targets the tool/environment itself, it is
+Lane 3. Within Lane 1, a verb with a single natural target defaults to the
+solution (`lint`, `test`); a verb spanning several objects requires the object
+explicitly (`run`, `get`, `diff`, ...).
 
-### Rules that apply to both lanes
+### Rules that apply across lanes
 
 1. **Verbs act; be natural and discoverable.** Prefer what a developer would
-   naturally type (`scafctl test`, not `scafctl test run`), following go / cargo
-   / git / npm conventions. When the exact command is not obvious, it must be
-   discoverable by walking the help tree (`scafctl --help` ->
-   `scafctl test --help` -> `scafctl test list --help`).
-2. **Ambiguity rule for sub-verbs.** A positional argument to an operation verb
-   is treated as a **target** unless it exactly matches a known subcommand name;
-   `-f` always forces a file target. So `scafctl test list` runs the `list`
-   sub-verb, while `scafctl test -f ./list` tests the file `./list`. Keep
-   sub-verb names short and unlikely to collide with real solution names, and
-   document them.
-3. **Do not hyphenate two separately-meaningful command tokens; nest instead.**
-   A hyphen that joins two concepts (a namespace + a thing, or a verb + an
-   object) is hiding a hierarchy -- express it by nesting: `get cel functions`,
-   not `get cel-functions`. A hyphen is acceptable only when it is part of a
-   single established compound term (`credential-helper`, `go-template`) -- the
-   same way git keeps `cherry-pick`. Hyphenated *flag* names are always fine.
-4. **Bare invocation never errors with a raw cobra message.** A subsystem, a
-   multi-noun verb (a parent that dispatches to nouns), or a single-target verb
-   with no discoverable target shows help or a clear, actionable error (see the
-   silent-failure fix in `inspect solution`, PR #646) -- not
-   `requires at least 1 arg`.
-5. **Schema/kind documentation lives under `explain`.** The schema of a kind and
-   its field docs are `explain <kind>` (e.g. `explain solution`, `explain
-   provider`). Sub-verbs that are auxiliary operations of a *specific verb* stay
-   under that verb (e.g. `lint rules` lists the lint engine's rules; it belongs
-   to `lint`, not to `explain`).
+   naturally type (`scafctl test`, not `scafctl test run`). When the exact
+   command is not obvious, it must be discoverable by walking the help tree.
+2. **One gate verb: `validate`. `lint` is its advisory subset. There is no
+   `verify`.** "validate", "verify", and "lint" are near-synonyms in plain
+   English; shipping all three would force users to guess which one gates their
+   CI. So the checking surface is deliberately minimal, organized by *when in the
+   lifecycle* a check happens, not by synonym:
+   - **`lint <object>`** answers "am I *authoring this well*?" -- style, smells,
+     deprecated fields, best-practice **warnings**. Advisory, fast, for the inner
+     authoring loop. Standalone and optional; you never *need* to run it
+     separately.
+   - **`validate <object>`** is **the** gate: "is this *good*?" It is pass/fail,
+     and it **runs lint internally** (lint findings surface as warnings; errors
+     fail). Each object defines what "good" means for it -- `validate solution`
+     (parses, schema-conforms, refs resolve), `validate schema` (data vs schema).
+     This is the single command a user or CI runs to know their source is sound.
+   - **Built-artifact completeness is not a verb.** Checking that a *built bundle*
+     is complete (all files, globs, plugins present) rides on the two lifecycle
+     transitions where it matters, automatically:
+     - **Producer side -- `package`:** building an artifact completeness-checks
+       its output; the build **fails** if the bundle is incomplete.
+     - **Consumer side -- `install` / `pull`:** acquiring a bundle
+       completeness-checks it before caching/running and **refuses or warns** on a
+       broken artifact -- the way `npm install`, `apt`, and `docker pull` verify
+       what they fetch. The consumer never runs a separate check verb.
+     A `--strict` flag on `package` / `install` exposes deep checks for CI.
+   - **Why this is enough.** To know an object is good, a user runs **one**
+     command at the stage they are at: `validate` on source; nothing extra on a
+     bundle (it is checked when produced and when acquired). A typical CI gate is
+     two lines that both do real work -- `validate solution` then
+     `package solution` -- with no dedicated "checking" commands to learn.
+   - **Help-text contract:** `validate` Short must read as the gate (e.g.
+     `Check a definition is correct and ready (runs lint; fails on errors)`);
+     `lint` Short must state it is the advisory subset (e.g.
+     `Report authoring warnings (a subset of 'validate'; advisory, non-fatal)`).
+     This is enforced by review so users never read this file to pick a verb.
+3. **Two information verbs, not three: `get` (data) and `explain` (schema); no
+   `inspect`.** "get", "inspect", and "describe" all read as "show me the thing,"
+   so scafctl keeps only the two that answer genuinely different questions:
+   - **`get <object>`** returns *instances* -- at any depth. `get solution` lists
+     many; `get solution my-app` shows that one; `get solution my-app -o yaml`
+     (or `--detail`) shows it in full. "List vs. detail" is a *depth* axis
+     expressed by the positional arg and output flags, not a separate verb -- the
+     way `kubectl get pods` / `kubectl get pod x -o yaml` and `gh pr list` /
+     `gh pr view` already work.
+   - **`explain <kind>`** documents the *schema/type* of a kind (its fields and
+     docs), independent of any instance (kubectl `explain`). This is a different
+     question -- definition, not data.
+   - There is no `inspect`/`describe` verb: it would duplicate `get`'s job on a
+     depth axis `get` already covers. If a "resolved/computed" view is needed
+     (effective config, resolved resolvers), it is a **flag on `get`**
+     (`get solution --resolved`), not a new verb.
+4. **One term per concept.** Go templates are `template` everywhere
+   (`eval template`, `get template functions`); help text may clarify "Go
+   template," but the command word is `template`. CEL is `cel`. Do not mix
+   `template` and `go-template` as command tokens.
+5. **`package` builds; `plugins` manages.** `package solution` and
+   `package plugin` are the polymorphic *build-into-catalog* verb. The `plugins`
+   subsystem manages the *local plugin cache* (`plugins install/update/prune/
+   list/search`). They are different concerns (build vs. cache management), so
+   both are correct; use `plugin` (singular) for the object, `plugins` for the
+   management group.
+6. **Ambiguity rule for sub-verbs.** A positional argument to an operation verb is
+   a **target** unless it exactly matches a known subcommand; `-f` always forces a
+   file target. So `scafctl test list` runs the `list` sub-verb, while
+   `scafctl test -f ./list` tests the file `./list`.
+7. **Do not hyphenate two separately-meaningful tokens; nest instead.**
+   `get cel functions`, not `get cel-functions`. A hyphen is acceptable only for a
+   single established compound term (`credential-helper`). Hyphenated *flag* names
+   are always fine.
+8. **Bare invocation never errors with a raw cobra message.** A subsystem, a
+   multi-noun verb, or a single-target verb with no discoverable target shows help
+   or a clear, actionable error -- not `requires at least 1 arg`.
 
 ## Seam fixes (bringing existing commands into line)
 
 | Seam | Today | Target | Rationale |
 |------|-------|--------|-----------|
-| `solution` straddle | `solution diff <a> <b>` (top-level noun group) | `diff solution <a> <b>` | `diff` becomes an operation verb; retires the top-level `solution` group. |
-| lint ergonomics | `lint [name]` + `lint rules` + `lint explain <rule>` | `lint [solution]` (acts by default) + `lint rules` (list) + `lint rule <name>` (detail) | `lint` acts by default; its rule-metadata stay as natural sub-verbs under `lint` (git-stash-style). `lint explain <rule>` -> `lint rule <name>` (nested noun, no hyphen). Positional-vs-subcommand resolved by the ambiguity rule. |
-| test ergonomics | `test [ref]` (runs functional) + `test functional/init/list` | `test [solution]` (acts by default, runs functional tests) + `test list` + `test init` | `test` acts by default like `go test`/`cargo test`; `functional` folds into the default (aliased); `list`/`init` remain natural sub-verbs. |
-| `auth handlers` | `auth handlers [name]` (lists) + `install`/`remove` | `auth handlers list` / `auth handlers install <h>` / `auth handlers remove <h>` | `auth` is a subsystem (Lane 2), so `handlers` is a sub-subsystem whose children are verbs -- explicit, no bare-acts. |
-| `serve` + openapi | `serve` (starts server) + `serve openapi` | `serve` stays a pure leaf (starts the server); OpenAPI export moves to `get openapi`. | Starting the server is `serve`'s one obvious action (leaf); exporting the generated spec is a `get` of an artifact, not a sub-mode of the running server. |
-| Hyphenated `get cel-functions` / `get go-template-functions` | verb + hyphenated token | `get cel functions` / `get go-template functions` (nested) | Listing available functions is the `get` lane (like `get provider`, `get examples`). The hyphen joins a namespace (`cel`) and a thing (`functions`) -- nest it. `go-template` stays hyphenated as a single established term. |
-| `run provider` no-args | `requires at least 1 arg` | Show help (or a clear error) | Rule 4. |
-| New: schema/data validation | (does not exist) | `validate schema --schema <s> --data <d>` | The concrete driver for #649; lands cleanly in the operation-verb lane. |
+| artifact straddle -- diff | `solution diff` / `bundle diff` / `snapshot diff` (three spellings) | `diff solution` / `diff bundle` / `diff snapshot` | `diff` is one polymorphic operation verb; retires the top-level `solution`/`bundle`/`snapshot` groups. |
+| artifact straddle -- detail | `snapshot show <f>` | `get snapshot <f>` (with `-o`/`--detail`) | Snapshot is an object; showing its detail is `get` at depth, not a separate verb (Rule 3). |
+| artifact straddle -- completeness | `bundle verify <ref>` (standalone check-verb) | folded into `package` (producer) and `install`/`pull` (consumer); `verify` retired | Completeness is a guarantee of building/acquiring an artifact, not a verb users invoke; kills the `validate`/`verify` synonym clash (Rule 2). |
+| artifact straddle -- extract | `bundle extract <ref>` | `extract bundle <ref>` | Extraction as a polymorphic verb, ready for `extract <other object>`. |
+| snapshot creation | `snapshot save` | `render solution --snapshot [file]` | Creating a snapshot is a *render output*, not an action on an existing snapshot; render already executes-and-captures. |
+| lint ergonomics | `lint [name]` + `lint rules` + `lint explain <rule>` | `lint [solution]` (acts) + `lint rules` (list) + `lint rule <name>` (detail) | `lint` acts by default; rule-metadata stay as sub-verbs; de-hyphenate `explain <rule>` -> `rule <name>`. |
+| test ergonomics | `test [ref]` + `test functional/init/list` | `test [solution]` (acts, runs functional) + `test list` + `test init` | `test` acts by default like `go test`; `functional` folds into the default (aliased). |
+| `auth handlers` dual-mode | `auth handlers [name]` (lists) + install/remove | `auth handlers list` / `install <h>` / `remove <h>` | `auth` is a subsystem; `handlers` is a sub-subsystem whose children are verbs. |
+| `serve` + openapi | `serve` + `serve openapi` | `serve` (leaf, starts server); export moves to `get openapi` | Exporting the spec is a `get` of an artifact, not a sub-mode of the server. |
+| terminology | `eval template` vs `get go-template-functions` | `eval template` + `get template functions` | One term (`template`) per concept (Rule 4); de-hyphenate (Rule 7). |
+| hyphenated `get cel-functions` | verb + hyphenated token | `get cel functions` (nested) | Rule 7. |
+| `run provider` no-args | `requires at least 1 arg` | Show help (or a clear error) | Rule 8. |
+| New: schema/data validation | (does not exist) | `validate schema --schema <s> --data <d>` | The concrete driver for #649; lands in the operation-verb lane. |
 
-Note the two existing "validate" surfaces are reconciled by the lanes:
-`validate <noun>` (solution/resolver/schema) is the operation-verb form;
-`eval validate` (CEL/template syntax) stays under the `eval` sandbox subsystem
-because it validates ad-hoc expressions, not domain artifacts.
+Note the two "validate" surfaces are reconciled by the lanes: `validate <object>`
+(solution/resolver/schema) is the operation-verb form; `eval validate` (CEL/
+template syntax) stays under the `eval` sandbox subsystem because it validates
+ad-hoc expressions, not domain artifacts.
 
 ## Future fit
 
-A grammar is only useful if new commands slot in without debate. The
-capabilities scafctl is likely to grow -- several already requested -- map onto
-the three lanes as follows. This is illustrative, not a commitment to build.
+New commands must slot in without debate. Likely capabilities map onto the lanes
+via the object-vs-subsystem test. Illustrative, not a commitment to build.
 
 | Anticipated capability | Lane / form | Prior art |
 |------------------------|-------------|-----------|
 | Self-update (#239) | Lane 3: `update` (alias `upgrade`) | `brew upgrade`, `rustup update` |
 | Setup diagnostics | Lane 3: `doctor` / `env` | `brew doctor`, `npm doctor` |
-| Shell completion | Lane 3: `completion` (exists) | universal |
-| Inspect a provider (#319) | Lane 1 multi-noun: `inspect provider <name>` | `kubectl describe` |
-| Replay / verify / drift (#242) | Lane 1: `verify solution`, `replay solution` | `terraform plan` |
+| Inspect a provider (#319) | Lane 1: `get provider <name>` (with `--detail`) | `kubectl get -o yaml` |
+| Drift / replay (#242) | Lane 1: `diff solution` (against a snapshot), `replay solution` | `terraform plan` |
 | Format a solution file | Lane 1 single-target: `fmt` (defaults to solution) | `gofmt`, `terraform fmt` |
 | Edit in `$EDITOR` | Lane 1 single-target: `edit` | `kubectl edit` |
 | Live-follow output | Flag, not a verb: `-w`/`--watch` on operation verbs | `kubectl get -w` |
-| Execution logs / history | Lane 1 or `run` sub-verb: `logs` / `run logs` | `docker logs` |
-| Graph / visualize | Extend existing `render solution -o mermaid` | `terraform graph` |
 | Plugins search (#535) | Lane 2: `plugins search` | `brew search` |
 | MCP inspector (#419) | Lane 2: `mcp tools` / `mcp call` / `mcp ping` | -- |
-| Schema/UI generation (#243) | Lane 1 multi-noun: `get schema` / `generate schema` | -- |
+| Schema/UI generation (#243) | Lane 1: `get schema` / `generate schema` | -- |
 
 **Open question -- `pipeline` (#60):** catalog-regression testing does not fit
 cleanly. Options: a `test` sub-verb (`test catalog`), a Lane 2 subsystem
-(`pipeline run`/`test`), or fold into `catalog` (`catalog test`). Decide when
-that feature is designed; noting it here so the grammar is not assumed to have
-already answered it.
+(`pipeline run`/`test`), or fold into `catalog` (`catalog test`). Decide when that
+feature is designed.
 
 ## Consequences
 
 - **Breaking CLI-path changes** (pre-production, squash-merge -- acceptable, noted
   per change). Each moved command ships with a **deprecated alias** forwarding to
-  the new path for one release where practical, so scripts and muscle memory get
-  a transition window; aliases are removed in a later major.
-- New commands have an unambiguous home: pick the lane by class, then the verb
-  (Lane 1) or subsystem+verb (Lane 2).
-- Operation verbs are natural to type -- `scafctl test`, `scafctl lint`,
-  `scafctl run` all do the obvious thing -- with auxiliary sub-verbs discoverable
-  in each verb's help.
-- The top-level `solution` group is retired (its sole child `diff` moves to
-  `diff solution`); this resolves the #648 placement question.
+  the new path for one release where practical; aliases are removed in a later
+  major.
+- New commands have an unambiguous home: run the object-vs-subsystem test, then
+  pick the verb (Lane 1) or subsystem+verb (Lane 2).
+- The top-level `solution`, `bundle`, and `snapshot` groups are retired; their
+  operations become polymorphic verbs (`diff`/`get`/`extract <object>`), and
+  bundle completeness folds into `package`/`install` (`verify` retired). This
+  resolves the #648 placement question.
+- Operation verbs are natural to type and consistent across objects -- learn
+  `diff` once, use it on every artifact.
 
 ## Migration (phased PRs)
 
-This is too large for one PR. Suggested sequence, each its own PR with aliases:
+Too large for one PR. Suggested sequence, each its own PR with aliases:
 
 1. **Grammar doc** (this document) -- ratify the rule set. No code.
-2. **`diff solution`** -- add the operation verb, alias `solution diff` -> it,
-   retire the top-level `solution` group. Resolves #648.
-3. **`validate schema`** -- implement the schema/data validation command (the
-   driver). Reconcile the `validate` lane.
-4. **Tidy `lint`** -- keep `lint [solution]` acting by default; rename
-   `lint explain <rule>` -> `lint rule <name>` and keep `lint rules` (list);
-   apply the ambiguity rule. Alias old paths.
-5. **Tidy `test`** -- keep `test [solution]` acting by default (running
-   functional tests), fold `test functional` into the default (alias), keep
-   `test list`/`test init`. De-dual-mode `auth handlers` (-> explicit verbs) and
-   move `serve openapi` -> `get openapi`. One PR or split as needed.
-6. **De-hyphenate** `get cel-functions` / `get go-template-functions` ->
-   `get cel functions` / `get go-template functions` (nested). Alias old paths.
-7. **No-args UX sweep** -- ensure every bare command shows help or acts on its
-   default target; fix `run provider` and audit the rest.
+2. **`diff <object>`** -- add the polymorphic `diff` verb; alias
+   `solution diff` / `bundle diff` / `snapshot diff` -> it; retire those top-level
+   groups. Resolves #648.
+3. **`extract` / `get` for artifacts** -- move `bundle extract` ->
+   `extract bundle`, `snapshot show` -> `get snapshot` (detail via `-o`/
+   `--detail`); retire `inspect` (folded into `get`); alias old paths.
+4. **Retire `verify`; fold completeness into `package` + `install`** -- remove the
+   standalone `bundle verify`; make `package` fail on an incomplete build and
+   `install`/`pull` refuse/warn on a broken bundle (`--strict` for deep checks).
+5. **`validate` as the single gate** -- implement `validate schema` (the driver);
+   make `validate` run `lint` internally; align help text per Rule 2.
+6. **Tidy `lint`** -- `lint [solution]` acts; `lint explain <rule>` ->
+   `lint rule <name>`; keep `lint rules`; apply the ambiguity rule. Alias.
+7. **Tidy `test`** -- `test [solution]` acts (functional); fold `test functional`
+   into the default; keep `test list`/`test init`. De-dual-mode `auth handlers`;
+   move `serve openapi` -> `get openapi`.
+8. **Terminology + de-hyphenate** -- `template` everywhere;
+   `get cel functions` / `get template functions` (nested). Alias old paths.
+9. **Snapshot creation** -- `snapshot save` -> `render solution --snapshot`.
+10. **No-args UX sweep** -- every bare command shows help or acts on its default
+    target; fix `run provider` and audit the rest.
 
 Each PR updates `docs/design/cli.md`, integration tests, and MCP tool
 descriptions that reference the moved paths, and notes the breaking change and


### PR DESCRIPTION
Ratifies a command grammar for scafctl so users can predict how to invoke a command and new features have an obvious home. Design only -- implementation follows as phased PRs.

Adds `docs/design/cli-command-grammar.md`.

## Related Issues

Closes #649
Subsumes #648 (top-level `solution` / `solution diff` placement)

## The grammar (summary)

The lane split is decided by a single test: **is the noun an OBJECT you act on, or a SUBSYSTEM you operate within?**

**Lane 1 -- Operation verbs on objects (verb-first).** Objects are artifacts you make (solution, bundle, snapshot, provider, schema ...), single instances whose verbs generalize across them. So the same verb works on every object: `diff solution|bundle|snapshot`, `get solution|bundle|snapshot`, `extract bundle`, `validate solution|schema`, `run|render|new|package <object>`. Single-target verbs (`lint`, `test`) default to the solution (go/cargo/git style); multi-noun verbs require the object and show help when bare.

**Lane 2 -- Subsystem management (noun-first).** Subsystems are standing stores/services with bespoke, non-generalizing verbs: `config`, `auth`, `catalog`, `secrets`, `state`, `plugins`, `cache`, `mcp`, `kube`, `eval`, `vendor`, `credential-helper`. You would never say "diff catalog" or "login auth" -- you *use* them.

**Lane 3 -- Meta/self:** `version`, `update`, `completion`, `options`.

### Verb surface deliberately minimized

Three separate rounds of "why do these commands overlap?" collapsed the surface:

- **Checking: one gate verb.** `validate <object>` is the pass/fail gate and **runs `lint` internally** (lint = its advisory, standalone subset). Built-artifact completeness is **not a verb** -- it folds into `package` (build fails if incomplete) and `install`/`pull` (refuses/warns on a broken bundle, like npm/apt/docker). **`verify` is retired.** A CI gate is two lines that both do real work: `validate solution`, `package solution`.
- **Information: two verbs.** `get <object>` returns instances at any depth (list many, or one in full via arg + `-o`/`--detail`/`--resolved`); `explain <kind>` returns the schema/type. **`inspect` is retired** -- instance detail is a depth axis on `get` (like `kubectl get pod x -o yaml`, `gh pr view`), not a separate verb.
- **`package` vs `plugins`:** `package solution|plugin` is the build-into-catalog verb; the `plugins` subsystem manages the local cache. Different concerns; both kept. One term per concept: `template` everywhere (not `go-template`).

Plus: no hyphenated tokens that hide a hierarchy (nest instead; established compounds like `credential-helper` are fine), and bare invocation -> help, never a raw cobra error.

See the doc for the full rules, the object-vs-subsystem test table, prior-art comparison, and the 10-phase migration plan.

## Command changes (old -> new)

This transition table lives in the PR (not the doc, which is the durable grammar record). Every renamed/moved command ships with the **old form kept as a deprecated alias** for one release, removed in a later major.

| Old command | New command | Notes |
|-------------|-------------|-------|
| `solution diff <a> <b>` | `diff solution <a> <b>` | `diff` becomes a polymorphic operation verb; top-level `solution` group retired. |
| `bundle diff` / `snapshot diff` | `diff bundle` / `diff snapshot` | Same verb, one spelling across all artifacts. |
| `bundle extract <ref>` | `extract bundle <ref>` | Polymorphic verb, ready for `extract <other object>`. |
| `snapshot show <f>` | `get snapshot <f>` (`-o`/`--detail`) | Detail is `get` at depth; `inspect` retired. |
| `inspect solution <name>` | `get solution <name> --detail` | `inspect` folds into `get`. |
| `bundle verify <ref>` | (retired) folded into `package` + `install`/`pull` | Completeness is a guarantee of building/acquiring, not a verb. |
| `lint explain <rule>` | `lint rule <name>` | Rename; shows one rule detail. |
| `lint [name]` | `lint [solution]` | Behavior unchanged; documented as acting on the solution by default. |
| `test` (runs functional) | `test [solution]` | Behavior unchanged; default runs functional tests. |
| `test functional` | `test [solution]` | Folds into the default `test`; kept as an alias. |
| `auth handlers` (lists) | `auth handlers list` | Explicit verb; bare shows help. |
| `serve openapi` | `get openapi` | Export moves out of the server-start command. |
| `get cel-functions` | `get cel functions` | De-hyphenate by nesting. |
| `get go-template-functions` | `get template functions` | De-hyphenate + one term (`template`). |
| `snapshot save` | `render solution --snapshot` | Creating a snapshot is a render output. |
| `run provider` (no args -> error) | `run provider` (no args -> help) | UX fix; behavior with args unchanged. |
| (did not exist) | `validate schema --schema <s> --data <d>` | New: validate arbitrary data against a schema; the #649 driver. |

Unchanged and already grammar-conforming: `run|render|new|package <object>`, `validate solution|resolver`, `explain <kind>`, `credential-helper`, and all Lane 2 subsystems.

## Type of Change

- [x] Documentation update (design decision)
- [ ] Breaking change (the *implementation* PRs will be breaking; this doc is not)

## Checklist

- [x] Commits signed (`-S`) and DCO signed-off (`-s`)
- [x] ASCII-only markdown per repo conventions

## Migration (follow-up PRs)

1. This doc.
2. `diff <object>` (+ aliases, retire `solution`/`bundle`/`snapshot` groups) -- resolves #648.
3. `extract bundle` / `get snapshot` (retire `inspect`, alias old paths).
4. Retire `verify`; fold completeness into `package` + `install`/`pull`.
5. `validate` as the single gate (`validate schema` driver; `validate` runs `lint`).
6. Tidy `lint` (`lint rule` rename, ambiguity rule).
7. Tidy `test` (fold `functional`), `auth handlers`, `serve openapi` -> `get openapi`.
8. Terminology + de-hyphenate (`template`; `get cel/template functions`).
9. `snapshot save` -> `render solution --snapshot`.
10. No-args UX sweep (`run provider`, audit).
