### PR TITLE
refactor: de-hyphenate 'get cel/template functions' and 'catalog remote default' (grammar phase 8)

### DIFF
--- a/docs/design/catalog-cli-design-decision.md
+++ b/docs/design/catalog-cli-design-decision.md
@@ -230,7 +230,7 @@ scafctl catalog pull ghcr.io/myorg/custom-path/deploy:1.0.0
 
 ### Rationale
 
-Option B offers the lowest learning curve, least typing after initial setup, and requires no new commands. It integrates naturally with the existing `scafctl catalog remote add` / `scafctl catalog remote set-default` CLI. Kind inference from local catalog metadata ensures correctness without user-facing complexity.
+Option B offers the lowest learning curve, least typing after initial setup, and requires no new commands. It integrates naturally with the existing `scafctl catalog remote add` / `scafctl catalog remote default` CLI. Kind inference from local catalog metadata ensures correctness without user-facing complexity.
 
 ### Implementation Summary
 

--- a/docs/design/cli-contributing.md
+++ b/docs/design/cli-contributing.md
@@ -1233,7 +1233,7 @@ This section tracks which commands from the design are implemented and what work
 | `config unset` | ✅ | Remove config value |
 | `catalog remote add` | ✅ | Add catalog configuration |
 | `catalog remote remove` | ✅ | Remove catalog |
-| `catalog remote set-default` | ✅ | Set default catalog |
+| `catalog remote default` | ✅ | Set default catalog |
 | `config init` | ✅ | Initialize configuration |
 | `config schema` | ✅ | Show config schema |
 | `config validate` | ✅ | Validate config file |

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -769,7 +769,7 @@ scafctl catalog remote add internal --type oci --url oci://registry.example.com/
 scafctl catalog remote remove internal
 
 # Set the default catalog
-scafctl catalog remote set-default internal
+scafctl catalog remote default internal
 ~~~
 
 ### Environment Variables

--- a/docs/design/mcp-server-implementation-guide.md
+++ b/docs/design/mcp-server-implementation-guide.md
@@ -826,7 +826,7 @@ func (s *Server) handleGetProviderSchema(ctx context.Context, request mcp.CallTo
 
 **Purpose:** List all available CEL functions — both scafctl custom functions and standard CEL built-ins.
 
-**Maps to:** `scafctl get cel-functions`
+**Maps to:** `scafctl get cel functions`
 
 **Input schema:**
 

--- a/docs/design/mcp-server.md
+++ b/docs/design/mcp-server.md
@@ -219,7 +219,7 @@ We would essentially be creating thin adapters from MCP tool handlers → existi
 - Providers, resolvers, and solutions all have well-defined interfaces
 - `context.Context` is used throughout, so cancellation propagates naturally
 - The KVX output system already supports JSON, making tool responses trivial
-- The `scafctl get cel-functions` command proves the `ext.All()` API works end-to-end for the `list_cel_functions` MCP tool
+- The `scafctl get cel functions` command proves the `ext.All()` API works end-to-end for the `list_cel_functions` MCP tool
 
 ### What Makes It Harder
 

--- a/docs/tutorials/config-tutorial.md
+++ b/docs/tutorials/config-tutorial.md
@@ -261,12 +261,12 @@ scafctl catalog remote remove my-catalog
 {{< tabs "config-tutorial-cmd-9" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl catalog remote set-default my-catalog
+scafctl catalog remote default my-catalog
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl catalog remote set-default my-catalog
+scafctl catalog remote default my-catalog
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -500,7 +500,7 @@ scafctl config validate
 {{% tab "Bash" %}}
 ```bash
 # Use staging catalog
-scafctl catalog remote set-default staging
+scafctl catalog remote default staging
 
 # Increase logging for debugging
 scafctl config set logging.level debug
@@ -512,7 +512,7 @@ scafctl config unset logging.level
 {{% tab "PowerShell" %}}
 ```powershell
 # Use staging catalog
-scafctl catalog remote set-default staging
+scafctl catalog remote default staging
 
 # Increase logging for debugging
 scafctl config set logging.level debug

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -2316,12 +2316,12 @@ List all available functions:
 {{< tabs "go-templates-tutorial-cmd-29" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl get go-template-functions
+scafctl get template functions
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl get go-template-functions
+scafctl get template functions
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -2331,12 +2331,12 @@ Filter to custom functions only:
 {{< tabs "go-templates-tutorial-cmd-30" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl get go-template-functions --custom
+scafctl get template functions --custom
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl get go-template-functions --custom
+scafctl get template functions --custom
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -2346,12 +2346,12 @@ Filter to Sprig functions only:
 {{< tabs "go-templates-tutorial-cmd-31" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl get go-template-functions --sprig
+scafctl get template functions --sprig
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl get go-template-functions --sprig
+scafctl get template functions --sprig
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -2361,12 +2361,12 @@ Get details for a specific function:
 {{< tabs "go-templates-tutorial-cmd-32" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl get go-template-functions toHcl
+scafctl get template functions toHcl
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl get go-template-functions toHcl
+scafctl get template functions toHcl
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -2376,12 +2376,12 @@ Output as JSON:
 {{< tabs "go-templates-tutorial-cmd-33" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl get go-template-functions -o json
+scafctl get template functions -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl get go-template-functions -o json
+scafctl get template functions -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -2397,7 +2397,7 @@ The AI calls `list_go_template_functions` and returns a curated list of matching
 
 ### What You Learned
 
-- **CLI discovery** — `scafctl get go-template-functions` lists all available functions with `--custom`, `--sprig`, and `-o json` flags.
+- **CLI discovery** — `scafctl get template functions` lists all available functions with `--custom`, `--sprig`, and `-o json` flags.
 - **MCP discovery** — The `list_go_template_functions` tool lets AI agents search and filter functions.
 - **Function detail** — Pass a function name as an argument to see its full description, signature, and examples.
 

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -2397,9 +2397,9 @@ The AI calls `list_go_template_functions` and returns a curated list of matching
 
 ### What You Learned
 
-- **CLI discovery** — `scafctl get template functions` lists all available functions with `--custom`, `--sprig`, and `-o json` flags.
-- **MCP discovery** — The `list_go_template_functions` tool lets AI agents search and filter functions.
-- **Function detail** — Pass a function name as an argument to see its full description, signature, and examples.
+- **CLI discovery** -- `scafctl get template functions` lists all available functions with `--custom`, `--sprig`, and `-o json` flags.
+- **MCP discovery** -- The `list_go_template_functions` tool lets AI agents search and filter functions.
+- **Function detail** -- Pass a function name as an argument to see its full description, signature, and examples.
 
 ---
 

--- a/opencode.json
+++ b/opencode.json
@@ -8,7 +8,7 @@
   "plugin": [
     "opencode-vibeguard",
     "opencode-notify",
-    "opencode-dynamic-context-pruning"
+    "@tarquinen/opencode-dcp@3.1.14"
   ],
   "formatter": {},
   "lsp": {

--- a/pkg/cmd/scafctl/catalog/remote.go
+++ b/pkg/cmd/scafctl/catalog/remote.go
@@ -287,6 +287,11 @@ func commandRemoteDefault(cliParams *settings.Run, ioStreams *terminal.IOStreams
 		CliParams: cliParams,
 	}
 
+	name := cliParams.BinaryName
+	if name == "" {
+		name = settings.CliBinaryName
+	}
+
 	cmd := &cobra.Command{
 		Use:   "default <name>",
 		Short: "Set the default catalog",
@@ -301,7 +306,7 @@ func commandRemoteDefault(cliParams *settings.Run, ioStreams *terminal.IOStreams
 
 			  # Clear default catalog
 			  %[1]s catalog remote default ""
-		`, settings.CliBinaryName),
+		`, name),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Name = args[0]

--- a/pkg/cmd/scafctl/catalog/remote.go
+++ b/pkg/cmd/scafctl/catalog/remote.go
@@ -38,7 +38,8 @@ func CommandRemote(cliParams *settings.Run, ioStreams *terminal.IOStreams, path 
 	cmdPath := fmt.Sprintf("%s/%s", path, cmd.Use)
 	cmd.AddCommand(commandRemoteAdd(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(commandRemoteRemove(cliParams, ioStreams, cmdPath))
-	cmd.AddCommand(commandRemoteSetDefault(cliParams, ioStreams, cmdPath))
+	cmd.AddCommand(commandRemoteDefault(cliParams, ioStreams, cmdPath))
+	cmd.AddCommand(commandRemoteSetDefaultDeprecated(cliParams, ioStreams, cmdPath))
 	cmd.AddCommand(commandRemoteList(cliParams, ioStreams, cmdPath))
 
 	return cmd
@@ -270,9 +271,9 @@ func runRemoteRemove(ctx context.Context, opts *RemoteRemoveOptions) error {
 	return nil
 }
 
-// --- remote set-default ---
+// --- remote default ---
 
-// RemoteSetDefaultOptions holds options for the remote set-default command.
+// RemoteSetDefaultOptions holds options for the remote default command.
 type RemoteSetDefaultOptions struct {
 	IOStreams  *terminal.IOStreams
 	CliParams  *settings.Run
@@ -280,15 +281,62 @@ type RemoteSetDefaultOptions struct {
 	Name       string
 }
 
-func commandRemoteSetDefault(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+func commandRemoteDefault(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
 	opts := &RemoteSetDefaultOptions{
 		IOStreams: ioStreams,
 		CliParams: cliParams,
 	}
 
 	cmd := &cobra.Command{
-		Use:   "set-default <name>",
+		Use:   "default <name>",
 		Short: "Set the default catalog",
+		Long: heredoc.Docf(`
+			Set a catalog as the default.
+
+			The default catalog is used when no --catalog flag is specified.
+
+			Examples:
+			  # Set default catalog
+			  %[1]s catalog remote default my-registry
+
+			  # Clear default catalog
+			  %[1]s catalog remote default ""
+		`, settings.CliBinaryName),
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.Name = args[0]
+
+			if configFlag := cmd.Root().Flag("config"); configFlag != nil && configFlag.Value.String() != "" {
+				opts.ConfigPath = configFlag.Value.String()
+			}
+
+			return runRemoteSetDefault(cmd.Context(), opts)
+		},
+		SilenceUsage: true,
+	}
+
+	return cmd
+}
+
+// commandRemoteSetDefaultDeprecated is the hidden, deprecated twin of
+// 'catalog remote default'. It shares the same runRemoteSetDefault logic.
+func commandRemoteSetDefaultDeprecated(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
+	opts := &RemoteSetDefaultOptions{
+		IOStreams: ioStreams,
+		CliParams: cliParams,
+	}
+
+	name := cliParams.BinaryName
+	if name == "" {
+		name = settings.CliBinaryName
+	}
+
+	cmd := &cobra.Command{
+		Use:    "set-default <name>",
+		Short:  "Set the default catalog",
+		Hidden: true,
+		Deprecated: fmt.Sprintf(`use "%s catalog remote default" instead`,
+			name),
 		Long: heredoc.Docf(`
 			Set a catalog as the default.
 

--- a/pkg/cmd/scafctl/catalog/remote.go
+++ b/pkg/cmd/scafctl/catalog/remote.go
@@ -353,7 +353,7 @@ func commandRemoteSetDefaultDeprecated(cliParams *settings.Run, ioStreams *termi
 
 			  # Clear default catalog
 			  %[1]s catalog remote set-default ""
-		`, settings.CliBinaryName),
+		`, name),
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Name = args[0]

--- a/pkg/cmd/scafctl/catalog/remote_test.go
+++ b/pkg/cmd/scafctl/catalog/remote_test.go
@@ -453,6 +453,33 @@ func TestCommandRemote_EmbedderBinaryName(t *testing.T) {
 
 	assert.Equal(t, "remote", cmd.Use)
 	assert.NotEmpty(t, cmd.Commands(), "subcommands should be registered for embedder binary")
+
+	// Both the canonical 'default' command and the hidden deprecated
+	// 'set-default' twin must render their help examples with the embedder
+	// binary name, never a hardcoded "scafctl".
+	var defaultCmd, setDefaultCmd *cobra.Command
+	for _, sub := range cmd.Commands() {
+		switch sub.Name() {
+		case "default":
+			defaultCmd = sub
+		case "set-default":
+			setDefaultCmd = sub
+		}
+	}
+	require.NotNil(t, defaultCmd, "canonical 'default' command must be registered")
+	require.NotNil(t, setDefaultCmd, "deprecated 'set-default' twin must be registered")
+
+	assert.Contains(t, defaultCmd.Long, "mycli catalog remote default",
+		"canonical Long examples must use the embedder binary name")
+	assert.NotContains(t, defaultCmd.Long, "scafctl catalog remote",
+		"canonical Long must not hardcode scafctl")
+
+	assert.Contains(t, setDefaultCmd.Long, "mycli catalog remote set-default",
+		"deprecated twin Long examples must use the embedder binary name")
+	assert.NotContains(t, setDefaultCmd.Long, "scafctl catalog remote",
+		"deprecated twin Long must not hardcode scafctl")
+	assert.Contains(t, setDefaultCmd.Deprecated, "mycli catalog remote default",
+		"deprecation message must point at the embedder binary")
 }
 
 func TestRunRemoteList_Empty(t *testing.T) {

--- a/pkg/cmd/scafctl/catalog/remote_test.go
+++ b/pkg/cmd/scafctl/catalog/remote_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,8 +44,39 @@ func TestCommandRemote_SubcommandRegistration(t *testing.T) {
 
 	assert.Contains(t, subCmdNames, "add")
 	assert.Contains(t, subCmdNames, "remove")
+	assert.Contains(t, subCmdNames, "default")
 	assert.Contains(t, subCmdNames, "set-default")
 	assert.Contains(t, subCmdNames, "list")
+}
+
+// TestCommandRemote_DefaultCanonicalAndDeprecated verifies the canonical
+// 'default' command and the hidden deprecated 'set-default' twin.
+func TestCommandRemote_DefaultCanonicalAndDeprecated(t *testing.T) {
+	t.Parallel()
+
+	cliParams := settings.NewCliParams()
+	ioStreams := terminal.NewIOStreams(nil, &bytes.Buffer{}, &bytes.Buffer{}, false)
+
+	cmd := CommandRemote(cliParams, ioStreams, "scafctl/catalog")
+
+	var canonical, deprecated *cobra.Command
+	for _, c := range cmd.Commands() {
+		switch c.Name() {
+		case "default":
+			canonical = c
+		case "set-default":
+			deprecated = c
+		}
+	}
+
+	require.NotNil(t, canonical, "canonical 'default' command must be registered")
+	assert.False(t, canonical.Hidden)
+	assert.Empty(t, canonical.Deprecated)
+
+	require.NotNil(t, deprecated, "deprecated 'set-default' twin must be registered")
+	assert.True(t, deprecated.Hidden)
+	assert.NotEmpty(t, deprecated.Deprecated)
+	assert.Contains(t, deprecated.Deprecated, "catalog remote default")
 }
 
 func TestRunRemoteAdd(t *testing.T) {

--- a/pkg/cmd/scafctl/get/cel/cel.go
+++ b/pkg/cmd/scafctl/get/cel/cel.go
@@ -1,0 +1,29 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package cel
+
+import (
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/celfunction"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/cobra"
+)
+
+// CommandCel creates the 'get cel' command group. A bare invocation shows help;
+// its 'functions' child is the canonical form of the former 'get cel-functions'.
+func CommandCel(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	cCmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
+		Use:          "cel",
+		Short:        "CEL resources",
+		SilenceUsage: true,
+	})
+
+	cmdPath := fmt.Sprintf("%s/%s", path, cCmd.Use)
+	cCmd.AddCommand(celfunction.CommandFunctions(cliParams, ioStreams, cmdPath))
+
+	return cCmd
+}

--- a/pkg/cmd/scafctl/get/cel/cel_test.go
+++ b/pkg/cmd/scafctl/get/cel/cel_test.go
@@ -71,4 +71,13 @@ func TestEmbedderBinaryName(t *testing.T) {
 	require.NotNil(t, cmd)
 	assert.Contains(t, cmd.Deprecated, "mycli")
 	assert.NotContains(t, cmd.Deprecated, "scafctl")
+
+	// The canonical child's Long/Examples must also honor the embedder binary
+	// name for command-prefix tokens, while product-name prose stays literal.
+	canonical := celfunction.CommandFunctions(cliParams, ioStreams, "mycli/get/cel")
+	require.NotNil(t, canonical)
+	assert.Contains(t, canonical.Long, "mycli get cel functions")
+	assert.NotContains(t, canonical.Long, "scafctl get cel functions")
+	// Product-name prose must NOT be rewritten to the binary name.
+	assert.Contains(t, canonical.Long, "scafctl-specific")
 }

--- a/pkg/cmd/scafctl/get/cel/cel_test.go
+++ b/pkg/cmd/scafctl/get/cel/cel_test.go
@@ -1,0 +1,74 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package cel
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/celfunction"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandCel(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandCel(cliParams, ioStreams, "scafctl/get")
+	require.NotNil(t, cmd)
+	assert.Equal(t, "cel", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, c := range cmd.Commands() {
+		names = append(names, c.Name())
+	}
+	assert.Contains(t, names, "functions", "get cel should wire up the 'functions' child")
+}
+
+// TestCommandCel_BareShowsHelp verifies a bare 'get cel' shows help (exit 0)
+// and an unknown subcommand errors.
+func TestCommandCel_BareShowsHelp(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandCel(cliParams, ioStreams, "scafctl/get")
+	cmd.SetArgs([]string{})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	assert.NoError(t, cmd.Execute())
+}
+
+func TestCommandCel_UnknownSubcommandErrors(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandCel(cliParams, ioStreams, "scafctl/get")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+}
+
+// TestEmbedderBinaryName verifies the deprecated cel-functions leaf reachable
+// through 'get cel' honors a non-default (embedder) binary name in its
+// user-facing deprecation notice rather than hardcoding "scafctl".
+func TestEmbedderBinaryName(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := celfunction.CommandCelFunctionDeprecated(cliParams, ioStreams, "mycli/get")
+	require.NotNil(t, cmd)
+	assert.Contains(t, cmd.Deprecated, "mycli")
+	assert.NotContains(t, cmd.Deprecated, "scafctl")
+}

--- a/pkg/cmd/scafctl/get/celfunction/celfunction.go
+++ b/pkg/cmd/scafctl/get/celfunction/celfunction.go
@@ -34,7 +34,7 @@ type FunctionSummary struct {
 	Custom      bool   `json:"custom" yaml:"custom"`
 }
 
-// Options holds configuration for the get cel-functions command
+// Options holds configuration for the get cel functions command
 type Options struct {
 	BinaryName string
 	IOStreams  *terminal.IOStreams
@@ -54,13 +54,33 @@ type Options struct {
 	builtInFn func() celexp.ExtFunctionList
 }
 
-// CommandCelFunction creates the 'get cel-functions' subcommand
-func CommandCelFunction(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+// CommandFunctions creates the canonical 'get cel functions' subcommand,
+// wired as a child of the 'get cel' group.
+func CommandFunctions(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	return newCommand(cliParams, ioStreams, path, "functions", nil, "", false)
+}
+
+// CommandCelFunctionDeprecated creates the hidden, deprecated 'get cel-functions'
+// leaf command. It shares the same RunE/flags as the canonical
+// 'get cel functions' child via newCommand.
+func CommandCelFunctionDeprecated(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	name := cliParams.BinaryName
+	if name == "" {
+		name = settings.CliBinaryName
+	}
+	deprecated := fmt.Sprintf(`use "%s get cel functions" instead`, name)
+	return newCommand(cliParams, ioStreams, path, "cel-functions", []string{"cel-funcs", "cf"}, deprecated, true)
+}
+
+// newCommand is the shared builder for both the canonical 'get cel functions'
+// child and the deprecated 'get cel-functions' leaf. Both forms wire identical
+// Options, RunE, and flags so their behavior is guaranteed to match.
+func newCommand(cliParams *settings.Run, ioStreams *terminal.IOStreams, path, use string, aliases []string, deprecated string, hidden bool) *cobra.Command {
 	options := &Options{}
 
 	cCmd := &cobra.Command{
-		Use:     "cel-functions",
-		Aliases: []string{"cel-funcs", "cel", "cf"},
+		Use:     use,
+		Aliases: aliases,
 		Short:   "List available CEL extension functions",
 		Long: `List all available CEL extension functions, including built-in cel-go
 extensions and custom scafctl-specific functions.
@@ -75,22 +95,24 @@ OUTPUT FORMATS:
 
 Examples:
   # List all CEL functions
-  scafctl get cel-functions
+  scafctl get cel functions
 
   # List only custom scafctl functions
-  scafctl get cel-functions --custom
+  scafctl get cel functions --custom
 
   # List only built-in cel-go functions
-  scafctl get cel-functions --builtin
+  scafctl get cel functions --builtin
 
   # Output as JSON
-  scafctl get cel-functions -o json
+  scafctl get cel functions -o json
 
   # Get details about a specific function
-  scafctl get cel-functions map.merge
+  scafctl get cel functions map.merge
 
   # Browse interactively
-  scafctl get cel-functions -i`,
+  scafctl get cel functions -i`,
+		Deprecated: deprecated,
+		Hidden:     hidden,
 		RunE: func(cCmd *cobra.Command, args []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
 			ctx := settings.IntoContext(cCmd.Context(), cliParams)
@@ -323,7 +345,7 @@ func (o *Options) writeOutput(ctx context.Context, data any) error {
 	kvxOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags,
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(o.CliParams.NoColor),
-		kvx.WithOutputAppName(o.BinaryName+" get cel-functions"),
+		kvx.WithOutputAppName(o.BinaryName+" get cel functions"),
 		kvx.WithIOStreams(o.IOStreams),
 		kvx.WithOutputDisplaySchemaJSON(celFunctionSchemaJSON),
 		kvx.WithOutputColumnOrder([]string{"name", "functions", "description"}),

--- a/pkg/cmd/scafctl/get/celfunction/celfunction.go
+++ b/pkg/cmd/scafctl/get/celfunction/celfunction.go
@@ -78,11 +78,16 @@ func CommandCelFunctionDeprecated(cliParams *settings.Run, ioStreams *terminal.I
 func newCommand(cliParams *settings.Run, ioStreams *terminal.IOStreams, path, use string, aliases []string, deprecated string, hidden bool) *cobra.Command {
 	options := &Options{}
 
+	name := cliParams.BinaryName
+	if name == "" {
+		name = settings.CliBinaryName
+	}
+
 	cCmd := &cobra.Command{
 		Use:     use,
 		Aliases: aliases,
 		Short:   "List available CEL extension functions",
-		Long: `List all available CEL extension functions, including built-in cel-go
+		Long: fmt.Sprintf(`List all available CEL extension functions, including built-in cel-go
 extensions and custom scafctl-specific functions.
 
 By default, lists all functions. Use --custom or --builtin to filter.
@@ -95,22 +100,22 @@ OUTPUT FORMATS:
 
 Examples:
   # List all CEL functions
-  scafctl get cel functions
+  %[1]s get cel functions
 
   # List only custom scafctl functions
-  scafctl get cel functions --custom
+  %[1]s get cel functions --custom
 
   # List only built-in cel-go functions
-  scafctl get cel functions --builtin
+  %[1]s get cel functions --builtin
 
   # Output as JSON
-  scafctl get cel functions -o json
+  %[1]s get cel functions -o json
 
   # Get details about a specific function
-  scafctl get cel functions map.merge
+  %[1]s get cel functions map.merge
 
   # Browse interactively
-  scafctl get cel functions -i`,
+  %[1]s get cel functions -i`, name),
 		Deprecated: deprecated,
 		Hidden:     hidden,
 		RunE: func(cCmd *cobra.Command, args []string) error {

--- a/pkg/cmd/scafctl/get/celfunction/celfunction.go
+++ b/pkg/cmd/scafctl/get/celfunction/celfunction.go
@@ -96,7 +96,7 @@ OUTPUT FORMATS:
   table     Table view with key information (default)
   json      Full function information as JSON
   yaml      Full function information as YAML
-  quiet     Function names only (one per line)
+  quiet     Suppress output (exit code only)
 
 Examples:
   # List all CEL functions
@@ -347,10 +347,14 @@ func (o *Options) printFunctionDetail(ctx context.Context, fn *celexp.ExtFunctio
 
 // writeOutput writes the output using kvx
 func (o *Options) writeOutput(ctx context.Context, data any) error {
+	bin := o.BinaryName
+	if bin == "" {
+		bin = settings.CliBinaryName
+	}
 	kvxOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags,
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(o.CliParams.NoColor),
-		kvx.WithOutputAppName(o.BinaryName+" get cel functions"),
+		kvx.WithOutputAppName(bin+" get cel functions"),
 		kvx.WithIOStreams(o.IOStreams),
 		kvx.WithOutputDisplaySchemaJSON(celFunctionSchemaJSON),
 		kvx.WithOutputColumnOrder([]string{"name", "functions", "description"}),

--- a/pkg/cmd/scafctl/get/celfunction/celfunction_test.go
+++ b/pkg/cmd/scafctl/get/celfunction/celfunction_test.go
@@ -412,3 +412,19 @@ func TestCommandCelFunction_SearchFlag(t *testing.T) {
 	assert.NotNil(t, f)
 	assert.Equal(t, "s", f.Shorthand)
 }
+
+// TestWriteOutput_EmptyBinaryNameFallback verifies writeOutput does not blank
+// the kvx app name when BinaryName is unset (embedder didn't set it): the
+// local fallback to settings.CliBinaryName keeps the name non-blank.
+func TestWriteOutput_EmptyBinaryNameFallback(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	opts := mkTestOpts(&buf) // BinaryName intentionally empty
+	require.Empty(t, opts.BinaryName)
+	ctx := settings.IntoContext(context.Background(), opts.CliParams)
+	ctx = writer.WithWriter(ctx, writer.New(opts.IOStreams, opts.CliParams))
+
+	err := opts.writeOutput(ctx, []FunctionSummary{{Name: "x"}})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "x")
+}

--- a/pkg/cmd/scafctl/get/celfunction/celfunction_test.go
+++ b/pkg/cmd/scafctl/get/celfunction/celfunction_test.go
@@ -6,6 +6,7 @@ package celfunction
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
@@ -236,21 +237,76 @@ func TestBuildFunctionListOutput(t *testing.T) {
 	assert.Equal(t, "test.builtin", result[1]["name"])
 }
 
-func TestCommandCelFunction_Creation(t *testing.T) {
+func TestCommandFunctions_Creation(t *testing.T) {
 	t.Parallel()
 	cliParams := &settings.Run{}
 	ioStreams := &terminal.IOStreams{}
-	cmd := CommandCelFunction(cliParams, ioStreams, "test/path")
+	cmd := CommandFunctions(cliParams, ioStreams, "test/path")
 
-	assert.Equal(t, "cel-functions", cmd.Use)
-	assert.Contains(t, cmd.Aliases, "cel")
-	assert.Contains(t, cmd.Aliases, "cf")
+	assert.Equal(t, "functions", cmd.Use)
+	assert.Empty(t, cmd.Aliases)
+	assert.False(t, cmd.Hidden)
+	assert.Empty(t, cmd.Deprecated)
 	assert.NotNil(t, cmd.RunE)
 	assert.NotNil(t, cmd.Flags().Lookup("output"))
 	assert.NotNil(t, cmd.Flags().Lookup("interactive"))
 	assert.NotNil(t, cmd.Flags().Lookup("expression"))
 	assert.NotNil(t, cmd.Flags().Lookup("custom"))
 	assert.NotNil(t, cmd.Flags().Lookup("builtin"))
+}
+
+func TestCommandCelFunctionDeprecated_Creation(t *testing.T) {
+	t.Parallel()
+	cliParams := &settings.Run{BinaryName: "scafctl"}
+	ioStreams := &terminal.IOStreams{}
+	cmd := CommandCelFunctionDeprecated(cliParams, ioStreams, "test/path")
+
+	assert.Equal(t, "cel-functions", cmd.Use)
+	assert.Contains(t, cmd.Aliases, "cel-funcs")
+	assert.Contains(t, cmd.Aliases, "cf")
+	assert.NotContains(t, cmd.Aliases, "cel", "bare 'cel' alias is now claimed by the group")
+	assert.True(t, cmd.Hidden)
+	assert.NotEmpty(t, cmd.Deprecated)
+	assert.Contains(t, cmd.Deprecated, "get cel functions")
+	assert.NotNil(t, cmd.RunE)
+	assert.NotNil(t, cmd.Flags().Lookup("custom"))
+	assert.NotNil(t, cmd.Flags().Lookup("builtin"))
+}
+
+// TestCanonicalAndDeprecated_ShareRunE verifies the canonical child and the
+// deprecated leaf produce identical output for the same args, since both share
+// the newCommand builder / RunE.
+func TestCanonicalAndDeprecated_ShareRunE(t *testing.T) {
+	t.Parallel()
+	cliParams := &settings.Run{BinaryName: "scafctl"}
+
+	var outC, errC, outD, errD bytes.Buffer
+	ioC := terminal.NewIOStreams(nil, &outC, &errC, false)
+	ioD := terminal.NewIOStreams(nil, &outD, &errD, false)
+
+	canonical := CommandFunctions(cliParams, ioC, "scafctl/get/cel")
+	deprecated := CommandCelFunctionDeprecated(cliParams, ioD, "scafctl/get")
+
+	canonical.SetOut(&outC)
+	canonical.SetErr(&errC)
+	canonical.SetArgs([]string{"-o", "json"})
+	require.NoError(t, canonical.Execute())
+
+	deprecated.SetOut(&outD)
+	deprecated.SetErr(&errD)
+	deprecated.SetArgs([]string{"-o", "json"})
+	require.NoError(t, deprecated.Execute())
+
+	// The deprecated leaf emits a cobra deprecation warning before the output.
+	// Strip that leading warning line, then the rendered function list must be
+	// byte-identical to the canonical child's output (shared RunE).
+	depOut := outD.String()
+	assert.Contains(t, depOut, "deprecated")
+	if idx := strings.Index(depOut, "\n"); idx >= 0 {
+		depOut = depOut[idx+1:]
+	}
+	assert.Equal(t, outC.String(), depOut)
+	assert.Contains(t, outC.String(), "\"name\"")
 }
 
 func TestRunListFunctions_SearchByFunctionName(t *testing.T) {
@@ -349,7 +405,7 @@ func TestCommandCelFunction_SearchFlag(t *testing.T) {
 	t.Parallel()
 	cliParams := &settings.Run{}
 	ioStreams := &terminal.IOStreams{}
-	cmd := CommandCelFunction(cliParams, ioStreams, "test/path")
+	cmd := CommandFunctions(cliParams, ioStreams, "test/path")
 
 	f := cmd.Flags().Lookup("search")
 	assert.NotNil(t, f)

--- a/pkg/cmd/scafctl/get/celfunction/celfunction_test.go
+++ b/pkg/cmd/scafctl/get/celfunction/celfunction_test.go
@@ -6,7 +6,6 @@ package celfunction
 import (
 	"bytes"
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
@@ -287,26 +286,28 @@ func TestCanonicalAndDeprecated_ShareRunE(t *testing.T) {
 	canonical := CommandFunctions(cliParams, ioC, "scafctl/get/cel")
 	deprecated := CommandCelFunctionDeprecated(cliParams, ioD, "scafctl/get")
 
-	canonical.SetOut(&outC)
+	canonical.SetOut(&errC)
 	canonical.SetErr(&errC)
 	canonical.SetArgs([]string{"-o", "json"})
 	require.NoError(t, canonical.Execute())
 
-	deprecated.SetOut(&outD)
+	deprecated.SetOut(&errD)
 	deprecated.SetErr(&errD)
 	deprecated.SetArgs([]string{"-o", "json"})
 	require.NoError(t, deprecated.Execute())
 
-	// The deprecated leaf emits a cobra deprecation warning before the output.
-	// Strip that leading warning line, then the rendered function list must be
-	// byte-identical to the canonical child's output (shared RunE).
-	depOut := outD.String()
-	assert.Contains(t, depOut, "deprecated")
-	if idx := strings.Index(depOut, "\n"); idx >= 0 {
-		depOut = depOut[idx+1:]
-	}
-	assert.Equal(t, outC.String(), depOut)
+	// The rendered function list is written through IOStreams.Out (outC/outD),
+	// which is independent of cobra's own writer. Cobra emits its deprecation
+	// notice through the command's writer (pointed at errC/errD here), so the
+	// two streams stay cleanly separated: the deprecated leaf's stdout must be
+	// byte-identical to the canonical child's stdout (shared RunE), with no
+	// stripping required.
+	assert.Equal(t, outC.String(), outD.String())
 	assert.Contains(t, outC.String(), "\"name\"")
+	// The deprecation notice must be emitted on the deprecated leaf's cobra
+	// writer (errD), not mixed into the function-list output on stdout.
+	assert.Contains(t, errD.String(), `is deprecated`)
+	assert.NotContains(t, outD.String(), `is deprecated`)
 }
 
 func TestRunListFunctions_SearchByFunctionName(t *testing.T) {

--- a/pkg/cmd/scafctl/get/get.go
+++ b/pkg/cmd/scafctl/get/get.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/cel"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/celfunction"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/commands"
 	getexamples "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/examples"
@@ -15,6 +16,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/provider"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/snapshot"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/solution"
+	gettemplate "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/template"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/spf13/cobra"
@@ -44,8 +46,10 @@ func CommandGet(cliParams *settings.Run, ioStreams *terminal.IOStreams, path str
 	cCmd.AddCommand(solution.CommandSolution(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
 	cCmd.AddCommand(snapshot.CommandSnapshot(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
 	cCmd.AddCommand(getexamples.CommandExamples(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
-	cCmd.AddCommand(celfunction.CommandCelFunction(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
-	cCmd.AddCommand(gotmplfunction.CommandGotmplFunction(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
+	cCmd.AddCommand(cel.CommandCel(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
+	cCmd.AddCommand(gettemplate.CommandTemplate(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
+	cCmd.AddCommand(celfunction.CommandCelFunctionDeprecated(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
+	cCmd.AddCommand(gotmplfunction.CommandGotmplFunctionDeprecated(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
 	cCmd.AddCommand(commands.CommandCommands(cliParams, ioStreams, path))
 	return cCmd
 }

--- a/pkg/cmd/scafctl/get/get_test.go
+++ b/pkg/cmd/scafctl/get/get_test.go
@@ -31,7 +31,7 @@ func TestCommandGet(t *testing.T) {
 	for _, c := range cmd.Commands() {
 		names = append(names, c.Name())
 	}
-	for _, want := range []string{"provider", "solution", "examples", "cel-functions", "go-template-functions", "commands"} {
+	for _, want := range []string{"provider", "solution", "examples", "cel", "template", "cel-functions", "go-template-functions", "commands"} {
 		assert.Contains(t, names, want, "get should wire up the %q subcommand", want)
 	}
 }

--- a/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
+++ b/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
@@ -33,7 +33,7 @@ type FunctionSummary struct {
 	Custom      bool   `json:"custom" yaml:"custom"`
 }
 
-// Options holds configuration for the get go-template-functions command
+// Options holds configuration for the get template functions command
 type Options struct {
 	BinaryName string
 	IOStreams  *terminal.IOStreams
@@ -53,13 +53,34 @@ type Options struct {
 	sprigFn  func() gotmpl.ExtFunctionList
 }
 
-// CommandGotmplFunction creates the 'get go-template-functions' subcommand
-func CommandGotmplFunction(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+// CommandFunctions creates the canonical 'get template functions' subcommand,
+// wired as a child of the 'get template' group.
+func CommandFunctions(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	return newCommand(cliParams, ioStreams, path, "functions", nil, "", false)
+}
+
+// CommandGotmplFunctionDeprecated creates the hidden, deprecated
+// 'get go-template-functions' leaf command. It shares the same RunE/flags as the
+// canonical 'get template functions' child via newCommand.
+func CommandGotmplFunctionDeprecated(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	name := cliParams.BinaryName
+	if name == "" {
+		name = settings.CliBinaryName
+	}
+	deprecated := fmt.Sprintf(`use "%s get template functions" instead`, name)
+	return newCommand(cliParams, ioStreams, path, "go-template-functions", []string{"gotmpl-funcs", "gotmpl", "gtf"}, deprecated, true)
+}
+
+// newCommand is the shared builder for both the canonical
+// 'get template functions' child and the deprecated 'get go-template-functions'
+// leaf. Both forms wire identical Options, RunE, and flags so their behavior is
+// guaranteed to match.
+func newCommand(cliParams *settings.Run, ioStreams *terminal.IOStreams, path, use string, aliases []string, deprecated string, hidden bool) *cobra.Command {
 	options := &Options{}
 
 	cCmd := &cobra.Command{
-		Use:     "go-template-functions",
-		Aliases: []string{"gotmpl-funcs", "gotmpl", "gtf"},
+		Use:     use,
+		Aliases: aliases,
 		Short:   "List available Go template extension functions",
 		Long: `List all available Go template extension functions, including sprig
 library functions and custom scafctl-specific functions.
@@ -74,22 +95,24 @@ OUTPUT FORMATS:
 
 Examples:
   # List all Go template functions
-  scafctl get go-template-functions
+  scafctl get template functions
 
   # List only custom scafctl functions
-  scafctl get go-template-functions --custom
+  scafctl get template functions --custom
 
   # List only sprig library functions
-  scafctl get go-template-functions --sprig
+  scafctl get template functions --sprig
 
   # Output as JSON
-  scafctl get go-template-functions -o json
+  scafctl get template functions -o json
 
   # Get details about a specific function
-  scafctl get go-template-functions toHcl
+  scafctl get template functions toHcl
 
   # Browse interactively
-  scafctl get go-template-functions -i`,
+  scafctl get template functions -i`,
+		Deprecated: deprecated,
+		Hidden:     hidden,
 		RunE: func(cCmd *cobra.Command, args []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cCmd.Use)
 			ctx := settings.IntoContext(cCmd.Context(), cliParams)
@@ -297,7 +320,7 @@ func (o *Options) writeOutput(ctx context.Context, data any) error {
 	kvxOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags,
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(o.CliParams.NoColor),
-		kvx.WithOutputAppName(o.BinaryName+" get go-template-functions"),
+		kvx.WithOutputAppName(o.BinaryName+" get template functions"),
 		kvx.WithIOStreams(o.IOStreams),
 		kvx.WithOutputDisplaySchemaJSON(gotmplFunctionSchemaJSON),
 		kvx.WithOutputColumnOrder([]string{"name", "description"}),

--- a/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
+++ b/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
@@ -78,11 +78,16 @@ func CommandGotmplFunctionDeprecated(cliParams *settings.Run, ioStreams *termina
 func newCommand(cliParams *settings.Run, ioStreams *terminal.IOStreams, path, use string, aliases []string, deprecated string, hidden bool) *cobra.Command {
 	options := &Options{}
 
+	name := cliParams.BinaryName
+	if name == "" {
+		name = settings.CliBinaryName
+	}
+
 	cCmd := &cobra.Command{
 		Use:     use,
 		Aliases: aliases,
 		Short:   "List available Go template extension functions",
-		Long: `List all available Go template extension functions, including sprig
+		Long: fmt.Sprintf(`List all available Go template extension functions, including sprig
 library functions and custom scafctl-specific functions.
 
 By default, lists all functions. Use --custom or --sprig to filter.
@@ -95,22 +100,22 @@ OUTPUT FORMATS:
 
 Examples:
   # List all Go template functions
-  scafctl get template functions
+  %[1]s get template functions
 
   # List only custom scafctl functions
-  scafctl get template functions --custom
+  %[1]s get template functions --custom
 
   # List only sprig library functions
-  scafctl get template functions --sprig
+  %[1]s get template functions --sprig
 
   # Output as JSON
-  scafctl get template functions -o json
+  %[1]s get template functions -o json
 
   # Get details about a specific function
-  scafctl get template functions toHcl
+  %[1]s get template functions toHcl
 
   # Browse interactively
-  scafctl get template functions -i`,
+  %[1]s get template functions -i`, name),
 		Deprecated: deprecated,
 		Hidden:     hidden,
 		RunE: func(cCmd *cobra.Command, args []string) error {

--- a/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
+++ b/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
@@ -96,7 +96,7 @@ OUTPUT FORMATS:
   table     Table view with key information (default)
   json      Full function information as JSON
   yaml      Full function information as YAML
-  quiet     Function names only (one per line)
+  quiet     Suppress output (exit code only)
 
 Examples:
   # List all Go template functions
@@ -322,10 +322,14 @@ func (o *Options) printFunctionDetail(ctx context.Context, fn *gotmpl.ExtFunctio
 
 // writeOutput writes the output using kvx
 func (o *Options) writeOutput(ctx context.Context, data any) error {
+	bin := o.BinaryName
+	if bin == "" {
+		bin = settings.CliBinaryName
+	}
 	kvxOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags,
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(o.CliParams.NoColor),
-		kvx.WithOutputAppName(o.BinaryName+" get template functions"),
+		kvx.WithOutputAppName(bin+" get template functions"),
 		kvx.WithIOStreams(o.IOStreams),
 		kvx.WithOutputDisplaySchemaJSON(gotmplFunctionSchemaJSON),
 		kvx.WithOutputColumnOrder([]string{"name", "description"}),

--- a/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction_coverage_test.go
+++ b/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction_coverage_test.go
@@ -355,3 +355,16 @@ func BenchmarkRunGetFunction(b *testing.B) {
 		_ = opts.RunGetFunction(ctx, "testFunc")
 	}
 }
+
+// TestWriteOutput_EmptyBinaryNameFallback verifies writeOutput does not blank
+// the kvx app name when BinaryName is unset (embedder didn't set it): the
+// local fallback to settings.CliBinaryName keeps the name non-blank.
+func TestWriteOutput_EmptyBinaryNameFallback(t *testing.T) {
+	t.Parallel()
+	ctx, buf, opts := newGotmplCtx(t) // BinaryName intentionally empty
+	require.Empty(t, opts.BinaryName)
+
+	err := opts.writeOutput(ctx, []FunctionSummary{{Name: "x"}})
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "x")
+}

--- a/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction_test.go
+++ b/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction_test.go
@@ -4,6 +4,8 @@
 package gotmplfunction
 
 import (
+	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
@@ -13,23 +15,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCommandGotmplFunction(t *testing.T) {
+func TestCommandFunctions(t *testing.T) {
 	cliParams := settings.NewCliParams()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := CommandGotmplFunction(cliParams, ioStreams, "scafctl/get")
+	cmd := CommandFunctions(cliParams, ioStreams, "scafctl/get/template")
+	require.NotNil(t, cmd)
+	assert.Equal(t, "functions", cmd.Use)
+	assert.Empty(t, cmd.Aliases)
+	assert.False(t, cmd.Hidden)
+	assert.Empty(t, cmd.Deprecated)
+	assert.NotEmpty(t, cmd.Short)
+	assert.NotNil(t, cmd.RunE)
+}
+
+func TestCommandGotmplFunctionDeprecated(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "scafctl"
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandGotmplFunctionDeprecated(cliParams, ioStreams, "scafctl/get")
 	require.NotNil(t, cmd)
 	assert.Equal(t, "go-template-functions", cmd.Use)
 	assert.Contains(t, cmd.Aliases, "gotmpl-funcs")
 	assert.Contains(t, cmd.Aliases, "gotmpl")
 	assert.Contains(t, cmd.Aliases, "gtf")
+	assert.True(t, cmd.Hidden)
+	assert.NotEmpty(t, cmd.Deprecated)
+	assert.Contains(t, cmd.Deprecated, "get template functions")
 	assert.NotEmpty(t, cmd.Short)
 	assert.NotNil(t, cmd.RunE)
 }
 
-func TestCommandGotmplFunction_Flags(t *testing.T) {
+func TestCommandFunctions_Flags(t *testing.T) {
 	cliParams := settings.NewCliParams()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := CommandGotmplFunction(cliParams, ioStreams, "scafctl/get")
+	cmd := CommandFunctions(cliParams, ioStreams, "scafctl/get/template")
 	flags := []string{"output", "interactive", "expression", "custom", "sprig"}
 	for _, name := range flags {
 		t.Run(name, func(t *testing.T) {
@@ -39,10 +58,10 @@ func TestCommandGotmplFunction_Flags(t *testing.T) {
 	}
 }
 
-func TestCommandGotmplFunction_Shorthands(t *testing.T) {
+func TestCommandFunctions_Shorthands(t *testing.T) {
 	cliParams := settings.NewCliParams()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := CommandGotmplFunction(cliParams, ioStreams, "scafctl/get")
+	cmd := CommandFunctions(cliParams, ioStreams, "scafctl/get/template")
 	shorthands := map[string]string{
 		"o": "output",
 		"i": "interactive",
@@ -55,26 +74,26 @@ func TestCommandGotmplFunction_Shorthands(t *testing.T) {
 	}
 }
 
-func TestCommandGotmplFunction_NoSubcommands(t *testing.T) {
+func TestCommandFunctions_NoSubcommands(t *testing.T) {
 	cliParams := settings.NewCliParams()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := CommandGotmplFunction(cliParams, ioStreams, "scafctl/get")
-	assert.Len(t, cmd.Commands(), 0, "gotmplfunction should have no subcommands")
+	cmd := CommandFunctions(cliParams, ioStreams, "scafctl/get/template")
+	assert.Len(t, cmd.Commands(), 0, "functions should have no subcommands")
 }
 
-func BenchmarkCommandGotmplFunction(b *testing.B) {
+func BenchmarkCommandFunctions(b *testing.B) {
 	cliParams := settings.NewCliParams()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		CommandGotmplFunction(cliParams, ioStreams, "scafctl/get")
+		CommandFunctions(cliParams, ioStreams, "scafctl/get/template")
 	}
 }
 
-func TestCommandGotmplFunction_SearchFlag(t *testing.T) {
+func TestCommandFunctions_SearchFlag(t *testing.T) {
 	cliParams := settings.NewCliParams()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := CommandGotmplFunction(cliParams, ioStreams, "scafctl/get")
+	cmd := CommandFunctions(cliParams, ioStreams, "scafctl/get/template")
 
 	f := cmd.Flags().Lookup("search")
 	assert.NotNil(t, f, "search flag should exist")
@@ -107,4 +126,40 @@ func TestFilterBySearch(t *testing.T) {
 			assert.Len(t, result, tt.wantLen)
 		})
 	}
+}
+
+// TestCanonicalAndDeprecated_ShareRunE verifies the canonical child and the
+// deprecated leaf produce identical output for the same args, since both share
+// the newCommand builder / RunE.
+func TestCanonicalAndDeprecated_ShareRunE(t *testing.T) {
+	t.Parallel()
+	cliParams := &settings.Run{BinaryName: "scafctl"}
+
+	var outC, errC, outD, errD bytes.Buffer
+	ioC := terminal.NewIOStreams(nil, &outC, &errC, false)
+	ioD := terminal.NewIOStreams(nil, &outD, &errD, false)
+
+	canonical := CommandFunctions(cliParams, ioC, "scafctl/get/template")
+	deprecated := CommandGotmplFunctionDeprecated(cliParams, ioD, "scafctl/get")
+
+	canonical.SetOut(&outC)
+	canonical.SetErr(&errC)
+	canonical.SetArgs([]string{"-o", "json"})
+	require.NoError(t, canonical.Execute())
+
+	deprecated.SetOut(&outD)
+	deprecated.SetErr(&errD)
+	deprecated.SetArgs([]string{"-o", "json"})
+	require.NoError(t, deprecated.Execute())
+
+	// The deprecated leaf emits a cobra deprecation warning before the output.
+	// Strip that leading warning line, then the rendered function list must be
+	// byte-identical to the canonical child's output (shared RunE).
+	depOut := outD.String()
+	assert.Contains(t, depOut, "deprecated")
+	if idx := strings.Index(depOut, "\n"); idx >= 0 {
+		depOut = depOut[idx+1:]
+	}
+	assert.Equal(t, outC.String(), depOut)
+	assert.Contains(t, outC.String(), "\"name\"")
 }

--- a/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction_test.go
+++ b/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction_test.go
@@ -5,7 +5,6 @@ package gotmplfunction
 
 import (
 	"bytes"
-	"strings"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
@@ -142,24 +141,26 @@ func TestCanonicalAndDeprecated_ShareRunE(t *testing.T) {
 	canonical := CommandFunctions(cliParams, ioC, "scafctl/get/template")
 	deprecated := CommandGotmplFunctionDeprecated(cliParams, ioD, "scafctl/get")
 
-	canonical.SetOut(&outC)
+	canonical.SetOut(&errC)
 	canonical.SetErr(&errC)
 	canonical.SetArgs([]string{"-o", "json"})
 	require.NoError(t, canonical.Execute())
 
-	deprecated.SetOut(&outD)
+	deprecated.SetOut(&errD)
 	deprecated.SetErr(&errD)
 	deprecated.SetArgs([]string{"-o", "json"})
 	require.NoError(t, deprecated.Execute())
 
-	// The deprecated leaf emits a cobra deprecation warning before the output.
-	// Strip that leading warning line, then the rendered function list must be
-	// byte-identical to the canonical child's output (shared RunE).
-	depOut := outD.String()
-	assert.Contains(t, depOut, "deprecated")
-	if idx := strings.Index(depOut, "\n"); idx >= 0 {
-		depOut = depOut[idx+1:]
-	}
-	assert.Equal(t, outC.String(), depOut)
+	// The rendered function list is written through IOStreams.Out (outC/outD),
+	// which is independent of cobra's own writer. Cobra emits its deprecation
+	// notice through the command's writer (pointed at errC/errD here), so the
+	// two streams stay cleanly separated: the deprecated leaf's stdout must be
+	// byte-identical to the canonical child's stdout (shared RunE), with no
+	// stripping required.
+	assert.Equal(t, outC.String(), outD.String())
 	assert.Contains(t, outC.String(), "\"name\"")
+	// The deprecation notice must be emitted on the deprecated leaf's cobra
+	// writer (errD), not mixed into the function-list output on stdout.
+	assert.Contains(t, errD.String(), `is deprecated`)
+	assert.NotContains(t, outD.String(), `is deprecated`)
 }

--- a/pkg/cmd/scafctl/get/template/template.go
+++ b/pkg/cmd/scafctl/get/template/template.go
@@ -1,0 +1,30 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/gotmplfunction"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/cobra"
+)
+
+// CommandTemplate creates the 'get template' command group. A bare invocation
+// shows help; its 'functions' child is the canonical form of the former
+// 'get go-template-functions'.
+func CommandTemplate(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	cCmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
+		Use:          "template",
+		Short:        "Go template resources",
+		SilenceUsage: true,
+	})
+
+	cmdPath := fmt.Sprintf("%s/%s", path, cCmd.Use)
+	cCmd.AddCommand(gotmplfunction.CommandFunctions(cliParams, ioStreams, cmdPath))
+
+	return cCmd
+}

--- a/pkg/cmd/scafctl/get/template/template_test.go
+++ b/pkg/cmd/scafctl/get/template/template_test.go
@@ -71,4 +71,13 @@ func TestEmbedderBinaryName(t *testing.T) {
 	require.NotNil(t, cmd)
 	assert.Contains(t, cmd.Deprecated, "mycli")
 	assert.NotContains(t, cmd.Deprecated, "scafctl")
+
+	// The canonical child's Long/Examples must also honor the embedder binary
+	// name for command-prefix tokens, while product-name prose stays literal.
+	canonical := gotmplfunction.CommandFunctions(cliParams, ioStreams, "mycli/get/template")
+	require.NotNil(t, canonical)
+	assert.Contains(t, canonical.Long, "mycli get template functions")
+	assert.NotContains(t, canonical.Long, "scafctl get template functions")
+	// Product-name prose must NOT be rewritten to the binary name.
+	assert.Contains(t, canonical.Long, "scafctl-specific")
 }

--- a/pkg/cmd/scafctl/get/template/template_test.go
+++ b/pkg/cmd/scafctl/get/template/template_test.go
@@ -1,0 +1,74 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package template
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get/gotmplfunction"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandTemplate(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandTemplate(cliParams, ioStreams, "scafctl/get")
+	require.NotNil(t, cmd)
+	assert.Equal(t, "template", cmd.Use)
+	assert.NotEmpty(t, cmd.Short)
+
+	names := make([]string, 0, len(cmd.Commands()))
+	for _, c := range cmd.Commands() {
+		names = append(names, c.Name())
+	}
+	assert.Contains(t, names, "functions", "get template should wire up the 'functions' child")
+}
+
+// TestCommandTemplate_BareShowsHelp verifies a bare 'get template' shows help
+// (exit 0) and an unknown subcommand errors.
+func TestCommandTemplate_BareShowsHelp(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandTemplate(cliParams, ioStreams, "scafctl/get")
+	cmd.SetArgs([]string{})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	assert.NoError(t, cmd.Execute())
+}
+
+func TestCommandTemplate_UnknownSubcommandErrors(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := CommandTemplate(cliParams, ioStreams, "scafctl/get")
+	cmd.SetArgs([]string{"bogus-xyz"})
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+}
+
+// TestEmbedderBinaryName verifies the deprecated go-template-functions leaf
+// reachable through 'get template' honors a non-default (embedder) binary name
+// in its user-facing deprecation notice rather than hardcoding "scafctl".
+func TestEmbedderBinaryName(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	cmd := gotmplfunction.CommandGotmplFunctionDeprecated(cliParams, ioStreams, "mycli/get")
+	require.NotNil(t, cmd)
+	assert.Contains(t, cmd.Deprecated, "mycli")
+	assert.NotContains(t, cmd.Deprecated, "scafctl")
+}

--- a/pkg/gotmpl/README.md
+++ b/pkg/gotmpl/README.md
@@ -676,19 +676,19 @@ Identical to `toYaml` and `fromYaml` respectively. In Go templates, errors alway
 
 ```bash
 # List all available functions
-scafctl get go-template-functions
+scafctl get template functions
 
 # List only custom (non-sprig) functions
-scafctl get go-template-functions --custom
+scafctl get template functions --custom
 
 # List only sprig functions
-scafctl get go-template-functions --sprig
+scafctl get template functions --sprig
 
 # Get details for a specific function
-scafctl get go-template-functions toHcl
+scafctl get template functions toHcl
 
 # Output as JSON
-scafctl get go-template-functions -o json
+scafctl get template functions -o json
 ```
 
 #### MCP Server

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -411,6 +411,198 @@ func TestIntegration_GetGoTemplateFunctionDetailToYaml(t *testing.T) {
 }
 
 // ============================================================================
+// Get CEL Functions Tests (canonical 'get cel functions' path)
+// ============================================================================
+
+func TestIntegration_GetCelFunctionsCanonical(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "cel", "functions")
+
+	assert.Equal(t, 0, exitCode)
+	// Should list both built-in and custom functions
+	assert.Contains(t, stdout, "strings")
+	assert.Contains(t, stdout, "map.merge")
+}
+
+func TestIntegration_GetCelFunctionsCanonicalCustom(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "cel", "functions", "--custom")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "map.merge")
+	assert.Contains(t, stdout, "guid.new")
+}
+
+func TestIntegration_GetCelFunctionsCanonicalBuiltin(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "cel", "functions", "--builtin")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "strings")
+}
+
+func TestIntegration_GetCelFunctionsCanonicalJSON(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "cel", "functions", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "\"name\"")
+	assert.Contains(t, stdout, "\"custom\"")
+}
+
+func TestIntegration_GetCelFunctionsCanonicalQuiet(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "cel", "functions", "-o", "quiet")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Empty(t, stdout, "quiet format should suppress all output")
+}
+
+func TestIntegration_GetCelFunctionCanonicalDetail(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "cel", "functions", "map.merge")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "map.merge")
+}
+
+// TestIntegration_GetCelBareHelp verifies a bare 'get cel' group shows help
+// (exit 0) and advertises its 'functions' child.
+func TestIntegration_GetCelBareHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "cel")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "functions")
+}
+
+// TestIntegration_GetCelFunctionsDeprecatedNotice verifies the hidden
+// deprecated 'get cel-functions' path still exits 0 and emits cobra's
+// deprecation notice on stderr pointing at the canonical path.
+func TestIntegration_GetCelFunctionsDeprecatedNotice(t *testing.T) {
+	t.Parallel()
+	stdout, stderr, exitCode := runScafctl(t, "get", "cel-functions")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stderr, `Command "cel-functions" is deprecated`)
+	assert.Contains(t, stderr, "get cel functions")
+	// Deprecated path still produces the functional listing.
+	assert.Contains(t, stdout, "map.merge")
+}
+
+// TestIntegration_GetCelFunctionsCanonicalMatchesDeprecated verifies the
+// canonical and deprecated paths produce identical JSON output.
+func TestIntegration_GetCelFunctionsCanonicalMatchesDeprecated(t *testing.T) {
+	t.Parallel()
+	canonical, _, canonicalExit := runScafctl(t, "get", "cel", "functions", "-o", "json")
+	deprecated, _, deprecatedExit := runScafctl(t, "get", "cel-functions", "-o", "json")
+
+	assert.Equal(t, 0, canonicalExit)
+	assert.Equal(t, 0, deprecatedExit)
+	assert.Equal(t, canonical, deprecated,
+		"canonical 'get cel functions' and deprecated 'get cel-functions' must list the same functions")
+}
+
+// ============================================================================
+// Get Template Functions Tests (canonical 'get template functions' path)
+// ============================================================================
+
+func TestIntegration_GetTemplateFunctionsCanonical(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "template", "functions")
+
+	assert.Equal(t, 0, exitCode)
+	// Should list both sprig and custom functions
+	assert.Contains(t, stdout, "upper")
+	assert.Contains(t, stdout, "toHcl")
+	assert.Contains(t, stdout, "toYaml")
+	assert.Contains(t, stdout, "fromYaml")
+}
+
+func TestIntegration_GetTemplateFunctionsCanonicalCustom(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "template", "functions", "--custom")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "toHcl")
+	assert.Contains(t, stdout, "toYaml")
+	assert.Contains(t, stdout, "fromYaml")
+	assert.Contains(t, stdout, "mustToYaml")
+	assert.Contains(t, stdout, "mustFromYaml")
+}
+
+func TestIntegration_GetTemplateFunctionsCanonicalSprig(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "template", "functions", "--sprig")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "upper")
+	assert.Contains(t, stdout, "lower")
+}
+
+func TestIntegration_GetTemplateFunctionsCanonicalJSON(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "template", "functions", "-o", "json")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "\"name\"")
+	assert.Contains(t, stdout, "\"custom\"")
+}
+
+func TestIntegration_GetTemplateFunctionsCanonicalQuiet(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "template", "functions", "-o", "quiet")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Empty(t, stdout, "quiet format should suppress all output")
+}
+
+func TestIntegration_GetTemplateFunctionCanonicalDetail(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "template", "functions", "toHcl")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "toHcl")
+}
+
+// TestIntegration_GetTemplateBareHelp verifies a bare 'get template' group
+// shows help (exit 0) and advertises its 'functions' child.
+func TestIntegration_GetTemplateBareHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "get", "template")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "functions")
+}
+
+// TestIntegration_GetGoTemplateFunctionsDeprecatedNotice verifies the hidden
+// deprecated 'get go-template-functions' path still exits 0 and emits cobra's
+// deprecation notice on stderr pointing at the canonical path.
+func TestIntegration_GetGoTemplateFunctionsDeprecatedNotice(t *testing.T) {
+	t.Parallel()
+	stdout, stderr, exitCode := runScafctl(t, "get", "go-template-functions")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stderr, `Command "go-template-functions" is deprecated`)
+	assert.Contains(t, stderr, "get template functions")
+	// Deprecated path still produces the functional listing.
+	assert.Contains(t, stdout, "toHcl")
+}
+
+// TestIntegration_GetTemplateFunctionsCanonicalMatchesDeprecated verifies the
+// canonical and deprecated paths produce identical JSON output.
+func TestIntegration_GetTemplateFunctionsCanonicalMatchesDeprecated(t *testing.T) {
+	t.Parallel()
+	canonical, _, canonicalExit := runScafctl(t, "get", "template", "functions", "-o", "json")
+	deprecated, _, deprecatedExit := runScafctl(t, "get", "go-template-functions", "-o", "json")
+
+	assert.Equal(t, 0, canonicalExit)
+	assert.Equal(t, 0, deprecatedExit)
+	assert.Equal(t, canonical, deprecated,
+		"canonical 'get template functions' and deprecated 'get go-template-functions' must list the same functions")
+}
+
+// ============================================================================
 // Explain Schema Tests
 // ============================================================================
 
@@ -4960,6 +5152,60 @@ func TestIntegration_CatalogRemoteList_Empty(t *testing.T) {
 
 	_, _, exitCode := runScafctlWithEnv(t, env, "catalog", "remote", "list")
 	assert.Equal(t, 0, exitCode)
+}
+
+// TestIntegration_CatalogRemoteDefault sets the default catalog via the
+// canonical 'catalog remote default <name>' path and verifies it takes effect.
+func TestIntegration_CatalogRemoteDefault(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	env := map[string]string{
+		"XDG_CONFIG_HOME": tmpDir,
+	}
+
+	// Add a filesystem catalog to make the default target.
+	_, _, addExit := runScafctlWithEnv(t, env, "catalog", "remote", "add",
+		"mycat", "--type", "filesystem", "--path", "./catalogs")
+	require.Equal(t, 0, addExit)
+
+	stdout, _, exitCode := runScafctlWithEnv(t, env, "catalog", "remote", "default", "mycat")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "mycat")
+
+	// Verify the default is reflected in list output.
+	listOut, _, listExit := runScafctlWithEnv(t, env, "catalog", "remote", "list", "-o", "json")
+	assert.Equal(t, 0, listExit)
+	var items []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(listOut), &items))
+	var defaulted string
+	for _, it := range items {
+		if d, ok := it["default"].(bool); ok && d {
+			defaulted, _ = it["name"].(string)
+		}
+	}
+	assert.Equal(t, "mycat", defaulted, "mycat should be the default catalog")
+}
+
+// TestIntegration_CatalogRemoteSetDefaultDeprecatedNotice verifies the hidden
+// deprecated 'catalog remote set-default <name>' path still exits 0, sets the
+// default, and emits cobra's deprecation notice on stderr pointing at the
+// canonical path.
+func TestIntegration_CatalogRemoteSetDefaultDeprecatedNotice(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	env := map[string]string{
+		"XDG_CONFIG_HOME": tmpDir,
+	}
+
+	_, _, addExit := runScafctlWithEnv(t, env, "catalog", "remote", "add",
+		"mycat", "--type", "filesystem", "--path", "./catalogs")
+	require.Equal(t, 0, addExit)
+
+	stdout, stderr, exitCode := runScafctlWithEnv(t, env, "catalog", "remote", "set-default", "mycat")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stderr, `Command "set-default" is deprecated`)
+	assert.Contains(t, stderr, "catalog remote default")
+	assert.Contains(t, stdout, "mycat")
 }
 
 // =============================================================================


### PR DESCRIPTION
Grammar migration **phase 8**: de-hyphenate command tokens and align template terminology. Old paths are kept as **hidden deprecated aliases** for one release (this is additive + deprecation, not a hard cut).

## Command changes (old -> new; old still works, deprecated)

| Old (deprecated) | New (canonical) |
|---|---|
| `get cel-functions` | `get cel functions` |
| `get go-template-functions` | `get template functions` |
| `catalog remote set-default <name>` | `catalog remote default <name>` |

- `get cel functions` / `get template functions` are **nested**: new help-only `cel` / `template` groups (bare `get cel` shows help) with a `functions` child. The old single-token commands remain as `Hidden` + `Deprecated` leaves under `get` (short aliases `cel-funcs`/`cf`, `gotmpl-funcs`/`gotmpl`/`gtf` ride the leaves).
- `get template functions` also **drops "go-"** per the grammar's "`template` everywhere" rule (Rule 4).
- `catalog remote default` mirrors podman's `system connection default`; the old `set-default` is a hidden deprecated twin.

## Intentionally unchanged

- **`credential-helper`** stays hyphenated -- it is an established compound term (the Docker/Podman protocol name), which grammar Rule 7 explicitly allows.
- The **`go-template` provider name** (`provider: go-template` in solution YAML) and any `type: go-template` / `type: cel` data values are **not** changed. Those are user-facing API identifiers, not command tokens; renaming them would be a breaking solution-schema change and is out of scope. Only command tokens changed.

## Design notes

- **No logic duplication.** Each affected command uses a single shared `newCommand`/builder so the canonical child and the deprecated leaf share one RunE and flag set; a unit test asserts byte-identical output between the two forms.
- **Embedder-safe.** Deprecation notices and help/app-name strings use the runtime binary name (with an empty-name fallback), so an embedded CLI named `mycli` sees `use "mycli get cel functions" instead`, not `scafctl`.
- **Telemetry paths** compose correctly through the nesting (`.../get/cel/functions` canonical; `.../get/cel-functions` for the deprecated leaf).

## Testing

- Unit: new `get/cel` and `get/template` group tests (child present, bare-help, unknown-subcommand errors, embedder binary name); canonical-vs-deprecated shared-RunE parity tests for both function commands; `get`/`remote` child-set + deprecated-attribute assertions.
- Integration: canonical paths (`get cel functions`, `get template functions`, `catalog remote default`) with flags/positionals/`-o json`/`-o quiet`; deprecated paths still work and emit a deprecation notice; bare `get cel`/`get template` show help; canonical == deprecated output parity.
- Docs/tutorials swept to the canonical command paths (provider name / data values left intact).

## Quality gate

- `go-review`: APPROVE; all findings fixed (embedder-safe deprecation strings, empty-name guards, added parity + embedder tests).
- `completeness-check`: artifact-complete.
- `task integration`, `task test-cover` (0 failures), and `task lint:changed` (0 issues) pass; the `go-template` provider name (177 occurrences) confirmed unchanged.

## Type of Change

- [x] Refactor (additive command surface + deprecation aliases; no hard removal)
- [ ] Breaking change (old paths still work as deprecated aliases)

## Checklist

- [x] Commit signed (`-S`) + DCO signed-off (`-s`)
- [x] Tests for canonical + deprecated + bare-help + embedder; no 0% new files
- [x] Docs swept; provider name/data values preserved; MCP tool descriptions clean
