### PR TITLE
feat: make validate the single gate (validate schema, validate solution, lint-in-validate)

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -42,9 +42,13 @@ scafctl <verb> <kind> <name[@version(or constraint)]> [flags]
 | `eval cel` | ✅ Implemented | Evaluate CEL expressions from CLI |
 | `eval template` | ✅ Implemented | Evaluate Go templates from CLI |
 | `eval validate` | ✅ Implemented | Validate solution files from CLI |
+| `validate solution` | ✅ Implemented | Primary gate: loads a solution and runs lint (errors fail, warnings surface, `--strict` makes warnings fatal) |
+| `validate resolver` | ✅ Implemented | Validates resolvers, then runs lint as a gate (`--strict` makes lint warnings fatal) |
+| `validate schema` | ✅ Implemented | Validate arbitrary data (JSON/YAML, `--data -` for stdin) against a JSON Schema |
 | `new solution` | ✅ Implemented | Scaffold a new solution from template |
 | `lint rules` | ✅ Implemented | List all available lint rules |
 | `lint explain` | ✅ Implemented | Explain a specific lint rule |
+| `lint` | ✅ Implemented | Advisory subset of `validate`: reports authoring warnings/findings without being the pass/fail gate |
 | `examples list` | ✅ Implemented | List available example configurations |
 | `examples get` | ✅ Implemented | Get/download an example file |
 | `push solution/plugin` | 📋 Planned | Remote catalog feature |
@@ -988,6 +992,60 @@ scafctl new solution --name my-solution --providers static,exec,cel
 
 ---
 
+## Validation Gate
+
+`validate` is THE gate that decides whether a definition is correct and ready.
+It runs lint (which includes a JSON Schema conformance check) and turns findings
+into a pass/fail result suitable for CI pipelines and pre-commit checks. `lint`
+is the advisory subset -- it reports the same authoring findings but is not the
+pass/fail gate on its own.
+
+### Validate a Solution
+
+Loads a solution and runs lint. Lint errors (including schema violations) fail;
+lint warnings are surfaced but do not fail unless `--strict` is passed:
+
+~~~bash
+# Validate the auto-discovered solution (errors fail, warnings surface)
+scafctl validate solution
+
+# Validate a specific file
+scafctl validate solution -f ./my-solution.yaml
+
+# Treat warnings as fatal too
+scafctl validate solution -f ./my-solution.yaml --strict
+~~~
+
+### Validate Resolvers
+
+Executes the resolver phases (resolve, transform, validate) and, after they
+pass, additionally runs lint as part of the gate. `--strict` makes lint
+warnings fatal:
+
+~~~bash
+scafctl validate resolver -f ./my-solution.yaml
+scafctl validate resolver -f ./my-solution.yaml --strict
+~~~
+
+### Validate Data Against a JSON Schema
+
+Validates arbitrary data (JSON or YAML) against a JSON Schema. Unlike
+`validate solution`, this does NOT run lint -- it checks raw data conformance
+only. Pass `--data -` to read the data from stdin:
+
+~~~bash
+# Validate a data file against a schema (both JSON or YAML)
+scafctl validate schema --schema schema.json --data data.json
+
+# Read the data from stdin
+cat data.yaml | scafctl validate schema --schema schema.json --data -
+~~~
+
+Exit codes: `0` conforms, `2` violates the schema, `3` the schema itself is
+invalid, `4` a file was not found.
+
+---
+
 ## Exploring Lint Rules
 
 ### List Rules
@@ -1094,6 +1152,9 @@ scafctl uses two distinct command grammar patterns:
 | `scafctl lint explain` | lint | explain |
 | `scafctl eval cel` | eval | cel |
 | `scafctl eval template` | eval | template |
+| `scafctl validate solution` | validate | solution |
+| `scafctl validate resolver` | validate | resolver |
+| `scafctl validate schema` | validate | schema |
 | `scafctl get examples` | get | examples |
 | `scafctl cache clean` | cache | clean |
 | `scafctl plugins list` | plugins | list |

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -20,6 +20,13 @@ flowchart LR
   A["Solution<br/>YAML"] --> B["scafctl<br/>lint"] --> C["Findings<br/>(warnings, errors)"]
 ```
 
+> **`lint` is the advisory subset of `validate`.** `scafctl lint` reports
+> authoring findings but is not itself the pass/fail gate. When you want a
+> single pass/fail gate for CI or pre-commit, use `scafctl validate solution`
+> (which runs lint internally: errors fail, warnings surface, `--strict` makes
+> warnings fatal). See the [Validation Patterns tutorial](../validation-patterns-tutorial/#the-validate-gate)
+> for the gate commands.
+
 ## 1. Linting a Solution
 
 ### Basic Lint

--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -603,7 +603,7 @@ This reveals the provider returned `60000` — confirming the root cause is the 
 
 ## Validate Resolver
 
-When your primary intent is to **gate on validation** rather than inspect values, use the dedicated `scafctl validate resolver` command. It behaves like `run resolver` but presets fatal validation: validation failures exit `2` (validation failed). It is equivalent to `run resolver --fail-on-validation`, expressed as a first-class verb for clarity in scripts and CI pipelines.
+When your primary intent is to **gate on validation** rather than inspect values, use the dedicated `scafctl validate resolver` command. It behaves like `run resolver` but presets fatal validation: validation failures exit `2` (validation failed). After the resolver phases pass, it additionally runs `lint` as part of the gate -- lint errors (including JSON Schema violations) fail, lint warnings are surfaced, and `--strict` makes lint warnings fatal too. This makes `validate resolver` a first-class gate verb for scripts and CI pipelines.
 
 {{< tabs "run-resolver-tutorial-cmd-validate" >}}
 {{% tab "Bash" %}}
@@ -618,7 +618,7 @@ scafctl validate resolver -f phases-demo.yaml -o json
 {{% /tab %}}
 {{< /tabs >}}
 
-The resolved values are still printed and diagnostics still appear on stderr, but the command exits `2` when any resolver fails validation. Use `run resolver` for day-to-day troubleshooting (exit `0`) and `validate resolver` when a non-zero exit on validation failure is the goal.
+The resolved values are still printed and diagnostics still appear on stderr, but the command exits `2` when any resolver fails validation or when lint reports an error (or a warning under `--strict`). Use `run resolver` for day-to-day troubleshooting (exit `0`) and `validate resolver` when a non-zero exit on validation or lint failure is the goal. To validate a whole solution as a gate without focusing on resolvers, use [`scafctl validate solution`](../../design/cli/#validation-gate).
 
 ---
 

--- a/docs/tutorials/validation-patterns-tutorial.md
+++ b/docs/tutorials/validation-patterns-tutorial.md
@@ -26,7 +26,8 @@ block-beta
 - **Schema helper tags** — provider-level input constraints (type, length, pattern, enum)
 - **Validation provider** — runtime regex and CEL-based checks on resolver values
 - **Result schemas** — JSON Schema validation of action outputs
-- **Lint rules** — static analysis at `scafctl lint` time
+- **Lint rules** -- static analysis at `scafctl lint` time (the advisory subset)
+- **Validate gate** -- `scafctl validate` runs lint as a pass/fail gate for CI and pre-commit; `scafctl validate schema` checks arbitrary data against a JSON Schema
 
 ---
 
@@ -462,7 +463,78 @@ scafctl lint ./solutions/
 
 ---
 
-## 5. Common Validation Patterns Reference
+## 5. The `validate` Gate
+
+While `scafctl lint` is the **advisory** subset that reports authoring findings,
+`scafctl validate` is THE **gate** that turns those findings into a pass/fail
+result. It runs lint (which includes a JSON Schema conformance check) and exits
+non-zero when the definition is not ready -- ideal for CI pipelines and
+pre-commit checks.
+
+### Validate a Solution
+
+Loads a solution and runs lint. Lint errors (including schema violations) fail;
+lint warnings are surfaced but do not fail unless `--strict` is passed:
+
+{{< tabs "validation-patterns-tutorial-validate-solution" >}}
+{{% tab "Bash" %}}
+```bash
+# Errors fail, warnings surface (exit 0 if only warnings)
+scafctl validate solution -f my-solution.yaml
+
+# Treat warnings as fatal too
+scafctl validate solution -f my-solution.yaml --strict
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Errors fail, warnings surface (exit 0 if only warnings)
+scafctl validate solution -f my-solution.yaml
+
+# Treat warnings as fatal too
+scafctl validate solution -f my-solution.yaml --strict
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+`scafctl validate resolver` behaves the same way but first executes the resolver
+phases (resolve, transform, validate) and then runs lint as part of the gate;
+`--strict` makes lint warnings fatal there too.
+
+### Validate Arbitrary Data Against a JSON Schema
+
+`scafctl validate schema` validates any JSON or YAML document against a JSON
+Schema. Unlike `validate solution`, it does NOT run lint -- it checks raw data
+conformance only, so it works for config files, API payloads, or any document.
+Pass `--data -` to read the data from stdin:
+
+{{< tabs "validation-patterns-tutorial-validate-schema" >}}
+{{% tab "Bash" %}}
+```bash
+# Validate a data file against a schema (both JSON or YAML)
+scafctl validate schema --schema schema.json --data data.json
+
+# Read the data from stdin
+cat data.yaml | scafctl validate schema --schema schema.json --data -
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Validate a data file against a schema (both JSON or YAML)
+scafctl validate schema --schema schema.json --data data.json
+
+# Read the data from stdin
+Get-Content data.yaml | scafctl validate schema --schema schema.json --data -
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+Exit codes: `0` conforms, `2` violates the schema, `3` the schema itself is
+invalid, `4` a file was not found.
+
+---
+
+## 6. Common Validation Patterns Reference
 
 ### String Patterns
 
@@ -560,7 +632,7 @@ validate:
 
 ---
 
-## 6. Dynamic Validation Messages
+## 7. Dynamic Validation Messages
 
 The `message` field supports dynamic evaluation using `expr:` (CEL) or `tmpl:` (Go template) prefixes. This lets you include the actual value or computed context in error messages.
 
@@ -617,7 +689,7 @@ validate:
 
 ---
 
-## 7. Validation Failure Diagnostics
+## 8. Validation Failure Diagnostics
 
 When validation fails, scafctl provides structured error messages. Use the MCP `explain_error` tool or inspect the output directly:
 
@@ -648,7 +720,7 @@ Common validation error patterns and their meaning:
 
 ---
 
-## 8. Cross-Resolver (Two-Phase) Validation
+## 9. Cross-Resolver (Two-Phase) Validation
 
 Most validation rules check a single value against itself with `__self`. Sometimes
 you need to validate one resolver *against another* -- for example, ensuring a

--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -80,7 +80,7 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 	cmd := &cobra.Command{
 		Use:     "lint [name[@version]]",
 		Aliases: []string{"l", "check"},
-		Short:   "Lint a solution file for issues and best practices",
+		Short:   "Report authoring warnings and best practices (the advisory subset of 'validate')",
 		Long: heredoc.Doc(`
 			Analyze a solution file for potential issues, anti-patterns, and best practices.
 
@@ -242,30 +242,62 @@ func runLint(ctx context.Context, opts *Options) error {
 		return nil
 	}
 
-	kvxOpts := flags.ToKvxOutputOptions(&opts.KvxOutputFlags,
-		kvx.WithIOStreams(opts.IOStreams),
+	// Render via the shared renderer so 'scafctl lint', 'validate solution',
+	// and 'validate resolver's lint gate all produce identical finding output.
+	// runLint applies severity filtering (above) before rendering; the gate
+	// callers render unfiltered on purpose.
+	if renderErr := RenderResult(ctx, result, opts.BinaryName+" lint", opts.IOStreams, opts.KvxOutputFlags, opts.CliParams.NoColor); renderErr != nil {
+		writeError(opts, fmt.Sprintf("failed to write output: %v", renderErr))
+		return renderErr
+	}
+
+	if result.ErrorCount > 0 {
+		return exitcode.WithCode(fmt.Errorf("found %d errors", result.ErrorCount), exitcode.ValidationFailed)
+	}
+
+	return nil
+}
+
+// RenderResult renders a lint result using the same output path as the 'lint'
+// command, so callers (e.g. 'validate solution') produce identical findings
+// output. It writes findings to the provided IO streams via kvx and returns an
+// error only if writing fails -- it does NOT make a pass/fail decision, leaving
+// exit-code policy to the caller. The appName is used for kvx display context
+// (e.g. "scafctl validate solution").
+//
+// When the output format is a human-readable (non-structured) table and there
+// are no findings, a success message is emitted and nil is returned.
+func RenderResult(
+	ctx context.Context,
+	result *Result,
+	appName string,
+	ioStreams *terminal.IOStreams,
+	outputFlags flags.KvxOutputFlags,
+	noColor bool,
+) error {
+	if result == nil {
+		return nil
+	}
+
+	kvxOpts := flags.ToKvxOutputOptions(&outputFlags,
+		kvx.WithIOStreams(ioStreams),
 		kvx.WithOutputContext(ctx),
-		kvx.WithOutputNoColor(opts.CliParams.NoColor),
-		kvx.WithOutputAppName(opts.BinaryName+" lint"),
+		kvx.WithOutputNoColor(noColor),
+		kvx.WithOutputAppName(appName),
 		kvx.WithOutputDisplaySchemaJSON(lintSchemaJSON),
 		kvx.WithOutputColumnHints(findingsColumnHints()),
 		kvx.WithOutputColumnOrder([]string{"severity", "ruleName", "location", "message"}),
 	)
 
-	// For table output, project findings to the four visible columns so
-	// the columnar renderer sees exactly 4 fields (not the full 9-field
-	// struct) and stays in table mode at narrower terminal widths.
-	// For structured formats (json/yaml), emit the full result with all
-	// fields and summary counts.
 	var outputData any = result
-	if !kvx.IsStructuredFormat(kvxOpts.Format) && opts.KvxOutputFlags.Expression == "" {
+	if !kvx.IsStructuredFormat(kvxOpts.Format) && outputFlags.Expression == "" {
 		if len(result.Findings) == 0 {
-			w := writer.FromContext(ctx)
-			w.Success("No lint issues found.")
+			if w := writer.FromContext(ctx); w != nil {
+				w.Success("No lint issues found.")
+			}
 			return nil
 		}
-		if opts.KvxOutputFlags.Interactive {
-			// Interactive mode: pass full findings for rich detail view.
+		if outputFlags.Interactive {
 			outputData = result.Findings
 		} else {
 			outputData = projectFindings(result.Findings)
@@ -273,12 +305,7 @@ func runLint(ctx context.Context, opts *Options) error {
 	}
 
 	if err := kvxOpts.Write(outputData); err != nil {
-		writeError(opts, fmt.Sprintf("failed to write output: %v", err))
 		return exitcode.WithCode(err, exitcode.GeneralError)
-	}
-
-	if result.ErrorCount > 0 {
-		return exitcode.WithCode(fmt.Errorf("found %d errors", result.ErrorCount), exitcode.ValidationFailed)
 	}
 
 	return nil

--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -267,6 +267,9 @@ func runLint(ctx context.Context, opts *Options) error {
 //
 // When the output format is a human-readable (non-structured) table and there
 // are no findings, a success message is emitted and nil is returned.
+//
+// The 'quiet' format renders NOTHING to stdout (its contract is exit-code
+// only); all callers get this behavior consistently through this function.
 func RenderResult(
 	ctx context.Context,
 	result *Result,
@@ -276,6 +279,12 @@ func RenderResult(
 	noColor bool,
 ) error {
 	if result == nil {
+		return nil
+	}
+
+	// Quiet is exit-code only: emit no output regardless of findings. The
+	// caller is responsible for translating findings into an exit code.
+	if outputFlags.Output == "quiet" {
 		return nil
 	}
 

--- a/pkg/cmd/scafctl/lint/lint_test.go
+++ b/pkg/cmd/scafctl/lint/lint_test.go
@@ -648,7 +648,7 @@ spec:
 	solPath := filepath.Join(tmpDir, "solution.yaml")
 	require.NoError(t, os.WriteFile(solPath, []byte(sol), 0o600))
 
-	ioStreams, _, _ := terminal.NewTestIOStreams()
+	ioStreams, out, _ := terminal.NewTestIOStreams()
 	ctx := testContext(ioStreams)
 	opts := &Options{
 		File:           solPath,
@@ -660,6 +660,37 @@ spec:
 	}
 	err := runLint(ctx, opts)
 	assert.NoError(t, err)
+	assert.Empty(t, out.String(), "quiet must produce no stdout on a clean solution")
+}
+
+// TestRenderResult_QuietProducesNoOutput verifies the shared renderer emits
+// nothing for the quiet format, regardless of findings -- so all callers
+// (lint, validate solution, validate resolver's gate) honor quiet's
+// exit-code-only contract consistently.
+func TestRenderResult_QuietProducesNoOutput(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, out, errOut := terminal.NewTestIOStreams()
+	ctx := testContext(ioStreams)
+
+	// A clean result (no findings): must not print "No lint issues found."
+	clean := &Result{Findings: nil}
+	require.NoError(t, RenderResult(ctx, clean, "scafctl lint", ioStreams,
+		flags.KvxOutputFlags{Output: "quiet"}, false))
+	assert.Empty(t, out.String())
+	assert.Empty(t, errOut.String())
+
+	// A result WITH findings: still no output under quiet.
+	withFindings := &Result{Findings: []*Finding{{
+		Severity: SeverityError,
+		RuleName: "schema-violation",
+		Location: "spec",
+		Message:  "boom",
+	}}}
+	require.NoError(t, RenderResult(ctx, withFindings, "scafctl lint", ioStreams,
+		flags.KvxOutputFlags{Output: "quiet"}, false))
+	assert.Empty(t, out.String())
+	assert.Empty(t, errOut.String())
 }
 
 func TestRunLint_FileNotFound(t *testing.T) {

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -751,7 +751,9 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 func (o *ResolverOptions) runLintGate(ctx context.Context, sol *solution.Solution, reg *provider.Registry) error {
 	result := pkglint.Solution(sol, sol.GetPath(), reg)
 
-	if len(result.Findings) > 0 {
+	// Honor -o quiet: exit-code-only, no lint block (header or findings). The
+	// pass/fail policy below still applies via ErrorCount/WarnCount.
+	if len(result.Findings) > 0 && o.Output != "quiet" {
 		w := writer.FromContext(ctx)
 		if w == nil && o.IOStreams != nil {
 			cliParams := o.CliParams
@@ -782,8 +784,6 @@ func (o *ResolverOptions) runLintGate(ctx context.Context, sol *solution.Solutio
 			if o.CliParams != nil {
 				noColor = o.CliParams.NoColor
 			}
-			// Force a human-readable table render; do not inherit the
-			// resolver's -o json/yaml format for the lint findings block.
 			lintFlags := cmdflags.KvxOutputFlags{Output: "table"}
 			if renderErr := cmdlint.RenderResult(ctx, result, appName+" validate resolver", errStreams, lintFlags, noColor); renderErr != nil {
 				return renderErr

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -785,7 +785,7 @@ func (o *ResolverOptions) runLintGate(ctx context.Context, sol *solution.Solutio
 			// Force a human-readable table render; do not inherit the
 			// resolver's -o json/yaml format for the lint findings block.
 			lintFlags := cmdflags.KvxOutputFlags{Output: "table"}
-			if renderErr := cmdlint.RenderResult(ctx, result, appName+" lint", errStreams, lintFlags, noColor); renderErr != nil {
+			if renderErr := cmdlint.RenderResult(ctx, result, appName+" validate resolver", errStreams, lintFlags, noColor); renderErr != nil {
 				return renderErr
 			}
 		}

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -17,9 +17,12 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	cmdflags "github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	cmdlint "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/lint"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/filepath"
 	"github.com/oakwood-commons/scafctl/pkg/flags"
+	pkglint "github.com/oakwood-commons/scafctl/pkg/lint"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
@@ -77,6 +80,12 @@ type ResolverOptions struct {
 	// resolver fails validation. By default, validation failures are reported as
 	// non-fatal diagnostics (values are still shown) and the command exits 0.
 	FailOnValidation bool
+
+	// LintAfterValidate, when true, runs lint on the solution after resolver
+	// validation passes. It is set by 'validate resolver' so that command acts
+	// as a full gate (resolver validation + lint). 'run resolver' leaves it
+	// false.
+	LintAfterValidate bool
 
 	// DynamicArgs are resolver parameters from positional key=value syntax
 	// (e.g. env=prod region=us-east-1, captured from positional args containing '=').
@@ -287,7 +296,7 @@ Examples:
 // 'run resolver', it does not expose graph/snapshot modes — its sole purpose is
 // to validate resolver outputs and report failures.
 func CommandValidateResolver(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	options := &ResolverOptions{FailOnValidation: true}
+	options := &ResolverOptions{FailOnValidation: true, LintAfterValidate: true}
 
 	cfg := runCommandConfig{
 		cliParams: cliParams,
@@ -307,7 +316,7 @@ func CommandValidateResolver(cliParams *settings.Run, ioStreams *terminal.IOStre
 	cCmd := &cobra.Command{
 		Use:     "resolver [resolver-name...] [key=value...]",
 		Aliases: []string{"res", "resolvers"},
-		Short:   "Validate resolvers and fail when validation does not pass",
+		Short:   "Validate resolvers (then lint) and fail when validation does not pass",
 		Long: strings.ReplaceAll(`Validate a solution's resolvers and exit non-zero on validation failure.
 
 This command executes the resolvers (resolve, transform, and validate phases)
@@ -316,15 +325,20 @@ treats validation failures as non-fatal diagnostics and exits 0, this command
 exits with code 2 when any resolver fails validation. Use it as a validation
 gate in CI pipelines or pre-commit checks.
 
+After resolver validation passes, it additionally runs lint on the solution as
+part of the gate: lint errors (including JSON Schema violations) fail; lint
+warnings are surfaced and, with --strict, are also fatal. Resolver-validation
+failures are reported before lint and are never masked by lint output.
+
 Resolved values are still printed so failures can be inspected. Input
 parameters and solution sources work exactly as in 'run resolver'.
 
 `+ResolverParametersHelp+`
 
 EXIT CODES:
-  0  All resolvers validated successfully
+  0  All resolvers validated and lint passed
   1  Resolver execution failed
-  2  Validation failed
+  2  Validation failed (resolver validation, lint errors, or --strict warnings)
   3  Invalid solution (cycle/parse error)
   4  File not found
 
@@ -337,6 +351,9 @@ Examples:
 
   # Validate with parameters
   scafctl validate resolver -f ./my-solution.yaml env=prod region=us-east1
+
+  # Treat lint warnings as fatal too
+  scafctl validate resolver -f ./my-solution.yaml --strict
 
   # Validate specific resolvers (with their dependencies)
   scafctl validate resolver db config -f ./my-solution.yaml`, settings.CliBinaryName, cliParams.BinaryName),
@@ -356,6 +373,12 @@ Examples:
 	addSharedResolverFlags(cCmd, &options.sharedResolverOptions)
 	cCmd.Flags().BoolVar(&options.ShowExecution, "show-execution", false, "Include __execution metadata (phases, timing, dependencies, providers) in output")
 	cCmd.Flags().StringArrayVar(&options.Actions, "action", nil, "Scope validation to the resolvers consumed by this action (repeatable)")
+	// --strict is registered by addSharedResolverFlags (it also disables
+	// provider auto-resolution). In the validate gate it additionally makes
+	// lint warnings fatal; reflect that combined meaning in the help text.
+	if f := cCmd.Flags().Lookup("strict"); f != nil {
+		f.Usage = "Strict gate: treat lint warnings as fatal and require explicit bundle.plugins (errors and schema violations are always fatal)"
+	}
 
 	setResolverHelpFunc(cCmd)
 
@@ -702,6 +725,83 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 	// is set, exit non-zero so CI/gating callers detect the failure.
 	if execErr != nil && o.FailOnValidation {
 		return exitcode.WithCode(execErr, exitcode.ValidationFailed)
+	}
+
+	// Gate mode ('validate resolver'): after resolver validation passes, run
+	// lint on the solution as an additional gate. Lint errors fail; lint
+	// warnings are surfaced and, with --strict, are also fatal. This runs only
+	// when resolver validation did not already fail above, so resolver failures
+	// are never masked by lint output.
+	if o.LintAfterValidate {
+		if err := o.runLintGate(ctx, sol, reg); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// runLintGate runs lint on the solution and applies the validate-gate policy:
+// lint errors always fail; lint warnings fail only when --strict is set.
+// Findings are surfaced on stderr so they do not pollute resolver output on
+// stdout. It renders findings through the shared lint renderer
+// (cmdlint.RenderResult) so the finding format is identical to 'scafctl lint'
+// and 'validate solution'; the only difference is the stream (stderr, to keep
+// stdout clean for resolver JSON).
+func (o *ResolverOptions) runLintGate(ctx context.Context, sol *solution.Solution, reg *provider.Registry) error {
+	result := pkglint.Solution(sol, sol.GetPath(), reg)
+
+	if len(result.Findings) > 0 {
+		w := writer.FromContext(ctx)
+		if w == nil && o.IOStreams != nil {
+			cliParams := o.CliParams
+			if cliParams == nil {
+				cliParams = &settings.Run{}
+			}
+			w = writer.New(o.IOStreams, cliParams)
+		}
+		if w != nil {
+			w.WarnStderrf("lint reported %d error(s), %d warning(s):", result.ErrorCount, result.WarnCount)
+		}
+
+		// Render findings via the shared renderer so the format matches
+		// 'scafctl lint' and 'validate solution'. Redirect the renderer's
+		// stdout to stderr so resolver JSON on stdout stays clean.
+		if o.IOStreams != nil {
+			errStreams := &terminal.IOStreams{
+				In:           o.IOStreams.In,
+				Out:          o.IOStreams.ErrOut,
+				ErrOut:       o.IOStreams.ErrOut,
+				ColorEnabled: o.IOStreams.ColorEnabled,
+			}
+			appName := o.BinaryName
+			if appName == "" {
+				appName = settings.CliBinaryName
+			}
+			noColor := false
+			if o.CliParams != nil {
+				noColor = o.CliParams.NoColor
+			}
+			// Force a human-readable table render; do not inherit the
+			// resolver's -o json/yaml format for the lint findings block.
+			lintFlags := cmdflags.KvxOutputFlags{Output: "table"}
+			if renderErr := cmdlint.RenderResult(ctx, result, appName+" lint", errStreams, lintFlags, noColor); renderErr != nil {
+				return renderErr
+			}
+		}
+	}
+
+	if result.ErrorCount > 0 {
+		return exitcode.WithCode(
+			fmt.Errorf("lint failed: %d error(s)", result.ErrorCount),
+			exitcode.ValidationFailed,
+		)
+	}
+	if o.Strict && result.WarnCount > 0 {
+		return exitcode.WithCode(
+			fmt.Errorf("lint failed: %d warning(s) (strict mode)", result.WarnCount),
+			exitcode.ValidationFailed,
+		)
 	}
 
 	return nil

--- a/pkg/cmd/scafctl/run/validate_resolver_test.go
+++ b/pkg/cmd/scafctl/run/validate_resolver_test.go
@@ -281,6 +281,52 @@ spec:
 	assert.Equal(t, exitcode.ValidationFailed, exitcode.GetCode(err))
 }
 
+// TestResolverOptions_Run_LintGateQuietSuppressesOutput verifies that -o quiet
+// suppresses the lint gate's output entirely (header and findings) while still
+// applying the pass/fail policy via the exit code.
+func TestResolverOptions_Run_LintGateQuietSuppressesOutput(t *testing.T) {
+	t.Parallel()
+
+	orphanSolution := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: orphan-quiet
+  version: 1.0.0
+spec:
+  resolvers:
+    orphan:
+      type: string
+      description: never referenced
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "x"
+`
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(orphanSolution), 0o600))
+
+	// Quiet, non-strict: no output, exit 0.
+	var so1, se1 bytes.Buffer
+	opts := newResolverOptions(t, solutionPath, &so1, &se1)
+	opts.LintAfterValidate = true
+	opts.Output = "quiet"
+	require.NoError(t, opts.Run(ctx()))
+	assert.NotContains(t, se1.String(), "lint reported", "quiet must suppress the lint gate header")
+	assert.NotContains(t, se1.String(), "unused-resolver", "quiet must suppress the findings table")
+
+	// Quiet, strict: still fails via exit code, still no output.
+	var so2, se2 bytes.Buffer
+	strictOpts := newResolverOptions(t, solutionPath, &so2, &se2)
+	strictOpts.LintAfterValidate = true
+	strictOpts.Strict = true
+	strictOpts.Output = "quiet"
+	err := strictOpts.Run(ctx())
+	require.Error(t, err)
+	assert.Equal(t, exitcode.ValidationFailed, exitcode.GetCode(err))
+	assert.NotContains(t, se2.String(), "lint reported", "quiet must suppress output even when failing")
+}
+
 // ctx returns a background context seeded with a logger, for lint-gate tests.
 func ctx() context.Context {
 	return logger.WithLogger(context.Background(), logger.Get(0))

--- a/pkg/cmd/scafctl/run/validate_resolver_test.go
+++ b/pkg/cmd/scafctl/run/validate_resolver_test.go
@@ -187,3 +187,101 @@ func TestCommandValidateResolver_EmbedderBinaryName(t *testing.T) {
 	cmd := CommandValidateResolver(cliParams, streams, "")
 	assert.Contains(t, cmd.Long, "mycli validate resolver", "help text must use the embedder binary name")
 }
+
+func TestCommandValidateResolver_HasStrictFlagAndLintGate(t *testing.T) {
+	t.Parallel()
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateResolver(cliParams, streams, "")
+	strict := cmd.Flags().Lookup("strict")
+	require.NotNil(t, strict, "validate resolver must expose --strict")
+	assert.Contains(t, strict.Usage, "lint warnings")
+}
+
+// cleanReferencedSolution has a resolver 'name' referenced by 'greeting', so
+// there are no unused-resolver warnings and resolver validation passes.
+const cleanReferencedSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: clean-referenced
+  version: 1.0.0
+spec:
+  resolvers:
+    name:
+      type: string
+      description: the subject's name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "Bob"
+    greeting:
+      description: a greeting using name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                expr: '"Hello " + _.name'
+`
+
+func TestResolverOptions_Run_LintGatePassesClean(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(cleanReferencedSolution), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	opts := newResolverOptions(t, solutionPath, &stdout, &stderr)
+	opts.LintAfterValidate = true
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	require.NoError(t, opts.Run(ctx), "clean solution must pass the lint gate")
+}
+
+func TestResolverOptions_Run_LintGateWarningFailsStrict(t *testing.T) {
+	t.Parallel()
+
+	// A lone unused resolver produces an unused-resolver warning while still
+	// passing resolver validation.
+	orphanSolution := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: orphan-warn
+  version: 1.0.0
+spec:
+  resolvers:
+    orphan:
+      type: string
+      description: never referenced
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "x"
+`
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(orphanSolution), 0o600))
+
+	// Non-strict: warning does not fail the gate.
+	var so1, se1 bytes.Buffer
+	opts := newResolverOptions(t, solutionPath, &so1, &se1)
+	opts.LintAfterValidate = true
+	require.NoError(t, opts.Run(ctx()), "warning must not fail the lint gate without --strict")
+
+	// Strict: warning fails the gate.
+	var so2, se2 bytes.Buffer
+	strictOpts := newResolverOptions(t, solutionPath, &so2, &se2)
+	strictOpts.LintAfterValidate = true
+	strictOpts.Strict = true
+	err := strictOpts.Run(ctx())
+	require.Error(t, err, "warning must fail the lint gate under --strict")
+	assert.Equal(t, exitcode.ValidationFailed, exitcode.GetCode(err))
+}
+
+// ctx returns a background context seeded with a logger, for lint-gate tests.
+func ctx() context.Context {
+	return logger.WithLogger(context.Background(), logger.Get(0))
+}

--- a/pkg/cmd/scafctl/validate/schema.go
+++ b/pkg/cmd/scafctl/validate/schema.go
@@ -1,0 +1,196 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/schema"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"sigs.k8s.io/yaml"
+
+	"github.com/spf13/cobra"
+)
+
+// schemaOptions holds flags for the 'validate schema' command.
+type schemaOptions struct {
+	SchemaFile string
+	DataFile   string
+}
+
+// CommandValidateSchema creates the 'validate schema' subcommand. It validates
+// arbitrary data (JSON or YAML) against a JSON Schema (JSON or YAML). It does
+// NOT run lint -- it operates on arbitrary data, not on a scafctl solution.
+func CommandValidateSchema(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	opts := &schemaOptions{}
+
+	binaryName := cliParams.BinaryName
+	if binaryName == "" {
+		binaryName = settings.CliBinaryName
+	}
+
+	cCmd := &cobra.Command{
+		Use:   "schema --schema <schema> --data <data>",
+		Short: fmt.Sprintf("Validate data against a JSON Schema (used by %s as a low-level gate)", binaryName),
+		Long: strings.ReplaceAll(`Validate arbitrary data against a JSON Schema and fail on any violation.
+
+Both the schema and the data may be supplied as JSON or YAML. Pass '-' to
+--data to read the data from stdin. Unlike 'validate solution', this command
+does NOT run lint: it checks raw data conformance only, which makes it useful
+for validating configuration files, API payloads, or any document against a
+schema of your choosing.
+
+EXIT CODES:
+  0  Data conforms to the schema
+  2  Data violates the schema
+  3  The schema is invalid, or the data could not be parsed as JSON/YAML
+  4  A schema or data file was not found
+
+Examples:
+  # Validate a data file against a schema (both JSON)
+  scafctl validate schema --schema schema.json --data data.json
+
+  # Schema and data as YAML
+  scafctl validate schema --schema schema.yaml --data data.yaml
+
+  # Read the data from stdin
+  cat data.yaml | scafctl validate schema --schema schema.json --data -`, settings.CliBinaryName, binaryName),
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Bare invocation (no flags at all): show help rather than a raw
+			// "required flag(s) not set" error (grammar Rule 8).
+			if opts.SchemaFile == "" && opts.DataFile == "" {
+				return cmd.Help()
+			}
+			// Only one of the two provided: give a clear, actionable message
+			// naming exactly what is missing and how to supply it.
+			var missing []string
+			if opts.SchemaFile == "" {
+				missing = append(missing, "--schema <file>")
+			}
+			if opts.DataFile == "" {
+				missing = append(missing, "--data <file|->")
+			}
+			if len(missing) > 0 {
+				w := writer.FromContext(cmd.Context())
+				if w == nil {
+					w = writer.New(ioStreams, cliParams)
+				}
+				w.Errorf("missing required flag(s): %s", strings.Join(missing, ", "))
+				w.Plainlnf("Usage: %s validate schema --schema <schema> --data <data|->", binaryName)
+				w.Plainlnf("Run '%s validate schema --help' for details.", binaryName)
+				return exitcode.WithCode(fmt.Errorf("missing required flags: %s", strings.Join(missing, ", ")), exitcode.InvalidInput)
+			}
+
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Name())
+			ctx := settings.IntoContext(cmd.Context(), cliParams)
+			if lgr := logger.FromContext(cmd.Context()); lgr != nil {
+				ctx = logger.WithLogger(ctx, lgr)
+			}
+			w := writer.FromContext(cmd.Context())
+			if w == nil {
+				w = writer.New(ioStreams, cliParams)
+			}
+			ctx = writer.WithWriter(ctx, w)
+
+			return runValidateSchema(ctx, opts, ioStreams)
+		},
+		SilenceUsage: true,
+	}
+
+	cCmd.Flags().StringVar(&opts.SchemaFile, "schema", "", "Path to the JSON Schema file (JSON or YAML) (required)")
+	cCmd.Flags().StringVar(&opts.DataFile, "data", "", "Path to the data file to validate (JSON or YAML); use '-' for stdin (required)")
+
+	return cCmd
+}
+
+// runValidateSchema reads the schema and data, validates, renders violations,
+// and returns an exit-coded error on any failure. Failures are printed to the
+// writer so the user sees an actionable message, not a silent non-zero exit.
+func runValidateSchema(ctx context.Context, opts *schemaOptions, ioStreams *terminal.IOStreams) error {
+	w := writer.FromContext(ctx)
+
+	fail := func(err error, code int) error {
+		if w != nil {
+			w.Errorf("%v", err)
+		}
+		return exitcode.WithCode(err, code)
+	}
+
+	schemaBytes, err := os.ReadFile(opts.SchemaFile)
+	if err != nil {
+		return fail(fmt.Errorf("reading schema file %q: %w", opts.SchemaFile, err), exitcode.FileNotFound)
+	}
+
+	dataBytes, err := readData(opts.DataFile, ioStreams)
+	if err != nil {
+		if w != nil {
+			w.Errorf("%v", err)
+		}
+		return err
+	}
+
+	var data any
+	if err := yaml.Unmarshal(dataBytes, &data); err != nil {
+		return fail(fmt.Errorf("parsing data as JSON/YAML: %w", err), exitcode.InvalidInput)
+	}
+
+	violations, err := schema.ValidateDataAgainstSchema(schemaBytes, data)
+	if err != nil {
+		return fail(fmt.Errorf("invalid schema: %w", err), exitcode.InvalidInput)
+	}
+
+	if len(violations) == 0 {
+		if w != nil {
+			w.Success("Data is valid against the schema.")
+		}
+		return nil
+	}
+
+	if w != nil {
+		w.WarnStderrf("%d schema violation(s):", len(violations))
+		for _, v := range violations {
+			if v.Path != "" {
+				w.PlainStderrf("  - %s: %s", v.Path, v.Message)
+			} else {
+				w.PlainStderrf("  - %s", v.Message)
+			}
+		}
+	}
+
+	return exitcode.WithCode(fmt.Errorf("data failed schema validation with %d violation(s)", len(violations)), exitcode.ValidationFailed)
+}
+
+// readData reads the data document from a file, or from stdin when the path is
+// '-'. Errors are already exit-coded: a stdin read failure maps to GeneralError
+// (it is not a missing file), while a missing/unreadable file maps to
+// FileNotFound.
+func readData(dataFile string, ioStreams *terminal.IOStreams) ([]byte, error) {
+	if dataFile == "-" {
+		var in io.Reader = os.Stdin
+		if ioStreams != nil && ioStreams.In != nil {
+			in = ioStreams.In
+		}
+		b, err := io.ReadAll(in)
+		if err != nil {
+			return nil, exitcode.WithCode(fmt.Errorf("reading data from stdin: %w", err), exitcode.GeneralError)
+		}
+		return b, nil
+	}
+
+	b, err := os.ReadFile(dataFile)
+	if err != nil {
+		return nil, exitcode.WithCode(fmt.Errorf("reading data file %q: %w", dataFile, err), exitcode.FileNotFound)
+	}
+	return b, nil
+}

--- a/pkg/cmd/scafctl/validate/schema_test.go
+++ b/pkg/cmd/scafctl/validate/schema_test.go
@@ -1,0 +1,158 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testSchemaJSON = `{
+  "type": "object",
+  "properties": {"name": {"type": "string"}},
+  "required": ["name"],
+  "additionalProperties": false
+}`
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+	return p
+}
+
+func TestCommandValidateSchema_Metadata(t *testing.T) {
+	t.Parallel()
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+
+	cmd := CommandValidateSchema(cliParams, streams, "mycli/validate")
+	assert.Equal(t, "schema", cmd.Name())
+	assert.Contains(t, cmd.Short, "mycli")
+	assert.NotNil(t, cmd.Flags().Lookup("schema"))
+	assert.NotNil(t, cmd.Flags().Lookup("data"))
+}
+
+func TestCommandValidateSchema_ValidData(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := writeFile(t, dir, "schema.json", testSchemaJSON)
+	dataPath := writeFile(t, dir, "data.json", `{"name":"hi"}`)
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateSchema(cliParams, streams, "scafctl/validate")
+	cmd.SetArgs([]string{"--schema", schemaPath, "--data", dataPath})
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+
+func TestCommandValidateSchema_InvalidData(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := writeFile(t, dir, "schema.json", testSchemaJSON)
+	dataPath := writeFile(t, dir, "data.json", `{"extra":"nope"}`)
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateSchema(cliParams, streams, "scafctl/validate")
+	cmd.SetArgs([]string{"--schema", schemaPath, "--data", dataPath})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Equal(t, exitcode.ValidationFailed, exitcode.GetCode(err))
+}
+
+func TestCommandValidateSchema_MissingSchemaFile(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := writeFile(t, dir, "data.json", `{"name":"hi"}`)
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateSchema(cliParams, streams, "scafctl/validate")
+	cmd.SetArgs([]string{"--schema", filepath.Join(dir, "nope.json"), "--data", dataPath})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Equal(t, exitcode.FileNotFound, exitcode.GetCode(err))
+}
+
+func TestCommandValidateSchema_NoFlagsShowsHelp(t *testing.T) {
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	// Bare 'validate schema' with no flags should show help, not error.
+	cmd := CommandValidateSchema(cliParams, streams, "scafctl/validate")
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	require.NoError(t, err, "bare invocation should show help, not error")
+}
+
+func TestCommandValidateSchema_OneFlagMissingErrors(t *testing.T) {
+	dir := t.TempDir()
+	dataPath := writeFile(t, dir, "data.json", `{"name":"hi"}`)
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	// Only --data provided: a clear, actionable InvalidInput error naming the
+	// missing flag (not a raw cobra "required flag(s) not set").
+	cmd := CommandValidateSchema(cliParams, streams, "scafctl/validate")
+	cmd.SetArgs([]string{"--data", dataPath})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Equal(t, exitcode.InvalidInput, exitcode.GetCode(err))
+	assert.Contains(t, err.Error(), "--schema")
+}
+
+func TestCommandValidateSchema_BadSchema(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := writeFile(t, dir, "schema.json", "this: is: bad: yaml:")
+	dataPath := writeFile(t, dir, "data.json", `{"name":"hi"}`)
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateSchema(cliParams, streams, "scafctl/validate")
+	cmd.SetArgs([]string{"--schema", schemaPath, "--data", dataPath})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Equal(t, exitcode.InvalidInput, exitcode.GetCode(err))
+}
+
+func TestCommandValidateSchema_YAMLFiles(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := writeFile(t, dir, "schema.yaml",
+		"type: object\nproperties:\n  name:\n    type: string\nrequired:\n  - name\n")
+	dataPath := writeFile(t, dir, "data.yaml", "name: hi\n")
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateSchema(cliParams, streams, "scafctl/validate")
+	cmd.SetArgs([]string{"--schema", schemaPath, "--data", dataPath})
+	require.NoError(t, cmd.Execute())
+}
+
+func TestCommandValidateSchema_DataFromStdin(t *testing.T) {
+	dir := t.TempDir()
+	schemaPath := writeFile(t, dir, "schema.json", testSchemaJSON)
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	streams.In = io.NopCloser(strings.NewReader(`{"name":"hi"}`))
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateSchema(cliParams, streams, "scafctl/validate")
+	cmd.SetArgs([]string{"--schema", schemaPath, "--data", "-"})
+	require.NoError(t, cmd.Execute())
+}

--- a/pkg/cmd/scafctl/validate/schema_test.go
+++ b/pkg/cmd/scafctl/validate/schema_test.go
@@ -117,7 +117,7 @@ func TestCommandValidateSchema_OneFlagMissingErrors(t *testing.T) {
 
 func TestCommandValidateSchema_BadSchema(t *testing.T) {
 	dir := t.TempDir()
-	schemaPath := writeFile(t, dir, "schema.json", "this: is: bad: yaml:")
+	schemaPath := writeFile(t, dir, "schema.json", "type: 123")
 	dataPath := writeFile(t, dir, "data.json", `{"name":"hi"}`)
 
 	streams, _, _ := terminal.NewTestIOStreams()

--- a/pkg/cmd/scafctl/validate/solution.go
+++ b/pkg/cmd/scafctl/validate/solution.go
@@ -16,6 +16,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	pkgvalidate "github.com/oakwood-commons/scafctl/pkg/validate"
@@ -71,6 +72,9 @@ Examples:
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(_ *cobra.Command, args []string) error {
 			if len(args) > 0 {
+				if err := get.ValidatePositionalRef(args[0], opts.File, binaryName+" validate solution"); err != nil {
+					return err
+				}
 				opts.File = args[0]
 			}
 			return nil
@@ -92,7 +96,7 @@ Examples:
 		SilenceUsage: true,
 	}
 
-	cCmd.Flags().StringVarP(&opts.File, "file", "f", "", "Solution file path (auto-discovered if not provided, use '-' for stdin)")
+	cCmd.Flags().StringVarP(&opts.File, "file", "f", "", "Solution file path (auto-discovered if not provided)")
 	cCmd.Flags().BoolVar(&opts.Strict, "strict", false, "Treat lint warnings as fatal (errors and schema violations are always fatal)")
 	flags.AddKvxOutputFlagsToStruct(cCmd, &opts.KvxOutputFlags)
 

--- a/pkg/cmd/scafctl/validate/solution.go
+++ b/pkg/cmd/scafctl/validate/solution.go
@@ -1,0 +1,153 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	cmdlint "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/lint"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	pkgvalidate "github.com/oakwood-commons/scafctl/pkg/validate"
+
+	"github.com/spf13/cobra"
+)
+
+// solutionOptions holds flags for the 'validate solution' command.
+type solutionOptions struct {
+	File           string
+	Strict         bool
+	KvxOutputFlags flags.KvxOutputFlags
+}
+
+// CommandValidateSolution creates the 'validate solution' subcommand -- the
+// primary validation gate. It loads a solution and runs lint: lint errors (and
+// schema violations, which lint reports) fail; lint warnings are surfaced and,
+// with --strict, are also fatal. Schema conformance is covered by lint's
+// built-in schema check, so it is not double-reported here.
+func CommandValidateSolution(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	opts := &solutionOptions{}
+
+	binaryName := cliParams.BinaryName
+	if binaryName == "" {
+		binaryName = settings.CliBinaryName
+	}
+
+	cCmd := &cobra.Command{
+		Use:     "solution [name[@version]]",
+		Aliases: []string{"sol"},
+		Short:   fmt.Sprintf("Validate that a %s solution is correct and ready (runs lint)", binaryName),
+		Long: strings.ReplaceAll(`Validate a solution and fail on any error. This is the primary gate: it loads
+the solution and runs lint, which includes a JSON Schema conformance check.
+
+Lint errors (including schema violations) always fail. Lint warnings are
+surfaced but do not fail by default; pass --strict to treat warnings as fatal
+too. Use it in CI pipelines or pre-commit checks as a single pass/fail gate.
+
+EXIT CODES:
+  0  Solution is valid (no errors; warnings allowed unless --strict)
+  2  Validation failed (lint errors, or warnings with --strict)
+  4  Solution file not found
+
+Examples:
+  # Validate the auto-discovered solution
+  scafctl validate solution
+
+  # Validate a specific solution file
+  scafctl validate solution -f ./my-solution.yaml
+
+  # Treat warnings as fatal
+  scafctl validate solution -f ./my-solution.yaml --strict`, settings.CliBinaryName, binaryName),
+		Args: cobra.MaximumNArgs(1),
+		PreRunE: func(_ *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				opts.File = args[0]
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Name())
+			ctx := settings.IntoContext(cmd.Context(), cliParams)
+			if lgr := logger.FromContext(cmd.Context()); lgr != nil {
+				ctx = logger.WithLogger(ctx, lgr)
+			}
+			w := writer.FromContext(cmd.Context())
+			if w == nil {
+				w = writer.New(ioStreams, cliParams)
+			}
+			ctx = writer.WithWriter(ctx, w)
+
+			return runValidateSolution(ctx, opts, cliParams, ioStreams)
+		},
+		SilenceUsage: true,
+	}
+
+	cCmd.Flags().StringVarP(&opts.File, "file", "f", "", "Solution file path (auto-discovered if not provided, use '-' for stdin)")
+	cCmd.Flags().BoolVar(&opts.Strict, "strict", false, "Treat lint warnings as fatal (errors and schema violations are always fatal)")
+	flags.AddKvxOutputFlagsToStruct(cCmd, &opts.KvxOutputFlags)
+
+	return cCmd
+}
+
+// runValidateSolution orchestrates loading + linting via the domain helper,
+// renders findings using the lint command's shared renderer, and applies the
+// pass/fail policy. The finding FORMAT is identical to 'scafctl lint' (same
+// renderer), but validate is intentionally UNFILTERED: as a gate it shows all
+// findings regardless of severity, whereas 'scafctl lint' filters by
+// --severity (default info). So the two match at default severity but validate
+// deliberately never hides findings.
+func runValidateSolution(ctx context.Context, opts *solutionOptions, cliParams *settings.Run, ioStreams *terminal.IOStreams) error {
+	registry := defaultRegistry(ctx)
+
+	res, err := pkgvalidate.Solution(ctx, opts.File, registry)
+	if err != nil {
+		if w := writer.FromContext(ctx); w != nil {
+			w.Errorf("%v", err)
+		}
+		return exitcode.WithCode(err, exitcode.FileNotFound)
+	}
+
+	appName := cliParams.BinaryName
+	if appName == "" {
+		appName = settings.CliBinaryName
+	}
+	if renderErr := cmdlint.RenderResult(ctx, res.Lint, appName+" validate solution", ioStreams, opts.KvxOutputFlags, cliParams.NoColor); renderErr != nil {
+		return renderErr
+	}
+
+	if res.Passed(opts.Strict) {
+		return nil
+	}
+
+	// Failure: distinguish error-driven vs strict-warning-driven failures.
+	if res.Lint.ErrorCount > 0 {
+		return exitcode.WithCode(
+			fmt.Errorf("validation failed: %d error(s)", res.Lint.ErrorCount),
+			exitcode.ValidationFailed,
+		)
+	}
+	return exitcode.WithCode(
+		fmt.Errorf("validation failed: %d warning(s) (strict mode)", res.Lint.WarnCount),
+		exitcode.ValidationFailed,
+	)
+}
+
+// defaultRegistry returns the builtin provider registry, falling back to the
+// global registry so provider-aware lint rules resolve correctly.
+func defaultRegistry(ctx context.Context) *provider.Registry {
+	reg, err := builtin.DefaultRegistry(ctx)
+	if err != nil {
+		return provider.GetGlobalRegistry()
+	}
+	return reg
+}

--- a/pkg/cmd/scafctl/validate/solution_test.go
+++ b/pkg/cmd/scafctl/validate/solution_test.go
@@ -131,3 +131,83 @@ func TestCommandValidateSolution_MissingFile(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, exitcode.FileNotFound, exitcode.GetCode(err))
 }
+
+// TestCommandValidateSolution_QuietEmptyStdout verifies that `-o quiet` on a
+// clean solution produces NO stdout (quiet's exit-code-only contract).
+func TestCommandValidateSolution_QuietEmptyStdout(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(cleanSolution), 0o600))
+
+	streams, _, out := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateSolution(cliParams, streams, "scafctl/validate")
+	cmd.SetArgs([]string{"-f", p, "-o", "quiet"})
+	require.NoError(t, cmd.Execute())
+	assert.Empty(t, out.String(), "quiet must produce no stdout on a clean solution")
+}
+
+// TestCommandValidateSolution_PositionalCatalogRef verifies a positional
+// catalog reference is accepted (routed to opts.File) rather than being
+// rejected as a local path.
+func TestCommandValidateSolution_PositionalCatalogRef(t *testing.T) {
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateSolution(cliParams, streams, "scafctl/validate")
+	// A bare catalog name (not a local path). It won't resolve to a real
+	// solution here, but PreRunE must accept it (no "must use -f" error).
+	cmd.SetArgs([]string{"nonexistent-catalog-ref", "-o", "quiet"})
+	err := cmd.Execute()
+	// Execution fails at load time (catalog miss), NOT at arg validation.
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "must use -f/--file")
+	assert.NotContains(t, err.Error(), "cannot use both")
+}
+
+// TestCommandValidateSolution_PositionalConflictsWithFile verifies that
+// supplying both a positional arg and -f is rejected clearly.
+func TestCommandValidateSolution_PositionalConflictsWithFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(cleanSolution), 0o600))
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateSolution(cliParams, streams, "scafctl/validate")
+	cmd.SetArgs([]string{"some-ref", "-f", p})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot use both")
+}
+
+// TestCommandValidateSolution_PositionalLocalPathRejected verifies that a
+// positional local file path is rejected in favor of -f (mirroring lint).
+func TestCommandValidateSolution_PositionalLocalPathRejected(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(cleanSolution), 0o600))
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateSolution(cliParams, streams, "scafctl/validate")
+	cmd.SetArgs([]string{"./" + filepath.Base(p)})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "-f/--file")
+}
+
+// TestCommandValidateSolution_NoStdinClaim verifies the file flag help no
+// longer advertises stdin support (which the loader does not implement).
+func TestCommandValidateSolution_NoStdinClaim(t *testing.T) {
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateSolution(cliParams, streams, "scafctl/validate")
+	fileFlag := cmd.Flags().Lookup("file")
+	require.NotNil(t, fileFlag)
+	assert.NotContains(t, fileFlag.Usage, "stdin")
+}

--- a/pkg/cmd/scafctl/validate/solution_test.go
+++ b/pkg/cmd/scafctl/validate/solution_test.go
@@ -1,0 +1,133 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const cleanSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: valid-solution
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      name: greeting
+      description: a friendly greeting
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+  workflow:
+    actions:
+      show:
+        name: show
+        description: print the greeting
+        provider: message
+        inputs:
+          message: "{{ ._.greeting }}"
+`
+
+// unusedResolverSolution defines a resolver that is never referenced, which
+// triggers the unused-resolver lint WARNING (fatal only under --strict).
+const unusedResolverSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: bad-solution
+  version: 1.0.0
+spec:
+  resolvers:
+    orphan:
+      name: orphan
+      description: never referenced anywhere
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+  workflow:
+    actions:
+      show:
+        name: show
+        description: print a constant
+        provider: message
+        inputs:
+          message: "hi"
+`
+
+func TestCommandValidateSolution_Metadata(t *testing.T) {
+	t.Parallel()
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+
+	cmd := CommandValidateSolution(cliParams, streams, "mycli/validate")
+	assert.Equal(t, "solution", cmd.Name())
+	assert.Contains(t, cmd.Short, "mycli")
+	assert.NotNil(t, cmd.Flags().Lookup("file"))
+	assert.NotNil(t, cmd.Flags().Lookup("strict"))
+}
+
+func TestCommandValidateSolution_Clean(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(cleanSolution), 0o600))
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateSolution(cliParams, streams, "scafctl/validate")
+	cmd.SetArgs([]string{"-f", p, "-o", "quiet"})
+	require.NoError(t, cmd.Execute())
+}
+
+func TestCommandValidateSolution_WarningPassesNonStrict(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(unusedResolverSolution), 0o600))
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateSolution(cliParams, streams, "scafctl/validate")
+	cmd.SetArgs([]string{"-f", p, "-o", "quiet"})
+	require.NoError(t, cmd.Execute(), "a lint warning must not fail without --strict")
+}
+
+func TestCommandValidateSolution_WarningFailsStrict(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(unusedResolverSolution), 0o600))
+
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateSolution(cliParams, streams, "scafctl/validate")
+	cmd.SetArgs([]string{"-f", p, "-o", "quiet", "--strict"})
+	err := cmd.Execute()
+	require.Error(t, err, "a lint warning must fail under --strict")
+	assert.Equal(t, exitcode.ValidationFailed, exitcode.GetCode(err))
+}
+
+func TestCommandValidateSolution_MissingFile(t *testing.T) {
+	streams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+
+	cmd := CommandValidateSolution(cliParams, streams, "scafctl/validate")
+	cmd.SetArgs([]string{"-f", filepath.Join(t.TempDir(), "nope.yaml"), "-o", "quiet"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Equal(t, exitcode.FileNotFound, exitcode.GetCode(err))
+}

--- a/pkg/cmd/scafctl/validate/validate.go
+++ b/pkg/cmd/scafctl/validate/validate.go
@@ -18,20 +18,28 @@ import (
 func CommandValidate(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
 	cCmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
 		Use:   "validate",
-		Short: fmt.Sprintf("Validate %s solution artifacts and fail on validation errors", path),
-		Long: `Validate executes a solution's artifacts and exits non-zero when validation fails.
+		Short: fmt.Sprintf("Validate that a %s definition is correct and ready (runs lint)", path),
+		Long: `Validate is THE gate that determines whether a definition is correct and ready.
 
-Unlike the 'run' commands, which surface validation failures as non-fatal
-diagnostics, 'validate' treats them as errors. Use it as a validation gate in
-CI pipelines or pre-commit checks.
+'validate solution' loads a solution and runs lint (which includes a JSON
+Schema conformance check): lint errors and schema violations fail; lint
+warnings are surfaced and, with --strict, are also fatal. 'validate resolver'
+executes the resolver phases and, after they pass, additionally runs lint. In
+this way 'validate' is the pass/fail gate for CI pipelines and pre-commit
+checks, while 'lint' is the advisory subset that only reports authoring
+warnings.
 
 SUBCOMMANDS:
-  resolver  Validate resolvers (resolve, transform, and validate phases)`,
+  solution  Validate a solution end-to-end (load + lint) -- the primary gate
+  resolver  Validate resolvers (resolve, transform, validate) then run lint
+  schema    Validate arbitrary data against a JSON Schema (JSON or YAML)`,
 		SilenceUsage: true,
 	})
 
 	validatePath := fmt.Sprintf("%s/%s", path, cCmd.Use)
+	cCmd.AddCommand(CommandValidateSolution(cliParams, ioStreams, validatePath))
 	cCmd.AddCommand(run.CommandValidateResolver(cliParams, ioStreams, validatePath))
+	cCmd.AddCommand(CommandValidateSchema(cliParams, ioStreams, validatePath))
 
 	return cCmd
 }

--- a/pkg/cmd/scafctl/validate/validate_test.go
+++ b/pkg/cmd/scafctl/validate/validate_test.go
@@ -23,14 +23,14 @@ func TestCommandValidate(t *testing.T) {
 	assert.Equal(t, "validate", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
 
-	// The resolver subcommand must be wired up.
-	var resolverCmd bool
+	// The subcommands must be wired up.
+	subs := map[string]bool{}
 	for _, sub := range cmd.Commands() {
-		if sub.Name() == "resolver" {
-			resolverCmd = true
-		}
+		subs[sub.Name()] = true
 	}
-	require.True(t, resolverCmd, "validate must register the resolver subcommand")
+	require.True(t, subs["resolver"], "validate must register the resolver subcommand")
+	require.True(t, subs["solution"], "validate must register the solution subcommand")
+	require.True(t, subs["schema"], "validate must register the schema subcommand")
 }
 
 func TestCommandValidate_EmbedderBinaryName(t *testing.T) {

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -90,7 +90,9 @@ func Solution(sol *solution.Solution, filePath string, registry *provider.Regist
 
 	// Schema validation: validate the raw YAML against the generated JSON Schema.
 	// This catches unknown fields, type mismatches, pattern violations, etc.
-	lintSchema(filePath, result)
+	// Prefer the already-loaded raw content (works for URL/catalog sources too);
+	// fall back to reading the file from disk only when raw content is absent.
+	lintSchema(sol.RawContent(), filePath, result)
 
 	if !sol.Spec.HasResolvers() && !sol.Spec.HasWorkflow() {
 		result.addFinding(SeverityError, "structure", "spec", "Solution has no resolvers or workflow", "", "empty-solution")
@@ -2047,16 +2049,25 @@ func testFileReachable(solutionDir, entry string) bool {
 	return err == nil
 }
 
-// lintSchema reads the solution file from disk, unmarshals it into a generic
-// map (preserving unknown fields), and validates it against the generated
-// JSON Schema. Any violations are added to the result as schema-violation findings.
-func lintSchema(filePath string, result *Result) {
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		// If we can't read the file, skip schema validation silently.
-		// The caller already loaded the solution successfully, so this is
-		// likely a non-file source (URL, catalog, etc.).
-		return
+// lintSchema unmarshals the solution's raw content into a generic map
+// (preserving unknown fields) and validates it against the generated JSON
+// Schema. Any violations are added to the result as schema-violation findings.
+//
+// It prefers rawContent (the bytes the solution was actually loaded from,
+// available for file, URL, and catalog sources alike). Only when rawContent is
+// empty does it fall back to reading filePath from disk, so schema violations
+// are never silently skipped for non-file sources.
+func lintSchema(rawContent []byte, filePath string, result *Result) {
+	data := rawContent
+	if len(data) == 0 {
+		var err error
+		data, err = os.ReadFile(filePath)
+		if err != nil {
+			// No raw content and no readable file: nothing to validate.
+			// This should be rare, since the caller already loaded the
+			// solution (which populates raw content for byte-based sources).
+			return
+		}
 	}
 
 	var raw any

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -808,8 +808,8 @@ func BenchmarkLintNullResolver(b *testing.B) {
 
 func TestLintSchema_FileNotFound(t *testing.T) {
 	result := &Result{Findings: make([]*Finding, 0)}
-	lintSchema("/nonexistent/path/solution.yaml", result)
-	// Should silently skip when file cannot be read
+	lintSchema(nil, "/nonexistent/path/solution.yaml", result)
+	// Should silently skip when there is no raw content and the file cannot be read.
 	assert.Empty(t, result.Findings)
 }
 
@@ -818,7 +818,7 @@ func TestLintSchema_ValidYAML(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "solution.yaml")
 	require.NoError(t, os.WriteFile(tmpFile, []byte("name: test\nkind: Solution\napiVersion: v1\n"), 0o600))
 	result := &Result{Findings: make([]*Finding, 0)}
-	lintSchema(tmpFile, result)
+	lintSchema(nil, tmpFile, result)
 	// Might have findings or none, but should not panic
 }
 
@@ -827,9 +827,53 @@ func TestLintSchema_InvalidYAML(t *testing.T) {
 	tmpFile := filepath.Join(t.TempDir(), "solution.yaml")
 	require.NoError(t, os.WriteFile(tmpFile, []byte("{\ninvalid: [yaml\n"), 0o600))
 	result := &Result{Findings: make([]*Finding, 0)}
-	lintSchema(tmpFile, result)
+	lintSchema(nil, tmpFile, result)
 	// Should silently skip invalid YAML
 	assert.Empty(t, result.Findings)
+}
+
+// TestLintSchema_RawContentPreferred verifies that when raw content is present,
+// schema validation runs against it regardless of the (possibly bogus) file
+// path -- so URL/catalog-sourced solutions with schema violations are caught
+// instead of being silently skipped.
+func TestLintSchema_RawContentPreferred(t *testing.T) {
+	// Unknown top-level field "bogusField" violates the solution schema.
+	raw := []byte("name: test\nkind: Solution\napiVersion: v1\nbogusField: nope\n")
+	result := &Result{Findings: make([]*Finding, 0)}
+	// A file path that does not exist on disk: the old behavior would read
+	// this path, fail, and silently skip. With raw content preferred, the
+	// violation must still be reported.
+	lintSchema(raw, "/nonexistent/from-url/solution.yaml", result)
+
+	found := false
+	for _, f := range result.Findings {
+		if f.RuleName == "schema-violation" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected a schema-violation finding from raw content, got %+v", result.Findings)
+}
+
+// TestLintSchema_RawContentFromNonFileSolution verifies the end-to-end path:
+// a solution loaded from bytes (no file on disk) with an unknown top-level
+// field still produces a schema-violation finding through lint.Solution.
+func TestLintSchema_RawContentFromNonFileSolution(t *testing.T) {
+	raw := []byte("apiVersion: scaffolding.oakwood-commons.io/v1\nkind: Solution\nmetadata:\n  name: test-sol\nspec:\n  resolvers:\n    r1:\n      value: hello\nbogusTopLevel: nope\n")
+	sol := &solution.Solution{}
+	require.NoError(t, sol.FromYAML(raw))
+
+	// Path points at a non-existent file to simulate a URL/catalog source.
+	result := Solution(sol, "https://example.com/solution.yaml", nil)
+
+	found := false
+	for _, f := range result.Findings {
+		if f.RuleName == "schema-violation" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected schema-violation from non-file source, got %+v", result.Findings)
 }
 
 func TestLintExpressions_AllPaths(t *testing.T) {

--- a/pkg/mcp/tools_schema.go
+++ b/pkg/mcp/tools_schema.go
@@ -54,7 +54,7 @@ func (s *Server) registerSchemaTools() {
 
 	// validate_schema — validate arbitrary data against a JSON Schema
 	validateSchemaTool := mcp.NewTool("validate_schema",
-		mcp.WithDescription("Validate arbitrary data against a JSON Schema. Both the schema and the data may be JSON or YAML. Returns the list of violations (path + message), or confirms the data is valid. This is the low-level data-conformance gate: it does NOT run lint. To validate a scafctl solution end-to-end (load + lint, including schema conformance), use lint_solution instead."),
+		mcp.WithDescription(fmt.Sprintf("Validate arbitrary data against a JSON Schema. Both the schema and the data may be JSON or YAML. Returns the list of violations (path + message), or confirms the data is valid. This is a general-purpose, low-level data-conformance gate: it does NOT run lint and is not specific to solutions. To validate a %s solution end-to-end (load + lint, including schema conformance), use lint_solution instead.", s.name)),
 		mcp.WithTitleAnnotation("Validate Data Against Schema"),
 		mcp.WithToolIcons(toolIcons["schema"]),
 		mcp.WithReadOnlyHintAnnotation(true),

--- a/pkg/mcp/tools_schema.go
+++ b/pkg/mcp/tools_schema.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/schema"
+	"sigs.k8s.io/yaml"
 )
 
 // registerSchemaTools registers schema-related MCP tools.
@@ -50,6 +51,68 @@ func (s *Server) registerSchemaTools() {
 		),
 	)
 	s.addTool(explainKindTool, s.handleExplainKind)
+
+	// validate_schema — validate arbitrary data against a JSON Schema
+	validateSchemaTool := mcp.NewTool("validate_schema",
+		mcp.WithDescription("Validate arbitrary data against a JSON Schema. Both the schema and the data may be JSON or YAML. Returns the list of violations (path + message), or confirms the data is valid. This is the low-level data-conformance gate: it does NOT run lint. To validate a scafctl solution end-to-end (load + lint, including schema conformance), use lint_solution instead."),
+		mcp.WithTitleAnnotation("Validate Data Against Schema"),
+		mcp.WithToolIcons(toolIcons["schema"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("schema",
+			mcp.Required(),
+			mcp.Description("The JSON Schema to validate against, as a JSON or YAML string."),
+		),
+		mcp.WithString("data",
+			mcp.Required(),
+			mcp.Description("The data to validate, as a JSON or YAML string."),
+		),
+	)
+	s.addTool(validateSchemaTool, s.handleValidateSchema)
+}
+
+// handleValidateSchema validates arbitrary data against a JSON Schema and
+// returns any violations. It is a thin wrapper over schema.ValidateDataAgainstSchema.
+func (s *Server) handleValidateSchema(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	schemaStr, err := request.RequireString("schema")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("schema"),
+			WithSuggestion("Provide a JSON or YAML schema string"),
+		), nil
+	}
+	dataStr, err := request.RequireString("data")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("data"),
+			WithSuggestion("Provide a JSON or YAML data string"),
+		), nil
+	}
+
+	var data any
+	if err := yaml.Unmarshal([]byte(dataStr), &data); err != nil {
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("failed to parse data as JSON/YAML: %v", err),
+			WithField("data"),
+			WithSuggestion("Ensure the data is valid JSON or YAML"),
+		), nil
+	}
+
+	violations, err := schema.ValidateDataAgainstSchema([]byte(schemaStr), data)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("invalid schema: %v", err),
+			WithField("schema"),
+			WithSuggestion("Ensure the schema is a valid JSON Schema (JSON or YAML)"),
+		), nil
+	}
+
+	result := map[string]any{
+		"valid":          len(violations) == 0,
+		"violationCount": len(violations),
+		"violations":     violations,
+	}
+	return mcp.NewToolResultJSON(result)
 }
 
 // handleGetSolutionSchema returns the full JSON Schema for a solution YAML file.

--- a/pkg/mcp/tools_schema_test.go
+++ b/pkg/mcp/tools_schema_test.go
@@ -173,3 +173,80 @@ func extractText(t *testing.T, result *mcp.CallToolResult) string {
 	require.True(t, ok, "expected TextContent")
 	return tc.Text
 }
+
+func TestHandleValidateSchema(t *testing.T) {
+	const jsonSchema = `{"type":"object","properties":{"name":{"type":"string"}},"required":["name"],"additionalProperties":false}`
+
+	newReq := func(schemaStr, dataStr string) mcp.CallToolRequest {
+		req := mcp.CallToolRequest{}
+		req.Params.Name = "validate_schema"
+		req.Params.Arguments = map[string]any{"schema": schemaStr, "data": dataStr}
+		return req
+	}
+
+	t.Run("valid data reports valid", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		result, err := srv.handleValidateSchema(context.Background(), newReq(jsonSchema, `{"name":"hi"}`))
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.IsError)
+
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal([]byte(extractText(t, result)), &doc))
+		assert.Equal(t, true, doc["valid"])
+		assert.Equal(t, float64(0), doc["violationCount"])
+	})
+
+	t.Run("invalid data reports violations", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		result, err := srv.handleValidateSchema(context.Background(), newReq(jsonSchema, `{"extra":"x"}`))
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.False(t, result.IsError)
+
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal([]byte(extractText(t, result)), &doc))
+		assert.Equal(t, false, doc["valid"])
+		assert.Greater(t, doc["violationCount"], float64(0))
+	})
+
+	t.Run("yaml schema and data work", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		yamlSchema := "type: object\nproperties:\n  name:\n    type: string\nrequired:\n  - name\n"
+		result, err := srv.handleValidateSchema(context.Background(), newReq(yamlSchema, "name: hi\n"))
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		var doc map[string]any
+		require.NoError(t, json.Unmarshal([]byte(extractText(t, result)), &doc))
+		assert.Equal(t, true, doc["valid"])
+	})
+
+	t.Run("malformed schema errors", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		result, err := srv.handleValidateSchema(context.Background(), newReq("this: is: bad: yaml:", `{}`))
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("missing schema argument errors", func(t *testing.T) {
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		req := mcp.CallToolRequest{}
+		req.Params.Name = "validate_schema"
+		req.Params.Arguments = map[string]any{"data": `{}`}
+		result, err := srv.handleValidateSchema(context.Background(), req)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}

--- a/pkg/mcp/tools_schema_test.go
+++ b/pkg/mcp/tools_schema_test.go
@@ -174,6 +174,32 @@ func extractText(t *testing.T, result *mcp.CallToolResult) string {
 	return tc.Text
 }
 
+// validateSchemaToolDescription returns the registered validate_schema tool
+// description for the given server, or "" if not found.
+func validateSchemaToolDescription(s *Server) string {
+	for _, st := range s.mcpServer.ListTools() {
+		if st.Tool.Name == "validate_schema" {
+			return st.Tool.Description
+		}
+	}
+	return ""
+}
+
+// TestValidateSchemaTool_DescriptionEmbedderSafe verifies the validate_schema
+// tool description is built from the configured server name (not a hardcoded
+// "scafctl") and describes a general JSON-schema validator rather than a
+// solution-specific one.
+func TestValidateSchemaTool_DescriptionEmbedderSafe(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"), WithServerName("mycli"))
+	require.NoError(t, err)
+
+	desc := validateSchemaToolDescription(srv)
+	require.NotEmpty(t, desc, "validate_schema tool must be registered")
+	assert.NotContains(t, desc, "scafctl", "description must not hardcode scafctl")
+	assert.Contains(t, desc, "mycli", "description must use the configured server name")
+	assert.Contains(t, desc, "arbitrary data", "description must present a general schema validator")
+}
+
 func TestHandleValidateSchema(t *testing.T) {
 	const jsonSchema = `{"type":"object","properties":{"name":{"type":"string"}},"required":["name"],"additionalProperties":false}`
 

--- a/pkg/mcp/tools_schema_test.go
+++ b/pkg/mcp/tools_schema_test.go
@@ -258,7 +258,7 @@ func TestHandleValidateSchema(t *testing.T) {
 		srv, err := NewServer(WithServerVersion("test"))
 		require.NoError(t, err)
 
-		result, err := srv.handleValidateSchema(context.Background(), newReq("this: is: bad: yaml:", `{}`))
+		result, err := srv.handleValidateSchema(context.Background(), newReq("type: 123", `{}`))
 		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.True(t, result.IsError)

--- a/pkg/schema/validate.go
+++ b/pkg/schema/validate.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/google/jsonschema-go/jsonschema"
+	"sigs.k8s.io/yaml"
 )
 
 // Violation represents a single validation error found when validating
@@ -33,14 +34,35 @@ func ValidateSolutionAgainstSchema(data any) ([]Violation, error) {
 		return nil, fmt.Errorf("generating solution schema: %w", err)
 	}
 
+	return ValidateDataAgainstSchema(schemaBytes, data)
+}
+
+// ValidateDataAgainstSchema validates arbitrary data against a JSON Schema
+// provided as raw bytes. The schemaBytes may be either JSON or YAML -- YAML is
+// normalized to JSON before it is unmarshalled into the jsonschema-go schema
+// type. It returns a list of violations, or an error if the schema itself
+// could not be parsed, resolved, or compiled.
+//
+// The data parameter should be the result of unmarshalling YAML/JSON into a
+// plain any (not into a typed struct), so unknown fields are preserved.
+func ValidateDataAgainstSchema(schemaBytes []byte, data any) ([]Violation, error) {
+	// Normalize YAML-or-JSON schema bytes to JSON so both formats are
+	// accepted. yaml.YAMLToJSON reparses and re-emits the input (it may
+	// reorder map keys); for already-JSON input this is a harmless reformat,
+	// not a byte-identity no-op.
+	jsonBytes, err := yaml.YAMLToJSON(schemaBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parsing schema: %w", err)
+	}
+
 	var schema jsonschema.Schema
-	if err := json.Unmarshal(schemaBytes, &schema); err != nil {
-		return nil, fmt.Errorf("unmarshalling solution schema: %w", err)
+	if err := json.Unmarshal(jsonBytes, &schema); err != nil {
+		return nil, fmt.Errorf("unmarshalling schema: %w", err)
 	}
 
 	resolved, err := schema.Resolve(nil)
 	if err != nil {
-		return nil, fmt.Errorf("resolving solution schema: %w", err)
+		return nil, fmt.Errorf("resolving schema: %w", err)
 	}
 
 	if err := resolved.Validate(data); err != nil {

--- a/pkg/schema/validate_benchmark_test.go
+++ b/pkg/schema/validate_benchmark_test.go
@@ -1,0 +1,26 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package schema
+
+import "testing"
+
+func BenchmarkValidateDataAgainstSchema(b *testing.B) {
+	jsonSchema := []byte(`{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"},
+			"count": {"type": "integer", "minimum": 1}
+		},
+		"required": ["name"],
+		"additionalProperties": false
+	}`)
+	data := map[string]any{"name": "hi", "count": 3}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := ValidateDataAgainstSchema(jsonSchema, data); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/schema/validate_test.go
+++ b/pkg/schema/validate_test.go
@@ -234,7 +234,10 @@ func TestValidateDataAgainstSchema(t *testing.T) {
 	})
 
 	t.Run("malformed schema returns error", func(t *testing.T) {
-		bad := []byte("this: is: not: valid: json: or: yaml:")
+		// A structurally-invalid schema (type must be a string, not a number)
+		// deterministically fails schema compilation, unlike a fixture that
+		// merely relies on a YAML parse quirk.
+		bad := []byte("type: 123")
 		violations, err := ValidateDataAgainstSchema(bad, map[string]any{})
 		require.Error(t, err)
 		assert.Nil(t, violations)

--- a/pkg/schema/validate_test.go
+++ b/pkg/schema/validate_test.go
@@ -177,6 +177,84 @@ func conditionSolution(sourceExtra map[string]any) map[string]any {
 	}
 }
 
+func TestValidateDataAgainstSchema(t *testing.T) {
+	// A small self-contained schema: an object with a required string "name"
+	// and an integer "count" with a minimum.
+	jsonSchema := []byte(`{
+		"type": "object",
+		"properties": {
+			"name": {"type": "string"},
+			"count": {"type": "integer", "minimum": 1}
+		},
+		"required": ["name"],
+		"additionalProperties": false
+	}`)
+
+	yamlSchema := []byte("type: object\n" +
+		"properties:\n" +
+		"  name:\n" +
+		"    type: string\n" +
+		"  count:\n" +
+		"    type: integer\n" +
+		"    minimum: 1\n" +
+		"required:\n" +
+		"  - name\n" +
+		"additionalProperties: false\n")
+
+	t.Run("valid data passes with JSON schema", func(t *testing.T) {
+		data := map[string]any{"name": "hi", "count": 3}
+		violations, err := ValidateDataAgainstSchema(jsonSchema, data)
+		require.NoError(t, err)
+		assert.Nil(t, violations)
+	})
+
+	t.Run("valid data passes with YAML schema", func(t *testing.T) {
+		data := map[string]any{"name": "hi", "count": 3}
+		violations, err := ValidateDataAgainstSchema(yamlSchema, data)
+		require.NoError(t, err)
+		assert.Nil(t, violations)
+	})
+
+	t.Run("invalid data returns violations", func(t *testing.T) {
+		// Missing required "name" and count below minimum.
+		data := map[string]any{"count": 0}
+		violations, err := ValidateDataAgainstSchema(jsonSchema, data)
+		require.NoError(t, err)
+		assert.NotEmpty(t, violations)
+		for _, v := range violations {
+			assert.NotEmpty(t, v.Message, "violation should carry a message")
+		}
+	})
+
+	t.Run("unknown key is flagged with path", func(t *testing.T) {
+		data := map[string]any{"name": "hi", "extra": "nope"}
+		violations, err := ValidateDataAgainstSchema(jsonSchema, data)
+		require.NoError(t, err)
+		require.NotEmpty(t, violations)
+	})
+
+	t.Run("malformed schema returns error", func(t *testing.T) {
+		bad := []byte("this: is: not: valid: json: or: yaml:")
+		violations, err := ValidateDataAgainstSchema(bad, map[string]any{})
+		require.Error(t, err)
+		assert.Nil(t, violations)
+	})
+
+	t.Run("empty data against required schema returns violations", func(t *testing.T) {
+		violations, err := ValidateDataAgainstSchema(jsonSchema, map[string]any{})
+		require.NoError(t, err)
+		assert.NotEmpty(t, violations)
+	})
+
+	t.Run("nil data does not panic", func(t *testing.T) {
+		// A permissive schema accepts anything, including null.
+		permissive := []byte(`{"type": ["object", "null"]}`)
+		violations, err := ValidateDataAgainstSchema(permissive, nil)
+		require.NoError(t, err)
+		_ = violations
+	})
+}
+
 func TestJsonPointerToDotPath(t *testing.T) {
 	tests := []struct {
 		pointer  string

--- a/pkg/solution/builder/preflight_test.go
+++ b/pkg/solution/builder/preflight_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/lint"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -109,8 +110,11 @@ func TestRunPreflight_LintClean(t *testing.T) {
 	// Create a minimal valid solution to pass lint.
 	sol := buildMinimalValidSolution(t)
 
+	reg, regErr := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, regErr)
 	result, err := RunPreflight(context.Background(), sol, "test.yaml", PreflightOptions{
 		SkipTests: true,
+		Registry:  reg,
 		Logger:    logr.Discard(),
 	})
 
@@ -144,8 +148,11 @@ func TestRunPreflight_LintWarnings_NotBlocked(t *testing.T) {
 	// We test the logic by running with a valid solution that may produce warnings.
 	sol := buildMinimalValidSolution(t)
 
+	reg, regErr := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, regErr)
 	result, err := RunPreflight(context.Background(), sol, "test.yaml", PreflightOptions{
 		SkipTests: true,
+		Registry:  reg,
 		Logger:    logr.Discard(),
 	})
 
@@ -237,14 +244,21 @@ metadata:
 spec:
   resolvers:
     greeting:
-      value: hello
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
 `
 	var sol solution.Solution
 	err := sol.LoadFromBytes([]byte(yaml))
 	require.NoError(t, err)
 
-	// Verify it passes lint so the test is meaningful.
-	lintResult := lint.Solution(&sol, "test.yaml", nil)
+	// Verify it passes lint (with the builtin registry so the 'static' provider
+	// resolves) so the test is meaningful.
+	reg, regErr := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, regErr)
+	lintResult := lint.Solution(&sol, "test.yaml", reg)
 	require.Equal(t, 0, lintResult.ErrorCount,
 		"test fixture should pass lint; findings: %v", lintResult.Findings)
 
@@ -261,7 +275,11 @@ metadata:
 spec:
   resolvers:
     greeting:
-      value: hello
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
 `
 	var sol solution.Solution
 	if err := sol.LoadFromBytes([]byte(yaml)); err != nil {

--- a/pkg/solution/soltesting/types.go
+++ b/pkg/solution/soltesting/types.go
@@ -376,7 +376,7 @@ type InitStep struct {
 // TestCase defines a single functional test for a solution.
 type TestCase struct {
 	// Name is the test name (auto-set from map key).
-	Name string `json:"name" yaml:"name" doc:"Test name (auto-set from map key)" maxLength:"100" pattern:"^[a-zA-Z0-9_][a-zA-Z0-9_-]*$" patternDescription:"Must start with a letter, digit, or underscore and contain only letters, digits, hyphens, and underscores"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty" doc:"Test name (auto-set from map key; not authored in YAML)" maxLength:"100" pattern:"^[a-zA-Z0-9_][a-zA-Z0-9_-]*$" patternDescription:"Must start with a letter, digit, or underscore and contain only letters, digits, hyphens, and underscores"`
 
 	// Description is a human-readable test description.
 	Description string `json:"description" yaml:"description" doc:"Human-readable test description" maxLength:"500"`

--- a/pkg/validate/solution.go
+++ b/pkg/validate/solution.go
@@ -1,0 +1,102 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package validate provides the domain orchestration behind the 'validate'
+// command group. It is a leaf package: it depends on pkg/lint and the solution
+// loader, but nothing in those packages depends on it, avoiding an import
+// cycle (pkg/lint already imports pkg/schema, so this helper cannot live in
+// pkg/schema).
+package validate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/lint"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
+)
+
+// SolutionResult captures the outcome of validating a solution. It bundles the
+// resolved file path with the lint result so callers can render findings and
+// decide pass/fail via Passed.
+type SolutionResult struct {
+	// File is the resolved solution file path that was validated.
+	File string
+	// Lint is the lint result produced by lint.Solution.
+	Lint *lint.Result
+}
+
+// Passed reports whether validation passed. A solution passes when it has no
+// lint errors. When strict is true, warnings are also treated as fatal, so any
+// warning causes Passed to return false.
+func (r *SolutionResult) Passed(strict bool) bool {
+	if r == nil || r.Lint == nil {
+		return false
+	}
+	if r.Lint.ErrorCount > 0 {
+		return false
+	}
+	if strict && r.Lint.WarnCount > 0 {
+		return false
+	}
+	return true
+}
+
+// Solution loads a solution and runs lint against it, returning a
+// SolutionResult. It reuses the same resolution chain as the lint command
+// (explicit file > positional arg > auto-discovery) so behavior matches
+// 'scafctl lint'. Schema conformance is checked by lint.Solution itself, so
+// callers must NOT additionally invoke the standalone schema validator.
+//
+// The registry is used for provider-aware lint rules; when nil, lint falls
+// back to a default registry.
+func Solution(ctx context.Context, filePath string, registry *provider.Registry) (*SolutionResult, error) {
+	getter := newGetter(ctx)
+
+	resolvedPath, err := get.Resolve(ctx, getter, filePath, "", get.ResolveOptions{
+		Risk: get.DiscoveryRiskLow,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("resolving solution path: %w", err)
+	}
+
+	sol, err := getter.Get(ctx, resolvedPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading solution: %w", err)
+	}
+
+	return LoadedSolution(sol, resolvedPath, registry), nil
+}
+
+// LoadedSolution runs lint against an already-loaded solution. It is
+// the pure orchestration seam used by Solution and is convenient for
+// tests that construct a solution in memory.
+func LoadedSolution(sol *solution.Solution, filePath string, registry *provider.Registry) *SolutionResult {
+	result := lint.Solution(sol, filePath, registry)
+	return &SolutionResult{
+		File: filePath,
+		Lint: result,
+	}
+}
+
+// newGetter builds a solution getter wired with the local (and any remote)
+// catalog resolver so bare catalog names resolve, mirroring the lint command.
+func newGetter(ctx context.Context) *get.Getter {
+	lgr := logger.FromContext(ctx)
+
+	var getterOpts []get.Option
+	if localCatalog, err := catalog.NewLocalCatalog(*lgr); err == nil {
+		resolver := catalog.NewSolutionResolver(localCatalog, *lgr,
+			catalog.WithResolverRemoteCatalogs(catalog.RemoteCatalogsFromContext(ctx, *lgr)),
+		)
+		getterOpts = append(getterOpts, get.WithCatalogResolver(resolver))
+	} else {
+		lgr.V(1).Info("catalog not available for solution resolution", "error", err)
+	}
+
+	return get.NewGetterFromContext(ctx, getterOpts...)
+}

--- a/pkg/validate/solution_test.go
+++ b/pkg/validate/solution_test.go
@@ -1,0 +1,117 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/lint"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSolutionResult_Passed(t *testing.T) {
+	tests := []struct {
+		name       string
+		result     *SolutionResult
+		strict     bool
+		wantPassed bool
+	}{
+		{
+			name:       "nil result fails",
+			result:     nil,
+			wantPassed: false,
+		},
+		{
+			name:       "nil lint fails",
+			result:     &SolutionResult{},
+			wantPassed: false,
+		},
+		{
+			name:       "clean passes",
+			result:     &SolutionResult{Lint: &lint.Result{}},
+			wantPassed: true,
+		},
+		{
+			name:       "errors fail",
+			result:     &SolutionResult{Lint: &lint.Result{ErrorCount: 1}},
+			wantPassed: false,
+		},
+		{
+			name:       "warnings pass in non-strict",
+			result:     &SolutionResult{Lint: &lint.Result{WarnCount: 2}},
+			strict:     false,
+			wantPassed: true,
+		},
+		{
+			name:       "warnings fail in strict",
+			result:     &SolutionResult{Lint: &lint.Result{WarnCount: 2}},
+			strict:     true,
+			wantPassed: false,
+		},
+		{
+			name:       "errors fail in strict even with no warnings",
+			result:     &SolutionResult{Lint: &lint.Result{ErrorCount: 1}},
+			strict:     true,
+			wantPassed: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.wantPassed, tc.result.Passed(tc.strict))
+		})
+	}
+}
+
+func TestValidateSolution_LoadsAndLints(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "solution.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: valid-solution
+  version: 1.0.0
+spec:
+  resolvers:
+    greeting:
+      name: greeting
+      description: a friendly greeting
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+  workflow:
+    actions:
+      show:
+        name: show
+        description: print the greeting
+        provider: message
+        inputs:
+          message: "{{ ._.greeting }}"
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+
+	res, err := Solution(context.Background(), path, reg)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, path, res.File)
+	require.NotNil(t, res.Lint)
+	assert.Equal(t, 0, res.Lint.ErrorCount, "clean solution should have no lint errors: %+v", res.Lint.Findings)
+	assert.True(t, res.Passed(false))
+}
+
+func TestValidateSolution_MissingFile(t *testing.T) {
+	res, err := Solution(context.Background(), filepath.Join(t.TempDir(), "nope.yaml"), nil)
+	require.Error(t, err)
+	assert.Nil(t, res)
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1498,9 +1498,13 @@ func TestIntegration_Validate_Help(t *testing.T) {
 	stdout, _, exitCode := runScafctl(t, "validate", "--help")
 
 	assert.Equal(t, 0, exitCode)
-	// Top-level validate command help advertises the resolver subcommand.
+	// Top-level validate command help advertises all three subcommands and
+	// frames validate as the gate that runs lint.
 	assert.Contains(t, stdout, "Validate")
 	assert.Contains(t, stdout, "resolver")
+	assert.Contains(t, stdout, "solution")
+	assert.Contains(t, stdout, "schema")
+	assert.Contains(t, stdout, "lint")
 }
 
 func TestIntegration_ValidateResolver_Help(t *testing.T) {
@@ -1535,6 +1539,206 @@ func TestIntegration_ValidateResolver_FailsNonZero(t *testing.T) {
 	)
 
 	assert.Equal(t, exitcode.ValidationFailed, exitCode)
+}
+
+// --- validate schema ---
+
+// writeValidateSchemaFixtures writes a minimal JSON Schema plus valid and
+// invalid data files into a temp dir and returns their paths.
+func writeValidateSchemaFixtures(t *testing.T) (schemaPath, validPath, invalidPath string) {
+	t.Helper()
+	dir := t.TempDir()
+
+	schemaPath = filepath.Join(dir, "schema.json")
+	schemaContent := `{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "age": { "type": "integer" }
+  },
+  "required": ["name", "age"]
+}`
+	require.NoError(t, os.WriteFile(schemaPath, []byte(schemaContent), 0o600))
+
+	validPath = filepath.Join(dir, "valid.json")
+	require.NoError(t, os.WriteFile(validPath, []byte(`{"name": "alice", "age": 30}`), 0o600))
+
+	invalidPath = filepath.Join(dir, "invalid.json")
+	// age is a string here, violating the integer constraint.
+	require.NoError(t, os.WriteFile(invalidPath, []byte(`{"name": "alice", "age": "thirty"}`), 0o600))
+
+	return schemaPath, validPath, invalidPath
+}
+
+func TestIntegration_ValidateSchema_ValidData(t *testing.T) {
+	t.Parallel()
+	schemaPath, validPath, _ := writeValidateSchemaFixtures(t)
+
+	_, _, exitCode := runScafctl(t,
+		"validate", "schema",
+		"--schema", schemaPath,
+		"--data", validPath,
+	)
+
+	assert.Equal(t, 0, exitCode)
+}
+
+func TestIntegration_ValidateSchema_InvalidData(t *testing.T) {
+	t.Parallel()
+	schemaPath, _, invalidPath := writeValidateSchemaFixtures(t)
+
+	_, stderr, exitCode := runScafctl(t,
+		"validate", "schema",
+		"--schema", schemaPath,
+		"--data", invalidPath,
+	)
+
+	// Invalid data violates the schema -> ValidationFailed (2).
+	assert.Equal(t, exitcode.ValidationFailed, exitCode)
+	// The violation message should name the offending field and the constraint.
+	assert.Contains(t, stderr, "violation")
+	assert.Contains(t, stderr, "age")
+}
+
+func TestIntegration_ValidateSchema_DataFromStdin(t *testing.T) {
+	t.Parallel()
+	schemaPath, validPath, _ := writeValidateSchemaFixtures(t)
+
+	data, err := os.ReadFile(validPath)
+	require.NoError(t, err)
+
+	_, _, exitCode := runScafctlWithStdin(t, bytes.NewReader(data),
+		"validate", "schema",
+		"--schema", schemaPath,
+		"--data", "-",
+	)
+
+	assert.Equal(t, 0, exitCode)
+}
+
+func TestIntegration_ValidateSchema_MissingSchemaFile(t *testing.T) {
+	t.Parallel()
+	schemaPath, validPath, _ := writeValidateSchemaFixtures(t)
+	missing := filepath.Join(filepath.Dir(schemaPath), "does-not-exist.json")
+
+	_, _, exitCode := runScafctl(t,
+		"validate", "schema",
+		"--schema", missing,
+		"--data", validPath,
+	)
+
+	// A missing schema file -> FileNotFound (4).
+	assert.Equal(t, exitcode.FileNotFound, exitCode)
+}
+
+// --- validate solution ---
+
+func TestIntegration_ValidateSolution_Help(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "validate", "solution", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "solution")
+	assert.Contains(t, stdout, "--strict")
+}
+
+// writeLintWarningSolution writes a solution whose only lint findings are
+// warnings (a hyphenated resolver name and an unused resolver). It never
+// produces a lint error.
+func writeLintWarningSolution(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "solution.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: validate-warn-sol
+  version: 1.0.0
+  description: "Solution with a hyphenated resolver name to trigger a lint warning"
+spec:
+  resolvers:
+    my-resolver:
+      description: "hyphenated name triggers a hyphenated-name warning"
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "hello"
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestIntegration_ValidateSolution_Clean(t *testing.T) {
+	t.Parallel()
+	// A clean solution fixture (schema-valid, no lint errors) exits 0.
+	_, _, exitCode := runScafctl(t,
+		"validate", "solution",
+		"-f", "tests/integration/solutions/lint-schema/valid-minimal.yaml",
+	)
+
+	assert.Equal(t, 0, exitCode)
+}
+
+func TestIntegration_ValidateSolution_LintWarningPasses(t *testing.T) {
+	t.Parallel()
+	// A solution whose only lint findings are warnings exits 0 by default,
+	// but the warnings are surfaced in the output.
+	path := writeLintWarningSolution(t)
+
+	stdout, stderr, exitCode := runScafctl(t,
+		"validate", "solution",
+		"-f", path,
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout+stderr, "hyphenated-name")
+}
+
+func TestIntegration_ValidateSolution_LintErrorFails(t *testing.T) {
+	t.Parallel()
+	// A solution with a lint ERROR (unknown top-level field ->
+	// schema-violation) fails with ValidationFailed (2).
+	stdout, stderr, exitCode := runScafctl(t,
+		"validate", "solution",
+		"-f", "tests/integration/solutions/lint-schema/unknown-field.yaml",
+	)
+
+	assert.Equal(t, exitcode.ValidationFailed, exitCode)
+	assert.Contains(t, stdout+stderr, "schema-violation")
+}
+
+func TestIntegration_ValidateSolution_StrictWarningFails(t *testing.T) {
+	t.Parallel()
+	// With --strict, a solution whose only lint findings are warnings fails
+	// with ValidationFailed (2).
+	path := writeLintWarningSolution(t)
+
+	stdout, stderr, exitCode := runScafctl(t,
+		"validate", "solution",
+		"-f", path,
+		"--strict",
+	)
+
+	assert.Equal(t, exitcode.ValidationFailed, exitCode)
+	assert.Contains(t, stdout+stderr, "hyphenated-name")
+}
+
+func TestIntegration_ValidateResolver_StrictLintWarningFails(t *testing.T) {
+	t.Parallel()
+	// 'validate resolver' also runs lint as a gate. With --strict, a solution
+	// whose resolvers validate cleanly but that has a lint warning
+	// (hyphenated-name) must fail with ValidationFailed (2).
+	path := writeLintWarningSolution(t)
+
+	_, stderr, exitCode := runScafctl(t,
+		"validate", "resolver",
+		"-f", path,
+		"--strict",
+	)
+
+	assert.Equal(t, exitcode.ValidationFailed, exitCode)
+	assert.Contains(t, stderr, "hyphens")
 }
 
 func TestIntegration_RunResolver_GraphJSON(t *testing.T) {


### PR DESCRIPTION
Grammar migration **phase 5**: makes `validate` the single pass/fail gate and frames `lint` as its advisory subset (grammar Rule 2). Continues the ratified rollout after phase 4 (#658).

## What changed

- **`validate schema --schema <s> --data <d|->`** -- validate arbitrary data (JSON or YAML, or `-` for stdin) against a JSON Schema. The concrete driver for issue #649. Uses the already-direct `google/jsonschema-go`; **no new dependency**.
- **`validate solution [-f] [--strict]`** -- the primary gate: loads a solution and runs lint. Lint errors (including schema violations) always fail; warnings are surfaced and, with `--strict`, are also fatal.
- **`validate resolver`** now runs lint after resolver validation (with `--strict`), without masking resolver failures.
- **Unified lint rendering** -- lint findings render through one shared renderer, so output is identical across `scafctl lint`, `validate solution`, and `validate resolver` (the resolver path keeps lint on stderr so it does not pollute resolver JSON on stdout). `-o quiet` is honored consistently (no output) across all three.
- **Help text aligned** -- `validate` reads as the gate; `lint` as the advisory subset.
- **`validate_schema` MCP tool** -- a general-purpose JSON-schema validator; its description is built from the server name (embedder-safe).

## Correctness: the schema gate is now fail-closed

Previously, schema validation re-read the solution from disk and silently skipped when that read failed -- so URL/catalog-sourced solutions with schema violations passed the gate (exit 0). Schema validation now runs against the already-loaded `RawContent()`, so violations are caught regardless of source. This also corrected a schema-accuracy issue: `TestCase.Name` is auto-set from the map key and never authored in YAML, so it is now `omitempty` (composed solutions validate correctly).

## Design notes

- **No double schema report.** `validate solution` relies on lint's built-in JSON Schema check; the standalone `ValidateDataAgainstSchema` backs only `validate schema` and the MCP tool.
- **Import cycle avoided.** `pkg/lint` imports `pkg/schema`, so the solution-validation helper lives in a new leaf package `pkg/validate`.
- **UX.** Bare `validate schema` shows help; a single missing flag names it; `-f`+positional conflicts error (via `get.ValidatePositionalRef`) instead of silently overwriting `-f`; missing/unreadable files print a clear error instead of a silent exit.

## Testing

- Domain: `ValidateDataAgainstSchema` (valid/invalid/bad-schema/JSON+YAML) with a benchmark; `pkg/validate` `Passed` (strict vs non-strict) + load+lint; `lintSchema` now covered for RawContent + non-file sources.
- Cmd: `validate schema` (valid/invalid/stdin/YAML/bad-schema/missing-file/bare/one-flag-missing); `validate solution` (clean/warn/strict/missing-file/positional/quiet); embedder tests.
- Integration: all `validate schema`/`validate solution`/`validate resolver --strict` paths, plus bare `validate` -> help.
- MCP: `validate_schema` handler + embedder-safe description test.
- Docs: `cli.md` (Validation Gate section) and the validation/linting/run-resolver tutorials updated to the gate framing.

## Quality gate

- `go-review`: APPROVE; all substantive review findings fixed (fail-open schema gate, stdin claim, quiet leak, MCP branding, `-f` overwrite).
- `completeness-check`: artifact-complete.
- `task integration`, `task test-cover` (0 failures), `task lint:changed` (0 issues), and `go mod tidy` (no new direct dep) all pass on the final diff.

## Type of Change

- [x] New feature (additive command paths)
- [x] Behavior: `validate resolver` now runs lint; the schema gate is fail-closed for all sources; help text reframed

## Checklist

- [x] Commits signed (`-S`) + DCO signed-off (`-s`)
- [x] Tests + benchmark for new code; embedder coverage; no 0% new files
- [x] Docs + tutorials updated; MCP tool added
