### PR TITLE
docs: require interactive display schema for array CLI output

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ Go-based CLI tool using CEL (Common Expression Language) for dynamic configurati
 ## Key Patterns
 
 - **CLI Output**: Use `writer.FromContext(ctx)` -- never `fmt.Fprintf` directly. See `pkg/terminal/writer/`
-- **Data Output**: Use `kvx.OutputOptions` for structured table/json/yaml/quiet output. See `pkg/terminal/kvx/`
+- **Data Output**: Use `kvx.OutputOptions` for structured table/json/yaml/quiet output. See `pkg/terminal/kvx/`. Commands that emit an **array of objects** should attach an interactive display schema via `kvx.WithOutputDisplaySchemaJSON` (a `go:embed`-ed `<cmd>_schema.json` with `x-kvx-list`/`x-kvx-detail` extensions) so `-i` renders a card/detail view; single-object output does not need one. See `.github/instructions/cli-commands.instructions.md`.
 - **HTTP Client**: See `pkg/httpc/README.md`
 - **Paths**: Use xdg paths via `pkg/paths`
 - **Configuration**: `pkg/settings` for defaults, `pkg/config/` for app configuration

--- a/.github/instructions/cli-commands.instructions.md
+++ b/.github/instructions/cli-commands.instructions.md
@@ -12,6 +12,17 @@ Commands are **thin wiring only** -- they parse flags, call domain packages, and
 - **No business logic** -- delegate to packages in `pkg/`
 - Use `writer.FromContext(ctx)` for all terminal output, never `fmt.Fprintf`
 - Use `kvx.OutputOptions` for structured data (table/json/yaml/quiet)
+- **Array output ships an interactive display schema by default** -- when a command
+  emits an **array of objects** via kvx, attach an interactive display schema with
+  `kvx.WithOutputDisplaySchemaJSON` so `-i` renders a card list + detail pane instead
+  of a raw KEY/VALUE table. Prefer a `go:embed`-ed `<cmd>_schema.json` (a JSON Schema
+  whose root `type` is `array`, decorated with `x-kvx-list`/`x-kvx-detail` extensions).
+  See `pkg/cmd/scafctl/get/provider/provider.go` + `provider_schema.json` for the
+  canonical pattern. Note the two distinct slots: `kvx.WithOutputSchemaJSON` only tunes
+  **table column hints**, while `kvx.WithOutputDisplaySchemaJSON` drives the **interactive
+  TUI** -- an array command wants the display schema (and may add both). **Single-object
+  or scalar output does not need a schema** (e.g. `auth token`) -- the author may still
+  add one, but it is not required.
 - Use `cobra.Command` for command definition and flag binding
 - Wire up `settings.Run` parameters from flags
 - Always add new commands to CLI integration tests (`tests/integration/cli_test.go`)

--- a/.opencode/agent/artifact-auditor.md
+++ b/.opencode/agent/artifact-auditor.md
@@ -30,7 +30,10 @@ prompt's steps. This agent file provides the shared procedure and checklist.
    - New/changed provider (`pkg/provider/**`) -> docs, example, solution
      integration test, benchmark, `mock.go`, MCP schema exposure.
    - New/changed CLI command (`pkg/cmd/scafctl/**`) -> docs, CLI integration
-     test, `--help` coverage.
+     test, `--help` coverage. If the command emits an **array of objects** via
+     kvx, an interactive display schema (`kvx.WithOutputDisplaySchemaJSON`,
+     typically a `go:embed`-ed `<cmd>_schema.json` with `x-kvx-list`/`x-kvx-detail`)
+     is an expected artifact; single-object/scalar output is exempt.
    - New/changed exported type or interface -> unit tests in `*_test.go`,
      doc comments on exported symbols, mock updates if an interface changed.
    - New/changed feature or behavior -> docs, tutorial (if user-facing), example.

--- a/.opencode/agent/go-reviewer.md
+++ b/.opencode/agent/go-reviewer.md
@@ -26,6 +26,7 @@ When invoked directly (not via a prompt), run this procedure:
 
 - **Terminal output**: Must use `writer.FromContext(ctx)`, never `fmt.Fprintf` directly
 - **Structured data output**: Must use `kvx.OutputOptions` with table/json/yaml support
+- **Array output display schema**: A command that emits an **array of objects** via kvx should attach an interactive display schema (`kvx.WithOutputDisplaySchemaJSON`, a `go:embed`-ed `<cmd>_schema.json` with `x-kvx-list`/`x-kvx-detail` extensions) so `-i` renders a card/detail view rather than a plain KEY/VALUE table. Note `WithOutputSchemaJSON` only tunes table column hints; it is not a substitute. Single-object/scalar output does not need one. Canonical example: `pkg/cmd/scafctl/get/provider/provider.go` + `provider_schema.json`
 - **Business logic placement**: Must be in `pkg/`, never in `pkg/cmd/scafctl/...` or `pkg/mcp/tools_*.go`
 - **Struct tags**: Must have JSON/YAML tags and Huma validation tags (`doc`, `maxLength`, `example`, etc.)
 - **Constants**: No magic strings or numbers -- use constants or settings

--- a/docs/design/cli-contributing.md
+++ b/docs/design/cli-contributing.md
@@ -601,6 +601,51 @@ Enable with `-i` or `--interactive`:
 scafctl run solution -f config.yaml -i
 ```
 
+### Display Schemas for Array Output
+
+`kvx.OutputOptions` has **two distinct schema slots**, and they do different things:
+
+| Option | Slot | Effect |
+|--------|------|--------|
+| `kvx.WithOutputSchemaJSON` | column-hint schema | Tunes the **table** view only (column titles, widths). |
+| `kvx.WithOutputDisplaySchemaJSON` | display schema | Drives the **interactive TUI** (`-i`): a card list plus a sectioned detail pane. |
+
+**Rule of thumb:** a command that emits an **array of objects** should attach a
+**display schema** by default so `-i` renders a rich card/detail view instead of
+falling back to a plain KEY/VALUE table. A command that emits a **single object**
+or a scalar (for example `auth token`) does not need one -- a KEY/VALUE table
+renders fine, and the author may add a schema only if they want to.
+
+Prefer a `go:embed`-ed `<cmd>_schema.json` file. The schema is a JSON Schema whose
+root `type` is `array`, decorated with `x-kvx-*` vendor extensions:
+
+- `x-kvx-icon`, `x-kvx-collectionTitle` -- collection-level chrome.
+- `x-kvx-list` -- card rendering (`titleField`, `subtitleField`, `badgeFields`).
+- `x-kvx-detail` -- detail pane (`titleField`, `hiddenFields`, `sections[]` with a
+  per-section `layout` of `inline`, `paragraph`, `tags`, or `table`).
+- `items` -- a standard JSON Schema object describing each element.
+
+The canonical example is `get provider`:
+
+```go
+//go:embed provider_schema.json
+var providerSchemaJSON []byte
+
+func (o *Options) writeOutput(ctx context.Context, data any) error {
+    kvxOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags,
+        kvx.WithOutputContext(ctx),
+        kvx.WithOutputAppName(o.BinaryName+" get provider"),
+        kvx.WithOutputDisplaySchemaJSON(providerSchemaJSON), // interactive card/detail
+        kvx.WithIOStreams(o.IOStreams),
+    )
+    return kvxOpts.Write(data)
+}
+```
+
+See `pkg/cmd/scafctl/get/provider/provider.go` and its `provider_schema.json` for
+the full schema. You can attach **both** slots -- a column-hint schema for the table
+and a display schema for `-i` -- when you want to tune both views.
+
 ### CEL Filtering
 
 Use `-e` or `--expression` to filter/transform output:


### PR DESCRIPTION
## Description

Commands that emit an array of objects through kvx should attach an interactive display schema (`kvx.WithOutputDisplaySchemaJSON`) by default so `-i` renders a card list + detail pane instead of a plain KEY/VALUE table. Single-object or scalar output does not need one.

- `cli-commands.instructions.md`: add the path-scoped rule, documenting the two schema slots (`WithOutputSchemaJSON` tunes the table; `WithOutputDisplaySchemaJSON` drives the interactive TUI) and the `go:embed <cmd>_schema.json` convention, citing get provider as the canonical example.
- `copilot-instructions.md`: extend the Data Output bullet with a pointer to the array display-schema convention.
- `cli-contributing.md`: add a *Display Schemas for Array Output* subsection under *Data Output with kvx* with the two-slot table and a `go:embed` example.

## Examples

### Interactive mode with no schema

`scafctl catalog list -i`:

<img width="2292" height="1008" alt="image" src="https://github.com/user-attachments/assets/bc3c319a-3046-4024-b56c-b8bbabb551cf" />

### Interactive mode with schema

 `scafctl get providers -i`:

<img width="2306" height="1028" alt="image" src="https://github.com/user-attachments/assets/72e786cf-1462-4e94-b202-21132052e4db" />

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My commits follow conventional commit format
- [ ] I have added/updated tests for my changes
- [ ] `go test ./...` passes
- [ ] `task lint` passes
- [x] I have signed off my commits (`git commit -s -S`)
