### PR TITLE
feat(mcp): add context-variables tool and authoring context concepts to explain_concepts

### DIFF
--- a/docs/tutorials/mcp-server-tutorial.md
+++ b/docs/tutorials/mcp-server-tutorial.md
@@ -490,12 +490,12 @@ evaluation, and which ones exist depends on the phase. The AI calls
 ```
 In an action's when/inputs you can use:
 
-- **_** — resolved resolver values (_.region)
-- **__execution** — resolver execution metadata (__execution.resolvers.build.status)
-- **__actions** — results of completed actions (__actions.build.results.exitCode)
-- **__cwd** — the original working directory (actions only)
+- **_** -- resolved resolver values (_.region)
+- **__execution** -- resolver execution metadata (__execution.resolvers.build.status)
+- **__actions** -- results of completed actions (__actions.build.results.exitCode)
+- **__cwd** -- the original working directory (actions only)
 
-Note: __self, __item/__index, and __plan are NOT available in actions — they
+Note: __self, __item/__index, and __plan are NOT available in actions -- they
 belong to resolver phases. Call list_context_variables with no phase to see the
 full matrix, or explain_concepts name='context-variables' for guidance.
 ```

--- a/docs/tutorials/mcp-server-tutorial.md
+++ b/docs/tutorials/mcp-server-tutorial.md
@@ -74,6 +74,7 @@ You should see JSON output listing all available tools:
     { "name": "auth_list_tokens", "description": "List all cached access tokens across auth handlers..." },
     { "name": "auth_purge_expired", "description": "Remove expired access tokens from the cache..." },
     { "name": "list_cel_functions", "description": "List all available CEL functions..." },
+    { "name": "list_context_variables", "description": "List the context variables injected into CEL/Go-template evaluation and the phase each is available in..." },
     { "name": "list_go_template_functions", "description": "List all available Go template extension functions..." },
     { "name": "list_examples", "description": "List available scafctl example files..." },
     { "name": "list_providers", "description": "List all available providers..." },
@@ -474,6 +475,35 @@ Here are the custom scafctl CEL functions for string manipulation:
 
 Use `evaluate_cel` to test any of these interactively.
 ```
+
+### Discover Context Variables
+
+No files needed.
+
+> [!NOTE]
+> **You:** "What variables can I use inside an action's `when` condition?"
+
+Beyond functions, scafctl injects *context variables* into CEL and Go-template
+evaluation, and which ones exist depends on the phase. The AI calls
+`list_context_variables` with `phase: "action"` and returns something like:
+
+```
+In an action's when/inputs you can use:
+
+- **_** — resolved resolver values (_.region)
+- **__execution** — resolver execution metadata (__execution.resolvers.build.status)
+- **__actions** — results of completed actions (__actions.build.results.exitCode)
+- **__cwd** — the original working directory (actions only)
+
+Note: __self, __item/__index, and __plan are NOT available in actions — they
+belong to resolver phases. Call list_context_variables with no phase to see the
+full matrix, or explain_concepts name='context-variables' for guidance.
+```
+
+For narrative guidance on the runtime evaluation environment -- context
+variables, phase execution order, the CEL cost model, template dependency
+inference, snapshot masking, and the authoring workflow -- use the `context`
+category: `explain_concepts` with `category: "context"`.
 
 ### Discover Go Template Functions
 

--- a/pkg/concepts/builtin.go
+++ b/pkg/concepts/builtin.go
@@ -367,4 +367,134 @@ The catalog supports versioning, visibility controls (public/private), and beta 
 		},
 		SeeAlso: []string{"resolver", "provider", "cel-expression"},
 	},
+	// --- Context / authoring ---
+	{
+		Name:     "context-variables",
+		Title:    "Context Variables",
+		Category: "context",
+		Summary:  "The special variables injected into CEL and Go-template evaluation (_, __self, __item, __plan, __execution, __actions, __cwd, __params, __error, and the Go-template .__file* path parts) and the phase each is available in.",
+		Explanation: `Beyond the CEL and template functions, scafctl injects a set of *context variables* into expression evaluation. Which variables exist depends on the phase — a variable available in an action is not necessarily available in a resolver. No function list covers these; use the 'list_context_variables' tool for the full, machine-readable matrix (optionally filtered by phase).
+
+**CEL context variables**
+- **_** — map of resolved resolver values (_.region). Available in resolve inputs/when, transform, validate, and action when/inputs. Referencing _.other also creates an implicit dependency edge.
+- **__self** — the current resolver's in-progress value. Available in transform (the resolved value) and validate (the final value) only; NOT during resolve.
+- **__item / __index** — the current element / zero-based index inside a forEach iteration (resolve or transform).
+- **__plan** — pre-execution resolver topology injected before any resolver runs, so a resolver's when/inputs can read __plan["name"].phase, .dependsOn, and .dependencyCount.
+- **__execution** — resolver execution metadata available to ACTIONS: __execution.resolvers.<name>.status/phase/duration and __execution.summary.
+- **__actions** — results of completed actions, available to downstream ACTIONS: __actions.<name>.results and .status.
+- **__cwd** — the original working directory, available in ACTIONS ONLY (useful when --output-dir redirects action output). Not injected into resolvers.
+- **__params** — raw CLI parameters (-r key=value), available in STATE BACKEND input expressions only. Unlike _ (resolver outputs), __params always holds the raw parameters.
+- **__error** — the error text bound in failure contexts: continueOnError conditions and messages.error, for resolvers and actions.
+
+**Go-template file-generation variables** (available in the file provider's outputPath during directory -> render-tree -> write-tree generation): .__filePath, .__fileName, .__fileStem, .__fileExtension, .__fileDir — used to rename or restructure output files (e.g. strip a .tpl suffix).
+
+Decision guide: prefer _.other to reference another resolver (it also wires the dependency); use __self only to talk about the value currently being built.`,
+		Examples: []string{
+			"# __self in a transform, __plan in a resolver when\nresolvers:\n  name:\n    resolve:\n      with:\n        - provider: parameter\n          inputs: { name: name }\n    transform:\n      with:\n        - provider: cel\n          inputs: { expression: \"__self.trimSpace()\" }\n  gated:\n    when: '__plan[\"name\"].phase == 1'\n    resolve:\n      with:\n        - provider: static\n          inputs: { value: ok }",
+		},
+		SeeAlso: []string{"cel-expression", "resolver", "action", "foreach", "go-template-provider"},
+	},
+	{
+		Name:     "phase-execution",
+		Title:    "Resolver Phase Execution",
+		Category: "context",
+		Summary:  "How the resolve, transform, and validate phases actually execute at runtime — ordering, fallback, and fatality — which the schema shape does not describe.",
+		Explanation: `A resolver runs up to three phases with distinct runtime behavior:
+
+**resolve** — the 'with' steps are tried in order and the FIRST step that produces a value wins and stops the chain; a step that fails is treated as a fallback and evaluation continues to the next step. An optional 'until' condition (which can read __self) can stop earlier. This makes 'with' a fallback chain: parameter first, static default last.
+
+**transform** — steps run SEQUENTIALLY, each seeing the previous value via __self. Transform steps default to FAIL on error (a broken transform is fatal to that resolver).
+
+**validate** — all inline rules are evaluated and their failures are AGGREGATED (you see every failure, not just the first). Validation is NON-FATAL by default: the value is still returned and dependents still run, with failures reported as diagnostics. Rules that reference only the owning resolver (via __self) run inline; rules that reference another resolver (via _.other) are deferred until after all resolvers resolve and do NOT add edges to the resolution DAG (so two resolvers can validate against each other without a false cycle).
+
+**forEach** — 'in' is required on a resolve step but defaults to __self on a transform step; the body runs once per element with __item and __index bound.
+
+**DAG** — resolvers are topologically sorted into phases from explicit dependsOn plus implicit CEL/template references; cycles in resolve/transform/when are rejected at lint.`,
+		Examples: []string{
+			"# resolve = first-success fallback chain; static default is the floor\nresolvers:\n  region:\n    resolve:\n      with:\n        - provider: parameter\n          inputs: { name: region }\n        - provider: static\n          inputs: { value: us-east-1 }",
+		},
+		SeeAlso: []string{"resolver", "foreach", "dag", "cel-expression"},
+	},
+	{
+		Name:     "cel-cost-model",
+		Title:    "CEL Cost Model",
+		Category: "context",
+		Summary:  "How scafctl bounds CEL evaluation cost, the per-solution override, and the anti-patterns that blow the budget.",
+		Explanation: `Every CEL expression is evaluated under a cost limit to guard against runaway or malicious expressions. The default limit is 1,000,000 cost units. When an expression exceeds the limit, evaluation fails with a diagnostic showing the actual cost versus the limit.
+
+**Overriding** — a solution may raise or lower its own limit via spec.options.cel.costLimit (0 = use the global default). The EFFECTIVE limit is min(solution, global): a solution can lower the ceiling but cannot exceed the operator-configured global. When global limiting is disabled (global = 0), solution overrides are ignored.
+
+**Anti-patterns** (conceptual — cost grows with data size):
+- Nested comprehensions over large lists (list.filter(...).map(...) where both are large) are roughly O(n*m); narrow the list before joining.
+- Repeated re-computation of the same sub-expression; use cel.bind to compute once.
+
+Keep expressions small and push heavy shaping into transform steps or dedicated resolvers. See 'list_cel_functions' for the available functions.`,
+		Examples: []string{
+			"spec:\n  options:\n    cel:\n      costLimit: 2000000\n  resolvers:\n    example:\n      resolve:\n        with:\n          - provider: cel\n            inputs: { expression: \"_.items.filter(i, i.active).size()\" }",
+		},
+		SeeAlso: []string{"cel-expression", "authoring-workflow"},
+	},
+	{
+		Name:     "template-dependency-inference",
+		Title:    "Go-Template Dependency Inference",
+		Category: "context",
+		Summary:  "How scafctl decides whether a Go-template accessor is a resolver reference, a data-input key, or a forEach alias — and why unknown accessors silently render empty.",
+		Explanation: `A Go template's root namespace is the UNION of three sources:
+
+1. Resolver values — every resolver in the solution.
+2. The step's 'data' input keys — variables passed explicitly to the template.
+3. forEach aliases — the item/index bindings when the step iterates.
+
+Accessor rules:
+- {{ ._.name }} is ALWAYS a resolver reference (and creates a dependency edge).
+- {{ .field }} is a resolver dependency only when there is no matching 'data' key and it is not a forEach alias.
+- When 'data' is present with statically-known keys, matching keys resolve to the data value; unknown keys still resolve against resolver data.
+- When the data keys are not statically knowable, the whole root is treated as the data context.
+- {{ .__* }} accessors are special context variables, never dependencies.
+
+Because Go templates default to rendering a missing key as empty, a typo'd accessor silently blanks out rather than erroring. The 'template-unknown-accessor' lint rule (WARNING) flags a root accessor that is neither a resolver, a data key, nor an alias. Use 'extract_resolver_refs' to see the inferred references and 'explain_lint_rule template-unknown-accessor' for details.`,
+		Examples: []string{
+			"# .env comes from data; ._.region is a resolver reference\nresolve:\n  with:\n    - provider: go-template\n      inputs:\n        data: { env: prod }\n        template: \"{{ .env }}-{{ ._.region }}\"",
+		},
+		SeeAlso: []string{"go-template-provider", "depends-on", "resolver"},
+	},
+	{
+		Name:     "snapshot-masking",
+		Title:    "Snapshot Masking",
+		Category: "context",
+		Summary:  "How golden/snapshot functional tests normalize volatile output via built-in presets and custom masks so runs stay deterministic.",
+		Explanation: `Snapshot tests compare a solution's output against a stored golden file. Because output often contains volatile regions (timestamps, UUIDs, sandbox paths), scafctl masks those regions before comparison.
+
+**Built-in presets** — 'timestamp', 'uuid', and 'sandbox' are enabled by default. Additional presets ('email', 'ipv4', 'mac') are opt-in. Toggle presets in a test case with masks: [{use: <name>}], and disable a default with {use: <name>, disabled: true}.
+
+**Custom masks** — provide {name, pattern, placeholder, path} to normalize solution-specific volatile content.
+
+**Snapshot source** — snapshotSource: stdout (default) compares captured output; snapshotSource: files compares the rendered file tree (required when a mask is scoped with 'path').
+
+**Updating goldens** — run tests with --update-snapshots to regenerate the stored baselines after an intentional change.
+
+In the test report, a case shown as PASS* is a RELAXED pass: it passed but masks loosened snapshot fidelity, so a masked region was not compared literally. See 'functional-testing' and 'get_solution_schema' for the full spec.testing.cases shape.`,
+		Examples: []string{
+			"spec:\n  testing:\n    cases:\n      - name: render\n        snapshotSource: files\n        masks:\n          - name: build-id\n            pattern: \"build-[0-9]+\"\n            placeholder: \"build-<ID>\"",
+		},
+		SeeAlso: []string{"functional-testing", "test-assertions", "test-sandbox"},
+	},
+	{
+		Name:     "authoring-workflow",
+		Title:    "Authoring Workflow",
+		Category: "context",
+		Summary:  "The recommended MCP tool loop for authoring a solution: scaffold -> verify shapes -> preview -> lint -> test -> run.",
+		Explanation: `When authoring a solution with AI assistance, drive the scafctl MCP tools in this order rather than hand-writing YAML and guessing:
+
+1. **Scaffold** — 'scaffold_solution' generates a valid skeleton to start from.
+2. **Verify shapes ("what")** — 'get_solution_schema' and 'explain_kind' for the spec; 'get_provider_schema' and 'list_providers' for provider inputs/outputs. Never guess field or provider names.
+3. **Check expressions in isolation** — 'validate_expression', 'evaluate_cel', and 'evaluate_go_template' before wiring them in.
+4. **Preview** — 'preview_resolvers' (use the resolver argument to focus on one) to confirm resolved values; 'preview_action' or 'dry_run_solution' to preview the action graph without side effects.
+5. **Lint** — 'lint_solution' to validate structure; 'list_lint_rules' and 'explain_lint_rule' to resolve findings.
+6. **Test** — 'generate_test_scaffold' then 'run_solution_tests' for functional tests.
+7. **Run** — 'get_run_command' for the exact CLI invocation.
+
+For the runtime evaluation environment these tools operate against, see 'context-variables' and 'phase-execution'. These tools are the source of truth for schemas, functions, and providers — reference them rather than relying on static copies, which drift.`,
+		SeeAlso: []string{"resolver", "provider", "functional-testing", "context-variables", "phase-execution"},
+	},
 }

--- a/pkg/concepts/builtin.go
+++ b/pkg/concepts/builtin.go
@@ -167,7 +167,7 @@ Use list_cel_functions to see all available CEL functions and evaluate_cel to te
 When forEach is present, the provider executes once per element and results are collected into an output array preserving order.
 
 Key difference between phases:
-- On resolve steps, forEach.in is REQUIRED (no __self available in resolve phase).
+- On resolve steps, forEach.in is REQUIRED (there is no resolved __self value to iterate yet).
 - On transform steps, forEach.in defaults to __self (the current value).
 
 Fields:
@@ -377,7 +377,7 @@ The catalog supports versioning, visibility controls (public/private), and beta 
 
 **CEL context variables**
 - **_** — map of resolved resolver values (_.region). Available in resolve inputs/when, transform, validate, and action when/inputs. Referencing _.other also creates an implicit dependency edge.
-- **__self** — the current resolver's in-progress value. Available in transform (the resolved value) and validate (the final value) only; NOT during resolve.
+- **__self** — the current resolver's in-progress value: the resolved value in transform, the final value in validate, and the current candidate value in a resolve-phase 'until' condition. Not available in a plain resolve provider input.
 - **__item / __index** — the current element / zero-based index inside a forEach iteration (resolve or transform).
 - **__plan** — pre-execution resolver topology injected before any resolver runs, so a resolver's when/inputs can read __plan["name"].phase, .dependsOn, and .dependencyCount.
 - **__execution** — resolver execution metadata available to ACTIONS: __execution.resolvers.<name>.status/phase/duration and __execution.summary.

--- a/pkg/concepts/builtin.go
+++ b/pkg/concepts/builtin.go
@@ -372,7 +372,7 @@ The catalog supports versioning, visibility controls (public/private), and beta 
 		Name:     "context-variables",
 		Title:    "Context Variables",
 		Category: "context",
-		Summary:  "The special variables injected into CEL and Go-template evaluation (_, __self, __item, __plan, __execution, __actions, __cwd, __params, __error, and the Go-template .__file* path parts) and the phase each is available in.",
+		Summary:  "The special variables injected into CEL and Go-template evaluation (_, __self, __item, __plan, __execution, __actions, __cwd, __params, __error, and the Go-template __file* path parts) and the phase each is available in.",
 		Explanation: `Beyond the CEL and template functions, scafctl injects a set of *context variables* into expression evaluation. Which variables exist depends on the phase — a variable available in an action is not necessarily available in a resolver. No function list covers these; use the 'list_context_variables' tool for the full, machine-readable matrix (optionally filtered by phase).
 
 **CEL context variables**
@@ -386,9 +386,9 @@ The catalog supports versioning, visibility controls (public/private), and beta 
 - **__params** — raw CLI parameters (-r key=value), available in STATE BACKEND input expressions only. Unlike _ (resolver outputs), __params always holds the raw parameters.
 - **__error** — the error bound in failure contexts (continueOnError conditions and messages.error). Its shape is context-dependent: in RESOLVER contexts it is a string (__error.contains("...")); in ACTION contexts it is a structured map with message, statusCode, attempt, and maxAttempts (__error.message.contains("..."), __error.statusCode).
 
-**Go-template availability** — most of these (_, __self, __item, __index, __actions, __cwd, __execution) are injected into BOTH CEL and Go-template evaluation, so {{ ._.region }}, {{ .__self }}, and {{ .__item }} also work. __plan, __params, and __error are CEL-only; the .__file* path parts below are Go-template only.
+**Go-template availability** — most of these (_, __self, __item, __index, __actions, __cwd, __execution) are injected into BOTH CEL and Go-template evaluation, so {{ ._.region }}, {{ .__self }}, and {{ .__item }} also work. __plan, __params, and __error are CEL-only; the __file* path parts below are Go-template only.
 
-**Go-template file-generation variables** (available in the file provider's outputPath during directory -> render-tree -> write-tree generation): .__filePath, .__fileName, .__fileStem, .__fileExtension, .__fileDir — used to rename or restructure output files (e.g. strip a .tpl suffix).
+**Go-template file-generation variables** (available in the file provider's outputPath during directory -> render-tree -> write-tree generation): __filePath, __fileName, __fileStem, __fileExtension, __fileDir -- injected without a leading dot and accessed in templates as {{ .__fileStem }} etc., used to rename or restructure output files (e.g. strip a .tpl suffix).
 
 Decision guide: prefer _.other to reference another resolver (it also wires the dependency); use __self only to talk about the value currently being built.`,
 		Examples: []string{

--- a/pkg/concepts/builtin.go
+++ b/pkg/concepts/builtin.go
@@ -392,7 +392,7 @@ The catalog supports versioning, visibility controls (public/private), and beta 
 
 Decision guide: prefer _.other to reference another resolver (it also wires the dependency); use __self only to talk about the value currently being built.`,
 		Examples: []string{
-			"# __self in a transform, __plan in a resolver when\nresolvers:\n  name:\n    resolve:\n      with:\n        - provider: parameter\n          inputs: { name: name }\n    transform:\n      with:\n        - provider: cel\n          inputs: { expression: \"__self.trimSpace()\" }\n  gated:\n    when: '__plan[\"name\"].phase == 1'\n    resolve:\n      with:\n        - provider: static\n          inputs: { value: ok }",
+			"# __self in a transform, __plan in a resolver when\nresolvers:\n  name:\n    resolve:\n      with:\n        - provider: parameter\n          inputs: { name: name }\n    transform:\n      with:\n        - provider: cel\n          inputs: { expression: \"__self.trim()\" }\n  gated:\n    when: '__plan[\"name\"].phase == 1'\n    resolve:\n      with:\n        - provider: static\n          inputs: { value: ok }",
 		},
 		SeeAlso: []string{"cel-expression", "resolver", "action", "foreach", "go-template-provider"},
 	},

--- a/pkg/concepts/builtin.go
+++ b/pkg/concepts/builtin.go
@@ -384,7 +384,9 @@ The catalog supports versioning, visibility controls (public/private), and beta 
 - **__actions** — results of completed actions, available to downstream ACTIONS: __actions.<name>.results and .status.
 - **__cwd** — the original working directory, available in ACTIONS ONLY (useful when --output-dir redirects action output). Not injected into resolvers.
 - **__params** — raw CLI parameters (-r key=value), available in STATE BACKEND input expressions only. Unlike _ (resolver outputs), __params always holds the raw parameters.
-- **__error** — the error text bound in failure contexts: continueOnError conditions and messages.error, for resolvers and actions.
+- **__error** — the error bound in failure contexts (continueOnError conditions and messages.error). Its shape is context-dependent: in RESOLVER contexts it is a string (__error.contains("...")); in ACTION contexts it is a structured map with message, statusCode, attempt, and maxAttempts (__error.message.contains("..."), __error.statusCode).
+
+**Go-template availability** — most of these (_, __self, __item, __index, __actions, __cwd, __execution) are injected into BOTH CEL and Go-template evaluation, so {{ ._.region }}, {{ .__self }}, and {{ .__item }} also work. __plan, __params, and __error are CEL-only; the .__file* path parts below are Go-template only.
 
 **Go-template file-generation variables** (available in the file provider's outputPath during directory -> render-tree -> write-tree generation): .__filePath, .__fileName, .__fileStem, .__fileExtension, .__fileDir — used to rename or restructure output files (e.g. strip a .tpl suffix).
 
@@ -475,7 +477,7 @@ Because Go templates default to rendering a missing key as empty, a typo'd acces
 
 In the test report, a case shown as PASS* is a RELAXED pass: it passed but masks loosened snapshot fidelity, so a masked region was not compared literally. See 'functional-testing' and 'get_solution_schema' for the full spec.testing.cases shape.`,
 		Examples: []string{
-			"spec:\n  testing:\n    cases:\n      - name: render\n        snapshotSource: files\n        masks:\n          - name: build-id\n            pattern: \"build-[0-9]+\"\n            placeholder: \"build-<ID>\"",
+			"spec:\n  testing:\n    cases:\n      render:\n        description: renders with volatile ids masked\n        command: [run, resolver]\n        snapshotSource: files\n        masks:\n          - name: build-id\n            pattern: \"build-[0-9]+\"\n            placeholder: \"build-<ID>\"",
 		},
 		SeeAlso: []string{"functional-testing", "test-assertions", "test-sandbox"},
 	},

--- a/pkg/concepts/builtin.go
+++ b/pkg/concepts/builtin.go
@@ -384,7 +384,7 @@ The catalog supports versioning, visibility controls (public/private), and beta 
 - **__actions** — results of completed actions, available to downstream ACTIONS: __actions.<name>.results and .status.
 - **__cwd** — the original working directory, available in ACTIONS ONLY (useful when --output-dir redirects action output). Not injected into resolvers.
 - **__params** — raw CLI parameters (-r key=value), available in STATE BACKEND input expressions only. Unlike _ (resolver outputs), __params always holds the raw parameters.
-- **__error** — the error bound in failure contexts (continueOnError conditions and messages.error). Its shape is context-dependent: in RESOLVER contexts it is a string (__error.contains("...")); in ACTION contexts it is a structured map with message, statusCode, attempt, and maxAttempts (__error.message.contains("..."), __error.statusCode).
+- **__error** — the error bound in failure contexts (continueOnError conditions and messages.error). Its shape is context-dependent: in RESOLVER contexts it is a string (__error.contains("...")); in ACTION contexts it is a structured map with message, type, statusCode, exitCode, attempt, and maxAttempts (e.g. __error.message.contains("..."), __error.statusCode == 503, or __error.type == "exec").
 
 **Go-template availability** — most of these (_, __self, __item, __index, __actions, __cwd, __execution) are injected into BOTH CEL and Go-template evaluation, so {{ ._.region }}, {{ .__self }}, and {{ .__item }} also work. __plan, __params, and __error are CEL-only; the __file* path parts below are Go-template only.
 

--- a/pkg/concepts/concepts_test.go
+++ b/pkg/concepts/concepts_test.go
@@ -69,3 +69,71 @@ func TestSearch_NoMatch(t *testing.T) {
 	results := Search("zzzznonexistentzzzz")
 	assert.Empty(t, results)
 }
+
+// TestSeeAlso_NoDanglingLinks asserts that every SeeAlso target resolves to a
+// registered concept, so cross-references never point at a typo or a removed
+// concept.
+func TestSeeAlso_NoDanglingLinks(t *testing.T) {
+	for _, c := range List() {
+		for _, target := range c.SeeAlso {
+			_, ok := Get(target)
+			assert.True(t, ok, "concept %q has dangling SeeAlso target %q", c.Name, target)
+		}
+	}
+}
+
+// TestContextCategory_Present asserts the new context category exists and
+// contains exactly the expected authoring/runtime concepts.
+func TestContextCategory_Present(t *testing.T) {
+	assert.Contains(t, Categories(), "context")
+
+	items := ByCategory("context")
+	names := make([]string, 0, len(items))
+	for _, c := range items {
+		assert.Equal(t, "context", c.Category)
+		names = append(names, c.Name)
+	}
+	assert.ElementsMatch(t, []string{
+		"context-variables",
+		"phase-execution",
+		"cel-cost-model",
+		"template-dependency-inference",
+		"snapshot-masking",
+		"authoring-workflow",
+	}, names)
+}
+
+// TestContextConcepts_WellFormed asserts each new concept is complete.
+func TestContextConcepts_WellFormed(t *testing.T) {
+	for _, name := range []string{
+		"context-variables",
+		"phase-execution",
+		"cel-cost-model",
+		"template-dependency-inference",
+		"snapshot-masking",
+		"authoring-workflow",
+	} {
+		c, ok := Get(name)
+		require.True(t, ok, "concept %q must be registered", name)
+		assert.Equal(t, "context", c.Category)
+		assert.NotEmpty(t, c.Summary, "%q summary", name)
+		assert.NotEmpty(t, c.Explanation, "%q explanation", name)
+		assert.NotEmpty(t, c.SeeAlso, "%q seeAlso", name)
+	}
+}
+
+// TestContextConcepts_PointToLiveTools guards against drift: concepts must
+// reference the live tools rather than mirroring their output.
+func TestContextConcepts_PointToLiveTools(t *testing.T) {
+	cv, ok := Get("context-variables")
+	require.True(t, ok)
+	assert.Contains(t, cv.Explanation, "list_context_variables")
+
+	tdi, ok := Get("template-dependency-inference")
+	require.True(t, ok)
+	assert.Contains(t, tdi.Explanation, "extract_resolver_refs")
+
+	aw, ok := Get("authoring-workflow")
+	require.True(t, ok)
+	assert.Contains(t, aw.Explanation, "get_provider_schema")
+}

--- a/pkg/contextvars/contextvars.go
+++ b/pkg/contextvars/contextvars.go
@@ -114,7 +114,7 @@ var builtinVariables = []ContextVariable{
 		Languages:   langBoth,
 		Phases:      []string{PhaseTransform, PhaseValidate, PhaseForEach},
 		Description: "The current resolver's in-progress value: the resolved value in transform steps, and the final value in validate steps. Also bound during forEach iterations (carrying the transform-phase in-progress value). Available in CEL (__self) and Go templates ({{ .__self }}). Not available during a plain resolve step.",
-		Example:     "__self.trimSpace()",
+		Example:     "__self.trim()",
 	},
 	{
 		Name:        celexp.VarItem, // "__item"

--- a/pkg/contextvars/contextvars.go
+++ b/pkg/contextvars/contextvars.go
@@ -112,8 +112,8 @@ var builtinVariables = []ContextVariable{
 	{
 		Name:        celexp.VarSelf, // "__self"
 		Languages:   langBoth,
-		Phases:      []string{PhaseTransform, PhaseValidate, PhaseForEach},
-		Description: "The current resolver's in-progress value: the resolved value in transform steps, and the final value in validate steps. Also bound during forEach iterations (carrying the transform-phase in-progress value). Available in CEL (__self) and Go templates ({{ .__self }}). Not available during a plain resolve step.",
+		Phases:      []string{PhaseResolve, PhaseTransform, PhaseValidate, PhaseForEach},
+		Description: "The current resolver's in-progress value. In transform it is the resolved value; in validate it is the final value; in a resolve-phase 'until' condition it is the current candidate value; and it is also bound during forEach iterations. Available in CEL (__self) and Go templates ({{ .__self }}). Not available in a plain resolve provider input (only in that step's 'until' condition).",
 		Example:     "__self.trim()",
 	},
 	{

--- a/pkg/contextvars/contextvars.go
+++ b/pkg/contextvars/contextvars.go
@@ -9,8 +9,9 @@
 // No other tool in scafctl enumerates these injected variables or the phase in
 // which each is available: list_cel_functions returns functions, and the
 // solution schema describes shape, not the runtime evaluation environment. This
-// package is the single source of truth consumed by both the MCP
-// list_context_variables tool and the "context-variables" concept prose.
+// package backs the MCP list_context_variables tool; the "context-variables"
+// concept in pkg/concepts documents the same knowledge in prose and points
+// clients at this tool (it does not import this package).
 //
 // The canonical variable names are pinned to the celexp.Var* constants where
 // they exist, so the registry cannot silently drift from the names the engine

--- a/pkg/contextvars/contextvars.go
+++ b/pkg/contextvars/contextvars.go
@@ -61,9 +61,11 @@ type ContextVariable struct {
 	// or ".__filePath" for Go-template path parts).
 	Name string `json:"name" yaml:"name"`
 
-	// Language is the expression language the variable applies to (cel or
-	// go-template).
-	Language string `json:"language" yaml:"language"`
+	// Languages lists the expression languages the variable is available in
+	// (cel, go-template, or both). Most scafctl context variables are injected
+	// into both CEL evaluation and Go-template data; a few (the .__file* path
+	// parts) are Go-template only.
+	Languages []string `json:"languages" yaml:"languages"`
 
 	// Phases lists the evaluation phases in which the variable is available.
 	Phases []string `json:"phases" yaml:"phases"`
@@ -75,110 +77,131 @@ type ContextVariable struct {
 	Example string `json:"example,omitempty" yaml:"example,omitempty"`
 }
 
+// clonePhasesAndLangs returns a copy of v with its Languages and Phases slices
+// deep-copied, so callers cannot mutate the package-level registry through a
+// returned value.
+func clonePhasesAndLangs(v ContextVariable) ContextVariable {
+	langs := make([]string, len(v.Languages))
+	copy(langs, v.Languages)
+	phases := make([]string, len(v.Phases))
+	copy(phases, v.Phases)
+	v.Languages = langs
+	v.Phases = phases
+	return v
+}
+
+// langBoth and langTemplateOnly are the common language sets, defined once to
+// keep the registry entries terse.
+var (
+	langBoth         = []string{LangCEL, LangTemplate}
+	langCELOnly      = []string{LangCEL}
+	langTemplateOnly = []string{LangTemplate}
+)
+
 // builtinVariables is the canonical list of context variables. Names are pinned
 // to celexp.Var* constants where available so this registry tracks the engine.
 var builtinVariables = []ContextVariable{
 	{
 		Name:        "_",
-		Language:    LangCEL,
-		Phases:      []string{PhaseResolve, PhaseTransform, PhaseValidate, PhaseAction},
-		Description: "Map of resolved resolver values, keyed by resolver name. The primary way to reference other resolvers' outputs. Referencing _.other also creates an implicit dependency edge.",
+		Languages:   langBoth,
+		Phases:      []string{PhaseResolve, PhaseTransform, PhaseValidate, PhaseForEach, PhaseAction},
+		Description: "Map of resolved resolver values, keyed by resolver name. The primary way to reference other resolvers' outputs. Available in both CEL (_.region) and Go templates ({{ ._.region }}). Referencing _.other also creates an implicit dependency edge. Resolver data is in scope during forEach iterations too.",
 		Example:     "_.region",
 	},
 	{
 		Name:        celexp.VarSelf, // "__self"
-		Language:    LangCEL,
-		Phases:      []string{PhaseTransform, PhaseValidate},
-		Description: "The current resolver's in-progress value: the resolved value in transform steps, and the final value in validate steps. Not available during resolve.",
+		Languages:   langBoth,
+		Phases:      []string{PhaseTransform, PhaseValidate, PhaseForEach},
+		Description: "The current resolver's in-progress value: the resolved value in transform steps, and the final value in validate steps. Also bound during forEach iterations (carrying the transform-phase in-progress value). Available in CEL (__self) and Go templates ({{ .__self }}). Not available during a plain resolve step.",
 		Example:     "__self.trimSpace()",
 	},
 	{
 		Name:        celexp.VarItem, // "__item"
-		Language:    LangCEL,
+		Languages:   langBoth,
 		Phases:      []string{PhaseForEach},
-		Description: "The current element in a forEach iteration (resolve or transform).",
+		Description: "The current element in a forEach iteration (resolve or transform). Available in CEL (__item) and Go templates ({{ .__item }}).",
 		Example:     "__item.name",
 	},
 	{
 		Name:        celexp.VarIndex, // "__index"
-		Language:    LangCEL,
+		Languages:   langBoth,
 		Phases:      []string{PhaseForEach},
-		Description: "The current zero-based index in a forEach iteration (resolve or transform).",
+		Description: "The current zero-based index in a forEach iteration (resolve or transform). Available in CEL (__index) and Go templates ({{ .__index }}).",
 		Example:     "__index == 0",
 	},
 	{
 		Name:        celexp.VarPlan, // "__plan"
-		Language:    LangCEL,
+		Languages:   langCELOnly,
 		Phases:      []string{PhaseResolve},
 		Description: "Pre-execution resolver topology, injected before any resolver runs, so resolver when conditions and provider inputs can reason about the plan. Each entry exposes .phase, .dependsOn, and .dependencyCount.",
 		Example:     "__plan[\"myResolver\"].phase",
 	},
 	{
 		Name:        celexp.VarExecution, // "__execution"
-		Language:    LangCEL,
+		Languages:   langBoth,
 		Phases:      []string{PhaseAction},
-		Description: "Resolver execution metadata available to actions: __execution.resolvers.<name>.status/phase/duration and __execution.summary.{phaseCount,resolverCount,totalDuration}.",
+		Description: "Resolver execution metadata available to actions: __execution.resolvers.<name>.status/phase/duration and __execution.summary.{phaseCount,resolverCount,totalDuration}. Available in CEL and Go templates.",
 		Example:     "__execution.resolvers.build.status",
 	},
 	{
 		Name:        celexp.VarActions, // "__actions"
-		Language:    LangCEL,
+		Languages:   langBoth,
 		Phases:      []string{PhaseAction},
-		Description: "Results of completed actions, keyed by action name: __actions.<name>.results and __actions.<name>.status. Available in downstream action when conditions and inputs.",
+		Description: "Results of completed actions, keyed by action name: __actions.<name>.results and __actions.<name>.status. Available in downstream action when conditions and inputs, in both CEL (__actions.build.results) and Go templates ({{ .__actions.build.results }}).",
 		Example:     "__actions.build.results.exitCode",
 	},
 	{
 		Name:        celexp.VarCwd, // "__cwd"
-		Language:    LangCEL,
+		Languages:   langBoth,
 		Phases:      []string{PhaseAction},
-		Description: "The original working directory, available in ACTIONS ONLY. Useful when --output-dir redirects action output but an action still needs to reference the invocation directory. Not injected into resolvers.",
+		Description: "The original working directory, available in ACTIONS ONLY (in both CEL and Go templates). Useful when --output-dir redirects action output but an action still needs to reference the invocation directory. Not injected into resolvers.",
 		Example:     "__cwd + \"/dist\"",
 	},
 	{
 		Name:        celexp.VarParams, // "__params"
-		Language:    LangCEL,
+		Languages:   langCELOnly,
 		Phases:      []string{PhaseStateBackend},
 		Description: "Raw CLI parameters (-r key=value), available in STATE BACKEND input expressions only. Unlike _, which holds resolver outputs, __params always holds the raw parameters regardless of resolver execution state.",
 		Example:     "__params.gcp_project",
 	},
 	{
 		Name:        celexp.VarError, // "__error"
-		Language:    LangCEL,
+		Languages:   langCELOnly,
 		Phases:      []string{PhaseError},
-		Description: "The error text bound in failure contexts: continueOnError conditions and messages.error, for both resolvers and actions.",
-		Example:     "__error.contains(\"timeout\")",
+		Description: "The error bound in failure contexts. Its SHAPE is context-dependent: in RESOLVER continueOnError conditions and messages.error it is a STRING (the error text), so __error.contains(\"...\") works. In ACTION continueOnError and retryIf conditions it is a structured MAP with fields message, type, statusCode, exitCode, attempt, and maxAttempts -- use __error.message.contains(\"...\") and __error.statusCode there, not __error.contains(...).",
+		Example:     "__error.contains(\"timeout\") // resolver; use __error.message.contains(\"timeout\") in actions",
 	},
 	{
 		Name:        ".__filePath",
-		Language:    LangTemplate,
+		Languages:   langTemplateOnly,
 		Phases:      []string{PhaseTemplateFile},
 		Description: "Full source path of the current file during directory -> render-tree -> write-tree generation. Available in the file provider's outputPath template for renaming files.",
 		Example:     "{{ .__fileDir }}/{{ .__fileStem }}",
 	},
 	{
 		Name:        ".__fileName",
-		Language:    LangTemplate,
+		Languages:   langTemplateOnly,
 		Phases:      []string{PhaseTemplateFile},
 		Description: "Base file name (including extension) of the current file during tree generation.",
 		Example:     "{{ .__fileName }}",
 	},
 	{
 		Name:        ".__fileStem",
-		Language:    LangTemplate,
+		Languages:   langTemplateOnly,
 		Phases:      []string{PhaseTemplateFile},
 		Description: "File name without its extension during tree generation. Commonly used to strip a .tpl suffix.",
 		Example:     "{{ .__fileStem }}",
 	},
 	{
 		Name:        ".__fileExtension",
-		Language:    LangTemplate,
+		Languages:   langTemplateOnly,
 		Phases:      []string{PhaseTemplateFile},
 		Description: "File extension (including the leading dot) of the current file during tree generation.",
 		Example:     "{{ .__fileExtension }}",
 	},
 	{
 		Name:        ".__fileDir",
-		Language:    LangTemplate,
+		Languages:   langTemplateOnly,
 		Phases:      []string{PhaseTemplateFile},
 		Description: "Directory portion of the current file's path during tree generation, used to preserve the source tree structure in output.",
 		Example:     "{{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}",
@@ -194,19 +217,31 @@ var registry = func() map[string]ContextVariable {
 	return m
 }()
 
-// lessByLangName orders context variables by language then name. It is the
-// shared comparator used by List and ByPhase so their ordering cannot drift.
+// primaryLang returns the variable's first declared language, or "" if none.
+// Used only for stable ordering.
+func primaryLang(v ContextVariable) string {
+	if len(v.Languages) == 0 {
+		return ""
+	}
+	return v.Languages[0]
+}
+
+// lessByLangName orders context variables by primary language then name. It is
+// the shared comparator used by List and ByPhase so their ordering cannot drift.
 func lessByLangName(a, b ContextVariable) bool {
-	if a.Language != b.Language {
-		return a.Language < b.Language
+	if la, lb := primaryLang(a), primaryLang(b); la != lb {
+		return la < lb
 	}
 	return a.Name < b.Name
 }
 
-// List returns all context variables sorted by language then name.
+// List returns all context variables sorted by language then name. Returned
+// values are deep-copied, so callers cannot mutate the package registry.
 func List() []ContextVariable {
 	out := make([]ContextVariable, len(builtinVariables))
-	copy(out, builtinVariables)
+	for i, v := range builtinVariables {
+		out[i] = clonePhasesAndLangs(v)
+	}
 	sort.Slice(out, func(i, j int) bool {
 		return lessByLangName(out[i], out[j])
 	})
@@ -214,20 +249,25 @@ func List() []ContextVariable {
 }
 
 // Get returns a context variable by exact name. The second return value is
-// false if no variable with that name exists.
+// false if no variable with that name exists. The returned value is deep-copied,
+// so mutating its slices cannot corrupt the package registry.
 func Get(name string) (ContextVariable, bool) {
 	v, ok := registry[name]
-	return v, ok
+	if !ok {
+		return ContextVariable{}, false
+	}
+	return clonePhasesAndLangs(v), true
 }
 
 // ByPhase returns all context variables available in the given phase, sorted by
-// language then name. An unknown phase yields an empty slice.
+// language then name. An unknown phase yields an empty slice. Returned values
+// are deep-copied, so callers cannot mutate the package registry.
 func ByPhase(phase string) []ContextVariable {
 	var out []ContextVariable
 	for _, v := range builtinVariables {
 		for _, p := range v.Phases {
 			if p == phase {
-				out = append(out, v)
+				out = append(out, clonePhasesAndLangs(v))
 				break
 			}
 		}

--- a/pkg/contextvars/contextvars.go
+++ b/pkg/contextvars/contextvars.go
@@ -57,13 +57,14 @@ const (
 
 // ContextVariable describes a single injected evaluation variable.
 type ContextVariable struct {
-	// Name is the variable identifier as used in an expression (e.g. "__self",
-	// or ".__filePath" for Go-template path parts).
+	// Name is the canonical injected variable name, without any accessor
+	// syntax (e.g. "__self", "__filePath"). In Go templates it is accessed
+	// with a leading dot ({{ .__filePath }}); in CEL it is used bare (__self).
 	Name string `json:"name" yaml:"name"`
 
 	// Languages lists the expression languages the variable is available in
 	// (cel, go-template, or both). Most scafctl context variables are injected
-	// into both CEL evaluation and Go-template data; a few (the .__file* path
+	// into both CEL evaluation and Go-template data; a few (the __file* path
 	// parts) are Go-template only.
 	Languages []string `json:"languages" yaml:"languages"`
 
@@ -172,35 +173,35 @@ var builtinVariables = []ContextVariable{
 		Example:     "__error.contains(\"timeout\") // resolver; use __error.message.contains(\"timeout\") in actions",
 	},
 	{
-		Name:        ".__filePath",
+		Name:        "__filePath",
 		Languages:   langTemplateOnly,
 		Phases:      []string{PhaseTemplateFile},
 		Description: "Full source path of the current file during directory -> render-tree -> write-tree generation. Available in the file provider's outputPath template for renaming files.",
 		Example:     "{{ .__fileDir }}/{{ .__fileStem }}",
 	},
 	{
-		Name:        ".__fileName",
+		Name:        "__fileName",
 		Languages:   langTemplateOnly,
 		Phases:      []string{PhaseTemplateFile},
 		Description: "Base file name (including extension) of the current file during tree generation.",
 		Example:     "{{ .__fileName }}",
 	},
 	{
-		Name:        ".__fileStem",
+		Name:        "__fileStem",
 		Languages:   langTemplateOnly,
 		Phases:      []string{PhaseTemplateFile},
 		Description: "File name without its extension during tree generation. Commonly used to strip a .tpl suffix.",
 		Example:     "{{ .__fileStem }}",
 	},
 	{
-		Name:        ".__fileExtension",
+		Name:        "__fileExtension",
 		Languages:   langTemplateOnly,
 		Phases:      []string{PhaseTemplateFile},
 		Description: "File extension (including the leading dot) of the current file during tree generation.",
 		Example:     "{{ .__fileExtension }}",
 	},
 	{
-		Name:        ".__fileDir",
+		Name:        "__fileDir",
 		Languages:   langTemplateOnly,
 		Phases:      []string{PhaseTemplateFile},
 		Description: "Directory portion of the current file's path during tree generation, used to preserve the source tree structure in output.",

--- a/pkg/contextvars/contextvars.go
+++ b/pkg/contextvars/contextvars.go
@@ -4,7 +4,7 @@
 // Package contextvars provides a registry of the special "context variables"
 // injected into scafctl CEL and Go-template evaluation (e.g. _, __self, __item,
 // __plan, __execution, __actions, __cwd, __params, __error, and the Go-template
-// .__file* path parts).
+// __file* path parts).
 //
 // No other tool in scafctl enumerates these injected variables or the phase in
 // which each is available: list_cel_functions returns functions, and the

--- a/pkg/contextvars/contextvars.go
+++ b/pkg/contextvars/contextvars.go
@@ -1,0 +1,256 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package contextvars provides a registry of the special "context variables"
+// injected into scafctl CEL and Go-template evaluation (e.g. _, __self, __item,
+// __plan, __execution, __actions, __cwd, __params, __error, and the Go-template
+// .__file* path parts).
+//
+// No other tool in scafctl enumerates these injected variables or the phase in
+// which each is available: list_cel_functions returns functions, and the
+// solution schema describes shape, not the runtime evaluation environment. This
+// package is the single source of truth consumed by both the MCP
+// list_context_variables tool and the "context-variables" concept prose.
+//
+// The canonical variable names are pinned to the celexp.Var* constants where
+// they exist, so the registry cannot silently drift from the names the engine
+// actually injects. The phase/availability metadata is authored here because the
+// engine constants do not carry it.
+package contextvars
+
+import (
+	"sort"
+
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+)
+
+// Phase identifiers describe where in evaluation a context variable is
+// available. They are stable strings suitable for filtering (e.g. via the MCP
+// list_context_variables tool's "phase" argument).
+const (
+	// PhaseResolve is a resolver's resolve phase (provider inputs and when).
+	PhaseResolve = "resolve"
+	// PhaseTransform is a resolver's transform phase.
+	PhaseTransform = "transform"
+	// PhaseValidate is a resolver's validate phase.
+	PhaseValidate = "validate"
+	// PhaseForEach is a forEach iteration (resolve or transform).
+	PhaseForEach = "forEach"
+	// PhaseAction is an action's when conditions and inputs.
+	PhaseAction = "action"
+	// PhaseStateBackend is a state backend's input expressions.
+	PhaseStateBackend = "state-backend"
+	// PhaseError is a failure context (continueOnError conditions, error messages).
+	PhaseError = "error"
+	// PhaseTemplateFile is Go-template file generation (directory/render-tree/
+	// write-tree outputPath rendering).
+	PhaseTemplateFile = "template-file"
+)
+
+// Language identifies the expression language a variable applies to.
+const (
+	// LangCEL means the variable is available in CEL expressions.
+	LangCEL = "cel"
+	// LangTemplate means the variable is available in Go templates.
+	LangTemplate = "go-template"
+)
+
+// ContextVariable describes a single injected evaluation variable.
+type ContextVariable struct {
+	// Name is the variable identifier as used in an expression (e.g. "__self",
+	// or ".__filePath" for Go-template path parts).
+	Name string `json:"name" yaml:"name"`
+
+	// Language is the expression language the variable applies to (cel or
+	// go-template).
+	Language string `json:"language" yaml:"language"`
+
+	// Phases lists the evaluation phases in which the variable is available.
+	Phases []string `json:"phases" yaml:"phases"`
+
+	// Description explains what the variable contains and how to use it.
+	Description string `json:"description" yaml:"description"`
+
+	// Example is a short expression demonstrating the variable.
+	Example string `json:"example,omitempty" yaml:"example,omitempty"`
+}
+
+// builtinVariables is the canonical list of context variables. Names are pinned
+// to celexp.Var* constants where available so this registry tracks the engine.
+var builtinVariables = []ContextVariable{
+	{
+		Name:        "_",
+		Language:    LangCEL,
+		Phases:      []string{PhaseResolve, PhaseTransform, PhaseValidate, PhaseAction},
+		Description: "Map of resolved resolver values, keyed by resolver name. The primary way to reference other resolvers' outputs. Referencing _.other also creates an implicit dependency edge.",
+		Example:     "_.region",
+	},
+	{
+		Name:        celexp.VarSelf, // "__self"
+		Language:    LangCEL,
+		Phases:      []string{PhaseTransform, PhaseValidate},
+		Description: "The current resolver's in-progress value: the resolved value in transform steps, and the final value in validate steps. Not available during resolve.",
+		Example:     "__self.trimSpace()",
+	},
+	{
+		Name:        celexp.VarItem, // "__item"
+		Language:    LangCEL,
+		Phases:      []string{PhaseForEach},
+		Description: "The current element in a forEach iteration (resolve or transform).",
+		Example:     "__item.name",
+	},
+	{
+		Name:        celexp.VarIndex, // "__index"
+		Language:    LangCEL,
+		Phases:      []string{PhaseForEach},
+		Description: "The current zero-based index in a forEach iteration (resolve or transform).",
+		Example:     "__index == 0",
+	},
+	{
+		Name:        celexp.VarPlan, // "__plan"
+		Language:    LangCEL,
+		Phases:      []string{PhaseResolve},
+		Description: "Pre-execution resolver topology, injected before any resolver runs, so resolver when conditions and provider inputs can reason about the plan. Each entry exposes .phase, .dependsOn, and .dependencyCount.",
+		Example:     "__plan[\"myResolver\"].phase",
+	},
+	{
+		Name:        celexp.VarExecution, // "__execution"
+		Language:    LangCEL,
+		Phases:      []string{PhaseAction},
+		Description: "Resolver execution metadata available to actions: __execution.resolvers.<name>.status/phase/duration and __execution.summary.{phaseCount,resolverCount,totalDuration}.",
+		Example:     "__execution.resolvers.build.status",
+	},
+	{
+		Name:        celexp.VarActions, // "__actions"
+		Language:    LangCEL,
+		Phases:      []string{PhaseAction},
+		Description: "Results of completed actions, keyed by action name: __actions.<name>.results and __actions.<name>.status. Available in downstream action when conditions and inputs.",
+		Example:     "__actions.build.results.exitCode",
+	},
+	{
+		Name:        celexp.VarCwd, // "__cwd"
+		Language:    LangCEL,
+		Phases:      []string{PhaseAction},
+		Description: "The original working directory, available in ACTIONS ONLY. Useful when --output-dir redirects action output but an action still needs to reference the invocation directory. Not injected into resolvers.",
+		Example:     "__cwd + \"/dist\"",
+	},
+	{
+		Name:        celexp.VarParams, // "__params"
+		Language:    LangCEL,
+		Phases:      []string{PhaseStateBackend},
+		Description: "Raw CLI parameters (-r key=value), available in STATE BACKEND input expressions only. Unlike _, which holds resolver outputs, __params always holds the raw parameters regardless of resolver execution state.",
+		Example:     "__params.gcp_project",
+	},
+	{
+		Name:        celexp.VarError, // "__error"
+		Language:    LangCEL,
+		Phases:      []string{PhaseError},
+		Description: "The error text bound in failure contexts: continueOnError conditions and messages.error, for both resolvers and actions.",
+		Example:     "__error.contains(\"timeout\")",
+	},
+	{
+		Name:        ".__filePath",
+		Language:    LangTemplate,
+		Phases:      []string{PhaseTemplateFile},
+		Description: "Full source path of the current file during directory -> render-tree -> write-tree generation. Available in the file provider's outputPath template for renaming files.",
+		Example:     "{{ .__fileDir }}/{{ .__fileStem }}",
+	},
+	{
+		Name:        ".__fileName",
+		Language:    LangTemplate,
+		Phases:      []string{PhaseTemplateFile},
+		Description: "Base file name (including extension) of the current file during tree generation.",
+		Example:     "{{ .__fileName }}",
+	},
+	{
+		Name:        ".__fileStem",
+		Language:    LangTemplate,
+		Phases:      []string{PhaseTemplateFile},
+		Description: "File name without its extension during tree generation. Commonly used to strip a .tpl suffix.",
+		Example:     "{{ .__fileStem }}",
+	},
+	{
+		Name:        ".__fileExtension",
+		Language:    LangTemplate,
+		Phases:      []string{PhaseTemplateFile},
+		Description: "File extension (including the leading dot) of the current file during tree generation.",
+		Example:     "{{ .__fileExtension }}",
+	},
+	{
+		Name:        ".__fileDir",
+		Language:    LangTemplate,
+		Phases:      []string{PhaseTemplateFile},
+		Description: "Directory portion of the current file's path during tree generation, used to preserve the source tree structure in output.",
+		Example:     "{{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}",
+	},
+}
+
+// registry indexes builtinVariables by name for O(1) lookup.
+var registry = func() map[string]ContextVariable {
+	m := make(map[string]ContextVariable, len(builtinVariables))
+	for _, v := range builtinVariables {
+		m[v.Name] = v
+	}
+	return m
+}()
+
+// lessByLangName orders context variables by language then name. It is the
+// shared comparator used by List and ByPhase so their ordering cannot drift.
+func lessByLangName(a, b ContextVariable) bool {
+	if a.Language != b.Language {
+		return a.Language < b.Language
+	}
+	return a.Name < b.Name
+}
+
+// List returns all context variables sorted by language then name.
+func List() []ContextVariable {
+	out := make([]ContextVariable, len(builtinVariables))
+	copy(out, builtinVariables)
+	sort.Slice(out, func(i, j int) bool {
+		return lessByLangName(out[i], out[j])
+	})
+	return out
+}
+
+// Get returns a context variable by exact name. The second return value is
+// false if no variable with that name exists.
+func Get(name string) (ContextVariable, bool) {
+	v, ok := registry[name]
+	return v, ok
+}
+
+// ByPhase returns all context variables available in the given phase, sorted by
+// language then name. An unknown phase yields an empty slice.
+func ByPhase(phase string) []ContextVariable {
+	var out []ContextVariable
+	for _, v := range builtinVariables {
+		for _, p := range v.Phases {
+			if p == phase {
+				out = append(out, v)
+				break
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return lessByLangName(out[i], out[j])
+	})
+	return out
+}
+
+// Phases returns the sorted set of distinct phase identifiers across all
+// registered variables.
+func Phases() []string {
+	seen := map[string]bool{}
+	for _, v := range builtinVariables {
+		for _, p := range v.Phases {
+			seen[p] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/pkg/contextvars/contextvars_test.go
+++ b/pkg/contextvars/contextvars_test.go
@@ -136,7 +136,7 @@ func TestByPhase_TemplateFile(t *testing.T) {
 	for _, v := range tmpl {
 		assert.Equal(t, []string{LangTemplate}, v.Languages)
 	}
-	_, ok := Get(".__fileStem")
+	_, ok := Get("__fileStem")
 	assert.True(t, ok)
 }
 

--- a/pkg/contextvars/contextvars_test.go
+++ b/pkg/contextvars/contextvars_test.go
@@ -18,18 +18,21 @@ func TestList_ReturnsAllSortedAndWellFormed(t *testing.T) {
 
 	for _, v := range all {
 		assert.NotEmpty(t, v.Name, "name must not be empty")
-		assert.Contains(t, []string{LangCEL, LangTemplate}, v.Language, "language must be cel or go-template: %s", v.Name)
+		assert.NotEmpty(t, v.Languages, "languages must not be empty: %s", v.Name)
+		for _, lang := range v.Languages {
+			assert.Contains(t, []string{LangCEL, LangTemplate}, lang, "language must be cel or go-template: %s", v.Name)
+		}
 		assert.NotEmpty(t, v.Phases, "phases must not be empty: %s", v.Name)
 		assert.NotEmpty(t, v.Description, "description must not be empty: %s", v.Name)
 	}
 
-	// Sorted by language then name.
+	// Sorted by primary language then name.
 	for i := 1; i < len(all); i++ {
 		prev, cur := all[i-1], all[i]
-		if prev.Language == cur.Language {
+		if primaryLang(prev) == primaryLang(cur) {
 			assert.LessOrEqual(t, prev.Name, cur.Name)
 		} else {
-			assert.Less(t, prev.Language, cur.Language)
+			assert.Less(t, primaryLang(prev), primaryLang(cur))
 		}
 	}
 }
@@ -38,8 +41,9 @@ func TestGet(t *testing.T) {
 	v, ok := Get("__self")
 	require.True(t, ok)
 	assert.Equal(t, celexp.VarSelf, v.Name)
-	assert.Equal(t, LangCEL, v.Language)
-	assert.ElementsMatch(t, []string{PhaseTransform, PhaseValidate}, v.Phases)
+	// __self is available in both CEL and Go templates.
+	assert.ElementsMatch(t, []string{LangCEL, LangTemplate}, v.Languages)
+	assert.ElementsMatch(t, []string{PhaseTransform, PhaseValidate, PhaseForEach}, v.Phases)
 
 	_, ok = Get("__nonexistent")
 	assert.False(t, ok)
@@ -76,10 +80,36 @@ func TestCorrectedScoping(t *testing.T) {
 	params, ok := Get(celexp.VarParams)
 	require.True(t, ok)
 	assert.Equal(t, []string{PhaseStateBackend}, params.Phases, "__params must be state-backend-only")
+	assert.Equal(t, []string{LangCEL}, params.Languages, "__params is CEL-only")
 
 	errVar, ok := Get(celexp.VarError)
 	require.True(t, ok)
 	assert.Equal(t, []string{PhaseError}, errVar.Phases, "__error must be error-context-only")
+	assert.Equal(t, []string{LangCEL}, errVar.Languages, "__error is CEL-only")
+}
+
+// TestDualLanguageVariables locks in that variables the engine injects into both
+// CEL and Go-template data are reported as available in both.
+func TestDualLanguageVariables(t *testing.T) {
+	for _, name := range []string{"_", celexp.VarSelf, celexp.VarItem, celexp.VarIndex, celexp.VarActions, celexp.VarCwd, celexp.VarExecution} {
+		v, ok := Get(name)
+		require.True(t, ok, "%s must be registered", name)
+		assert.ElementsMatch(t, []string{LangCEL, LangTemplate}, v.Languages, "%s must be available in both CEL and Go templates", name)
+	}
+}
+
+// TestForEachScoping locks in that resolver data (_) and __self are reported as
+// available inside forEach iterations, alongside __item and __index.
+func TestForEachScoping(t *testing.T) {
+	fe := ByPhase(PhaseForEach)
+	names := make(map[string]bool)
+	for _, v := range fe {
+		names[v.Name] = true
+	}
+	assert.True(t, names["_"], "_ (resolver data) is in scope during forEach")
+	assert.True(t, names[celexp.VarSelf], "__self is bound during forEach iterations")
+	assert.True(t, names[celexp.VarItem], "__item is bound during forEach")
+	assert.True(t, names[celexp.VarIndex], "__index is bound during forEach")
 }
 
 func TestByPhase(t *testing.T) {
@@ -104,7 +134,7 @@ func TestByPhase_TemplateFile(t *testing.T) {
 	tmpl := ByPhase(PhaseTemplateFile)
 	require.NotEmpty(t, tmpl)
 	for _, v := range tmpl {
-		assert.Equal(t, LangTemplate, v.Language)
+		assert.Equal(t, []string{LangTemplate}, v.Languages)
 	}
 	_, ok := Get(".__fileStem")
 	assert.True(t, ok)
@@ -120,12 +150,53 @@ func TestPhases(t *testing.T) {
 	assert.Contains(t, phases, PhaseResolve)
 	assert.Contains(t, phases, PhaseAction)
 	assert.Contains(t, phases, PhaseTemplateFile)
+	assert.Contains(t, phases, PhaseForEach)
 }
 
-func TestList_ReturnsCopy(t *testing.T) {
+// TestList_ReturnsDeepCopy asserts callers cannot mutate the package registry
+// through the returned values -- neither the top-level fields nor the nested
+// Languages/Phases slices.
+func TestList_ReturnsDeepCopy(t *testing.T) {
 	a := List()
 	require.NotEmpty(t, a)
 	a[0].Name = "mutated"
+	// Mutate the nested slices too.
+	if len(a[0].Phases) > 0 {
+		a[0].Phases[0] = "mutated-phase"
+	}
+	if len(a[0].Languages) > 0 {
+		a[0].Languages[0] = "mutated-lang"
+	}
+
 	b := List()
-	assert.NotEqual(t, "mutated", b[0].Name, "List must return a defensive copy")
+	assert.NotEqual(t, "mutated", b[0].Name, "List must return a defensive copy of fields")
+	assert.NotContains(t, b[0].Phases, "mutated-phase", "List must deep-copy Phases")
+	assert.NotContains(t, b[0].Languages, "mutated-lang", "List must deep-copy Languages")
+}
+
+// TestGet_ReturnsDeepCopy asserts Get's returned value does not alias registry slices.
+func TestGet_ReturnsDeepCopy(t *testing.T) {
+	v, ok := Get("_")
+	require.True(t, ok)
+	require.NotEmpty(t, v.Phases)
+	v.Phases[0] = "mutated"
+	v.Languages[0] = "mutated"
+
+	again, ok := Get("_")
+	require.True(t, ok)
+	assert.NotContains(t, again.Phases, "mutated", "Get must deep-copy Phases")
+	assert.NotContains(t, again.Languages, "mutated", "Get must deep-copy Languages")
+}
+
+// TestByPhase_ReturnsDeepCopy asserts ByPhase's returned values do not alias registry slices.
+func TestByPhase_ReturnsDeepCopy(t *testing.T) {
+	vs := ByPhase(PhaseAction)
+	require.NotEmpty(t, vs)
+	vs[0].Phases[0] = "mutated"
+
+	again := ByPhase(PhaseAction)
+	require.NotEmpty(t, again)
+	for _, v := range again {
+		assert.NotContains(t, v.Phases, "mutated", "ByPhase must deep-copy Phases")
+	}
 }

--- a/pkg/contextvars/contextvars_test.go
+++ b/pkg/contextvars/contextvars_test.go
@@ -43,7 +43,8 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, celexp.VarSelf, v.Name)
 	// __self is available in both CEL and Go templates.
 	assert.ElementsMatch(t, []string{LangCEL, LangTemplate}, v.Languages)
-	assert.ElementsMatch(t, []string{PhaseTransform, PhaseValidate, PhaseForEach}, v.Phases)
+	// __self is bound in transform, validate, forEach, and resolve-phase until conditions.
+	assert.ElementsMatch(t, []string{PhaseResolve, PhaseTransform, PhaseValidate, PhaseForEach}, v.Phases)
 
 	_, ok = Get("__nonexistent")
 	assert.False(t, ok)

--- a/pkg/contextvars/contextvars_test.go
+++ b/pkg/contextvars/contextvars_test.go
@@ -1,0 +1,131 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package contextvars
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestList_ReturnsAllSortedAndWellFormed(t *testing.T) {
+	all := List()
+	require.NotEmpty(t, all)
+	assert.Equal(t, len(builtinVariables), len(all))
+
+	for _, v := range all {
+		assert.NotEmpty(t, v.Name, "name must not be empty")
+		assert.Contains(t, []string{LangCEL, LangTemplate}, v.Language, "language must be cel or go-template: %s", v.Name)
+		assert.NotEmpty(t, v.Phases, "phases must not be empty: %s", v.Name)
+		assert.NotEmpty(t, v.Description, "description must not be empty: %s", v.Name)
+	}
+
+	// Sorted by language then name.
+	for i := 1; i < len(all); i++ {
+		prev, cur := all[i-1], all[i]
+		if prev.Language == cur.Language {
+			assert.LessOrEqual(t, prev.Name, cur.Name)
+		} else {
+			assert.Less(t, prev.Language, cur.Language)
+		}
+	}
+}
+
+func TestGet(t *testing.T) {
+	v, ok := Get("__self")
+	require.True(t, ok)
+	assert.Equal(t, celexp.VarSelf, v.Name)
+	assert.Equal(t, LangCEL, v.Language)
+	assert.ElementsMatch(t, []string{PhaseTransform, PhaseValidate}, v.Phases)
+
+	_, ok = Get("__nonexistent")
+	assert.False(t, ok)
+}
+
+// TestCanonicalNamesTrackEngine guards against drift: the registry names must
+// match the celexp.Var* constants the engine actually injects.
+func TestCanonicalNamesTrackEngine(t *testing.T) {
+	expected := map[string]struct{}{
+		celexp.VarSelf:      {},
+		celexp.VarItem:      {},
+		celexp.VarIndex:     {},
+		celexp.VarPlan:      {},
+		celexp.VarExecution: {},
+		celexp.VarActions:   {},
+		celexp.VarCwd:       {},
+		celexp.VarParams:    {},
+		celexp.VarError:     {},
+	}
+	for name := range expected {
+		_, ok := Get(name)
+		assert.True(t, ok, "engine variable %q must be registered", name)
+	}
+}
+
+// TestCorrectedScoping locks in the accuracy fixes validated against the engine:
+// __cwd is action-only, __params is state-backend-only, __error is error-only.
+func TestCorrectedScoping(t *testing.T) {
+	cwd, ok := Get(celexp.VarCwd)
+	require.True(t, ok)
+	assert.Equal(t, []string{PhaseAction}, cwd.Phases, "__cwd must be action-only")
+	assert.NotContains(t, cwd.Phases, PhaseResolve, "__cwd must NOT be available in resolvers")
+
+	params, ok := Get(celexp.VarParams)
+	require.True(t, ok)
+	assert.Equal(t, []string{PhaseStateBackend}, params.Phases, "__params must be state-backend-only")
+
+	errVar, ok := Get(celexp.VarError)
+	require.True(t, ok)
+	assert.Equal(t, []string{PhaseError}, errVar.Phases, "__error must be error-context-only")
+}
+
+func TestByPhase(t *testing.T) {
+	action := ByPhase(PhaseAction)
+	require.NotEmpty(t, action)
+	names := make(map[string]bool)
+	for _, v := range action {
+		names[v.Name] = true
+		assert.Contains(t, v.Phases, PhaseAction)
+	}
+	assert.True(t, names[celexp.VarExecution])
+	assert.True(t, names[celexp.VarActions])
+	assert.True(t, names[celexp.VarCwd])
+	// A resolve-only variable must not appear.
+	assert.False(t, names[celexp.VarPlan], "__plan is resolve-phase, not action")
+
+	// Unknown phase yields empty.
+	assert.Empty(t, ByPhase("no-such-phase"))
+}
+
+func TestByPhase_TemplateFile(t *testing.T) {
+	tmpl := ByPhase(PhaseTemplateFile)
+	require.NotEmpty(t, tmpl)
+	for _, v := range tmpl {
+		assert.Equal(t, LangTemplate, v.Language)
+	}
+	_, ok := Get(".__fileStem")
+	assert.True(t, ok)
+}
+
+func TestPhases(t *testing.T) {
+	phases := Phases()
+	require.NotEmpty(t, phases)
+	// Sorted and unique.
+	for i := 1; i < len(phases); i++ {
+		assert.Less(t, phases[i-1], phases[i])
+	}
+	assert.Contains(t, phases, PhaseResolve)
+	assert.Contains(t, phases, PhaseAction)
+	assert.Contains(t, phases, PhaseTemplateFile)
+}
+
+func TestList_ReturnsCopy(t *testing.T) {
+	a := List()
+	require.NotEmpty(t, a)
+	a[0].Name = "mutated"
+	b := List()
+	assert.NotEqual(t, "mutated", b[0].Name, "List must return a defensive copy")
+}

--- a/pkg/mcp/tools_concepts.go
+++ b/pkg/mcp/tools_concepts.go
@@ -67,8 +67,8 @@ func (s *Server) handleListContextVariables(_ context.Context, request mcp.CallT
 	if phase != "" {
 		vars = contextvars.ByPhase(phase)
 		if len(vars) == 0 {
-			return newStructuredError(ErrCodeNotFound,
-				fmt.Sprintf("no context variables available in phase %q", phase),
+			return newStructuredError(ErrCodeInvalidInput,
+				fmt.Sprintf("unknown phase %q; no context variables are available in it", phase),
 				WithSuggestion("Call list_context_variables without a phase to see all variables and their phases"),
 				WithField("phase"),
 			), nil

--- a/pkg/mcp/tools_concepts.go
+++ b/pkg/mcp/tools_concepts.go
@@ -35,7 +35,7 @@ func (s *Server) registerConceptTools() {
 	s.addTool(tool, s.handleExplainConcepts)
 
 	ctxVarsTool := mcp.NewTool("list_context_variables",
-		mcp.WithDescription("List the special context variables injected into scafctl CEL and Go-template evaluation (e.g. _, __self, __item, __plan, __execution, __actions, __cwd, __params, __error, and the Go-template .__file* path parts), with the phase each is available in. No function list covers these injected variables. Optionally filter by phase to see only what is available in a given evaluation context. For narrative guidance use explain_concepts name='context-variables'."),
+		mcp.WithDescription("List the special context variables injected into scafctl CEL and Go-template evaluation (e.g. _, __self, __item, __plan, __execution, __actions, __cwd, __params, __error, and the Go-template __file* path parts), with the phase each is available in. No function list covers these injected variables. Optionally filter by phase to see only what is available in a given evaluation context. For narrative guidance use explain_concepts name='context-variables'."),
 		mcp.WithTitleAnnotation("List Context Variables"),
 		mcp.WithToolIcons(toolIcons["help"]),
 		mcp.WithReadOnlyHintAnnotation(true),

--- a/pkg/mcp/tools_concepts.go
+++ b/pkg/mcp/tools_concepts.go
@@ -9,12 +9,13 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/oakwood-commons/scafctl/pkg/concepts"
+	"github.com/oakwood-commons/scafctl/pkg/contextvars"
 )
 
 // registerConceptTools registers concept explanation MCP tools.
 func (s *Server) registerConceptTools() {
 	tool := mcp.NewTool("explain_concepts",
-		mcp.WithDescription("Look up and explain scafctl concepts such as resolvers, providers, actions, testing, CEL expressions, composition, and more. Use without arguments to list all concepts, or provide a name or search query to get detailed explanations with examples."),
+		mcp.WithDescription("Look up and explain scafctl concepts such as resolvers, providers, actions, testing, CEL expressions, composition, context variables, and more. Use without arguments to list all concepts, or provide a name or search query to get detailed explanations with examples. The 'context' category covers the runtime evaluation environment (context variables, phase execution, CEL cost model, template dependency inference, snapshot masking, and the authoring workflow)."),
 		mcp.WithTitleAnnotation("Explain Concepts"),
 		mcp.WithToolIcons(toolIcons["help"]),
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -28,10 +29,61 @@ func (s *Server) registerConceptTools() {
 			mcp.Description("Free-text search across concept names, titles, and summaries"),
 		),
 		mcp.WithString("category",
-			mcp.Description("Filter concepts by category (e.g., 'resolvers', 'testing', 'providers', 'actions')"),
+			mcp.Description("Filter concepts by category (e.g., 'resolvers', 'testing', 'providers', 'actions', 'context')"),
 		),
 	)
 	s.addTool(tool, s.handleExplainConcepts)
+
+	ctxVarsTool := mcp.NewTool("list_context_variables",
+		mcp.WithDescription("List the special context variables injected into scafctl CEL and Go-template evaluation (e.g. _, __self, __item, __plan, __execution, __actions, __cwd, __params, __error, and the Go-template .__file* path parts), with the phase each is available in. No function list covers these injected variables. Optionally filter by phase to see only what is available in a given evaluation context. For narrative guidance use explain_concepts name='context-variables'."),
+		mcp.WithTitleAnnotation("List Context Variables"),
+		mcp.WithToolIcons(toolIcons["help"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("phase",
+			mcp.Description("Filter to variables available in a specific evaluation phase."),
+			mcp.Enum(
+				contextvars.PhaseResolve,
+				contextvars.PhaseTransform,
+				contextvars.PhaseValidate,
+				contextvars.PhaseForEach,
+				contextvars.PhaseAction,
+				contextvars.PhaseStateBackend,
+				contextvars.PhaseError,
+				contextvars.PhaseTemplateFile,
+			),
+		),
+	)
+	s.addTool(ctxVarsTool, s.handleListContextVariables)
+}
+
+// handleListContextVariables handles the list_context_variables MCP tool.
+func (s *Server) handleListContextVariables(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	phase := request.GetString("phase", "")
+
+	vars := contextvars.List()
+	if phase != "" {
+		vars = contextvars.ByPhase(phase)
+		if len(vars) == 0 {
+			return newStructuredError(ErrCodeNotFound,
+				fmt.Sprintf("no context variables available in phase %q", phase),
+				WithSuggestion("Call list_context_variables without a phase to see all variables and their phases"),
+				WithField("phase"),
+			), nil
+		}
+	}
+
+	result := map[string]any{
+		"variables": vars,
+		"phases":    contextvars.Phases(),
+		"hint":      "Use explain_concepts name='context-variables' for narrative guidance and examples.",
+	}
+	if phase != "" {
+		result["phase"] = phase
+	}
+	return mcp.NewToolResultJSON(result)
 }
 
 // handleExplainConcepts handles the explain_concepts MCP tool.

--- a/pkg/mcp/tools_concepts_test.go
+++ b/pkg/mcp/tools_concepts_test.go
@@ -90,6 +90,16 @@ func TestHandleListContextVariables(t *testing.T) {
 		result, err := srv.handleListContextVariables(context.Background(), request)
 		require.NoError(t, err)
 		assert.True(t, result.IsError)
+
+		// It is a bad argument, not missing data: lock down the error code.
+		text := result.Content[0].(mcp.TextContent).Text
+		var te struct {
+			Code  string `json:"code"`
+			Field string `json:"field"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &te))
+		assert.Equal(t, ErrCodeInvalidInput, te.Code, "unknown phase is invalid input, not not-found")
+		assert.Equal(t, "phase", te.Field)
 	})
 }
 

--- a/pkg/mcp/tools_concepts_test.go
+++ b/pkg/mcp/tools_concepts_test.go
@@ -1,0 +1,150 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/contextvars"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type contextVarsResponse struct {
+	Variables []contextvars.ContextVariable `json:"variables"`
+	Phases    []string                      `json:"phases"`
+	Phase     string                        `json:"phase"`
+	Hint      string                        `json:"hint"`
+}
+
+func newConceptTestServer(t *testing.T) *Server {
+	t.Helper()
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+	return srv
+}
+
+func TestHandleListContextVariables(t *testing.T) {
+	t.Run("returns all variables when no phase given", func(t *testing.T) {
+		srv := newConceptTestServer(t)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "list_context_variables"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleListContextVariables(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+		require.NotEmpty(t, result.Content)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var resp contextVarsResponse
+		require.NoError(t, json.Unmarshal([]byte(text), &resp))
+
+		assert.Equal(t, len(contextvars.List()), len(resp.Variables))
+		assert.NotEmpty(t, resp.Phases)
+		assert.Empty(t, resp.Phase)
+		assert.Contains(t, resp.Hint, "context-variables")
+	})
+
+	t.Run("filters by phase", func(t *testing.T) {
+		srv := newConceptTestServer(t)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "list_context_variables"
+		request.Params.Arguments = map[string]any{"phase": contextvars.PhaseAction}
+
+		result, err := srv.handleListContextVariables(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var resp contextVarsResponse
+		require.NoError(t, json.Unmarshal([]byte(text), &resp))
+
+		require.NotEmpty(t, resp.Variables)
+		assert.Equal(t, contextvars.PhaseAction, resp.Phase)
+		names := make(map[string]bool)
+		for _, v := range resp.Variables {
+			assert.Contains(t, v.Phases, contextvars.PhaseAction)
+			names[v.Name] = true
+		}
+		// __execution/__actions/__cwd are action-scoped; __plan (resolve) is not.
+		assert.True(t, names["__execution"])
+		assert.True(t, names["__actions"])
+		assert.True(t, names["__cwd"])
+		assert.False(t, names["__plan"], "__plan is resolve-phase, not action")
+	})
+
+	t.Run("unknown phase returns structured error", func(t *testing.T) {
+		srv := newConceptTestServer(t)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "list_context_variables"
+		request.Params.Arguments = map[string]any{"phase": "no-such-phase"}
+
+		result, err := srv.handleListContextVariables(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+}
+
+// TestListContextVariables_EnumMatchesRegistry guards against the tool's
+// hardcoded phase enum diverging from the phases the registry actually uses.
+// Every phase a variable declares must be an accepted enum value, and every
+// enum value must return at least one variable.
+func TestListContextVariables_EnumMatchesRegistry(t *testing.T) {
+	// The enum values accepted by the list_context_variables "phase" argument.
+	enumPhases := []string{
+		contextvars.PhaseResolve,
+		contextvars.PhaseTransform,
+		contextvars.PhaseValidate,
+		contextvars.PhaseForEach,
+		contextvars.PhaseAction,
+		contextvars.PhaseStateBackend,
+		contextvars.PhaseError,
+		contextvars.PhaseTemplateFile,
+	}
+	enumSet := make(map[string]bool, len(enumPhases))
+	for _, p := range enumPhases {
+		enumSet[p] = true
+	}
+
+	// Every phase the registry actually uses must be an accepted enum value.
+	for _, p := range contextvars.Phases() {
+		assert.True(t, enumSet[p], "registry phase %q is not an accepted enum value in list_context_variables", p)
+	}
+
+	// Every enum value must resolve to at least one variable (no dead options).
+	for _, p := range enumPhases {
+		assert.NotEmpty(t, contextvars.ByPhase(p), "enum phase %q returns no variables", p)
+	}
+}
+
+func TestHandleExplainConcepts_ContextCategory(t *testing.T) {
+	srv := newConceptTestServer(t)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "explain_concepts"
+	request.Params.Arguments = map[string]any{"category": "context"}
+
+	result, err := srv.handleExplainConcepts(context.Background(), request)
+	require.NoError(t, err)
+	assert.False(t, result.IsError)
+
+	text := result.Content[0].(mcp.TextContent).Text
+	for _, name := range []string{
+		"context-variables",
+		"phase-execution",
+		"cel-cost-model",
+		"template-dependency-inference",
+		"snapshot-masking",
+		"authoring-workflow",
+	} {
+		assert.Contains(t, text, name)
+	}
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -7814,6 +7814,7 @@ func TestIntegration_MCPServeInfo(t *testing.T) {
 	assert.True(t, toolNames["get_provider_output_shape"], "expected get_provider_output_shape tool")
 	assert.True(t, toolNames["dry_run_solution"], "expected dry_run_solution tool")
 	assert.True(t, toolNames["explain_concepts"], "expected explain_concepts tool")
+	assert.True(t, toolNames["list_context_variables"], "expected list_context_variables tool")
 }
 
 func TestIntegration_MCPServeProtocol(t *testing.T) {
@@ -9341,6 +9342,28 @@ func TestIntegration_MCPServeInfo_ExplainConcepts(t *testing.T) {
 		toolNames[tool.Name] = true
 	}
 	assert.True(t, toolNames["explain_concepts"], "expected explain_concepts tool to be registered")
+}
+
+// TestIntegration_MCPServeInfo_ListContextVariables verifies the
+// list_context_variables tool is registered.
+func TestIntegration_MCPServeInfo_ListContextVariables(t *testing.T) {
+	t.Parallel()
+
+	stdout, _, exitCode := runScafctl(t, "mcp", "serve", "--info")
+	assert.Equal(t, 0, exitCode)
+
+	var info struct {
+		Tools []struct {
+			Name string `json:"name"`
+		} `json:"tools"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &info))
+
+	toolNames := make(map[string]bool)
+	for _, tool := range info.Tools {
+		toolNames[tool.Name] = true
+	}
+	assert.True(t, toolNames["list_context_variables"], "expected list_context_variables tool to be registered")
 }
 
 func TestIntegration_MCPServeInfo_AuthTokenTools(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds solution-authoring "gap knowledge" to the scafctl MCP server so it is queryable, version-accurate, and available to **every** MCP client (opencode, GitHub Copilot, Claude Code, Cursor) with no per-repo/per-agent config. Closes #667.

The MCP server is excellent at "what" (schemas, functions, provider inventories) but had gaps in the "how/why" that no tool could produce -- knowledge that previously lived only in hand-maintained skills that duplicate and drift from the live tools. This moves the non-duplicative gap knowledge into the MCP.

## What changed

- **New `pkg/contextvars` package** -- a typed registry of the context variables injected into CEL/Go-template evaluation (`_`, `__self`, `__item`, `__index`, `__plan`, `__execution`, `__actions`, `__cwd`, `__params`, `__error`, and the Go-template `.__file*` path parts) with per-phase availability and the language(s) each applies to. Canonical names are pinned to the `celexp.Var*` constants so the registry cannot silently drift from the engine. `List`/`Get`/`ByPhase` deep-copy the nested slices so callers cannot mutate the registry.
- **New `list_context_variables` MCP tool** -- a thin handler over `pkg/contextvars` with an optional `phase` filter. No function list covers these injected variables, so this fills a real gap. An unknown phase returns `INVALID_INPUT`.
- **Six new concepts** in a new `context` category in `explain_concepts`: `context-variables`, `phase-execution`, `cel-cost-model`, `template-dependency-inference`, `snapshot-masking`, and `authoring-workflow` (a meta-concept teaching the MCP write -> schema -> preview -> lint -> test loop). Concepts POINT at the live tools rather than mirroring their output.
- **Tests** -- new no-dangling-`SeeAlso` assertion, context-category and drift guards, `contextvars` registry tests (including deep-copy, dual-language, and forEach-scope guards), MCP handler tests, and `mcp serve --info` integration assertions.
- **Docs** -- `mcp-server-tutorial.md` gains the tool in the inventory and a "Discover Context Variables" section.

## Accuracy of the context-variable matrix (validated against the engine)

The matrix reflects the engine's real behavior, not a simplified guess:

- **Dual-language:** `_`, `__self`, `__item`, `__index`, `__actions`, `__cwd`, `__execution` are injected into **both** CEL and Go-template evaluation (per `pkg/spec/valueref.go` and `pkg/action/deferred.go`), so `{{ ._.region }}` / `{{ .__self }}` work too. `__plan`, `__params`, `__error` are CEL-only; the `.__file*` path parts are Go-template only.
- **forEach scope:** `_` (resolver data) and `__self` are in scope during forEach iterations, alongside `__item`/`__index`.
- **`__error` shape is context-dependent:** a **string** in resolver `continueOnError`/`messages.error` (`__error.contains(...)`), but a **structured map** (`message`, `statusCode`, `attempt`, `maxAttempts`) in action `continueOnError`/`retryIf` (`__error.message.contains(...)`).
- **`__cwd`** is action-only; **`__params`** is state-backend-only.
- Snapshot masking: `timestamp`/`uuid`/`sandbox` presets on by default; `PASS*` is the relaxed-snapshot-pass report marker.

## Scope note

This ships the `list_context_variables` tool, which issue #667 had listed as an optional follow-up. Because it adds a real MCP tool, it carries the standard `mcp serve --info` registration assertions.

## Testing

- `go test -race ./pkg/contextvars/... ./pkg/concepts/... ./pkg/mcp/...` -- all pass; coverage: contextvars 100%, concepts 100%, mcp 81.5%.
- Integration `--info` assertions pass; full `task integration` = 900 passed, 0 failed.
- The snapshot-masking concept example was verified to load via `scafctl lint`.
- `task lint:changed` -- 0 issues.

## Out of scope (deliberately)

Function catalogs, schemas, and provider inventories stay in the live tools (`list_cel_functions`, `get_solution_schema`, `list_providers`, `extract_resolver_refs`) -- concepts reference them rather than copying, which is exactly the drift this PR avoids. Thinning the existing `.github/skills/*` and cross-repo distribution are tracked as downstream follow-ups on #667.