### PR TITLE
refactor(cli): 'lint explain' -> 'lint rule' (grammar phase 6)

### DIFF
--- a/docs/design/cli-contributing.md
+++ b/docs/design/cli-contributing.md
@@ -1243,7 +1243,7 @@ This section tracks which commands from the design are implemented and what work
 | `new solution` | ✅ | Scaffold new solution |
 | `lint` | ✅ | Lint solution files |
 | `lint rules` | ✅ | List lint rules |
-| `lint explain` | ✅ | Explain a lint rule |
+| `lint rule` | ✅ | Explain a lint rule (was `lint explain`, now a hidden deprecated alias) |
 | `test functional` | ✅ | Run functional tests |
 | `test list` | ✅ | List test cases |
 | `test init` | ✅ | Scaffold test suite |

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -47,7 +47,7 @@ scafctl <verb> <kind> <name[@version(or constraint)]> [flags]
 | `validate schema` | ✅ Implemented | Validate arbitrary data (JSON/YAML, `--data -` for stdin) against a JSON Schema |
 | `new solution` | ✅ Implemented | Scaffold a new solution from template |
 | `lint rules` | ✅ Implemented | List all available lint rules |
-| `lint explain` | ✅ Implemented | Explain a specific lint rule |
+| `lint rule` | ✅ Implemented | Explain a specific lint rule |
 | `lint` | ✅ Implemented | Advisory subset of `validate`: reports authoring warnings/findings without being the pass/fail gate |
 | `examples list` | ✅ Implemented | List available example configurations |
 | `examples get` | ✅ Implemented | Get/download an example file |
@@ -1066,11 +1066,15 @@ Get a detailed explanation of a specific lint rule:
 
 ~~~bash
 # Show rule details, examples, and fix guidance
-scafctl lint explain <rule-id>
+scafctl lint rule <rule-id>
 
 # Output as JSON
-scafctl lint explain <rule-id> -o json
+scafctl lint rule <rule-id> -o json
 ~~~
+
+> The former `scafctl lint explain <rule-id>` still works as a hidden,
+> deprecated alias for `scafctl lint rule <rule-id>`.
+
 
 ---
 
@@ -1149,7 +1153,7 @@ scafctl uses two distinct command grammar patterns:
 | `scafctl diff snapshot` | diff | snapshot |
 | `scafctl diff solution` | diff | solution |
 | `scafctl lint rules` | lint | rules |
-| `scafctl lint explain` | lint | explain |
+| `scafctl lint rule` | lint | rule |
 | `scafctl eval cel` | eval | cel |
 | `scafctl eval template` | eval | template |
 | `scafctl validate solution` | validate | solution |

--- a/docs/tutorials/eval-tutorial.md
+++ b/docs/tutorials/eval-tutorial.md
@@ -390,12 +390,12 @@ Get a detailed explanation of a specific rule:
 {{< tabs "eval-tutorial-cmd-13" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl lint explain <rule-id>
+scafctl lint rule <rule-id>
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl lint explain <rule-id>
+scafctl lint rule <rule-id>
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -276,7 +276,7 @@ scafctl lint -f solution.yaml
 scafctl lint rules
 
 # Explain a lint rule
-scafctl lint explain <rule-id>
+scafctl lint rule <rule-id>
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
@@ -334,7 +334,7 @@ scafctl lint -f solution.yaml
 scafctl lint rules
 
 # Explain a lint rule
-scafctl lint explain <rule-id>
+scafctl lint rule <rule-id>
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -181,12 +181,12 @@ Get detailed information about any lint rule:
 {{< tabs "linting-tutorial-cmd-7" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl lint explain <rule-id>
+scafctl lint rule <rule-id>
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl lint explain <rule-id>
+scafctl lint rule <rule-id>
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -196,15 +196,19 @@ For example:
 {{< tabs "linting-tutorial-cmd-8" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl lint explain missing-description
+scafctl lint rule missing-description
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl lint explain missing-description
+scafctl lint rule missing-description
 ```
 {{% /tab %}}
 {{< /tabs >}}
+
+> **Migration note:** the older `scafctl lint explain <rule-id>` command still
+> works as a hidden, deprecated alias for `scafctl lint rule <rule-id>`. Prefer
+> `lint rule` in new scripts.
 
 This shows:
 
@@ -220,12 +224,12 @@ This shows:
 {{< tabs "linting-tutorial-cmd-9" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl lint explain missing-description -o json
+scafctl lint rule missing-description -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl lint explain missing-description -o json
+scafctl lint rule missing-description -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -265,12 +269,12 @@ Explain the rule for full guidance:
 {{< tabs "linting-tutorial-cmd-orvalue" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl lint explain orvalue-on-non-optional
+scafctl lint rule orvalue-on-non-optional
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl lint explain orvalue-on-non-optional
+scafctl lint rule orvalue-on-non-optional
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -333,14 +337,14 @@ Explain either rule for full guidance:
 {{< tabs "linting-tutorial-cmd-deprecated" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl lint explain deprecated-field
-scafctl lint explain deprecated-field-conflict
+scafctl lint rule deprecated-field
+scafctl lint rule deprecated-field-conflict
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl lint explain deprecated-field
-scafctl lint explain deprecated-field-conflict
+scafctl lint rule deprecated-field
+scafctl lint rule deprecated-field-conflict
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -503,12 +507,12 @@ For more details:
 {{< tabs "linting-tutorial-cmd-11" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl lint explain unreachable-test-path
+scafctl lint rule unreachable-test-path
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl lint explain unreachable-test-path
+scafctl lint rule unreachable-test-path
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -715,12 +719,12 @@ For more details:
 {{< tabs "linting-tutorial-cmd-12" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl lint explain transform-shape-mismatch
+scafctl lint rule transform-shape-mismatch
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl lint explain transform-shape-mismatch
+scafctl lint rule transform-shape-mismatch
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -788,12 +792,12 @@ For more details:
 {{< tabs "linting-tutorial-cmd-13" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl lint explain resolver-cycle
+scafctl lint rule resolver-cycle
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl lint explain resolver-cycle
+scafctl lint rule resolver-cycle
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -870,12 +874,12 @@ For more details:
 {{< tabs "linting-tutorial-cmd-14" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl lint explain missing-template-dependency
+scafctl lint rule missing-template-dependency
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl lint explain missing-template-dependency
+scafctl lint rule missing-template-dependency
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -975,7 +979,7 @@ spec:
 When using AI agents (VS Code Copilot, Claude, Cursor), the MCP server exposes lint functionality through:
 
 - **`lint_solution` tool** -- Same as `scafctl lint` but returns structured JSON to the AI
-- **`explain_lint_rule` tool** -- Same as `scafctl lint explain`
+- **`explain_lint_rule` tool** -- Same as `scafctl lint rule`
 - **`validate_expressions` tool** -- Validate CEL expressions without running them
 
 The AI agent can lint your solution as part of its workflow -- for example, the `debug_solution` and `update_solution` prompts automatically include linting steps.

--- a/pkg/cmd/scafctl/lint/explain_cmd.go
+++ b/pkg/cmd/scafctl/lint/explain_cmd.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	pkglint "github.com/oakwood-commons/scafctl/pkg/lint"
@@ -25,34 +24,59 @@ import (
 //go:embed lint_explain_schema.json
 var lintExplainSchemaJSON []byte
 
-// ExplainOptions holds options for the lint explain command.
-type ExplainOptions struct {
+// RuleOptions holds options for the 'lint rule' command (and its deprecated
+// 'lint explain' alias).
+type RuleOptions struct {
 	BinaryName     string
 	IOStreams      *terminal.IOStreams
 	CliParams      *settings.Run
 	KvxOutputFlags flags.KvxOutputFlags
 }
 
-// CommandExplainRule creates the 'lint explain' command.
-func CommandExplainRule(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	opts := &ExplainOptions{}
+// CommandRule creates the canonical 'lint rule' command.
+func CommandRule(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	return newRuleCommand(cliParams, ioStreams, path, "rule <rule-name>", "", false)
+}
+
+// CommandExplainRuleDeprecated creates the hidden, deprecated 'lint explain'
+// alias. It shares the same RunE/flags as the canonical 'lint rule' command via
+// newRuleCommand.
+func CommandExplainRuleDeprecated(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	name := cliParams.BinaryName
+	if name == "" {
+		name = settings.CliBinaryName
+	}
+	deprecated := fmt.Sprintf(`use "%s lint rule" instead`, name)
+	return newRuleCommand(cliParams, ioStreams, path, "explain <rule-name>", deprecated, true)
+}
+
+// newRuleCommand is the shared builder for both the canonical 'lint rule'
+// command and the deprecated 'lint explain' alias. Both forms wire identical
+// Options, RunE, and flags so their behavior is guaranteed to match.
+func newRuleCommand(cliParams *settings.Run, ioStreams *terminal.IOStreams, path, use, deprecated string, hidden bool) *cobra.Command {
+	opts := &RuleOptions{}
+
+	name := cliParams.BinaryName
+	if name == "" {
+		name = settings.CliBinaryName
+	}
 
 	cCmd := &cobra.Command{
-		Use:   "explain <rule-name>",
+		Use:   use,
 		Short: "Explain a specific lint rule in detail",
-		Long: heredoc.Doc(`
-			Show detailed information about a specific lint rule, including
-			its severity, category, description, why it matters, how to fix it,
-			and examples that would trigger it.
+		Long: fmt.Sprintf(`Show detailed information about a specific lint rule, including
+its severity, category, description, why it matters, how to fix it,
+and examples that would trigger it.
 
-			Examples:
-			  # Explain a rule
-			  scafctl lint explain missing-description
+Examples:
+  # Explain a rule
+  %[1]s lint rule missing-description
 
-			  # Explain with JSON output
-			  scafctl lint explain unknown-provider-input -o json
-		`),
-		Args: cobra.ExactArgs(1),
+  # Explain with JSON output
+  %[1]s lint rule unknown-provider-input -o json`, name),
+		Deprecated: deprecated,
+		Hidden:     hidden,
+		Args:       cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Name())
 			ctx := settings.IntoContext(cmd.Context(), cliParams)
@@ -85,8 +109,8 @@ func CommandExplainRule(cliParams *settings.Run, ioStreams *terminal.IOStreams, 
 // explainColumnOrder controls field display order in KVX visual output.
 var explainColumnOrder = []string{"rule", "severity", "category", "description", "why", "fix", "examples"}
 
-// Run executes the lint explain command.
-func (o *ExplainOptions) Run(ctx context.Context, ruleName string) error {
+// Run executes the lint rule command.
+func (o *RuleOptions) Run(ctx context.Context, ruleName string) error {
 	if o.BinaryName == "" {
 		o.BinaryName = settings.CliBinaryName
 	}
@@ -107,7 +131,7 @@ func (o *ExplainOptions) Run(ctx context.Context, ruleName string) error {
 		kvx.WithIOStreams(o.IOStreams),
 		kvx.WithOutputContext(ctx),
 		kvx.WithOutputNoColor(o.CliParams.NoColor),
-		kvx.WithOutputAppName(o.CliParams.BinaryName+" lint explain"),
+		kvx.WithOutputAppName(o.BinaryName+" lint rule"),
 		kvx.WithOutputDisplaySchemaJSON(lintExplainSchemaJSON),
 		kvx.WithOutputColumnOrder(explainColumnOrder),
 	)
@@ -124,7 +148,7 @@ func (o *ExplainOptions) Run(ctx context.Context, ruleName string) error {
 			kvx.WithIOStreams(o.IOStreams),
 			kvx.WithOutputContext(ctx),
 			kvx.WithOutputNoColor(o.CliParams.NoColor),
-			kvx.WithOutputAppName(o.CliParams.BinaryName+" lint explain"),
+			kvx.WithOutputAppName(o.BinaryName+" lint rule"),
 			kvx.WithOutputDisplaySchemaJSON(lintRulesSchemaJSON),
 		)
 		return interactiveOpts.Write([]any{projectRule(rule)})

--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -155,7 +155,8 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 	lintPath := fmt.Sprintf("%s/%s", path, cmd.Use)
 	cmd.AddCommand(CommandRules(cliParams, ioStreams, lintPath))
-	cmd.AddCommand(CommandExplainRule(cliParams, ioStreams, lintPath))
+	cmd.AddCommand(CommandRule(cliParams, ioStreams, lintPath))
+	cmd.AddCommand(CommandExplainRuleDeprecated(cliParams, ioStreams, lintPath))
 
 	return cmd
 }

--- a/pkg/cmd/scafctl/lint/lint_test.go
+++ b/pkg/cmd/scafctl/lint/lint_test.go
@@ -34,12 +34,13 @@ func TestCommandLint(t *testing.T) {
 	assert.NotEmpty(t, cmd.Short)
 	assert.NotNil(t, cmd.RunE, "lint command should have RunE")
 	subCmds := cmd.Commands()
-	require.Len(t, subCmds, 2, "should have 2 subcommands: rules, explain")
+	require.Len(t, subCmds, 3, "should have 3 subcommands: rules, rule, explain")
 	cmdNames := make([]string, len(subCmds))
 	for i, c := range subCmds {
 		cmdNames[i] = c.Name()
 	}
 	assert.Contains(t, cmdNames, "rules")
+	assert.Contains(t, cmdNames, "rule")
 	assert.Contains(t, cmdNames, "explain")
 }
 
@@ -192,23 +193,83 @@ func TestRulesRun_SeverityFilter(t *testing.T) {
 	}
 }
 
-func TestCommandExplainRule(t *testing.T) {
+func TestCommandRule(t *testing.T) {
 	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := CommandExplainRule(cliParams, ioStreams, "scafctl/lint")
+	cmd := CommandRule(cliParams, ioStreams, "scafctl/lint")
 	require.NotNil(t, cmd)
-	assert.Equal(t, "explain <rule-name>", cmd.Use)
+	assert.Equal(t, "rule <rule-name>", cmd.Use)
+	assert.True(t, strings.HasPrefix(cmd.Use, "rule"))
+	assert.False(t, cmd.Hidden, "canonical rule command must not be hidden")
+	assert.Empty(t, cmd.Deprecated, "canonical rule command must not be deprecated")
 	assert.NotEmpty(t, cmd.Short)
 	assert.NotNil(t, cmd.RunE)
+	// Embedder-safe help: Long must use the configured binary name, not scafctl.
+	assert.Contains(t, cmd.Long, "mycli lint rule")
+	assert.NotContains(t, cmd.Long, "scafctl lint rule")
 }
 
-func TestCommandExplainRule_RequiresArg(t *testing.T) {
+func TestCommandRule_RequiresArg(t *testing.T) {
 	cliParams := settings.NewCliParams()
 	ioStreams, _, _ := terminal.NewTestIOStreams()
-	cmd := CommandExplainRule(cliParams, ioStreams, "scafctl/lint")
+	cmd := CommandRule(cliParams, ioStreams, "scafctl/lint")
 	cmd.SetArgs([]string{})
 	err := cmd.Execute()
 	assert.Error(t, err, "should fail without rule-name argument")
+}
+
+func TestCommandExplainRuleDeprecated(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandExplainRuleDeprecated(cliParams, ioStreams, "scafctl/lint")
+	require.NotNil(t, cmd)
+	assert.Equal(t, "explain <rule-name>", cmd.Use)
+	assert.True(t, cmd.Hidden, "deprecated explain alias must be hidden")
+	assert.NotEmpty(t, cmd.Deprecated)
+	assert.Contains(t, cmd.Deprecated, "mycli lint rule", "deprecation should point at canonical command")
+	assert.NotNil(t, cmd.RunE)
+}
+
+func TestCommandExplainRuleDeprecated_RequiresArg(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandExplainRuleDeprecated(cliParams, ioStreams, "scafctl/lint")
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.Error(t, err, "should fail without rule-name argument")
+}
+
+// TestCanonicalAndDeprecated_ShareRunE verifies the canonical 'lint rule'
+// command and the deprecated 'lint explain' alias produce identical stdout for
+// the same args (shared RunE), and that the deprecation notice is emitted on
+// the deprecated command's stderr (cobra writer), not on stdout.
+func TestCanonicalAndDeprecated_ShareRunE(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "scafctl"
+
+	ioC, outC, errC := terminal.NewTestIOStreams()
+	ioD, outD, errD := terminal.NewTestIOStreams()
+
+	canonical := CommandRule(cliParams, ioC, "scafctl/lint")
+	deprecated := CommandExplainRuleDeprecated(cliParams, ioD, "scafctl/lint")
+
+	canonical.SetOut(errC)
+	canonical.SetErr(errC)
+	canonical.SetArgs([]string{"empty-solution", "-o", "json"})
+	require.NoError(t, canonical.Execute())
+
+	deprecated.SetOut(errD)
+	deprecated.SetErr(errD)
+	deprecated.SetArgs([]string{"empty-solution", "-o", "json"})
+	require.NoError(t, deprecated.Execute())
+
+	assert.Equal(t, outC.String(), outD.String(), "canonical and deprecated stdout must match")
+	assert.Contains(t, outC.String(), "empty-solution")
+	// Deprecation notice goes to the cobra writer (errD), not stdout.
+	assert.Contains(t, errD.String(), "is deprecated")
+	assert.NotContains(t, outD.String(), "is deprecated")
 }
 
 // ── ExplainRun output format tests ───────────────────────────────────────────
@@ -219,7 +280,7 @@ func TestExplainRun_JSONOutput(t *testing.T) {
 	cliParams := testCliParams()
 	ctx := testContext(ioStreams)
 
-	opts := &ExplainOptions{
+	opts := &RuleOptions{
 		BinaryName:     "scafctl",
 		IOStreams:      ioStreams,
 		CliParams:      cliParams,
@@ -247,7 +308,7 @@ func TestExplainRun_YAMLOutput(t *testing.T) {
 	cliParams := testCliParams()
 	ctx := testContext(ioStreams)
 
-	opts := &ExplainOptions{
+	opts := &RuleOptions{
 		BinaryName:     "scafctl",
 		IOStreams:      ioStreams,
 		CliParams:      cliParams,
@@ -269,7 +330,7 @@ func TestExplainRun_TableOutput(t *testing.T) {
 	cliParams := testCliParams()
 	ctx := testContext(ioStreams)
 
-	opts := &ExplainOptions{
+	opts := &RuleOptions{
 		BinaryName:     "scafctl",
 		IOStreams:      ioStreams,
 		CliParams:      cliParams,
@@ -291,7 +352,7 @@ func TestExplainRun_ListOutput(t *testing.T) {
 	cliParams := testCliParams()
 	ctx := testContext(ioStreams)
 
-	opts := &ExplainOptions{
+	opts := &RuleOptions{
 		BinaryName:     "scafctl",
 		IOStreams:      ioStreams,
 		CliParams:      cliParams,
@@ -312,7 +373,7 @@ func TestExplainRun_CSVOutput(t *testing.T) {
 	cliParams := testCliParams()
 	ctx := testContext(ioStreams)
 
-	opts := &ExplainOptions{
+	opts := &RuleOptions{
 		BinaryName:     "scafctl",
 		IOStreams:      ioStreams,
 		CliParams:      cliParams,
@@ -333,7 +394,7 @@ func TestExplainRun_UnknownRule(t *testing.T) {
 	cliParams := testCliParams()
 	ctx := testContext(ioStreams)
 
-	opts := &ExplainOptions{
+	opts := &RuleOptions{
 		BinaryName:     "scafctl",
 		IOStreams:      ioStreams,
 		CliParams:      cliParams,
@@ -353,7 +414,7 @@ func TestExplainRun_EmbedderBinaryName(t *testing.T) {
 	cliParams.BinaryName = "mycli"
 	ctx := testContext(ioStreams)
 
-	opts := &ExplainOptions{
+	opts := &RuleOptions{
 		BinaryName:     "mycli",
 		IOStreams:      ioStreams,
 		CliParams:      cliParams,
@@ -371,7 +432,7 @@ func TestExplainRun_DefaultFormat(t *testing.T) {
 	cliParams := testCliParams()
 	ctx := testContext(ioStreams)
 
-	opts := &ExplainOptions{
+	opts := &RuleOptions{
 		BinaryName:     "scafctl",
 		IOStreams:      ioStreams,
 		CliParams:      cliParams,

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -8236,6 +8236,41 @@ func TestIntegration_LintRules_JSON(t *testing.T) {
 	assert.Contains(t, rules[0], "severity")
 }
 
+func TestIntegration_LintRule_KnownRule(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "lint", "rule", "missing-description")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "missing-description")
+	assert.Contains(t, stdout, "severity")
+}
+
+func TestIntegration_LintRule_UnknownRule(t *testing.T) {
+	t.Parallel()
+	_, _, exitCode := runScafctl(t, "lint", "rule", "nonexistent-rule")
+	assert.NotEqual(t, 0, exitCode)
+}
+
+func TestIntegration_LintRule_JSON(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "lint", "rule", "missing-description", "-o", "json")
+	assert.Equal(t, 0, exitCode)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Equal(t, "missing-description", result["rule"])
+}
+
+// TestIntegration_LintExplain_DeprecatedAlias verifies the old 'lint explain'
+// alias still works and prints a deprecation notice on stderr, while producing
+// the same rule output on stdout as the canonical 'lint rule'.
+func TestIntegration_LintExplain_DeprecatedAlias(t *testing.T) {
+	t.Parallel()
+	stdout, stderr, exitCode := runScafctl(t, "lint", "explain", "missing-description")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "missing-description")
+	assert.Contains(t, stderr, "deprecated", "deprecated alias must emit a deprecation notice on stderr")
+}
+
 func TestIntegration_LintExplain_KnownRule(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "lint", "explain", "missing-description")


### PR DESCRIPTION
## Summary

CLI command grammar migration **phase 6** (`docs/design/cli-command-grammar.md`):
tidy the `lint` command tree.

- `lint explain <rule>` is renamed to the canonical **`lint rule <name>`**.
- `lint explain <rule>` is kept as a **hidden, deprecated alias** that shares the
  exact same RunE, so existing usage keeps working and emits a deprecation
  notice pointing at `lint rule`.
- `lint rules` (plural -- lists all rules) is unchanged.

New tree:

```
lint [solution]
├── rules            list all lint rules (unchanged)
├── rule <name>      explain one rule (canonical)
└── explain <name>   hidden, deprecated alias of `rule`
```

`rule` and `rules` do not collide -- cobra matches exact subcommand names before
treating a positional as a solution, so `lint [solution]` is unaffected.

This mirrors the already-merged phase 8 pattern (`get cel functions`,
`catalog remote default`): a canonical command plus a hidden deprecated twin
sharing one RunE.

## Embedder-safety

Built correctly from the start (phase 8 needed several rounds to get this
right). The command `Long`/Examples, the `Deprecated` message, and the kvx
`WithOutputAppName` all use the runtime binary name (`cliParams.BinaryName`)
with an empty-name fallback to `settings.CliBinaryName`, guarded at the point of
consumption. `mycli lint rule --help` renders `mycli`, and an empty embedder
binary name never produces a leading-space app name.

## Tests

- Unit (`pkg/cmd/scafctl/lint/lint_test.go`): canonical `rule` (exists,
  not-hidden, 1-arg, embedder-safe Long), deprecated `explain` (hidden,
  Deprecated message, 1-arg), and a parity test asserting identical stdout with
  the deprecation notice on stderr only.
- Integration (`tests/integration/cli_test.go`): `lint rule` known/unknown/JSON,
  and `lint explain` deprecated-alias still works and prints the stderr notice.

## Docs

`docs/design/cli.md`, `docs/design/cli-contributing.md`, and the linting / eval /
getting-started tutorials migrated to `lint rule`, with a migration note that
`lint explain` is a deprecated alias.

## Breaking changes

None in practice -- `lint explain` still works (deprecated). Pure command-grammar
tidy-up.
