### PR TITLE
fix(cli): error on unknown subcommands instead of silently exiting 0 (#655)

### DIFF
--- a/pkg/cmd/cmdutil/cmdutil.go
+++ b/pkg/cmd/cmdutil/cmdutil.go
@@ -1,0 +1,38 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cmdutil provides shared helpers for wiring scafctl cobra commands.
+package cmdutil
+
+import "github.com/spf13/cobra"
+
+// MakeHelpOnlyGroup configures a parent command group so that a bare invocation
+// (e.g. "scafctl catalog") prints help and exits 0, while an unknown subcommand
+// (e.g. "scafctl catalog bogus") errors with "unknown command" and a non-zero
+// exit code.
+//
+// This is required because cobra treats a *non-runnable* parent (one with no
+// Run/RunE) specially: its execute() path returns flag.ErrHelp -- which is
+// caught upstream and turned into "print help, return nil (exit 0)" -- *before*
+// it ever validates positional args. As a result, setting Args: cobra.NoArgs
+// alone has no effect on a non-runnable parent, and unknown subcommands are
+// silently swallowed as a successful help invocation.
+//
+// Making the parent runnable with a help-only RunE flips Runnable() to true, so
+// cobra validates args, and cobra.NoArgs then rejects the leftover positional
+// (the unknown subcommand) with a non-zero exit. Bare invocation still shows
+// help via the RunE, satisfying the CLI grammar rule that a group with no
+// default action shows help rather than erroring.
+//
+// Do NOT use this on commands that legitimately accept positional arguments
+// (e.g. "lint [name]" or "auth handlers [name]") -- it would reject their args.
+//
+// The command's Aliases, Short, Long, Example, and other fields are left
+// untouched; only Args and RunE are set.
+func MakeHelpOnlyGroup(cmd *cobra.Command) *cobra.Command {
+	cmd.Args = cobra.NoArgs
+	cmd.RunE = func(c *cobra.Command, _ []string) error {
+		return c.Help()
+	}
+	return cmd
+}

--- a/pkg/cmd/cmdutil/cmdutil_test.go
+++ b/pkg/cmd/cmdutil/cmdutil_test.go
@@ -1,0 +1,90 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package cmdutil_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newGroup builds a parent command with one child subcommand, configured as a
+// help-only group.
+func newGroup() *cobra.Command {
+	parent := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
+		Use:           "parent",
+		Short:         "parent group",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	})
+	child := &cobra.Command{
+		Use:  "child",
+		RunE: func(*cobra.Command, []string) error { return nil },
+	}
+	parent.AddCommand(child)
+	return parent
+}
+
+func TestMakeHelpOnlyGroup_BareShowsHelpExitZero(t *testing.T) {
+	cmd := newGroup()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{})
+
+	err := cmd.Execute()
+
+	require.NoError(t, err, "bare invocation must not error")
+	assert.Contains(t, out.String(), "Usage:", "bare invocation should print help")
+}
+
+func TestMakeHelpOnlyGroup_UnknownSubcommandErrors(t *testing.T) {
+	cmd := newGroup()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"bogus"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err, "unknown subcommand must return an error")
+	assert.Contains(t, err.Error(), "unknown command",
+		"error should identify the unknown subcommand")
+}
+
+func TestMakeHelpOnlyGroup_KnownSubcommandStillRuns(t *testing.T) {
+	cmd := newGroup()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"child"})
+
+	err := cmd.Execute()
+
+	require.NoError(t, err, "known subcommand should execute normally")
+}
+
+func TestMakeHelpOnlyGroup_SetsArgsAndRunE(t *testing.T) {
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{Use: "g"})
+	assert.NotNil(t, cmd.Args, "Args should be set to NoArgs")
+	assert.NotNil(t, cmd.RunE, "RunE should be set")
+
+	// NoArgs rejects a positional, permits none.
+	require.NoError(t, cmd.Args(cmd, []string{}))
+	require.Error(t, cmd.Args(cmd, []string{"x"}))
+}
+
+func TestMakeHelpOnlyGroup_PreservesExistingFields(t *testing.T) {
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
+		Use:     "g",
+		Short:   "short desc",
+		Aliases: []string{"gg"},
+	})
+	assert.Equal(t, "short desc", cmd.Short, "Short must be preserved")
+	assert.Equal(t, []string{"gg"}, cmd.Aliases, "Aliases must be preserved")
+}

--- a/pkg/cmd/scafctl/auth/alias.go
+++ b/pkg/cmd/scafctl/auth/alias.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
@@ -37,7 +38,7 @@ var aliasListSchema = []byte(`{
 // CommandAlias creates the 'auth alias' command group for managing static
 // hostname aliases (auth.handlers.<name>.hostname.aliases).
 func CommandAlias(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:   "alias",
 		Short: "Manage static hostname aliases for an auth handler",
 		Long: strings.ReplaceAll(heredoc.Doc(`
@@ -63,7 +64,7 @@ func CommandAlias(cliParams *settings.Run, ioStreams *terminal.IOStreams, path s
 			  scafctl auth alias remove openshift prod
 		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
-	}
+	})
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
 	cmd.AddCommand(commandAliasSet(cliParams, ioStreams, cmdPath))

--- a/pkg/cmd/scafctl/auth/auth.go
+++ b/pkg/cmd/scafctl/auth/auth.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -15,7 +16,7 @@ import (
 
 // CommandAuth creates the 'auth' command group.
 func CommandAuth(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:     "auth",
 		Aliases: []string{"authenticate"},
 		Short:   "Manage authentication",
@@ -38,7 +39,7 @@ func CommandAuth(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 			Use 'scafctl auth diagnose' to run health checks and troubleshoot issues.
 		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
-	}
+	})
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
 	cmd.AddCommand(CommandAlias(cliParams, ioStreams, cmdPath))

--- a/pkg/cmd/scafctl/auth/auth_test.go
+++ b/pkg/cmd/scafctl/auth/auth_test.go
@@ -42,3 +42,66 @@ func TestCommandAuth(t *testing.T) {
 	assert.Contains(t, cmdNames, "status [handler]")
 	assert.Contains(t, cmdNames, "token <handler>")
 }
+
+// TestCommandAuth_UnknownSubcommandErrors verifies that an unknown subcommand
+// errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandAuth_UnknownSubcommandErrors(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
+
+	cmd := CommandAuth(cliParams, ioStreams, "scafctl")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandAuth(cliParams, ioStreams, "scafctl")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+}
+
+// TestCommandAlias_UnknownSubcommandErrors verifies the nested 'auth alias'
+// group rejects unknown subcommands while bare invocation shows help.
+func TestCommandAlias_UnknownSubcommandErrors(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
+
+	cmd := CommandAlias(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandAlias(cliParams, ioStreams, "scafctl/auth")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+}
+
+// TestCommandProfile_UnknownSubcommandErrors verifies the nested 'auth profile'
+// group rejects unknown subcommands while bare invocation shows help.
+func TestCommandProfile_UnknownSubcommandErrors(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
+
+	cmd := CommandProfile(cliParams, ioStreams, "scafctl/auth")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandProfile(cliParams, ioStreams, "scafctl/auth")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+}

--- a/pkg/cmd/scafctl/auth/profile.go
+++ b/pkg/cmd/scafctl/auth/profile.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -15,7 +16,7 @@ import (
 
 // CommandProfile creates the 'auth profile' command group.
 func CommandProfile(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:   "profile",
 		Short: "Manage auth profiles",
 		Long: strings.ReplaceAll(heredoc.Doc(`
@@ -27,7 +28,7 @@ func CommandProfile(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 			Use 'scafctl auth profile delete <handler> <profile>' to remove a profile.
 		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
-	}
+	})
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
 	cmd.AddCommand(CommandProfileDelete(cliParams, ioStreams, cmdPath))

--- a/pkg/cmd/scafctl/bundle/bundle.go
+++ b/pkg/cmd/scafctl/bundle/bundle.go
@@ -7,6 +7,7 @@ package bundle
 
 import (
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -14,25 +15,16 @@ import (
 
 // CommandBundle creates the bundle command group.
 func CommandBundle(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:          "bundle",
 		Aliases:      []string{"bun"},
 		Short:        "Inspect and manage solution bundles",
 		SilenceUsage: true,
-		// Args: NoArgs + a RunE that shows help makes bare 'bundle' print help
-		// and exit 0, while an unknown subcommand (e.g. the hard-removed
-		// 'bundle diff') errors with "unknown command". A RunE is required:
-		// cobra returns flag.ErrHelp (help, exit 0) for a non-runnable parent
-		// *before* validating args, so NoArgs alone would never fire.
-		Args: cobra.NoArgs,
 		Long: heredoc.Doc(`
 			Commands for inspecting, verifying, and extracting
 			solution bundles built by 'scafctl build solution'.
 		`),
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
+	})
 
 	cmd.AddCommand(CommandVerify(cliParams, ioStreams, path))
 	cmd.AddCommand(CommandExtract(cliParams, ioStreams, path))

--- a/pkg/cmd/scafctl/cache/cache.go
+++ b/pkg/cmd/scafctl/cache/cache.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -16,7 +17,7 @@ import (
 
 // CommandCache creates the cache command group.
 func CommandCache(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:          "cache",
 		Short:        fmt.Sprintf("Manage the %s cache", path),
 		SilenceUsage: true,
@@ -30,7 +31,7 @@ func CommandCache(cliParams *settings.Run, ioStreams *terminal.IOStreams, path s
 			  - macOS: ~/.cache/scafctl/
 			  - Windows: %LOCALAPPDATA%\cache\scafctl\
 		`), settings.CliBinaryName, cliParams.BinaryName),
-	}
+	})
 
 	cmd.AddCommand(CommandClear(cliParams, ioStreams, path))
 	cmd.AddCommand(CommandInfo(cliParams, ioStreams, path))

--- a/pkg/cmd/scafctl/cache/cache_test.go
+++ b/pkg/cmd/scafctl/cache/cache_test.go
@@ -20,7 +20,7 @@ func TestCommandCache(t *testing.T) {
 	assert.Equal(t, "cache", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
 	assert.True(t, cmd.SilenceUsage)
-	assert.Nil(t, cmd.RunE, "parent cache command should not have RunE")
+	assert.NotNil(t, cmd.RunE, "parent cache command needs a help-only RunE so NoArgs rejects unknown subcommands")
 	subCmds := cmd.Commands()
 	require.Len(t, subCmds, 2, "should have 2 subcommands: clear, info")
 	cmdNames := make([]string, len(subCmds))
@@ -84,4 +84,25 @@ func BenchmarkCommandCache(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		CommandCache(cliParams, ioStreams, "scafctl")
 	}
+}
+
+// TestCommandCache_UnknownSubcommandErrors verifies that an unknown
+// subcommand errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandCache_UnknownSubcommandErrors(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandCache(cliParams, ioStreams, "scafctl")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandCache(cliParams, ioStreams, "scafctl")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
 }

--- a/pkg/cmd/scafctl/catalog/catalog.go
+++ b/pkg/cmd/scafctl/catalog/catalog.go
@@ -16,6 +16,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	catversion "github.com/oakwood-commons/scafctl/pkg/catalog/version"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -25,7 +26,7 @@ import (
 
 // CommandCatalog creates the catalog command group.
 func CommandCatalog(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:          "catalog",
 		Aliases:      []string{"cat"},
 		Short:        "Manage the local artifact catalog",
@@ -41,7 +42,7 @@ func CommandCatalog(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 			  - macOS: ~/.local/share/scafctl/catalog/
 			  - Windows: %LOCALAPPDATA%\scafctl\catalog\
 		`),
-	}
+	})
 
 	cmd.AddCommand(CommandList(cliParams, ioStreams, path))
 	cmd.AddCommand(CommandInspect(cliParams, ioStreams, path))

--- a/pkg/cmd/scafctl/catalog/catalog_test.go
+++ b/pkg/cmd/scafctl/catalog/catalog_test.go
@@ -1229,3 +1229,72 @@ func TestAuthHandlerName_NonNil(t *testing.T) {
 	mock := auth.NewMockHandler("entra")
 	assert.Equal(t, "entra", authHandlerName(mock))
 }
+
+// TestCommandCatalog_UnknownSubcommandErrors verifies that an unknown
+// subcommand errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandCatalog_UnknownSubcommandErrors(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandCatalog(cliParams, ioStreams, "scafctl/catalog")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandCatalog(cliParams, ioStreams, "scafctl/catalog")
+	var out bytes.Buffer
+	cmd2.SetArgs([]string{})
+	cmd2.SetOut(&out)
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+	assert.Contains(t, out.String(), "Usage:", "bare catalog must render help")
+}
+
+// TestCommandIndex_UnknownSubcommandErrors verifies the nested 'catalog index'
+// group rejects unknown subcommands while bare invocation shows help.
+func TestCommandIndex_UnknownSubcommandErrors(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandIndex(cliParams, ioStreams, "scafctl/catalog")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandIndex(cliParams, ioStreams, "scafctl/catalog")
+	var out bytes.Buffer
+	cmd2.SetArgs([]string{})
+	cmd2.SetOut(&out)
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+	assert.Contains(t, out.String(), "Usage:", "bare catalog index must render help")
+}
+
+// TestCommandRemote_UnknownSubcommandErrors verifies the nested 'catalog
+// remote' group rejects unknown subcommands while bare invocation shows help.
+func TestCommandRemote_UnknownSubcommandErrors(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandRemote(cliParams, ioStreams, "scafctl/catalog")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandRemote(cliParams, ioStreams, "scafctl/catalog")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+}

--- a/pkg/cmd/scafctl/catalog/index.go
+++ b/pkg/cmd/scafctl/catalog/index.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/catalog/search"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
@@ -78,7 +79,7 @@ type IndexDiffItem struct {
 
 // CommandIndex creates the catalog index command group.
 func CommandIndex(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:   "index",
 		Short: "Manage the catalog discovery index",
 		Long: heredoc.Doc(`
@@ -91,7 +92,7 @@ func CommandIndex(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			Supported artifact kinds: solution, provider, auth-handler.
 		`),
 		SilenceUsage: true,
-	}
+	})
 
 	cmd.AddCommand(commandIndexPush(cliParams, ioStreams))
 	cmd.AddCommand(commandIndexShow(cliParams, ioStreams))

--- a/pkg/cmd/scafctl/catalog/remote.go
+++ b/pkg/cmd/scafctl/catalog/remote.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	appconfig "github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -22,7 +23,7 @@ import (
 
 // CommandRemote creates the 'catalog remote' command group.
 func CommandRemote(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:          "remote",
 		Short:        "Manage remote catalog registries",
 		SilenceUsage: true,
@@ -32,7 +33,7 @@ func CommandRemote(cliParams *settings.Run, ioStreams *terminal.IOStreams, path 
 			Add, remove, and list configured remote registries for pushing and
 			pulling artifacts.
 		`),
-	}
+	})
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
 	cmd.AddCommand(commandRemoteAdd(cliParams, ioStreams, cmdPath))

--- a/pkg/cmd/scafctl/config/config.go
+++ b/pkg/cmd/scafctl/config/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -16,7 +17,7 @@ import (
 
 // CommandConfig creates the 'config' command.
 func CommandConfig(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cCmd := &cobra.Command{
+	cCmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:     "config",
 		Aliases: []string{"cfg"},
 		Short:   fmt.Sprintf("Manage %s configuration", path),
@@ -39,7 +40,7 @@ func CommandConfig(cliParams *settings.Run, ioStreams *terminal.IOStreams, path 
 			Use 'scafctl config paths' to see all resolved paths.
 		`)),
 		SilenceUsage: true,
-	}
+	})
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cCmd.Use)
 	cCmd.AddCommand(CommandInit(cliParams, ioStreams, cmdPath))

--- a/pkg/cmd/scafctl/config/config_test.go
+++ b/pkg/cmd/scafctl/config/config_test.go
@@ -377,3 +377,25 @@ auth:
 	// Other content remains.
 	assert.Contains(t, string(data), "bad")
 }
+
+// TestCommandConfig_UnknownSubcommandErrors verifies that an unknown
+// subcommand errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandConfig_UnknownSubcommandErrors(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandConfig(cliParams, ioStreams, "scafctl")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandConfig(cliParams, ioStreams, "scafctl")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+}

--- a/pkg/cmd/scafctl/credentialhelper/credentialhelper.go
+++ b/pkg/cmd/scafctl/credentialhelper/credentialhelper.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/credentialhelper"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
@@ -28,7 +29,7 @@ import (
 
 // CommandCredentialHelper returns the credential-helper command group.
 func CommandCredentialHelper(_ *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:   "credential-helper",
 		Short: "Docker/Podman credential helper protocol",
 		Long: fmt.Sprintf(`Implements the Docker credential helper protocol, exposing %[1]s's
@@ -40,7 +41,7 @@ Configure Docker to use %[1]s as a credential helper:
 
 Or add manually to ~/.docker/config.json:
   { "credsStore": "%[1]s" }`, path),
-	}
+	})
 
 	cmd.AddCommand(commandGet())
 	cmd.AddCommand(commandStore())

--- a/pkg/cmd/scafctl/credentialhelper/credentialhelper_test.go
+++ b/pkg/cmd/scafctl/credentialhelper/credentialhelper_test.go
@@ -128,3 +128,24 @@ func BenchmarkCommandCredentialHelper(b *testing.B) {
 		_ = CommandCredentialHelper(cliParams, ioStreams, "scafctl")
 	}
 }
+
+// TestCommandCredentialHelper_UnknownSubcommandErrors verifies that an unknown
+// subcommand errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandCredentialHelper_UnknownSubcommandErrors(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandCredentialHelper(cliParams, ioStreams, "scafctl")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandCredentialHelper(cliParams, ioStreams, "scafctl")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+}

--- a/pkg/cmd/scafctl/diff/diff.go
+++ b/pkg/cmd/scafctl/diff/diff.go
@@ -7,6 +7,7 @@ package diff
 
 import (
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -22,7 +23,7 @@ const (
 // CommandDiff creates the top-level `diff` command group. It is a polymorphic
 // verb whose subcommands compare different scafctl artifact kinds.
 func CommandDiff(cliParams *settings.Run, ioStreams *terminal.IOStreams, binaryName string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:          "diff",
 		Short:        "Compare two artifacts (solutions, bundles, snapshots)",
 		SilenceUsage: true,
@@ -44,10 +45,7 @@ func CommandDiff(cliParams *settings.Run, ioStreams *terminal.IOStreams, binaryN
 			# Compare two snapshots
 			$ %[1]s diff snapshot before.json after.json
 		`, binaryName),
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
+	})
 
 	cmd.AddCommand(CommandDiffSolution(cliParams, *ioStreams, binaryName))
 	cmd.AddCommand(CommandDiffBundle(cliParams, ioStreams, binaryName))

--- a/pkg/cmd/scafctl/diff/diff_test.go
+++ b/pkg/cmd/scafctl/diff/diff_test.go
@@ -4,6 +4,7 @@
 package diff
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -43,6 +44,36 @@ func TestCommandDiff_BareShowsHelp(t *testing.T) {
 
 	cmd := CommandDiff(cliParams, ioStreams, "scafctl")
 	require.NotNil(t, cmd.RunE, "bare diff should have RunE that shows help")
+
+	// Bare invocation renders help and exits 0.
+	var out, errBuf bytes.Buffer
+	cmd.SetArgs([]string{})
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SilenceErrors = true
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, out.String(), "Usage:", "bare diff must render help")
+}
+
+// TestCommandDiff_UnknownSubcommandErrors verifies that an unknown subcommand
+// errors (non-zero) with an "unknown command" message instead of falling back
+// to help/exit-0.
+func TestCommandDiff_UnknownSubcommandErrors(t *testing.T) {
+	t.Parallel()
+
+	cliParams := &settings.Run{}
+	ioStreams := &terminal.IOStreams{}
+
+	cmd := CommandDiff(cliParams, ioStreams, "scafctl")
+	var out, errBuf bytes.Buffer
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SetOut(&out)
+	cmd.SetErr(&errBuf)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
 }
 
 func TestCommandDiff_ExampleUsesBinaryName(t *testing.T) {

--- a/pkg/cmd/scafctl/eval/eval.go
+++ b/pkg/cmd/scafctl/eval/eval.go
@@ -7,6 +7,7 @@ package eval
 import (
 	"fmt"
 
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -14,7 +15,7 @@ import (
 
 // CommandEval creates the 'eval' command group.
 func CommandEval(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cCmd := &cobra.Command{
+	cCmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:     "eval",
 		Aliases: []string{"e"},
 		Short:   "Evaluate, validate, and analyze CEL expressions and Go templates",
@@ -28,7 +29,7 @@ func CommandEval(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 Useful for testing and analyzing expressions and templates before using them
 in solutions.`,
 		SilenceUsage: true,
-	}
+	})
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cCmd.Use)
 

--- a/pkg/cmd/scafctl/eval/eval_test.go
+++ b/pkg/cmd/scafctl/eval/eval_test.go
@@ -38,13 +38,14 @@ func TestCommandEval(t *testing.T) {
 	assert.Contains(t, cmdNames, "refs")
 }
 
-func TestCommandEval_NoRunE(t *testing.T) {
+func TestCommandEval_HasHelpOnlyRunE(t *testing.T) {
 	cliParams := settings.NewCliParams()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 
 	cmd := CommandEval(cliParams, ioStreams, "scafctl")
 
-	assert.Nil(t, cmd.RunE, "parent eval command should not have RunE, it is a group command")
+	assert.NotNil(t, cmd.RunE, "parent eval command needs a help-only RunE so NoArgs rejects unknown subcommands")
+	assert.NotNil(t, cmd.Args, "parent eval command must reject unknown subcommands via Args")
 }
 
 func BenchmarkCommandEval(b *testing.B) {
@@ -55,4 +56,25 @@ func BenchmarkCommandEval(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		CommandEval(cliParams, ioStreams, "scafctl")
 	}
+}
+
+// TestCommandEval_UnknownSubcommandErrors verifies that an unknown subcommand
+// errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandEval_UnknownSubcommandErrors(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandEval(cliParams, ioStreams, "scafctl")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandEval(cliParams, ioStreams, "scafctl")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
 }

--- a/pkg/cmd/scafctl/get/get.go
+++ b/pkg/cmd/scafctl/get/get.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/celfunction"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/commands"
 	getexamples "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/examples"
@@ -19,7 +20,7 @@ import (
 )
 
 func CommandGet(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cCmd := &cobra.Command{
+	cCmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:     "get",
 		Aliases: []string{"g"},
 		Short:   "List resources, or show one by name",
@@ -37,7 +38,7 @@ func CommandGet(cliParams *settings.Run, ioStreams *terminal.IOStreams, path str
 			  explain solution          Schema of the Solution kind (what fields are valid)
 		`),
 		SilenceUsage: true,
-	}
+	})
 	cCmd.AddCommand(provider.CommandProvider(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
 	cCmd.AddCommand(solution.CommandSolution(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
 	cCmd.AddCommand(getexamples.CommandExamples(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))

--- a/pkg/cmd/scafctl/get/get_test.go
+++ b/pkg/cmd/scafctl/get/get_test.go
@@ -35,3 +35,25 @@ func TestCommandGet(t *testing.T) {
 		assert.Contains(t, names, want, "get should wire up the %q subcommand", want)
 	}
 }
+
+// TestCommandGet_UnknownSubcommandErrors verifies that an unknown subcommand
+// errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandGet_UnknownSubcommandErrors(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandGet(cliParams, ioStreams, "scafctl")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandGet(cliParams, ioStreams, "scafctl")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+}

--- a/pkg/cmd/scafctl/inspect/inspect.go
+++ b/pkg/cmd/scafctl/inspect/inspect.go
@@ -5,6 +5,7 @@ package inspect
 
 import (
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -12,7 +13,7 @@ import (
 
 // CommandInspect creates the top-level 'inspect' command group.
 func CommandInspect(cliParams *settings.Run, ioStreams *terminal.IOStreams, binaryName string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:          "inspect",
 		Short:        "Inspect a specific resource instance (add --usage for how to run it)",
 		SilenceUsage: true,
@@ -42,7 +43,7 @@ func CommandInspect(cliParams *settings.Run, ioStreams *terminal.IOStreams, bina
 			# Interactive TUI for exploring solution structure
 			$ %[1]s inspect solution -f ./my-solution.yaml -i
 		`, binaryName),
-	}
+	})
 
 	cmd.AddCommand(CommandInspectSolution(cliParams, ioStreams, binaryName))
 

--- a/pkg/cmd/scafctl/inspect/inspect_group_test.go
+++ b/pkg/cmd/scafctl/inspect/inspect_group_test.go
@@ -1,0 +1,36 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package inspect
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommandInspect_UnknownSubcommandErrors verifies that an unknown
+// subcommand errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandInspect_UnknownSubcommandErrors(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandInspect(cliParams, ioStreams, "scafctl")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandInspect(cliParams, ioStreams, "scafctl")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+}

--- a/pkg/cmd/scafctl/kube/kube.go
+++ b/pkg/cmd/scafctl/kube/kube.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -16,7 +17,7 @@ import (
 // CommandKube creates the 'kube' command group for Kubernetes / OpenShift
 // cluster operations.
 func CommandKube(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:     "kube",
 		Aliases: []string{"k8s"},
 		Short:   "Manage Kubernetes / OpenShift cluster access",
@@ -35,7 +36,7 @@ func CommandKube(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 			'scafctl kube status' to inspect the current kubeconfig context.
 		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
-	}
+	})
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
 	cmd.AddCommand(CommandLogin(cliParams, ioStreams, cmdPath))

--- a/pkg/cmd/scafctl/kube/kube_test.go
+++ b/pkg/cmd/scafctl/kube/kube_test.go
@@ -43,3 +43,24 @@ func TestCommandKube_LongHelpUsesBinaryName(t *testing.T) {
 	assert.Contains(t, cmd.Long, "mycli kube login")
 	assert.NotContains(t, cmd.Long, "scafctl kube login")
 }
+
+// TestCommandKube_UnknownSubcommandErrors verifies that an unknown subcommand
+// errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandKube_UnknownSubcommandErrors(t *testing.T) {
+	t.Parallel()
+	ioStreams := terminal.NewIOStreams(nil, nil, nil, false)
+
+	cmd := CommandKube(embedderParams(), ioStreams, "mycli")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandKube(embedderParams(), ioStreams, "mycli")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+}

--- a/pkg/cmd/scafctl/mcp/mcp.go
+++ b/pkg/cmd/scafctl/mcp/mcp.go
@@ -6,6 +6,7 @@ package mcp
 import (
 	"fmt"
 
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -13,12 +14,12 @@ import (
 
 // CommandMCP creates the `scafctl mcp` parent command.
 func CommandMCP(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:          "mcp",
 		Short:        "MCP (Model Context Protocol) server for AI agent integration",
 		Long:         `Manage the MCP server that exposes scafctl capabilities to AI agents like GitHub Copilot, Claude, and Cursor.`,
 		SilenceUsage: true,
-	}
+	})
 	cmd.AddCommand(CommandServe(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cmd.Use)))
 	cmd.AddCommand(CommandList(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cmd.Use)))
 	return cmd

--- a/pkg/cmd/scafctl/mcp/mcp_test.go
+++ b/pkg/cmd/scafctl/mcp/mcp_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommandMCP_UnknownSubcommandErrors verifies that an unknown subcommand
+// errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandMCP_UnknownSubcommandErrors(t *testing.T) {
+	cliParams := &settings.Run{}
+	ioStreams := &terminal.IOStreams{}
+
+	cmd := CommandMCP(cliParams, ioStreams, "scafctl")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandMCP(cliParams, ioStreams, "scafctl")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+}

--- a/pkg/cmd/scafctl/new/new.go
+++ b/pkg/cmd/scafctl/new/new.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -15,14 +16,14 @@ import (
 
 // CommandNew creates the 'new' command group.
 func CommandNew(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cCmd := &cobra.Command{
+	cCmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:   "new",
 		Short: fmt.Sprintf("Create new %s resources", path),
 		Long: strings.ReplaceAll(`Create new solutions, templates, and other scafctl resources from scratch.
 
 Generates well-structured YAML scaffolds with best practices built in.`, settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
-	}
+	})
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cCmd.Use)
 

--- a/pkg/cmd/scafctl/new/solution_test.go
+++ b/pkg/cmd/scafctl/new/solution_test.go
@@ -34,12 +34,13 @@ func TestCommandNew(t *testing.T) {
 	assert.Contains(t, names, "solution")
 }
 
-func TestCommandNew_NoRunE(t *testing.T) {
+func TestCommandNew_HasHelpOnlyRunE(t *testing.T) {
 	cliParams := settings.NewCliParams()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 
 	cmd := CommandNew(cliParams, ioStreams, "scafctl")
-	assert.Nil(t, cmd.RunE, "parent new command should not have RunE")
+	assert.NotNil(t, cmd.RunE, "parent new command needs a help-only RunE so NoArgs rejects unknown subcommands")
+	assert.NotNil(t, cmd.Args, "parent new command must reject unknown subcommands via Args")
 }
 
 func TestCommandSolution(t *testing.T) {
@@ -131,4 +132,25 @@ func BenchmarkCommandSolution(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		CommandSolution(cliParams, ioStreams, "scafctl/new")
 	}
+}
+
+// TestCommandNew_UnknownSubcommandErrors verifies that an unknown subcommand
+// errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandNew_UnknownSubcommandErrors(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandNew(cliParams, ioStreams, "scafctl")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandNew(cliParams, ioStreams, "scafctl")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
 }

--- a/pkg/cmd/scafctl/packagecmd/package.go
+++ b/pkg/cmd/scafctl/packagecmd/package.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -15,7 +16,7 @@ import (
 
 // CommandPackage creates the package command group.
 func CommandPackage(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:          "package",
 		Aliases:      []string{"build", "b"},
 		Short:        "Package artifacts into the local catalog",
@@ -33,7 +34,7 @@ func CommandPackage(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 			  - macOS: ~/.local/share/scafctl/catalog/
 			  - Windows: %LOCALAPPDATA%\scafctl\catalog\
 		`), settings.CliBinaryName, cliParams.BinaryName),
-	}
+	})
 
 	cmd.AddCommand(CommandPackageSolution(cliParams, ioStreams, path))
 	cmd.AddCommand(CommandPackagePlugin(cliParams, ioStreams, path))

--- a/pkg/cmd/scafctl/packagecmd/package_group_test.go
+++ b/pkg/cmd/scafctl/packagecmd/package_group_test.go
@@ -1,0 +1,34 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package packagecmd
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommandPackage_UnknownSubcommandErrors verifies that an unknown
+// subcommand errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandPackage_UnknownSubcommandErrors(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandPackage(cliParams, ioStreams, "")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandPackage(cliParams, ioStreams, "")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+}

--- a/pkg/cmd/scafctl/plugins/plugins.go
+++ b/pkg/cmd/scafctl/plugins/plugins.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -16,7 +17,7 @@ import (
 
 // CommandPlugins creates the plugins command group.
 func CommandPlugins(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:          "plugins",
 		Short:        fmt.Sprintf("Manage %s plugins", path),
 		SilenceUsage: true,
@@ -32,7 +33,7 @@ func CommandPlugins(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 			  update   - Update cached plugins to newer versions
 			  prune    - Remove old cached plugin versions
 		`), settings.CliBinaryName, cliParams.BinaryName),
-	}
+	})
 
 	cmd.AddCommand(CommandInstall(cliParams, ioStreams, path))
 	cmd.AddCommand(CommandList(cliParams, ioStreams, path))

--- a/pkg/cmd/scafctl/plugins/plugins_test.go
+++ b/pkg/cmd/scafctl/plugins/plugins_test.go
@@ -20,7 +20,7 @@ func TestCommandPlugins(t *testing.T) {
 	assert.Equal(t, "plugins", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
 	assert.True(t, cmd.SilenceUsage)
-	assert.Nil(t, cmd.RunE, "parent plugins command should not have RunE")
+	assert.NotNil(t, cmd.RunE, "parent plugins command needs a help-only RunE so NoArgs rejects unknown subcommands")
 	subCmds := cmd.Commands()
 	require.Len(t, subCmds, 4, "should have 4 subcommands: install, list, update, prune")
 	cmdNames := make([]string, len(subCmds))
@@ -89,4 +89,25 @@ func BenchmarkCommandPlugins(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		CommandPlugins(cliParams, ioStreams, "scafctl")
 	}
+}
+
+// TestCommandPlugins_UnknownSubcommandErrors verifies that an unknown
+// subcommand errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandPlugins_UnknownSubcommandErrors(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandPlugins(cliParams, ioStreams, "scafctl")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandPlugins(cliParams, ioStreams, "scafctl")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
 }

--- a/pkg/cmd/scafctl/render/render.go
+++ b/pkg/cmd/scafctl/render/render.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -14,7 +15,7 @@ import (
 
 // CommandRender creates the 'render' command that renders artifacts for external execution.
 func CommandRender(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cCmd := &cobra.Command{
+	cCmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:     "render",
 		Aliases: []string{"rn"},
 		Short:   fmt.Sprintf("Renders %s artifacts for external execution", path),
@@ -35,7 +36,7 @@ The rendered artifact includes:
   - Dependency information for each action
   - Metadata including generation timestamp and statistics`, settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
-	}
+	})
 
 	cCmd.AddCommand(CommandSolution(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
 

--- a/pkg/cmd/scafctl/render/render_test.go
+++ b/pkg/cmd/scafctl/render/render_test.go
@@ -1,0 +1,49 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package render
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandRender_UnknownSubcommandErrors(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	// Unknown subcommand must error.
+	cmd := CommandRender(cliParams, ioStreams, "")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+}
+
+func TestCommandRender_BareShowsHelpExitZero(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandRender(cliParams, ioStreams, "")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{})
+	cmd.SilenceErrors = true
+
+	err := cmd.Execute()
+
+	require.NoError(t, err, "bare invocation should not error")
+	assert.Contains(t, out.String(), "Usage:", "bare invocation should print help")
+}

--- a/pkg/cmd/scafctl/run/run.go
+++ b/pkg/cmd/scafctl/run/run.go
@@ -6,6 +6,7 @@ package run
 import (
 	"fmt"
 
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -13,7 +14,7 @@ import (
 
 // CommandRun creates the 'run' command that executes solutions and other runnable artifacts.
 func CommandRun(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cCmd := &cobra.Command{
+	cCmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:     "run",
 		Aliases: []string{"r"},
 		Short:   fmt.Sprintf("Runs %s solutions, resolvers, actions, and providers", path),
@@ -28,7 +29,7 @@ SUBCOMMANDS:
   resolver  Run resolvers only (for debugging/inspection)
   provider  Run a single provider directly (for testing/debugging)`,
 		SilenceUsage: true,
-	}
+	})
 
 	runPath := fmt.Sprintf("%s/%s", path, cCmd.Use)
 	cCmd.AddCommand(CommandSolution(cliParams, ioStreams, runPath))

--- a/pkg/cmd/scafctl/run/run_test.go
+++ b/pkg/cmd/scafctl/run/run_test.go
@@ -1,0 +1,36 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommandRun_UnknownSubcommandErrors verifies that an unknown subcommand
+// errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandRun_UnknownSubcommandErrors(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandRun(cliParams, ioStreams, "scafctl")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandRun(cliParams, ioStreams, "scafctl")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+}

--- a/pkg/cmd/scafctl/secrets/secrets.go
+++ b/pkg/cmd/scafctl/secrets/secrets.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/secrets"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -29,7 +30,7 @@ func newStoreFromContext(ctx context.Context) (secrets.Store, error) {
 
 // CommandSecrets creates the 'secrets' command.
 func CommandSecrets(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:     "secrets",
 		Aliases: []string{"secret"},
 		Short:   "Manage encrypted secrets",
@@ -48,7 +49,7 @@ func CommandSecrets(cliParams *settings.Run, ioStreams *terminal.IOStreams, path
 			  By default they are hidden. Use --all on subcommands to include them.
 		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
-	}
+	})
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
 	cmd.AddCommand(CommandList(cliParams, ioStreams, cmdPath))

--- a/pkg/cmd/scafctl/secrets/secrets_test.go
+++ b/pkg/cmd/scafctl/secrets/secrets_test.go
@@ -21,7 +21,7 @@ func TestCommandSecrets(t *testing.T) {
 	assert.Contains(t, cmd.Aliases, "secret")
 	assert.NotEmpty(t, cmd.Short)
 	assert.True(t, cmd.SilenceUsage)
-	assert.Nil(t, cmd.RunE, "parent secrets command should not have RunE")
+	assert.NotNil(t, cmd.RunE, "parent secrets command needs a help-only RunE so NoArgs rejects unknown subcommands")
 	subCmds := cmd.Commands()
 	require.Len(t, subCmds, 8, "should have 8 subcommands")
 	cmdNames := make([]string, len(subCmds))
@@ -142,4 +142,25 @@ func BenchmarkCommandSecrets(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		CommandSecrets(cliParams, ioStreams, "scafctl")
 	}
+}
+
+// TestCommandSecrets_UnknownSubcommandErrors verifies that an unknown
+// subcommand errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandSecrets_UnknownSubcommandErrors(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandSecrets(cliParams, ioStreams, "scafctl")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandSecrets(cliParams, ioStreams, "scafctl")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
 }

--- a/pkg/cmd/scafctl/snapshot/snapshot.go
+++ b/pkg/cmd/scafctl/snapshot/snapshot.go
@@ -5,6 +5,7 @@ package snapshot
 
 import (
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -12,17 +13,11 @@ import (
 
 // CommandSnapshot creates the snapshot command
 func CommandSnapshot(cliParams *settings.Run, ioStreams terminal.IOStreams, binaryName string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:          "snapshot",
 		Aliases:      []string{"snap"},
 		Short:        "Manage resolver execution snapshots",
 		SilenceUsage: true,
-		// Args: NoArgs + a RunE that shows help makes bare 'snapshot' print
-		// help and exit 0, while an unknown subcommand (e.g. the hard-removed
-		// 'snapshot diff') errors with "unknown command". A RunE is required:
-		// cobra returns flag.ErrHelp (help, exit 0) for a non-runnable parent
-		// *before* validating args, so NoArgs alone would never fire.
-		Args: cobra.NoArgs,
 		Long: heredoc.Doc(`
 			Manage resolver execution snapshots for debugging, testing, and comparison.
 			
@@ -42,10 +37,7 @@ func CommandSnapshot(cliParams *settings.Run, ioStreams terminal.IOStreams, bina
 			# Compare two snapshots
 			$ %s diff snapshot before.json after.json
 		`, binaryName, binaryName, binaryName),
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
+	})
 
 	cmd.AddCommand(CommandShow(cliParams, ioStreams, binaryName))
 

--- a/pkg/cmd/scafctl/state/state.go
+++ b/pkg/cmd/scafctl/state/state.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -16,7 +17,7 @@ import (
 
 // CommandState creates the 'state' command group.
 func CommandState(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:   "state",
 		Short: "Manage solution state files",
 		Long: strings.ReplaceAll(heredoc.Doc(`
@@ -29,7 +30,7 @@ func CommandState(cliParams *settings.Run, ioStreams *terminal.IOStreams, path s
 			directory. Use an absolute path to reference files in other locations.
 		`), settings.CliBinaryName, cliParams.BinaryName),
 		SilenceUsage: true,
-	}
+	})
 
 	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
 	cmd.AddCommand(CommandList(cliParams, ioStreams, cmdPath))

--- a/pkg/cmd/scafctl/state/state_test.go
+++ b/pkg/cmd/scafctl/state/state_test.go
@@ -907,3 +907,25 @@ func TestSplitFingerprintKey(t *testing.T) {
 		})
 	}
 }
+
+// TestCommandState_UnknownSubcommandErrors verifies that an unknown
+// subcommand errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandState_UnknownSubcommandErrors(t *testing.T) {
+	t.Parallel()
+	cliParams := &settings.Run{BinaryName: "testcli"}
+	ios := &terminal.IOStreams{}
+
+	cmd := CommandState(cliParams, ios, "testcli")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandState(cliParams, ios, "testcli")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+}

--- a/pkg/cmd/scafctl/validate/validate.go
+++ b/pkg/cmd/scafctl/validate/validate.go
@@ -6,6 +6,7 @@ package validate
 import (
 	"fmt"
 
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/run"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -15,7 +16,7 @@ import (
 // CommandValidate creates the 'validate' command that validates solution
 // artifacts and exits non-zero when validation fails.
 func CommandValidate(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cCmd := &cobra.Command{
+	cCmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:   "validate",
 		Short: fmt.Sprintf("Validate %s solution artifacts and fail on validation errors", path),
 		Long: `Validate executes a solution's artifacts and exits non-zero when validation fails.
@@ -27,7 +28,7 @@ CI pipelines or pre-commit checks.
 SUBCOMMANDS:
   resolver  Validate resolvers (resolve, transform, and validate phases)`,
 		SilenceUsage: true,
-	}
+	})
 
 	validatePath := fmt.Sprintf("%s/%s", path, cCmd.Use)
 	cCmd.AddCommand(run.CommandValidateResolver(cliParams, ioStreams, validatePath))

--- a/pkg/cmd/scafctl/validate/validate_test.go
+++ b/pkg/cmd/scafctl/validate/validate_test.go
@@ -43,3 +43,26 @@ func TestCommandValidate_EmbedderBinaryName(t *testing.T) {
 	cmd := CommandValidate(cliParams, streams, "mycli")
 	assert.Contains(t, cmd.Short, "mycli")
 }
+
+// TestCommandValidate_UnknownSubcommandErrors verifies that an unknown
+// subcommand errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandValidate_UnknownSubcommandErrors(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	streams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandValidate(cliParams, streams, "scafctl")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandValidate(cliParams, streams, "scafctl")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
+}

--- a/pkg/cmd/scafctl/vendor/vendor.go
+++ b/pkg/cmd/scafctl/vendor/vendor.go
@@ -6,6 +6,7 @@ package vendor
 
 import (
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -13,7 +14,7 @@ import (
 
 // CommandVendor creates the vendor command group.
 func CommandVendor(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	cmd := &cobra.Command{
+	cmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:          "vendor",
 		Aliases:      []string{"vend"},
 		Short:        "Manage vendored solution dependencies",
@@ -22,7 +23,7 @@ func CommandVendor(cliParams *settings.Run, ioStreams *terminal.IOStreams, path 
 			Commands for managing vendored catalog dependencies
 			used by solution bundles.
 		`),
-	}
+	})
 
 	cmd.AddCommand(CommandUpdate(cliParams, ioStreams, path))
 

--- a/pkg/cmd/scafctl/vendor/vendor_test.go
+++ b/pkg/cmd/scafctl/vendor/vendor_test.go
@@ -28,7 +28,7 @@ func TestCommandVendor(t *testing.T) {
 	assert.Equal(t, "vendor", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
 	assert.True(t, cmd.SilenceUsage)
-	assert.Nil(t, cmd.RunE, "parent vendor command should not have RunE")
+	assert.NotNil(t, cmd.RunE, "parent vendor command needs a help-only RunE so NoArgs rejects unknown subcommands")
 	subCmds := cmd.Commands()
 	require.Len(t, subCmds, 1, "should have 1 subcommand: update")
 	assert.Equal(t, "update", subCmds[0].Name())
@@ -460,4 +460,26 @@ func BenchmarkCommandVendor(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		CommandVendor(cliParams, ioStreams, "scafctl")
 	}
+}
+
+// TestCommandVendor_UnknownSubcommandErrors verifies that an unknown
+// subcommand errors (non-zero) while a bare invocation shows help and exits 0.
+func TestCommandVendor_UnknownSubcommandErrors(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandVendor(cliParams, ioStreams, "scafctl")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+
+	cmd2 := CommandVendor(cliParams, ioStreams, "scafctl")
+	cmd2.SetArgs([]string{})
+	cmd2.SilenceErrors = true
+	cmd2.SilenceUsage = true
+	assert.NoError(t, cmd2.Execute())
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -9164,7 +9164,7 @@ func TestIntegration_OldDiffPaths_HardRemoved(t *testing.T) {
 func TestIntegration_BareGroups_ShowHelpExitZero(t *testing.T) {
 	t.Parallel()
 
-	cases := []string{"bundle", "snapshot"}
+	cases := []string{"bundle", "snapshot", "catalog", "config", "auth", "secrets", "cache"}
 
 	for _, group := range cases {
 		t.Run(group, func(t *testing.T) {
@@ -9172,6 +9172,51 @@ func TestIntegration_BareGroups_ShowHelpExitZero(t *testing.T) {
 			stdout, _, exitCode := runScafctl(t, group)
 			assert.Equal(t, 0, exitCode, "bare %q must show help and exit 0", group)
 			assert.Contains(t, stdout, "Usage:", "bare %q must print help", group)
+		})
+	}
+}
+
+// TestIntegration_UnknownSubcommand_ErrorsNonZero verifies that every parent
+// command group converted to cmdutil.MakeHelpOnlyGroup rejects an unknown
+// subcommand with a non-zero exit AND an "unknown command" error, rather than
+// silently falling back to parent help and exiting 0 (issue #655). Nested
+// groups are covered too.
+func TestIntegration_UnknownSubcommand_ErrorsNonZero(t *testing.T) {
+	t.Parallel()
+
+	cases := [][]string{
+		{"catalog", "bogus-xyz"},
+		{"config", "bogus-xyz"},
+		{"auth", "bogus-xyz"},
+		{"secrets", "bogus-xyz"},
+		{"state", "bogus-xyz"},
+		{"cache", "bogus-xyz"},
+		{"kube", "bogus-xyz"},
+		{"plugins", "bogus-xyz"},
+		{"mcp", "bogus-xyz"},
+		{"get", "bogus-xyz"},
+		{"run", "bogus-xyz"},
+		{"validate", "bogus-xyz"},
+		{"new", "bogus-xyz"},
+		{"eval", "bogus-xyz"},
+		{"vendor", "bogus-xyz"},
+		{"inspect", "bogus-xyz"},
+		{"package", "bogus-xyz"},
+		{"credential-helper", "bogus-xyz"},
+		{"diff", "bogus-xyz"},
+		// Nested groups.
+		{"auth", "alias", "bogus-xyz"},
+		{"catalog", "index", "bogus-xyz"},
+	}
+
+	for _, args := range cases {
+		t.Run(strings.Join(args, "_"), func(t *testing.T) {
+			t.Parallel()
+			_, stderr, exitCode := runScafctl(t, args...)
+			assert.NotEqual(t, 0, exitCode,
+				"unknown subcommand %v must exit non-zero", args)
+			assert.Contains(t, stderr, "unknown command",
+				"unknown subcommand %v must fail with an unknown-command error", args)
 		})
 	}
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -9164,7 +9164,7 @@ func TestIntegration_OldDiffPaths_HardRemoved(t *testing.T) {
 func TestIntegration_BareGroups_ShowHelpExitZero(t *testing.T) {
 	t.Parallel()
 
-	cases := []string{"bundle", "snapshot", "catalog", "config", "auth", "secrets", "cache"}
+	cases := []string{"bundle", "snapshot", "catalog", "config", "auth", "secrets", "cache", "render"}
 
 	for _, group := range cases {
 		t.Run(group, func(t *testing.T) {
@@ -9204,6 +9204,7 @@ func TestIntegration_UnknownSubcommand_ErrorsNonZero(t *testing.T) {
 		{"package", "bogus-xyz"},
 		{"credential-helper", "bogus-xyz"},
 		{"diff", "bogus-xyz"},
+		{"render", "bogus-xyz"},
 		// Nested groups.
 		{"auth", "alias", "bogus-xyz"},
 		{"catalog", "index", "bogus-xyz"},


### PR DESCRIPTION
Fixes #655. Parent command groups silently exited 0 on unknown subcommands -- a mistyped `scafctl catalog bogus` printed help and exited 0, masking the typo as success.

## Root cause

Command groups defined without a `Run`/`RunE` are **non-runnable**. In cobra's `execute()`, a non-runnable command returns `flag.ErrHelp` (caught upstream and turned into "print help, exit 0") **before** it ever validates positional args. So the unknown-subcommand token is never rejected, and `Args: cobra.NoArgs` alone is inert on such a parent.

## Fix

New shared helper `pkg/cmd/cmdutil/MakeHelpOnlyGroup(cmd)` sets a help-only `RunE` (flipping `Runnable()` to true so arg validation runs) **plus** `cobra.NoArgs`. Result:

- `scafctl catalog` (bare) -> prints help, exits 0 (grammar Rule 8 preserved).
- `scafctl catalog bogus` (unknown subcommand) -> `Error: unknown command "bogus" for "scafctl catalog"`, non-zero exit.

Applied across **23 parent groups**: 18 top-level (`run`, `validate`, `eval`, `get`, `inspect`, `new`, `package`, `vendor`, `catalog`, `config`, `secrets`, `state`, `auth`, `kube`, `cache`, `credential-helper`, `plugins`, `mcp`), 4 nested (`auth alias`, `auth profile`, `catalog index`, `catalog remote`), and the `diff` group -- which had a help-only RunE from #654 but was **missing `NoArgs`** (gap closed). `bundle`/`snapshot` refactored to use the helper, deduping the manual blocks introduced in #654.

**Intentionally excluded** (legitimate positional args): `lint [name]`, `auth handlers [name]`, `serve`.

## Testing

- `cmdutil` unit tests: bare-help/exit-0, unknown-subcommand-errors, known-subcommand-runs, field preservation.
- Per-group unknown-subcommand tests across all 23 groups (+ bare-help render assertions on representative groups).
- New integration test `TestIntegration_UnknownSubcommand_ErrorsNonZero` covering 19 top-level + 2 nested groups (non-zero exit + "unknown command"); extended `TestIntegration_BareGroups_ShowHelpExitZero`.

## Quality gate

- `go-review`: APPROVE (0 critical/high/medium; cobra mechanism verified against source).
- `completeness-check`: gaps found (missing `diff` test, stale integration test) and closed.
- Full `task integration` (900/0), `task test-cover` (0 failures), and `task lint:changed` (**0 issues**) all pass on the final diff.

## Type of Change

- [x] Bug fix
- [ ] Breaking change (behavior change: typos now error instead of silently succeeding -- pre-production, acceptable)

## Checklist

- [x] Commit signed (`-S`) + DCO signed-off (`-s`)
- [x] Tests for every changed group; no 0%-coverage cmd files
- [x] Shared helper avoids duplicating the pattern across 23 groups
