### PR TITLE
feat(provider)!: add fetch type; stop auto-fetching URLs in parameter provider

### DIFF
--- a/docs/design/resolvers.md
+++ b/docs/design/resolvers.md
@@ -1405,32 +1405,50 @@ scafctl run resolver -f solution.yaml -r body=@request.json
 
 ### URL References
 
+By default a URL value is stored as a literal string -- scafctl does **not**
+fetch it. To fetch remote content, opt in explicitly with `type: fetch` on the
+parameter resolver (an SSRF-guarded HTTP GET), or use the `http` provider for
+anything beyond a plain GET (auth, headers, methods, retries):
+
 ~~~bash
+# Stored as the literal string "https://example.com/data.json"
 -r data=https://example.com/data.json
+~~~
+
+~~~yaml
+# Fetch the body explicitly
+resolvers:
+  remoteConfig:
+    from:
+      provider: parameter
+      inputs:
+        key: data
+        type: fetch
 ~~~
 
 ### Parsing Precedence
 
-When multiple formats are ambiguous, scafctl applies the following parsing order:
+When multiple formats are ambiguous, scafctl applies the following parsing order
+for the default `auto` type:
 
 1. **Stdin check**: If value is exactly `-`, read from stdin
 2. **File protocol**: If value starts with `file://`, treat as file reference
-3. **HTTP protocol**: If value starts with `http://` or `https://`, treat as URL reference
-4. **JSON parse**: If value starts with `{` or `[`, attempt JSON parse
-5. **Boolean parse**: If value is exactly `true` or `false` (case-insensitive), parse as boolean
-6. **Number parse**: Attempt to parse as integer or float
-7. **CSV detection**: If value contains `,` and not enclosed in quotes, split as CSV list
-8. **Literal string**: Fallback to treating value as literal string
+3. **JSON parse**: If value starts with `{` or `[`, attempt JSON parse
+4. **Boolean parse**: If value is exactly `true` or `false` (case-insensitive), parse as boolean
+5. **Number parse**: Attempt to parse as integer or float
+6. **Literal string**: Fallback to treating value as literal string
+
+`http://`/`https://` values are **not** fetched under `auto` (use `type: fetch`),
+and comma-separated values are **not** auto-split (use `type: csv`).
 
 **Examples:**
 
-- `-r url=https://example.com` → URL reference (rule 3)
-- `-r url="https://example.com"` → Literal string (quotes override protocol detection)
-- `-r count=42` → Integer (rule 6)
-- `-r items=a,b,c` → Array `["a", "b", "c"]` (rule 7)
-- `-r items=a -r items=b -r items=c` → Array `["a", "b", "c"]` (rule 7)
-- `-r flag=true` → Boolean `true` (rule 5)
-- `-r config={"key":"value"}` → JSON object (rule 4)
+- `-r url=https://example.com` -> literal string `"https://example.com"` (no fetch)
+- `-r url=https://example.com` + `type: fetch` -> the fetched response body
+- `-r count=42` -> Integer (rule 5)
+- `-r items=a,b,c` -> literal string `"a,b,c"` (use `type: csv` for a list)
+- `-r flag=true` -> Boolean `true` (rule 4)
+- `-r config={"key":"value"}` -> JSON object (rule 3)
 
 ---
 

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -2170,7 +2170,7 @@ Access CLI parameters passed via `-r` flags.
 | `key` | string | ❌ | Parameter name (exact match). Provide either `key` or `keys`; `key` takes precedence over `keys` when both are set. |
 | `keys` | array of string | ❌ | Ordered list of parameter names (aliases) for a single logical parameter. The first name provided via CLI wins. Evaluated after `key`. |
 | `default` | any | ❌ | Value returned when the parameter is not provided. |
-| `type` | string | ❌ | How the value is coerced. One of `auto` (default), `string`, `raw`, `int`, `float`, `bool`, `json`, `csv`. See the table below. |
+| `type` | string | ❌ | How the value is coerced. One of `auto` (default), `string`, `raw`, `int`, `float`, `bool`, `json`, `csv`, `fetch`. See the table below. |
 
 At least one of `key` or `keys` must be provided.
 
@@ -2178,7 +2178,7 @@ At least one of `key` or `keys` must be provided.
 
 | Value | Behavior |
 |-------|----------|
-| `auto` | Default. Infers booleans, numbers, JSON, and `file://` + `http://` sources, falling back to the literal string. Comma-separated values are **not** split into a list -- opt in with `csv`. |
+| `auto` | Default. Infers booleans, numbers, JSON, and `file://` sources, falling back to the literal string. `http://`/`https://` values are **not** fetched (they stay literal strings -- use `fetch`), and comma-separated values are **not** split into a list (opt in with `csv`). |
 | `string` | Coerces the value to a string, stripping surrounding quotes. Use to keep a numeric-looking value (leading zeros, or a value used with CEL `matches()`) as a string. |
 | `raw` | Returns the value untouched -- no coercion or quote-stripping. A numeric YAML default stays numeric; a CLI string stays verbatim. The escape hatch to disable inference. |
 | `int` | Forces integer parsing. A non-integer value is an error. |
@@ -2186,6 +2186,7 @@ At least one of `key` or `keys` must be provided.
 | `bool` | Forces boolean parsing, accepting only `true`/`false` (case-insensitive). Any other value is an error. |
 | `json` | Parses a string value as JSON. Invalid JSON is an error; non-string values pass through unchanged. |
 | `csv` | Splits a comma-separated string into a list of trimmed strings. Non-string values pass through unchanged. |
+| `fetch` | Performs an SSRF-guarded HTTP GET on an `http://`/`https://` value and returns the response body. A non-URL value is an error. For anything beyond a plain GET (auth, headers, methods, retries), use the `http` provider. |
 
 ### Output
 
@@ -2222,7 +2223,8 @@ resolve:
 
 ```yaml
 # Coerce values with the "type" input. "auto" (default) infers bools,
-# numbers, JSON, and file://+http:// sources; other types force one coercion.
+# numbers, JSON, and file:// sources; http(s):// URLs stay literal strings
+# (use "fetch" to GET them); other types force one coercion.
 resolve:
   with:
     # Keep a numeric-looking ID as a string (leading zeros survive).

--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -1292,16 +1292,17 @@ scafctl run resolver -f param-demo.yaml unknown=value
 
 By default the parameter provider infers a type from the raw value: `true`/`false`
 become booleans, numeric strings become numbers, JSON objects/arrays are parsed,
-and `file://`/`http://` values are loaded. When automatic inference produces the
-wrong type -- for example a numeric ID with leading zeros that should stay a
-string, or a value that must be parsed a specific way -- set the `type` input to
-take explicit control.
+and `file://` values are loaded. `http://`/`https://` values are kept as literal
+strings -- they are not fetched. When automatic inference produces the wrong type
+-- for example a numeric ID with leading zeros that should stay a string, or a
+value that must be parsed a specific way -- set the `type` input to take explicit
+control.
 
 The `type` input accepts these values:
 
 | Type     | Behavior                                                                 |
 | -------- | ------------------------------------------------------------------------ |
-| `auto`   | Default. Infers bool, number, JSON, and `file://`/`http://` values.      |
+| `auto`   | Default. Infers bool, number, JSON, and `file://` values.                |
 | `string` | Coerces the value to a string (strips surrounding quotes).               |
 | `raw`    | Returns the value exactly as received, with no coercion or quote strip.  |
 | `int`    | Parses the value as an integer; errors if it is not a whole number.      |
@@ -1309,11 +1310,13 @@ The `type` input accepts these values:
 | `bool`   | Parses `true`/`false` (case-insensitive); errors on any other value.     |
 | `json`   | Parses the value as JSON; errors on invalid JSON.                        |
 | `csv`    | Splits the value on commas into a trimmed list of strings.               |
+| `fetch`  | Performs an SSRF-guarded HTTP GET and returns the response body.         |
 
-> **Breaking change:** Comma-separated values are no longer split into lists
-> automatically. A value like `a,b,c` now stays the string `"a,b,c"` under `auto`.
-> Set `type: csv` when you want a list. This removes a surprising footgun where
-> any value containing a comma silently became an array.
+> [!NOTE]
+> `auto` never triggers network I/O or list-splitting. A `http://`/`https://`
+> value stays the literal string (use `type: fetch` to retrieve the content, or
+> the `http` provider for anything beyond a plain GET), and a comma-separated
+> value like `a,b,c` stays the string `"a,b,c"` (use `type: csv` to get a list).
 
 An explicit `type` applies to both CLI-supplied values and the `default` input.
 When a typed value cannot be parsed (for example `type: int` on `abc`), the

--- a/examples/providers/parameter-types.yaml
+++ b/examples/providers/parameter-types.yaml
@@ -1,6 +1,11 @@
 # Run: scafctl run resolver -f examples/providers/parameter-types.yaml \
 #        billingId=00042 port=8080 ratio=1.5 enabled=true \
-#        config='{"replicas":3}' regions=us-east-1,us-west-2 -o json
+#        config='{"replicas":3}' regions=us-east-1,us-west-2 \
+#        repoUrl=https://github.com/org/repo -o json
+#
+# Fetch remote content explicitly (performs an HTTP GET):
+#   scafctl run resolver -f examples/providers/parameter-types.yaml \
+#        configUrl=https://example.com/config.json fetchedConfig -o json
 
 apiVersion: scafctl.io/v1
 kind: Solution
@@ -15,14 +20,16 @@ metadata:
   description: |
     Demonstrates the parameter provider's "type" input, which controls how a
     raw CLI value (or default) is coerced. "auto" (the default) infers bools,
-    numbers, JSON, and file://+http:// sources but does NOT split
-    comma-separated values -- opt in with "csv". Every other type forces a
+    numbers, JSON, and file:// sources. It does NOT fetch http://+https:// URLs
+    (they stay literal strings -- use "fetch") and does NOT split
+    comma-separated values (opt in with "csv"). Every other type forces a
     single coercion and errors if the value does not match.
 
 spec:
   resolvers:
-    # auto (default): infers bool, number, JSON, file://, http://.
-    # Comma-separated values are NOT split -- they stay a literal string.
+    # auto (default): infers bool, number, JSON, file://.
+    # Comma-separated values are NOT split and http(s):// URLs are NOT
+    # fetched -- they stay literal strings.
     inferred:
       description: Automatic inference (numeric-looking value becomes a number)
       resolve:
@@ -31,6 +38,34 @@ spec:
             inputs:
               key: port
               default: 8080
+
+    # auto keeps a URL as a literal string -- no network I/O based on the
+    # value's shape. This is the common case (store the URL, not its body).
+    repoUrl:
+      description: A URL stored verbatim under auto (never fetched)
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: repoUrl
+              default: "https://github.com/oakwood-commons/scafctl"
+
+    # fetch: explicit, SSRF-guarded HTTP GET that stores the response body.
+    # Use only when you want the remote content; for auth/headers/methods/
+    # retries use the http provider. continueOnError keeps this runnable
+    # offline by falling back when no configUrl is provided or it is unreachable.
+    fetchedConfig:
+      description: Remote content fetched explicitly with type fetch
+      resolve:
+        with:
+          - provider: parameter
+            continueOnError: true
+            inputs:
+              key: configUrl
+              type: fetch
+          - provider: static
+            inputs:
+              value: "<no configUrl provided; pass -r configUrl=https://...>"
 
     # string: keep a numeric-looking value as a string (e.g. an ID with
     # leading zeros, or a value used with CEL matches()).

--- a/pkg/provider/builtin/parameterprovider/parameter.go
+++ b/pkg/provider/builtin/parameterprovider/parameter.go
@@ -31,8 +31,9 @@ const (
 	Version = "1.0.0"
 
 	// TypeAuto is the default value for the "type" input. It infers booleans,
-	// numbers, JSON, and file://+http:// sources, falling back to the literal
-	// string. Comma-separated values are NOT auto-split; use TypeCSV for that.
+	// numbers, JSON, and file:// sources, falling back to the literal string.
+	// http://+https:// values are NOT fetched; use TypeFetch for that.
+	// Comma-separated values are NOT auto-split; use TypeCSV for that.
 	TypeAuto = "auto"
 	// TypeString forces the value to a string, stripping surrounding quotes and
 	// coercing non-string values to their string representation.
@@ -51,6 +52,11 @@ const (
 	TypeJSON = "json"
 	// TypeCSV splits a comma-separated value into a list of trimmed strings.
 	TypeCSV = "csv"
+	// TypeFetch performs an SSRF-guarded HTTP(S) GET and returns the response
+	// body. The value must be an http:// or https:// URL. This is the explicit
+	// opt-in for network fetching; auto never fetches. For anything beyond a
+	// plain GET (auth, headers, methods, retries), use the http provider.
+	TypeFetch = "fetch"
 )
 
 // paramTypes lists every value accepted by the "type" input, in schema
@@ -65,6 +71,7 @@ var paramTypes = []string{
 	TypeBool,
 	TypeJSON,
 	TypeCSV,
+	TypeFetch,
 }
 
 // paramTypeEnum is paramTypes converted to []any for the descriptor's enum
@@ -156,7 +163,7 @@ func NewParameterProvider(opts ...Option) *ParameterProvider {
 					schemahelper.WithMaxItems(50)),
 				"default": schemahelper.AnyProp("Default value to return when the parameter is not provided via CLI. Must be a literal value -- ValueRef expressions are resolved by the executor before Execute is called, so a ValueRef default would be evaluated even when the parameter exists.",
 					schemahelper.WithExample("fallback")),
-				"type": schemahelper.StringProp("Controls how the parameter value is coerced. \"auto\" (default) infers booleans, numbers, JSON, and file://+http:// sources, falling back to the literal string. \"string\" coerces to a string (stripping surrounding quotes). \"raw\" returns the value untouched. \"int\", \"float\", \"bool\", \"json\", and \"csv\" force that specific coercion and error if the value does not match. Comma-separated values are split into a string list only when type is \"csv\".",
+				"type": schemahelper.StringProp("Controls how the parameter value is coerced. \"auto\" (default) infers booleans, numbers, JSON, and file:// sources, falling back to the literal string. \"string\" coerces to a string (stripping surrounding quotes). \"raw\" returns the value untouched. \"int\", \"float\", \"bool\", \"json\", and \"csv\" force that specific coercion and error if the value does not match. Comma-separated values are split into a string list only when type is \"csv\". http:// and https:// values are NOT fetched under \"auto\"; use \"fetch\" to perform an SSRF-guarded HTTP GET, or the http provider for anything beyond a plain GET.",
 					schemahelper.WithEnum(paramTypeEnum...),
 					schemahelper.WithExample(TypeString)),
 			}),
@@ -229,6 +236,14 @@ inputs:
 inputs:
   key: token
   type: raw`,
+				},
+				{
+					Name:        "Fetch remote content over HTTP",
+					Description: "Perform an SSRF-guarded HTTP GET and store the response body (opt in with type: fetch). auto never fetches; a URL value stays a literal string.",
+					YAML: `provider: parameter
+inputs:
+  key: configUrl
+  type: fetch`,
 				},
 			},
 		},
@@ -352,6 +367,12 @@ func (p *ParameterProvider) resolveValue(ctx context.Context, value any, paramTy
 		return coerceJSON(value)
 	case TypeCSV:
 		return coerceCSV(value), nil
+	case TypeFetch:
+		str, ok := value.(string)
+		if !ok || !isHTTPURL(str) {
+			return nil, fmt.Errorf("%s: type %q requires an http:// or https:// value, got %q (%T)", ProviderName, TypeFetch, fmt.Sprintf("%v", value), value)
+		}
+		return p.fetchURL(ctx, str)
 	case TypeAuto:
 		return p.parseValue(ctx, value)
 	default:
@@ -522,8 +543,11 @@ func coerceCSV(value any) any {
 	return result
 }
 
-// parseValue applies the auto inference pipeline to a parameter value.
-func (p *ParameterProvider) parseValue(ctx context.Context, value any) (any, error) {
+// parseValue applies the auto inference pipeline to a parameter value. It is
+// purely local (no network I/O); http(s):// values are not fetched under auto
+// -- use TypeFetch for that. The context parameter is retained for signature
+// symmetry with the rest of the value-resolution pipeline.
+func (p *ParameterProvider) parseValue(_ context.Context, value any) (any, error) {
 	// If value is already parsed (not a string), return as-is
 	str, ok := value.(string)
 	if !ok {
@@ -545,32 +569,7 @@ func (p *ParameterProvider) parseValue(ctx context.Context, value any) (any, err
 		return string(content), nil
 	}
 
-	// 3. HTTP protocol
-	if strings.HasPrefix(str, "http://") || strings.HasPrefix(str, "https://") {
-		// Block requests to private/loopback/link-local IP addresses unless explicitly permitted.
-		if !httpc.PrivateIPsAllowed(ctx) {
-			if err := httpc.ValidateURLNotPrivate(str); err != nil {
-				return nil, fmt.Errorf("resolver parameter URL blocked: %w", err)
-			}
-		}
-		resp, err := p.httpClient.Get(ctx, str)
-		if err != nil {
-			return nil, fmt.Errorf("failed to fetch URL %q: %w", str, err)
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("HTTP request to %q failed with status %d", str, resp.StatusCode)
-		}
-
-		content, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read response from %q: %w", str, err)
-		}
-		return string(content), nil
-	}
-
-	// 4. JSON parse
+	// 3. JSON parse
 	if strings.HasPrefix(str, "{") || strings.HasPrefix(str, "[") {
 		var result any
 		if err := json.Unmarshal([]byte(str), &result); err == nil {
@@ -579,7 +578,7 @@ func (p *ParameterProvider) parseValue(ctx context.Context, value any) (any, err
 		// If JSON parsing fails, continue to next rule
 	}
 
-	// 5. Boolean parse
+	// 4. Boolean parse
 	lowerStr := strings.ToLower(str)
 	if lowerStr == "true" {
 		return true, nil
@@ -588,7 +587,7 @@ func (p *ParameterProvider) parseValue(ctx context.Context, value any) (any, err
 		return false, nil
 	}
 
-	// 6. Number parse
+	// 5. Number parse
 	// Try integer first
 	if intVal, err := strconv.ParseInt(str, 10, 64); err == nil {
 		return intVal, nil
@@ -598,13 +597,44 @@ func (p *ParameterProvider) parseValue(ctx context.Context, value any) (any, err
 		return floatVal, nil
 	}
 
-	// 7. Literal string (fallback)
+	// 6. Literal string (fallback)
 	// Remove surrounding quotes if present
 	if isQuoted(str) {
 		return strings.Trim(str, `"`), nil
 	}
 
 	return str, nil
+}
+
+// isHTTPURL reports whether s is an http:// or https:// URL.
+func isHTTPURL(s string) bool {
+	return strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://")
+}
+
+// fetchURL performs an SSRF-guarded HTTP GET and returns the response body as a
+// string. It backs TypeFetch; auto never fetches. Requests to
+// private/loopback/link-local addresses are blocked unless explicitly permitted.
+func (p *ParameterProvider) fetchURL(ctx context.Context, url string) (string, error) {
+	if !httpc.PrivateIPsAllowed(ctx) {
+		if err := httpc.ValidateURLNotPrivate(url); err != nil {
+			return "", fmt.Errorf("resolver parameter URL blocked: %w", err)
+		}
+	}
+	resp, err := p.httpClient.Get(ctx, url)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch URL %q: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("HTTP request to %q failed with status %d", url, resp.StatusCode)
+	}
+
+	content, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response from %q: %w", url, err)
+	}
+	return string(content), nil
 }
 
 // isQuoted checks if a string is surrounded by double quotes

--- a/pkg/provider/builtin/parameterprovider/parameter_benchmark_test.go
+++ b/pkg/provider/builtin/parameterprovider/parameter_benchmark_test.go
@@ -53,6 +53,7 @@ func BenchmarkParameterProvider_Execute_TypedCoercion(b *testing.B) {
 		typeIn string
 	}{
 		{"auto_int", "8080", TypeAuto},
+		{"auto_url_literal", "https://example.com/config", TypeAuto},
 		{"int", "8080", TypeInt},
 		{"float", "3.14", TypeFloat},
 		{"bool", "true", TypeBool},

--- a/pkg/provider/builtin/parameterprovider/parameter_test.go
+++ b/pkg/provider/builtin/parameterprovider/parameter_test.go
@@ -865,11 +865,11 @@ func TestWithHTTPClient_ExercisesOption(t *testing.T) {
 
 	mock := &MockHTTPClient{Err: errors.New("mock-error")}
 	p := NewParameterProvider(WithHTTPClient(mock))
-	_, err := p.parseValue(ctx, "http://127.0.0.1/data")
+	_, err := p.resolveValue(ctx, "http://127.0.0.1/data", TypeFetch)
 	assert.ErrorContains(t, err, "mock-error")
 }
 
-func TestParameterProvider_ParseValue_HTTP_Success(t *testing.T) {
+func TestParameterProvider_Fetch_Success(t *testing.T) {
 	t.Parallel()
 	allow := true
 	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: &allow}}
@@ -882,12 +882,12 @@ func TestParameterProvider_ParseValue_HTTP_Success(t *testing.T) {
 		},
 	}
 	p := NewParameterProvider(WithHTTPClient(mock))
-	result, err := p.parseValue(ctx, "http://127.0.0.1/data")
+	result, err := p.resolveValue(ctx, "http://127.0.0.1/data", TypeFetch)
 	require.NoError(t, err)
 	assert.Equal(t, "remote-value", result)
 }
 
-func TestParameterProvider_ParseValue_HTTP_NonOKStatus(t *testing.T) {
+func TestParameterProvider_Fetch_NonOKStatus(t *testing.T) {
 	t.Parallel()
 	allow := true
 	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: &allow}}
@@ -900,8 +900,114 @@ func TestParameterProvider_ParseValue_HTTP_NonOKStatus(t *testing.T) {
 		},
 	}
 	p := NewParameterProvider(WithHTTPClient(mock))
-	_, err := p.parseValue(ctx, "http://127.0.0.1/data")
+	_, err := p.resolveValue(ctx, "http://127.0.0.1/data", TypeFetch)
 	assert.ErrorContains(t, err, "404")
+}
+
+// TestParameterProvider_Fetch_SSRFBlocked verifies that fetch blocks a
+// private/loopback address when private IPs are not permitted, without issuing
+// the request (the mock fails if called).
+func TestParameterProvider_Fetch_SSRFBlocked(t *testing.T) {
+	t.Parallel()
+	deny := false
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: &deny}}
+	ctx := config.WithConfig(context.Background(), cfg)
+	mock := &MockHTTPClient{Err: errors.New("network should not be called")}
+	p := NewParameterProvider(WithHTTPClient(mock))
+
+	_, err := p.resolveValue(ctx, "http://127.0.0.1/data", TypeFetch)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "resolver parameter URL blocked")
+}
+
+// TestParameterProvider_Auto_DoesNotFetchURL is the core regression guard for
+// the breaking change: under auto, an http(s):// value is stored as a literal
+// string and no network I/O occurs. The mock client is configured to fail if
+// called, so a fetch would surface as an error.
+func TestParameterProvider_Auto_DoesNotFetchURL(t *testing.T) {
+	t.Parallel()
+	mock := &MockHTTPClient{Err: errors.New("network should not be called")}
+	p := NewParameterProvider(WithHTTPClient(mock))
+	ctx := context.Background()
+
+	for _, url := range []string{"http://example.com/data", "https://example.com/data"} {
+		result, err := p.parseValue(ctx, url)
+		require.NoError(t, err)
+		assert.Equal(t, url, result)
+	}
+}
+
+// TestParameterProvider_Fetch_RequiresURL verifies type: fetch rejects a
+// non-URL value with a descriptive error instead of silently falling through.
+func TestParameterProvider_Fetch_RequiresURL(t *testing.T) {
+	t.Parallel()
+	p := NewParameterProvider()
+	ctx := context.Background()
+
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{"plain string", "not-a-url"},
+		{"ftp scheme", "ftp://example.com"},
+		{"non-string", 42},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := p.resolveValue(ctx, tt.value, TypeFetch)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "requires an http:// or https:// value")
+		})
+	}
+}
+
+// TestParameterProvider_Execute_Fetch fetches remote content through the full
+// Execute path when type: fetch is requested for a URL parameter.
+func TestParameterProvider_Execute_Fetch(t *testing.T) {
+	t.Parallel()
+	allow := true
+	cfg := &config.Config{HTTPClient: config.HTTPClientConfig{AllowPrivateIPs: &allow}}
+	ctx := config.WithConfig(context.Background(), cfg)
+	ctx = provider.WithParameters(ctx, map[string]any{
+		"configUrl": "http://127.0.0.1/config",
+	})
+
+	mock := &MockHTTPClient{
+		Response: &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("remote-body")),
+		},
+	}
+	p := NewParameterProvider(WithHTTPClient(mock))
+	output, err := p.Execute(ctx, map[string]any{
+		"key":  "configUrl",
+		"type": TypeFetch,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, "remote-body", output.Data)
+	assert.Equal(t, true, output.Metadata["exists"])
+}
+
+// TestParameterProvider_Execute_Fetch_DryRunNoNetwork ensures dry-run never
+// performs the fetch: the mock is configured to fail if called.
+func TestParameterProvider_Execute_Fetch_DryRunNoNetwork(t *testing.T) {
+	t.Parallel()
+	mock := &MockHTTPClient{Err: errors.New("network should not be called")}
+	p := NewParameterProvider(WithHTTPClient(mock))
+	ctx := provider.WithDryRun(context.Background(), true)
+	ctx = provider.WithParameters(ctx, map[string]any{
+		"configUrl": "http://127.0.0.1/config",
+	})
+
+	output, err := p.Execute(ctx, map[string]any{
+		"key":  "configUrl",
+		"type": TypeFetch,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, "[DRY-RUN] Not retrieved", output.Data)
 }
 
 func TestDefaultFileOps_ReadFile(t *testing.T) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -6605,6 +6605,7 @@ func TestIntegration_Run_Resolver_ParameterTypes(t *testing.T) {
 		"-r", "enabled=true",
 		"-r", `config={"replicas":3}`,
 		"-r", "regions=us-east-1, us-west-2",
+		"-r", "repoUrl=https://github.com/org/repo",
 	)
 	require.Equal(t, 0, exitCode, "stdout: %s\nstderr: %s", stdout, stderr)
 
@@ -6613,6 +6614,10 @@ func TestIntegration_Run_Resolver_ParameterTypes(t *testing.T) {
 
 	// auto (default): numeric-looking value infers to a JSON number.
 	assert.InDelta(t, float64(8080), out["inferred"], 0, "auto should infer a number")
+	// auto: a URL value is stored verbatim, never fetched.
+	assert.Equal(t, "https://github.com/org/repo", out["repoUrl"], "auto should keep a URL literal")
+	// fetch: no configUrl provided, so the static fallback is used (no network).
+	assert.Equal(t, "<no configUrl provided; pass -r configUrl=https://...>", out["fetchedConfig"], "fetch should fall back when configUrl is absent")
 	// string: keep leading zeros as a string.
 	assert.Equal(t, "00042", out["billingId"], "type string should preserve leading zeros")
 	// raw: returned verbatim, no coercion.


### PR DESCRIPTION
Add an explicit "fetch" type to the parameter provider that performs an SSRF-guarded HTTP(S) GET and returns the response body. Auto inference no longer fetches http:// or https:// URLs -- they are stored as literal strings.

BREAKING CHANGE: parameter resolvers with type: auto (the default) no longer fetch http:// or https:// values. A URL is now kept as a literal string. Use type: fetch to opt into an SSRF-guarded HTTP GET, or the http provider for anything beyond a plain GET.

- Add TypeFetch ("fetch") to the accepted parameter types and schema enum
- Move the HTTP GET path out of parseValue into a dedicated fetchURL, invoked only for type: fetch; auto is now purely local (no network I/O)
- Reject non-http(s) or non-string values under type: fetch with a descriptive error
- Update provider examples, resolver design docs, and tutorials to document the fetch opt-in and the auto-literal behavior
- Add tests: auto keeps URLs literal, fetch success/non-OK/SSRF-blocked, dry-run performs no network I/O, and full Execute fetch path
- Extend the parameter-types example and CLI integration test to cover URL-literal and fetch fallback behavior