### PR TITLE
feat(cli): add --no-state flag to skip the state lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - *(provider)* Add optional per-entry `data` map to the go-template `render-tree` operation, shallow-merged over the shared `data` (per-entry values win), enabling single-resolver fan-out where one template renders once per item with its own variables and output path
 - *(auth)* [**breaking**] Drop the legacy OAuth token-metadata compatibility shim when bumping scafctl-plugin-sdk to v0.11.0. Credentials persisted by earlier versions (which carried fields such as `refreshTokenExpiresAt` / `loginFlow`) no longer deserialize, so a one-time re-login is required after upgrading.
 - *(state)* Add `saveOverrides` field to state backend for save-time-only input resolution, enabling patterns like loading from `main` and saving to a resolver-derived feature branch
+- *(cli)* Add `--no-state` flag to `run solution`, `run resolver`, `run action`, and `render solution` to skip the entire state lifecycle (load, immutable verification, and save) for CI/offline runs. A one-line stderr notice is emitted when a state-enabled solution is run with the flag; resolvers that read the `state` provider fall back to their defaults (#622)
 - *(lint)* Add `resolver-cycle` rule (error) to detect circular dependencies in the resolver dependency graph
 - *(lint)* Add `missing-template-dependency` rule (warning) to detect render-tree resolvers missing template file dependencies
 - *(lint)* Change `hyphenated-name` severity from info to warning and recommend camelCase instead of underscores

--- a/docs/design/state/state.md
+++ b/docs/design/state/state.md
@@ -55,6 +55,7 @@ State does not:
 | `http` provider state operations | Done | `pkg/provider/builtin/httpprovider/http_state.go` |
 | `github` provider state operations | External | Separate repository (not part of this project) |
 | State loading lifecycle (pre-execution) | Done | `pkg/cmd/scafctl/run/solution.go`, `resolver.go` |
+| `--no-state` lifecycle bypass | Done | `pkg/cmd/scafctl/run/`, `pkg/cmd/scafctl/render/solution.go` |
 | `scafctl state` CLI commands | Done | `pkg/cmd/scafctl/state/` |
 | Validation rules (backend, sensitive warnings) | Done | `pkg/lint/` |
 | Immutable resolver support | Done | `pkg/resolver/resolver.go` (field), `pkg/state/manager.go` (enforcement), `pkg/lint/` (rules) |
@@ -215,6 +216,17 @@ state:
 ~~~
 
 Here, `project_name` is a CLI parameter passed via `-r project_name=myapp`. Project A and Project B each get their own state file.
+
+### Bypassing State (`--no-state`)
+
+The `run solution`, `run resolver`, `run action`, and `render solution` commands accept a `--no-state` flag that bypasses the state lifecycle entirely for a single invocation. When set, the command-layer wiring simply does not construct a `state.Manager`, so:
+
+- `Load` is never called (no pre-execution read, no parameter replay).
+- `VerifyImmutables` / immutable-lock commits are skipped.
+- `Save` is never called (no post-execution write).
+
+Because the gate lives in the command layer (the `stateMgr` stays `nil`), no changes are required in `pkg/state`. When the solution declares a `state` block and `--no-state` is passed, a one-line stderr notice is emitted (respecting `--quiet`). Resolvers that read the `state` provider receive the provider's no-state fallback. The flag is intended for CI/offline runs; it deliberately disables immutability enforcement for that run.
+
 
 ---
 

--- a/docs/tutorials/state-tutorial.md
+++ b/docs/tutorials/state-tutorial.md
@@ -612,6 +612,26 @@ Use `render solution` to preview what an action graph would look like with curre
 | `run action` | Yes | Yes | After actions succeed |
 | `render solution` | Yes | No (read-only) | -- |
 
+### Skipping State (`--no-state`)
+
+Pass `--no-state` to `run solution`, `run resolver`, `run action`, or `render solution` to skip the **entire** state lifecycle for that invocation:
+
+- State is **not loaded** before resolvers run.
+- Immutable values are **neither verified nor locked**.
+- State is **not saved** afterward.
+
+This is intended for CI pipelines and offline environments where the state backend is unavailable or persistence is undesirable. When the solution declares a `state` block and `--no-state` is set, a one-line notice is written to stderr (suppressed by `--quiet`).
+
+Two consequences to keep in mind:
+
+- Resolvers that read the `state` provider fall back to their defaults, since no prior values are loaded.
+- Immutability is **not enforced** while `--no-state` is active -- values that are normally locked can change freely. Use the flag deliberately.
+
+~~~bash
+# Run without touching the state backend
+scafctl run solution -f ./solution.yaml --no-state
+~~~
+
 ---
 
 ## Save-Time Overrides

--- a/pkg/cmd/scafctl/render/solution.go
+++ b/pkg/cmd/scafctl/render/solution.go
@@ -63,6 +63,11 @@ type SolutionOptions struct {
 	NoTimestamp     bool
 	NoCache         bool
 
+	// NoState disables state loading. render is read-only (it never saves), so
+	// this only skips reading persisted state; resolvers that read the state
+	// provider fall back to their defaults.
+	NoState bool
+
 	// Mode flags (mutually exclusive)
 	ActionGraph  bool   // --action-graph: Show action dependency graph
 	GraphFormat  string // --graph-format: Graph format (ascii, dot, mermaid, json)
@@ -225,6 +230,7 @@ Examples:
 	cCmd.Flags().DurationVar(&options.ResolverTimeout, "resolver-timeout", settings.DefaultResolverTimeout, "Timeout per resolver")
 	cCmd.Flags().DurationVar(&options.PhaseTimeout, "phase-timeout", settings.DefaultPhaseTimeout, "Timeout per phase")
 	cCmd.Flags().BoolVar(&options.NoCache, "no-cache", false, "Bypass the artifact cache and fetch directly from the catalog")
+	cCmd.Flags().BoolVar(&options.NoState, "no-state", false, "Skip loading persisted state (for CI/offline runs)")
 
 	// Graph mode flags
 	cCmd.Flags().BoolVar(&options.ActionGraph, "action-graph", false, "Show action dependency graph (ASCII, DOT, Mermaid, JSON)")
@@ -769,6 +775,16 @@ type solutionResolverRegistryAdapter = solrender.ResolverRegistryAdapter
 // so the parameter provider can replay previously saved values.
 func (o *SolutionOptions) loadStateIntoContext(ctx context.Context, sol *solution.Solution, reg *provider.Registry, params map[string]any) (context.Context, map[string]any, error) {
 	if sol.State == nil {
+		return ctx, params, nil
+	}
+
+	// --no-state skips reading persisted state entirely. render never saves, so
+	// this only affects the load side. Emit a one-line stderr notice (respects
+	// --quiet) since the solution actually declares a state block.
+	if o.NoState {
+		if w := writer.FromContext(ctx); w != nil {
+			w.WarnStderrf("--no-state: skipping state load for solution %q", sol.Metadata.Name)
+		}
 		return ctx, params, nil
 	}
 

--- a/pkg/cmd/scafctl/render/solution_coverage_test.go
+++ b/pkg/cmd/scafctl/render/solution_coverage_test.go
@@ -530,7 +530,34 @@ func TestSolutionOptions_loadStateIntoContext_DisabledState(t *testing.T) {
 	assert.Nil(t, data)
 }
 
-// ── formatParams tests ──────────────────────────────────────────────────────
+func TestSolutionOptions_loadStateIntoContext_NoStateFlag(t *testing.T) {
+	t.Parallel()
+
+	opts := &SolutionOptions{NoState: true}
+	sol := &solution.Solution{
+		State: &state.Config{
+			Enabled: &spec.ValueRef{Literal: true},
+			Backend: state.Backend{
+				Provider: "file",
+				Inputs: map[string]*spec.ValueRef{
+					"path": {Literal: "test.json"},
+				},
+			},
+		},
+	}
+	sol.Metadata.Name = "no-state-render"
+	reg := provider.NewRegistry()
+
+	ctx := setupWriterContext()
+	result, params, err := opts.loadStateIntoContext(ctx, sol, reg, nil)
+
+	require.NoError(t, err)
+	// --no-state must skip loading entirely: no state data in context.
+	data, ok := state.FromContext(result)
+	assert.False(t, ok)
+	assert.Nil(t, data)
+	assert.Nil(t, params, "params should be unchanged when state load is skipped")
+}
 
 func TestFormatParams(t *testing.T) {
 	t.Parallel()

--- a/pkg/cmd/scafctl/render/solution_test.go
+++ b/pkg/cmd/scafctl/render/solution_test.go
@@ -137,6 +137,18 @@ func TestCommandSolution(t *testing.T) {
 				require.NotNil(t, flag)
 			},
 		},
+		{
+			name: "has_no_state_flag",
+			validate: func(t *testing.T) {
+				ioStreams, _, _ := terminal.NewTestIOStreams()
+				cliParams := &settings.Run{}
+				cmd := CommandSolution(cliParams, ioStreams, "render")
+
+				flag := cmd.Flags().Lookup("no-state")
+				require.NotNil(t, flag)
+				assert.Equal(t, "false", flag.DefValue)
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -380,7 +380,9 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 	// the state provider can serve previously saved values.
 	var stateMgr *state.Manager
 	var stateData *state.Data
-	if sol.State != nil {
+	if o.NoState {
+		warnStateSkipped(ctx, sol)
+	} else if sol.State != nil {
 		stateMgr = state.NewManager(sol.State, reg, state.RuntimeProvenanceFromContext(ctx))
 		cmdInfo := buildCommandInfo("run action", params)
 		loadResult, loadErr := stateMgr.Load(ctx, params, cmdInfo)

--- a/pkg/cmd/scafctl/run/action_test.go
+++ b/pkg/cmd/scafctl/run/action_test.go
@@ -85,6 +85,10 @@ func TestCommandAction_FlagDefaults(t *testing.T) {
 	backup, err := flags.GetBool("backup")
 	require.NoError(t, err)
 	assert.False(t, backup)
+
+	noState, err := flags.GetBool("no-state")
+	require.NoError(t, err)
+	assert.False(t, noState)
 }
 
 func TestParseActionArgs(t *testing.T) {

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -201,6 +201,12 @@ type sharedResolverOptions struct {
 	// declare them explicitly in bundle.plugins.
 	Strict bool
 
+	// NoState disables the entire state lifecycle for the run: state is not
+	// loaded before resolvers, immutable values are neither verified nor
+	// locked, and no state is saved afterward. Resolvers that read the state
+	// provider fall back to their defaults. Intended for CI/offline runs.
+	NoState bool
+
 	// nonFatalValidation, when true, makes executeResolvers treat resolver
 	// validation-only failures as non-fatal: it returns the populated values
 	// and resolver context alongside the error instead of discarding them.
@@ -886,6 +892,7 @@ func addSharedResolverFlags(cCmd *cobra.Command, o *sharedResolverOptions) {
 	cCmd.Flags().StringVar(&o.BaseDir, "base-dir", "", "Override base directory for resolver path resolution (when unset, paths resolve from the solution file's directory when known, otherwise the current directory; use '.' for CWD)")
 	cCmd.Flags().BoolVar(&o.PreRelease, "pre-release", false, "Include pre-release versions when resolving latest from catalog")
 	cCmd.Flags().BoolVar(&o.Strict, "strict", false, "Disable auto-resolution of official providers; require explicit bundle.plugins declarations")
+	cCmd.Flags().BoolVar(&o.NoState, "no-state", false, "Skip the entire state lifecycle: do not load, verify immutables, or save state (for CI/offline runs)")
 }
 
 // writeMetrics outputs provider execution metrics to stderr
@@ -964,6 +971,19 @@ func buildStateSolutionMeta(sol *solution.Solution) state.SolutionMeta {
 		meta.Version = sol.Metadata.Version.String()
 	}
 	return meta
+}
+
+// warnStateSkipped emits a one-line stderr notice when --no-state disables the
+// state lifecycle for a solution that actually declares a state block. It is a
+// no-op when the solution has no state or when no writer is in context. The
+// underlying WarnStderrf respects --quiet.
+func warnStateSkipped(ctx context.Context, sol *solution.Solution) {
+	if sol == nil || sol.State == nil {
+		return
+	}
+	if w := writer.FromContext(ctx); w != nil {
+		w.WarnStderrf("--no-state: skipping state load, immutable checks, and save for solution %q", sol.Metadata.Name)
+	}
 }
 
 // buildParamFlagHint formats missing param names as -r flags for user hints.

--- a/pkg/cmd/scafctl/run/common_test.go
+++ b/pkg/cmd/scafctl/run/common_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/oakwood-commons/scafctl/pkg/state"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
@@ -210,4 +211,48 @@ func TestHandleStateLoadError_GenericError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "state load: disk full")
 	assert.Equal(t, exitcode.GeneralError, exitcode.GetCode(err))
+}
+
+func TestWarnStateSkipped(t *testing.T) {
+	stateSol := &solution.Solution{
+		Metadata: solution.Metadata{Name: "demo"},
+		State:    &state.Config{},
+	}
+
+	t.Run("emits notice for state-enabled solution", func(t *testing.T) {
+		var buf bytes.Buffer
+		ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+		w := writer.New(ioStreams, settings.NewCliParams())
+		ctx := writer.WithWriter(context.Background(), w)
+
+		warnStateSkipped(ctx, stateSol)
+		assert.Contains(t, buf.String(), "--no-state")
+		assert.Contains(t, buf.String(), "demo")
+	})
+
+	t.Run("no-op when solution is nil", func(t *testing.T) {
+		var buf bytes.Buffer
+		ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+		w := writer.New(ioStreams, settings.NewCliParams())
+		ctx := writer.WithWriter(context.Background(), w)
+
+		warnStateSkipped(ctx, nil)
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("no-op when solution has no state block", func(t *testing.T) {
+		var buf bytes.Buffer
+		ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+		w := writer.New(ioStreams, settings.NewCliParams())
+		ctx := writer.WithWriter(context.Background(), w)
+
+		warnStateSkipped(ctx, &solution.Solution{Metadata: solution.Metadata{Name: "nostate"}})
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("no panic when no writer in context", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			warnStateSkipped(context.Background(), stateSol)
+		})
+	})
 }

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -596,7 +596,9 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 	// the state provider can serve previously saved values.
 	var stateMgr *state.Manager
 	var stateData *state.Data
-	if sol.State != nil {
+	if o.NoState {
+		warnStateSkipped(ctx, sol)
+	} else if sol.State != nil {
 		stateMgr = state.NewManager(sol.State, reg, state.RuntimeProvenanceFromContext(ctx))
 		cmdInfo := buildCommandInfo("run resolver", params)
 		loadResult, loadErr := stateMgr.Load(ctx, params, cmdInfo)

--- a/pkg/cmd/scafctl/run/resolver_test.go
+++ b/pkg/cmd/scafctl/run/resolver_test.go
@@ -93,6 +93,10 @@ func TestCommandResolver_FlagDefaults(t *testing.T) {
 	phaseTimeout, err := ff.GetDuration("phase-timeout")
 	require.NoError(t, err)
 	assert.Equal(t, 5*time.Minute, phaseTimeout)
+
+	noState, err := ff.GetBool("no-state")
+	require.NoError(t, err)
+	assert.False(t, noState)
 }
 
 func TestResolverOptions_Run_NoFile(t *testing.T) {

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -493,7 +493,9 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	// parameters via __params in CEL expressions (e.g. __params.appName).
 	var stateMgr *state.Manager
 	var stateData *state.Data
-	if sol.State != nil {
+	if o.NoState {
+		warnStateSkipped(ctx, sol)
+	} else if sol.State != nil {
 		stateMgr = state.NewManager(sol.State, reg, state.RuntimeProvenanceFromContext(ctx))
 		cmdInfo := buildCommandInfo("run solution", params)
 		loadResult, loadErr := stateMgr.Load(ctx, params, cmdInfo)

--- a/pkg/cmd/scafctl/run/solution_test.go
+++ b/pkg/cmd/scafctl/run/solution_test.go
@@ -119,6 +119,10 @@ func TestCommandSolution_FlagDefaults(t *testing.T) {
 	outputDir, err := flags.GetString("output-dir")
 	require.NoError(t, err)
 	assert.Empty(t, outputDir)
+
+	noState, err := flags.GetBool("no-state")
+	require.NoError(t, err)
+	assert.False(t, noState)
 }
 
 func TestSolutionOptions_getEffectiveActionConfig_OutputDir(t *testing.T) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1057,6 +1057,165 @@ spec:
 	assert.Contains(t, stateDoc.Resolvers, "region", "immutable region should be locked after a passing run")
 }
 
+// TestIntegration_RunSolution_NoStateFlag verifies that --no-state skips the
+// entire state lifecycle: no state file is written, immutable values are not
+// locked or verified, the action still runs, and a one-line stderr notice is
+// emitted because the solution declares a state block.
+func TestIntegration_RunSolution_NoStateFlag(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: no-state-flag
+  version: 1.0.0
+state:
+  enabled: true
+  backend:
+    provider: file
+    inputs:
+      path: state.json
+spec:
+  resolvers:
+    region:
+      type: string
+      immutable: true
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+              default: us-east1
+  workflow:
+    actions:
+      notify:
+        provider: message
+        inputs:
+          message: "ACTION_RAN"
+          type: info
+`
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(solutionContent), 0o600))
+	statePath := filepath.Join(tmpDir, "state.json")
+
+	// Run 1 with --no-state: action runs, no state file written, warning shown.
+	stdout, stderr, exitCode := runScafctlInDir(t, tmpDir, "run", "solution", "-f", solutionPath, "--no-state")
+	assert.Equal(t, 0, exitCode, "run with --no-state should exit zero")
+	assert.Contains(t, stdout, "ACTION_RAN", "action should still run with --no-state")
+	assert.NoFileExists(t, statePath, "state file must not be written when --no-state is set")
+	assert.Contains(t, stderr, "--no-state", "a stderr notice should be emitted when skipping a state-enabled solution")
+
+	// Run 2 with --no-state and a DIFFERENT immutable value: because nothing was
+	// locked, immutable verification is skipped and the run succeeds.
+	_, _, exitCode = runScafctlInDir(t, tmpDir, "run", "solution", "-f", solutionPath, "--no-state", "-r", "region=eu-west1")
+	assert.Equal(t, 0, exitCode, "immutable checks must be skipped under --no-state")
+	assert.NoFileExists(t, statePath, "state file must still not exist after a second --no-state run")
+}
+
+// TestIntegration_RunResolver_NoStateFlag verifies that --no-state on
+// `run resolver` skips the state lifecycle: no state file is written, immutable
+// values are not locked or verified, and a one-line stderr notice is emitted.
+func TestIntegration_RunResolver_NoStateFlag(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: no-state-resolver
+  version: 1.0.0
+state:
+  enabled: true
+  backend:
+    provider: file
+    inputs:
+      path: state.json
+spec:
+  resolvers:
+    region:
+      type: string
+      immutable: true
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+              default: us-east1
+`
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(solutionContent), 0o600))
+	statePath := filepath.Join(tmpDir, "state.json")
+
+	// Run 1 with --no-state: resolvers run, no state file written, warning shown.
+	stdout, stderr, exitCode := runScafctlInDir(t, tmpDir, "run", "resolver", "-f", solutionPath, "--no-state")
+	assert.Equal(t, 0, exitCode, "run resolver with --no-state should exit zero")
+	assert.Contains(t, stdout, "us-east1", "resolver should still resolve with --no-state")
+	assert.NoFileExists(t, statePath, "state file must not be written when --no-state is set")
+	assert.Contains(t, stderr, "--no-state", "a stderr notice should be emitted when skipping a state-enabled solution")
+
+	// Run 2 with --no-state and a DIFFERENT immutable value: nothing was locked,
+	// so immutable verification is skipped and the run succeeds.
+	_, _, exitCode = runScafctlInDir(t, tmpDir, "run", "resolver", "-f", solutionPath, "--no-state", "-r", "region=eu-west1")
+	assert.Equal(t, 0, exitCode, "immutable checks must be skipped under --no-state")
+	assert.NoFileExists(t, statePath, "state file must still not exist after a second --no-state run")
+}
+
+// TestIntegration_RunAction_NoStateFlag verifies that --no-state on
+// `run action` skips the state lifecycle: the action still runs, no state file
+// is written, and a one-line stderr notice is emitted.
+func TestIntegration_RunAction_NoStateFlag(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: no-state-action
+  version: 1.0.0
+state:
+  enabled: true
+  backend:
+    provider: file
+    inputs:
+      path: state.json
+spec:
+  resolvers:
+    region:
+      type: string
+      immutable: true
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+              default: us-east1
+  workflow:
+    actions:
+      notify:
+        provider: message
+        inputs:
+          message: "ACTION_RAN"
+          type: info
+`
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(solutionContent), 0o600))
+	statePath := filepath.Join(tmpDir, "state.json")
+
+	// Run 1 with --no-state: action runs, no state file written, warning shown.
+	stdout, stderr, exitCode := runScafctlInDir(t, tmpDir, "run", "action", "notify", "-f", solutionPath, "--no-state")
+	assert.Equal(t, 0, exitCode, "run action with --no-state should exit zero")
+	assert.Contains(t, stdout, "ACTION_RAN", "action should still run with --no-state")
+	assert.NoFileExists(t, statePath, "state file must not be written when --no-state is set")
+	assert.Contains(t, stderr, "--no-state", "a stderr notice should be emitted when skipping a state-enabled solution")
+
+	// Run 2 with --no-state and a DIFFERENT immutable value: nothing was locked,
+	// so immutable verification is skipped and the run succeeds.
+	_, _, exitCode = runScafctlInDir(t, tmpDir, "run", "action", "notify", "-f", solutionPath, "--no-state", "-r", "region=eu-west1")
+	assert.Equal(t, 0, exitCode, "immutable checks must be skipped under --no-state")
+	assert.NoFileExists(t, statePath, "state file must still not exist after a second --no-state run")
+}
+
 func TestIntegration_RunSolution_FileNotFound(t *testing.T) {
 	t.Parallel()
 	_, stderr, exitCode := runScafctl(t,


### PR DESCRIPTION
## Summary

Adds a `--no-state` flag to `run solution`, `run resolver`, `run action`, and `render solution` that bypasses the **entire** state lifecycle for a single invocation:

- State is **not loaded** before resolvers run.
- Immutable values are **neither verified nor locked**.
- State is **not saved** afterward.

Intended for CI pipelines and offline runs where the state backend is unavailable or persistence is undesirable.

## Design

The gate lives in the **command layer**: when `--no-state` is set, no `state.Manager` is constructed, so every downstream `if stateMgr != nil` save/immutable guard no-ops. This keeps business logic out of the command layer and requires **no changes to `pkg/state`**.

When a solution declares a `state` block and `--no-state` is passed, a one-line stderr notice is emitted (suppressed by `--quiet`).

Two documented consequences:

- Resolvers that read the `state` provider fall back to their defaults (no prior values loaded).
- Immutability is **not enforced** for that run -- an intentional escape hatch.

## Scope vs. #622

This PR implements **only** the `--no-state` portion of #622.

The request to let `state.enabled` / `state.backend.inputs` read resolved values (`_`) at load time is intentionally **not** implemented: state loads before resolvers (the `state` provider feeds them), so it is a genuine circular dependency. `saveOverrides` plus `__params` already cover the practical save-side cases.

Refs #622

## Tests

- Flag-default assertions on all four commands.
- `warnStateSkipped` unit test (state-enabled, nil solution, no-state-block, no-writer branches).
- Render `loadStateIntoContext` `--no-state` unit test.
- Integration tests for `run solution`, `run resolver`, and `run action` with `--no-state` (verify no state file written, action/resolver still runs, immutable checks skipped, stderr notice emitted).

## Docs

- `CHANGELOG.md`
- `docs/tutorials/state-tutorial.md`
- `docs/design/state/state.md`
