### PR TITLE
docs(skills): thin authoring skills to point at MCP tools and load them in opencode

### DIFF
--- a/.github/skills/cel-patterns/SKILL.md
+++ b/.github/skills/cel-patterns/SKILL.md
@@ -5,224 +5,37 @@ description: "CEL expression patterns, context variables, built-in functions, an
 
 # CEL Patterns in scafctl
 
+> Function reference is not duplicated here. For the authoritative, version-accurate
+> list of CEL functions (built-in and custom scafctl functions), call the MCP tool
+> **`list_cel_functions`** (filter with `custom_only: true` for scafctl extensions).
+> Test any expression with **`evaluate_cel`** / **`validate_expression`**. This skill
+> covers the knowledge those tools do not: context variables, patterns, pitfalls,
+> and the cost model.
+
 ## Context Variables
 
-Available during expression evaluation (defined as `celexp.Var*` constants):
+Context variables are the special values injected into CEL evaluation (they are
+**not** functions, so `list_cel_functions` does not cover them). For the
+authoritative per-phase matrix -- which variable is available in resolve vs.
+transform vs. validate vs. forEach vs. action vs. state-backend vs. error
+contexts -- call the MCP tool **`list_context_variables`** (optionally filtered
+by `phase`), or read the narrative in `explain_concepts name=context-variables`.
 
-| Variable | Available In | Contains |
-|----------|-------------|----------|
-| `_` | All contexts | Root data -- all resolved values as a map |
-| `__self` | Transform, Validate | Current resolver value being transformed/validated |
-| `__item` | forEach loops | Current array element |
-| `__index` | forEach loops | Current iteration index (0-based) |
-| `__actions` | Action `when` clauses | Map of completed action results |
-| `__cwd` | All contexts | Original working directory |
-| `__execution` | Post-resolve | Resolver execution metadata |
-| `__plan` | Pre-execution | Resolver topology/plan |
+Quick orientation (see the tool for the full, correct scoping):
 
-### Root Data (`_`)
+- `_` -- map of all resolved values (`_.my_resolver`, `_.config.database.host`).
+  Referencing `_.other` also creates an implicit dependency edge.
+- `__self` -- the current resolver's in-progress value (transform, validate, a
+  resolve-phase `until` condition, and forEach).
+- `__item` / `__index` -- current element / 0-based index inside `forEach`.
+- `__plan` -- pre-execution resolver topology (`__plan["name"].phase`).
+- `__execution` / `__actions` / `__cwd` -- available to actions.
+- `__params` -- raw CLI params, state-backend inputs only.
+- `__error` -- failure contexts (a string in resolvers; a structured map in
+  actions -- use `__error.message`, `__error.statusCode`).
 
-The root data map contains all resolved values keyed by resolver name:
-
-```cel
-_.my_resolver              // Access resolved value
-_.config.database.host     // Nested access (if resolver returns object)
-has(_.optional_resolver)   // Check if resolver exists/resolved
-```
-
-## Built-in Functions
-
-### String Operations (CEL strings v4)
-
-```cel
-_.name.upperAscii()           // "HELLO"
-_.name.lowerAscii()           // "hello"
-_.name.trim()                 // Strip whitespace (NOT trimSpace!)
-_.name.replace("old", "new")  // Replace all occurrences
-_.name.split("-")             // Split to list
-_.name.substring(0, 5)        // Substring
-_.name.contains("sub")        // Boolean check
-_.name.startsWith("pre")      // Prefix check
-_.name.endsWith("suf")        // Suffix check
-_.name.charAt(0)              // Single character
-_.name.indexOf("x")           // First index (-1 if not found)
-_.name.reverse()              // Reverse string
-_.name.join("-")              // Join list to string (on list type)
-size(_.name)                  // String length
-```
-
-### List Operations (CEL lists v3)
-
-```cel
-_.items.filter(x, x > 10)            // Filter
-_.items.map(x, x * 2)                // Map/transform
-_.items.exists(x, x == "target")     // Any match
-_.items.all(x, x > 0)               // All match
-_.items.size()                        // Length
-_.items.distinct()                    // Remove duplicates
-_.items.flatten()                     // Flatten nested lists
-_.items.reverse()                     // Reverse order
-_.items.slice(0, 5)                   // Sub-list
-_.items.sort()                        // Sort ascending
-_.items.sortBy(x, x.name)            // Sort by field
-```
-
-### Map Operations
-
-```cel
-_.config.key                     // Direct access
-has(_.config.key)                // Key exists check
-_.config.size()                  // Number of keys
-```
-
-### Math (CEL math extension)
-
-```cel
-math.ceil(3.2)    // 4
-math.floor(3.8)   // 3
-math.round(3.5)   // 4
-math.min(a, b)    // Minimum
-math.max(a, b)    // Maximum
-```
-
-### Encoding
-
-```cel
-base64.encode(bytes("hello"))   // Base64 encode
-base64.decode("aGVsbG8=")      // Base64 decode
-url.encode("hello world")      // URL form-encode -> "hello+world"
-url.decode("hello+world")      // URL form-decode -> "hello world"
-```
-
-### Bindings
-
-```cel
-cel.bind(x, _.long_expression, x + "_suffix")  // Bind intermediate values
-```
-
-## Custom scafctl Functions
-
-Registered via `ext.Custom()` in `pkg/celexp/ext/`. Only functions listed here
-are implemented. Check `ext.Custom()` for the authoritative list.
-
-### Arrays (`pkg/celexp/ext/arrays/`)
-
-```cel
-arrays.strings.add(["a", "b"], "c")       // Append string -> ["a","b","c"]
-arrays.strings.unique(["a", "b", "a"])     // Deduplicate -> ["a","b"]
-arrays.groupBy([{"k":"a","v":1},{"k":"b","v":2},{"k":"a","v":3}], "k")
-// -> {"a": [{"k":"a","v":1},{"k":"a","v":3}], "b": [{"k":"b","v":2}]}
-// O(n) single-pass grouping -- avoids quadratic CEL comprehension cost
-```
-
-### Debug (`pkg/celexp/ext/debug/`)
-
-```cel
-debug.out(_.value)                         // Print value to writer (requires Writer)
-debug.throw("something went wrong")       // Throw error for debugging
-debug.sleep(1000)                          // Sleep N milliseconds (testing only)
-```
-
-Note: `debug.out` is NOT included in `ext.Custom()` / `ext.All()` because it
-requires a Writer parameter. It is added separately via `debug.DebugOutFunc(w)`.
-
-### Filepath (`pkg/celexp/ext/filepath/`)
-
-```cel
-filepath.dir("/path/to/file.txt")          // Directory: "/path/to"
-filepath.normalize("path//to/../file")     // Clean path
-filepath.exists("/path/to/file")           // File exists check
-filepath.join("path", "to", "file")        // Join segments
-```
-
-### GUID (`pkg/celexp/ext/guid/`)
-
-```cel
-guid.new()                                 // UUID v4
-```
-
-### Host paths (`pkg/celexp/ext/host/`)
-
-```cel
-host.configDir()                           // Resolved config dir (branding-aware)
-hostConfigDir()                            // Portable alias; matches the Go template function
-host.configDir() + "/config.d/x.yaml"      // Build a config.d drop-in path
-```
-
-`host.configDir()` returns the host's resolved XDG config directory via
-`paths.ConfigDir()`, so it honors `paths.SetAppName` (a `cldctl` embedder gets
-`~/.config/cldctl`, not a hardcoded `scafctl` path). It is also registered under
-the dotless alias `hostConfigDir()` so the same name works in Go templates
-(`{{ hostConfigDir }}`).
-
-### Map (`pkg/celexp/ext/map/`)
-
-```cel
-map.add(_.config, "key", "value")          // Add key-value pair
-map.addFailIfExists(_.m, "k", "v")         // Add, error if key exists
-map.addIfMissing(_.m, "k", "v")            // Add only if key missing
-map.select(_.config, ["key1", "key2"])     // Pick keys
-map.omit(_.config, ["secret"])             // Remove keys
-map.merge(_.base, _.overrides)             // Merge maps (right wins)
-map.recurse(_.nested, "children", expr)    // Recursive tree operation
-map.fromEntries(_.list, "name")            // List of objects -> map keyed by field
-```
-
-### Marshalling (`pkg/celexp/ext/marshalling/`)
-
-```cel
-json.marshal(_.data)                       // Compact JSON string
-json.marshalPretty(_.data)                 // Pretty-printed JSON
-json.unmarshal(_.jsonString)               // Parse JSON string
-yaml.marshal(_.data)                       // YAML string
-yaml.unmarshal(_.yamlString)               // Parse YAML string
-```
-
-### Output (`pkg/celexp/ext/out/`)
-
-```cel
-out.nil()                                  // Returns null value
-```
-
-### Regex (`pkg/celexp/ext/regex/`)
-
-```cel
-regex.match("^[a-z]+$", _.name)            // Boolean match
-regex.replace("[0-9]+", _.input, "X")      // Replace matches
-regex.findAll("[a-z]+", _.input)           // List of matches
-regex.split("[,;]", _.input)               // Split by pattern
-```
-
-### Sort (`pkg/celexp/ext/sort/`)
-
-```cel
-sort.objects(_.items, "name")              // Sort objects by field (ascending)
-sort.objectsDescending(_.items, "score")   // Sort objects by field (descending)
-```
-
-### URL (`pkg/celexp/ext/url/`)
-
-```cel
-url.encode("hello world")                  // Form-encode -> "hello+world"
-url.decode("hello+world")                  // Form-decode -> "hello world"
-url.decode("hello%20world")                // Also decodes %XX -> "hello world"
-```
-
-### Strings (`pkg/celexp/ext/strings/`)
-
-```cel
-strings.clean(_.messy)                     // Normalize whitespace
-strings.title(_.name)                      // Title Case
-strings.repeat(_.char, 5)                  // Repeat string N times
-strings.slugify(_.orgName)                 // DNS-safe label (RFC 1123), e.g. "My Org!" -> "my-org"
-```
-
-### Time (`pkg/celexp/ext/time/`)
-
-```cel
-time.now()                                 // Current UTC timestamp (RFC3339)
-time.nowFmt("2006-01-02")                  // Current time with Go layout format
-```
+Most of these are injected into **both** CEL and Go templates. See
+`explain_concepts name=context-variables` for the exact language/phase details.
 
 ## Common Patterns
 
@@ -284,10 +97,12 @@ has(_.config) && has(_.config.database) && has(_.config.database.host)
 
 ## Reference Extraction
 
-`pkg/celexp/refs.go` provides static analysis of an expression's AST:
+To see which resolver references an expression produces (for dependency
+inference), use the MCP tool **`extract_resolver_refs`**. The underlying static
+analysis lives in `pkg/celexp/refs.go`:
 
 - `RequiredVariables(ctx)` / `GetUnderscoreVariables(ctx)` -- extract variable
-  and `_.` resolver references (used for dependency inference).
+  and `_.` resolver references.
 - `MapLiteralKeys(ctx) ([]string, bool)` -- when the expression's top-level node
   is a **map literal** with constant string keys (e.g.
   `{"appName": _.appName}`), returns those keys and `true`. Returns `nil, false`
@@ -306,31 +121,13 @@ has(_.config) && has(_.config.database) && has(_.config.database.host)
 
 ## Cost Limits
 
-CEL expressions have a runtime cost limit (default: 1,000,000) to prevent
-runaway computations. The limit is enforced by cel-go's cost tracker.
+CEL expressions run under a cost limit (default 1,000,000) to prevent runaway
+computations, enforced by cel-go's cost tracker. For the full model -- the
+`spec.options.cel.costLimit` override, the `min(solution, global)` semantics,
+and the high-cost anti-patterns -- see `explain_concepts name=cel-cost-model`.
 
-### Error Diagnostics
-
-When a cost limit is exceeded, the error includes actual cost, limit, and expression:
-
-```
-CEL expression cost limit exceeded (actual cost: 1500000, limit: 1000000)
-for expression "[large].map(x, x.filter(...))": runtime cost limit exceeded
-```
-
-### Per-Solution Override
-
-Solutions can lower the cost limit via `spec.options.cel.costLimit`:
-
-```yaml
-spec:
-  options:
-    cel:
-      costLimit: 500000  # Tighter limit for this solution
-```
-
-The effective limit is `min(solutionLimit, globalLimit)` -- solutions cannot
-raise the limit above the operator-configured global default.
+Quick reference: a solution can only *lower* the limit
+(`spec.options.cel.costLimit`), never raise it above the operator global.
 
 ### Avoiding High-Cost Patterns
 
@@ -339,3 +136,11 @@ raise the limit above the operator-configured global default.
 | `list.filter(x, list2.exists(y, ...))` | O(n*m) | Use `arrays.groupBy` + lookup |
 | `list.map(x, list.filter(...))` | O(n^2) | Pre-group with `arrays.groupBy` |
 | Nested `map` + `filter` | Multiplicative | Single-pass with custom extension |
+
+## See Also
+
+- MCP tools: `list_cel_functions`, `evaluate_cel`, `validate_expression`,
+  `list_context_variables`, `extract_resolver_refs`.
+- Concepts (`explain_concepts name=<...>`): `context-variables`, `cel-cost-model`,
+  `phase-execution`.
+- The `go-template-patterns` skill for the Go-template side.

--- a/.github/skills/go-template-patterns/SKILL.md
+++ b/.github/skills/go-template-patterns/SKILL.md
@@ -51,17 +51,19 @@ and which variables reach templates, call **`list_context_variables`** or read
 ### Built-in file-generation variables
 
 When rendering a directory tree (directory -> render-tree -> write-tree), the
-file provider injects per-file path parts. They are injected **without a leading
-dot** -- the dot is Go-template accessor syntax, so you write `{{ .__fileStem }}`
-(see `pkg/provider/builtin/fileprovider/file.go`):
+file provider injects per-file path parts for the entry being written. They are
+the entry's **relative** path (e.g. `k8s/deployment.yaml.tpl`), not an absolute
+path, and are injected **without a leading dot** -- the dot is Go-template
+accessor syntax, so you write `{{ .__fileStem }}` (see
+`pkg/provider/builtin/fileprovider/file.go`):
 
 | Injected name | Accessed as | Contains |
 |---------------|-------------|----------|
-| `__filePath` | `{{ .__filePath }}` | Full source path of the file |
-| `__fileName` | `{{ .__fileName }}` | File name including extension |
-| `__fileStem` | `{{ .__fileStem }}` | File name without extension |
-| `__fileExtension` | `{{ .__fileExtension }}` | Extension including the leading dot |
-| `__fileDir` | `{{ .__fileDir }}` | Directory portion of the path |
+| `__filePath` | `{{ .__filePath }}` | Relative path of the entry (forward slashes) |
+| `__fileName` | `{{ .__fileName }}` | Base file name, including extension |
+| `__fileStem` | `{{ .__fileStem }}` | File name with only the **last** extension removed (`deployment.yaml.tpl` -> `deployment.yaml`) |
+| `__fileExtension` | `{{ .__fileExtension }}` | The **last** extension, including the leading dot (`.tpl`) |
+| `__fileDir` | `{{ .__fileDir }}` | Directory portion of the relative path (empty for a top-level file) |
 
 A common `outputPath` that strips a `.tpl` suffix while preserving the tree:
 

--- a/.github/skills/go-template-patterns/SKILL.md
+++ b/.github/skills/go-template-patterns/SKILL.md
@@ -5,6 +5,13 @@ description: "Go template patterns, built-in functions, custom scafctl functions
 
 # Go Template Patterns in scafctl
 
+> Function reference is not duplicated here. For the authoritative, version-accurate
+> list of Go-template functions (Sprig plus custom scafctl functions like `toHcl`,
+> `toYaml`, `fromYaml`, `cel`, `slugify`), call the MCP tool
+> **`list_go_template_functions`**. Test a template with **`evaluate_go_template`**.
+> This skill covers the knowledge those tools do not: the execution API,
+> dependency inference, file-generation variables, and conventions.
+
 ## Execution API
 
 ```go
@@ -36,19 +43,36 @@ In solution templates, the root data (`.`) contains all resolved values:
 {{.config.database.host}}       <!-- Nested field access -->
 ```
 
-### Built-in Template Variables (for file templates)
+Many context variables are injected into Go templates too (`{{ ._.region }}`,
+`{{ .__self }}`, `{{ .__item }}`, etc.). For the authoritative per-phase matrix
+and which variables reach templates, call **`list_context_variables`** or read
+`explain_concepts name=context-variables`.
 
-When used with the directory provider for file generation:
+### Built-in file-generation variables
 
-| Variable | Contains |
-|----------|----------|
-| `.__filePath` | Full file path being generated |
-| `.__fileName` | File name with extension |
-| `.__fileStem` | File name without extension |
-| `.__fileDir` | Directory containing the file |
-| `.__fileExt` | File extension |
+When rendering a directory tree (directory -> render-tree -> write-tree), the
+file provider injects per-file path parts. They are injected **without a leading
+dot** -- the dot is Go-template accessor syntax, so you write `{{ .__fileStem }}`
+(see `pkg/provider/builtin/fileprovider/file.go`):
+
+| Injected name | Accessed as | Contains |
+|---------------|-------------|----------|
+| `__filePath` | `{{ .__filePath }}` | Full source path of the file |
+| `__fileName` | `{{ .__fileName }}` | File name including extension |
+| `__fileStem` | `{{ .__fileStem }}` | File name without extension |
+| `__fileExtension` | `{{ .__fileExtension }}` | Extension including the leading dot |
+| `__fileDir` | `{{ .__fileDir }}` | Directory portion of the path |
+
+A common `outputPath` that strips a `.tpl` suffix while preserving the tree:
+
+```gotemplate
+{{ if .__fileDir }}{{ .__fileDir }}/{{ end }}{{ .__fileStem }}
+```
 
 ## Dependency Inference (resolver ref vs data context)
+
+For the full model, see `explain_concepts name=template-dependency-inference`;
+to see the references a template actually produces, use **`extract_resolver_refs`**.
 
 A go-template render step's template root namespace is the **union** of three
 sources:
@@ -67,7 +91,7 @@ root accessors. It disambiguates them as follows:
 | `{{ .field }}`, **no** `data` input | Yes, unless `field` is a `forEach` alias. |
 | `{{ .field }}` where `field` is a statically-known `data` key | No -- it is local data context. |
 | `{{ .field }}` with a **dynamic** `data` input (keys not statically known) | No -- assumed to come from `data`. |
-| `{{ .__self }}`, `{{ .__item }}`, `{{ .__fan.* }}` and other `.__` vars | No -- internal/special variables. |
+| `{{ .__self }}`, `{{ .__item }}`, and other `.__` vars | No -- internal/special variables. |
 
 A `data` input's keys are statically known when it is a literal map or a CEL
 **map literal** expression (e.g. `expr: '{"appName": _.appName}'`). A `data`
@@ -83,8 +107,8 @@ the template, or add an explicit `dependsOn` entry.
 
 ```yaml
 # The forEach alias `proj` and the data keys (projects, appName) are NOT
-# resolver dependencies. `platformAppName`/`appName` become dependencies only
-# because the data expression references them via `_.`.
+# resolver dependencies. `appName` becomes a dependency only because the data
+# expression references it via `_.`.
 resolve:
   with:
     - provider: go-template
@@ -104,102 +128,7 @@ resolve:
 The `template-unknown-accessor` lint rule warns when a bare `{{ .field }}` or
 `{{ ._.name }}` accessor cannot resolve to any known resolver, data key, or
 forEach alias -- a likely typo, since such accessors render empty at runtime
-rather than failing.
-
-## Functions
-
-### Sprig v3 (100+ functions)
-
-All [Sprig v3](http://masterminds.github.io/sprig/) functions are available:
-
-**String:**
-```gotemplate
-{{trim .name}}                  <!-- Strip whitespace -->
-{{upper .name}}                 <!-- Uppercase -->
-{{lower .name}}                 <!-- Lowercase -->
-{{title .name}}                 <!-- Title case -->
-{{snakecase .name}}             <!-- snake_case -->
-{{camelcase .name}}             <!-- CamelCase -->
-{{kebabcase .name}}             <!-- kebab-case -->
-{{repeat 3 .char}}              <!-- Repeat string -->
-{{substr 0 5 .name}}            <!-- Substring -->
-{{replace "old" "new" .input}}  <!-- Replace -->
-{{contains "sub" .name}}        <!-- Contains check -->
-{{hasPrefix "pre" .name}}       <!-- Prefix check -->
-{{hasSuffix "suf" .name}}       <!-- Suffix check -->
-{{quote .name}}                 <!-- Add quotes -->
-{{squote .name}}                <!-- Add single quotes -->
-{{nospace .name}}               <!-- Remove spaces -->
-{{indent 4 .block}}             <!-- Indent text -->
-{{nindent 4 .block}}            <!-- Newline + indent -->
-```
-
-**Collections:**
-```gotemplate
-{{join "," .items}}             <!-- Join list -->
-{{first .items}}                <!-- First element -->
-{{last .items}}                 <!-- Last element -->
-{{slice .items 1 3}}            <!-- Sub-slice -->
-{{has .items "value"}}          <!-- List contains -->
-{{uniq .items}}                 <!-- Remove duplicates -->
-{{sortAlpha .items}}            <!-- Sort strings -->
-```
-
-**Dictionary:**
-```gotemplate
-{{keys .config}}                <!-- Map keys -->
-{{values .config}}              <!-- Map values -->
-{{hasKey .config "key"}}        <!-- Key exists -->
-{{pluck "name" .items}}         <!-- Extract field from list of maps -->
-{{pick .config "key1" "key2"}}  <!-- Select keys -->
-{{omit .config "secret"}}       <!-- Exclude keys -->
-```
-
-**Math:**
-```gotemplate
-{{add 1 2}}                     <!-- Addition -->
-{{sub 10 3}}                    <!-- Subtraction -->
-{{mul 2 5}}                     <!-- Multiplication -->
-{{div 10 3}}                    <!-- Division -->
-{{mod 10 3}}                    <!-- Modulo -->
-{{max 3 5 1}}                   <!-- Maximum -->
-{{min 3 5 1}}                   <!-- Minimum -->
-```
-
-**Type/Logic:**
-```gotemplate
-{{empty .value}}                <!-- Is zero/nil/empty -->
-{{default "fallback" .value}}   <!-- Default if empty -->
-{{ternary "yes" "no" .flag}}    <!-- Ternary -->
-{{typeOf .value}}               <!-- Go type name -->
-{{kindOf .value}}               <!-- Go kind name -->
-```
-
-**Encoding:**
-```gotemplate
-{{b64enc .data}}                <!-- Base64 encode -->
-{{b64dec .encoded}}             <!-- Base64 decode -->
-{{sha256sum .data}}             <!-- SHA256 hash -->
-```
-
-**UUID:**
-```gotemplate
-{{uuidv4}}                      <!-- Generate UUID v4 -->
-```
-
-### Custom scafctl Functions
-
-```gotemplate
-{{cel "_.name.upperAscii()"}}   <!-- Inline CEL evaluation -->
-{{toHcl .config}}               <!-- Convert to HCL body (attributes + blocks) -->
-{{toHclValue .bindings}}        <!-- Convert to HCL value expression (RHS of =) -->
-{{fromYaml .yamlString}}        <!-- Parse YAML string to object -->
-{{toYaml .data}}                <!-- Convert to YAML string -->
-{{slugify .title}}              <!-- URL-safe slug -->
-{{toDNSString .name}}           <!-- DNS-safe string -->
-{{where .items "condition"}}    <!-- Filter array -->
-{{select .items "mapping"}}     <!-- Transform array elements -->
-```
+rather than failing. Use `explain_lint_rule template-unknown-accessor` for details.
 
 ## CEL vs Go Template Decision Guide
 
@@ -236,3 +165,11 @@ All [Sprig v3](http://masterminds.github.io/sprig/) functions are available:
 
 - `pkg/gotmpl/`: Template execution, options, missing key modes
 - `pkg/provider/builtin/gotmplprovider/`: Go template provider for transform phase
+
+## See Also
+
+- MCP tools: `list_go_template_functions`, `evaluate_go_template`,
+  `extract_resolver_refs`, `list_context_variables`.
+- Concepts (`explain_concepts name=<...>`): `template-dependency-inference`,
+  `context-variables`, `go-template-provider`.
+- The `cel-patterns` skill for the CEL side.

--- a/.github/skills/provider-authoring/SKILL.md
+++ b/.github/skills/provider-authoring/SKILL.md
@@ -236,19 +236,10 @@ func (m *mockOps) DoThing(_ context.Context, _ string) (string, error) {
 
 ## Existing Providers Reference
 
-| Provider | Package | Capability | Key Pattern |
-|----------|---------|-----------|-------------|
-| parameter | parameterprovider | from | Interactive prompts via terminal |
-| env | envprovider | from | Env var reading with expand option |
-| static | staticprovider | from | Pass-through literal values |
-| file | fileprovider | from | File I/O with encoding options |
-| exec | execprovider | from | Command execution with expand |
-| http | httpprovider | from | HTTP client with auth support |
-| cel | celprovider | transform | CEL expression evaluation |
-| gotmpl | gotmplprovider | transform | Go template rendering |
-| validation | validationprovider | validation | Rule-based input validation |
-| directory | directoryprovider | action | File/directory operations |
-| message | messageprovider | action | Terminal output messages |
+To see the built-in and official providers (names, capabilities, categories),
+call the MCP tool **`list_providers`**, and **`get_provider_schema`** for a
+specific provider's input/output schema. This is the authoritative, version-accurate
+source -- a hand-maintained table here would drift out of sync.
 
 ## Key Packages
 

--- a/.github/skills/solution-spec/SKILL.md
+++ b/.github/skills/solution-spec/SKILL.md
@@ -5,6 +5,13 @@ description: "Solution YAML specification reference for scafctl. Schema, resolve
 
 # Solution Spec Reference
 
+> The authoritative field schema is not duplicated here. For the exact, version-accurate
+> structure of a solution, resolver, action, or workflow, call the MCP tools
+> **`get_solution_schema`** and **`explain_kind`** (kinds: solution, resolver, action,
+> workflow, spec, provider, schema, retry). Scaffold a valid starting point with
+> **`scaffold_solution`** and validate with **`lint_solution`**. This skill covers the
+> runtime semantics and authoring judgment those tools do not encode.
+
 ## Top-Level Structure
 
 ```yaml
@@ -15,20 +22,8 @@ metadata:
   version: 1.0.0             # Semver
   displayName: My Solution
   description: Short description
-  category: infrastructure
-  tags: [go, cloud]
-  maintainers:
-    - name: Team
-      email: team@example.com
-  links:
-    - name: Docs
-      url: https://example.com
-  icon: https://example.com/icon.png
-  banner: https://example.com/banner.png
 catalog:
   visibility: public         # public | private | internal
-  beta: false
-  disabled: false
 spec:
   resolvers: {}              # map[string]*Resolver
   workflow: {}               # Optional action workflow
@@ -37,126 +32,104 @@ spec:
 
 ## Resolver Structure
 
-Resolvers are the DAG nodes. Map keys are resolver names (DNS-safe).
+Resolvers are the DAG nodes. Map keys are resolver names (DNS-safe). Each has up
+to three phases, each a `with:` list of provider steps.
 
 ```yaml
 spec:
   resolvers:
-    my-resolver:
+    myResolver:
       description: What this resolver does
       type: string           # string|int|float|bool|array|object|time|duration|any
       sensitive: false       # Redact from logs/output
       when: "_.some_flag"    # CEL condition -- skip if false
-      dependsOn: [other]     # Explicit deps (rarely needed — auto-inferred from expr/rslvr/tmpl refs)
+      dependsOn: [other]     # Explicit deps (rarely needed -- auto-inferred)
       timeout: 30s
-      example: "sample"
 
-      # Phase 1: Resolve -- get the value
+      # Phase 1: Resolve -- get the value (first non-null step wins)
       resolve:
-        - provider: parameter  # Provider name
-          with:                # Provider inputs (ValueRef format)
-            prompt: "Enter name"
-            default: "world"
-        - provider: env        # Fallback chain -- first non-null wins
-          with:
-            name: MY_ENV_VAR
-          until: "_ != ''"     # Stop condition (CEL)
+        # 'until' is a peer of 'with' (a CEL condition; __self = candidate).
+        until:
+          expr: "__self != ''"
+        with:
+          - provider: parameter
+            inputs:
+              key: "name"
+              default: "world"
+          - provider: env       # Fallback chain -- first non-null wins
+            inputs:
+              name: MY_ENV_VAR
 
       # Phase 2: Transform -- reshape the value
       transform:
-        - provider: cel
-          with:
-            expression: "_.upperAscii()"
-        - provider: gotmpl
-          with:
-            template: "prefix-{{.}}"
+        with:
+          - provider: cel
+            inputs:
+              expression: "__self.upperAscii()"
 
       # Phase 3: Validate -- check the value
       validate:
-        - provider: validation
-          with:
-            rules:
-              - expr: "size(_) > 0"
-                message: "Must not be empty"
+        with:
+          - provider: validation
+            inputs:
+              expression: "size(__self) > 0"
+              message: "Must not be empty"
 
       messages:
         error: "Failed to resolve {{.name}}"  # Go template
 ```
 
-### Phase Execution Order
+Verify exact field names and types with `get_solution_schema` /
+`explain_kind resolver`.
 
-1. **Resolve**: Providers execute in order. First non-null result wins (`until:` controls early stop).
-2. **Transform**: Applied sequentially. `__self` is the current value. Supports `forEach` for array iteration.
-3. **Validate**: All rules checked. Resolver fails if any validation fails.
+### Phase Execution Order (runtime semantics)
+
+For the full behavioral detail see `explain_concepts name=phase-execution`:
+
+1. **Resolve**: `with:` steps run in order; the **first successful/non-null**
+   result wins and stops the chain. A failing step falls through to the next
+   (fallback chain). `until:` (which can read `__self`) can stop earlier.
+2. **Transform**: steps run **sequentially**, each seeing the prior value via
+   `__self`. Transform defaults to fatal-on-error.
+3. **Validate**: all inline rules are evaluated and failures aggregated;
+   validation is **non-fatal by default** (value still returned, dependents
+   still run). Rules referencing only `__self` run inline; rules referencing
+   another resolver (`_.other`) are deferred and do NOT add DAG edges.
 
 ### forEach (Resolve and Transform Steps)
 
-`forEach` is supported on both `resolve.with` and `transform.with` steps. It is NOT supported on `validate.with`.
-
-**Key difference**: On resolve steps, `forEach.in` is **required** (no `__self` available). On transform steps, `forEach.in` defaults to `__self`.
-
-```yaml
-# Resolve: fan-out HTTP requests directly
-resolve:
-  with:
-    - provider: http
-      forEach:
-        in:             # required on resolve (no __self)
-          rslvr: moduleList
-        item: mod
-        concurrency: 10
-      inputs:
-        url:
-          expr: 'mod.url'
-
-# Transform: double each number
-transform:
-  with:
-    - provider: cel
-      forEach:
-        item: num       # alias for __item (current element)
-        index: i        # alias for __index (current 0-based index)
-      inputs:
-        expression: "num * 2"
-```
-
-**Fields**: `item`, `index`, `in` (ValueRef; required on resolve, defaults to `__self` on transform), `concurrency` (int), `keepSkipped` (bool), `onError` (actions only: `fail`|`continue`).
-
-**Context variables**: `__item` and `__index` are always injected. Custom aliases (`item`, `index` fields) are added alongside them.
+`forEach` is supported on `resolve.with` and `transform.with` (not `validate`).
+On resolve, `forEach.in` is **required** (there is no resolved value to iterate
+yet); on transform it defaults to `__self`. `__item`/`__index` are injected;
+custom `item`/`index` aliases are added alongside. See `explain_concepts name=foreach`
+and `list_context_variables phase=forEach`.
 
 ### Dependency Resolution (DAG)
 
-Dependencies are extracted automatically from:
-- CEL expressions: `_.resolverName` and `_["resolverName"]` references
-- Resolver references: `rslvr: resolverName` in ValueRef inputs
-- Go templates: `{{.resolverName}}` references
-- Explicit `dependsOn` list (merged with auto-inferred deps)
-
-**Important**: `dependsOn` is usually unnecessary because dependencies are auto-inferred from value references. Only add explicit `dependsOn` when a resolver must run after another but does NOT reference its value (pure ordering dependency).
-
-The executor builds a DAG, topologically sorts into phases, then executes phases sequentially with concurrent execution within each phase.
+Dependencies are auto-inferred from value references -- CEL `_.name`, `rslvr:`
+inputs, and `{{ .name }}` template accessors -- plus any explicit `dependsOn`.
+Use `extract_resolver_refs` to see what a given expression/template infers. Only
+add `dependsOn` for pure ordering with no value reference. The executor topo-sorts
+the DAG into phases and runs each phase's nodes concurrently.
 
 ## ValueRef Format
 
-Used everywhere a value can be dynamic (resolver inputs, action inputs, messages):
+Used anywhere a value can be dynamic (resolver inputs, action inputs, messages):
 
 | Format | YAML | When to Use |
 |--------|------|-------------|
-| Literal | `key: value` | Static values |
-| Resolver | `key: {rslvr: resolver-name}` | Reference another resolver's output |
-| CEL | `key: {expr: "_.field.upperAscii()"}` | Dynamic computation |
-| Go Template | `key: {tmpl: "Hello {{.name}}"}` | Text rendering with template logic |
+| Literal | `key: value` | Static values known at authoring time |
+| Resolver | `key: {rslvr: resolver-name}` | Another resolver's raw output |
+| CEL | `key: {expr: "_.field.upperAscii()"}` | Data manipulation, conditionals, coercion |
+| Go Template | `key: {tmpl: "Hello {{.name}}"}` | Text rendering, multi-line, file content |
 
-### Decision Guide
-
-- **Literal**: When the value is known at authoring time
-- **Resolver ref** (`rslvr`): When you need another resolver's raw output
-- **CEL** (`expr`): Data manipulation, conditionals, type coercion, list/map operations
-- **Go Template** (`tmpl`): Text rendering, multi-line output, file content generation
+**Decision guide**: literal for static; `rslvr` for a raw value; `expr` for data
+logic; `tmpl` for text. (CEL for data, templates for text.)
 
 ## Action Workflow
 
-Actions execute after all resolvers complete. They form their own DAG.
+Actions execute after all resolvers complete and form their own DAG. Verify the
+exact shape with `explain_kind workflow` / `explain_kind action`.
 
 ```yaml
 spec:
@@ -168,60 +141,51 @@ spec:
         inputs:
           source: {rslvr: templates-dir}
           destination: {expr: "_.output_path"}
-        dependsOn: []
         when: "_.enabled"         # CEL condition
-        continueOnError: false    # bool or CEL (truthy continues, falsy fails); replaces deprecated onError
+        continueOnError: false    # bool or CEL; replaces deprecated onError
         timeout: 30s
         exclusive: [other-write]  # Mutual exclusion
         retry:
           maxAttempts: 3
           backoff: exponential
-        forEach:
-          source: "_.items"       # CEL expression returning array
-          item: __item            # Variable name for current item
 ```
 
 ### Action-Specific Context
 
-- `__actions`: Map of completed action results (keyed by action name)
-- Each action result has: `success` (bool), plus provider-specific fields
+Actions get extra context variables not available to resolvers: `__actions`
+(completed action results), `__execution` (resolver execution metadata), and
+`__cwd`. In actions, `__error` is a structured map (`__error.message`,
+`__error.statusCode`, `__error.type`, `__error.exitCode`, `__error.attempt`,
+`__error.maxAttempts`). See `list_context_variables phase=action`.
 
 ## Testing
 
-Solutions support functional tests via a separate `tests.yaml` composed into the solution:
+Solutions support functional tests under `spec.testing.cases` (a **map** keyed
+by test name -- not a sequence). Scaffold with `generate_test_scaffold`, run with
+`run_solution_tests`, and see `explain_concepts name=functional-testing`.
 
 ```yaml
-# tests.yaml
-apiVersion: scafctl.io/v1
-kind: Tests
-tests:
-  - name: basic-test
-    command: run solution
-    args: [-f, ./cldctl/solution.yaml]
-    inputs:
-      resolver-name: test-value
-    assertions:
-      - expr: "__output.resolver_name == 'expected'"
-    files:
-      - path: output/file.txt
-        contains: "expected content"
-    exitCode: 0
+spec:
+  testing:
+    cases:
+      basic-test:
+        description: basic run
+        command: [run, solution]
+        assertions:
+          - expression: "__exitCode == 0"
 ```
-
-Compose into solution: `compose: [tests.yaml]`
 
 ### Snapshot masking (golden baselines)
 
-A test case with `snapshot: <path>` compares against a golden file. Built-in
-presets (`timestamp`, `uuid`, `sandbox`) are always normalized. Declare `masks`
-to normalize other volatile values; set `snapshotSource: files` to snapshot the
-tree of rendered files instead of stdout:
+See `explain_concepts name=snapshot-masking` for the full model. Built-in presets
+(`timestamp`, `uuid`, `sandbox`) are on by default; declare `masks` to normalize
+other volatile values; `snapshotSource: files` snapshots the rendered tree.
 
 ```yaml
 cases:
   golden-render:
+    description: renders with volatile ids masked
     command: [run, solution]
-    snapshot: testdata/snapshots/rendered.txt
     snapshotSource: files          # stdout (default) | files
     masks:
       - name: entra-group          # custom regex mask
@@ -233,34 +197,14 @@ cases:
         disabled: true
 ```
 
-Any declared mask makes the test report a relaxed status (`PASS*`) with a
-per-mask match count. Regenerate golden files with `--update-snapshots`.
+Any declared mask makes the test report a relaxed status (`PASS*`). Regenerate
+golden files with `--update-snapshots`.
 
 ## Built-in Providers
 
-| Provider | Capability | Purpose |
-|----------|-----------|---------|
-| parameter | from | Interactive user prompts |
-| env | from | Environment variables |
-| static | from | Hardcoded values |
-| file | from | Read file contents |
-| exec | from | Run external commands |
-| shell | from | Shell command execution |
-| http | from | HTTP requests |
-| git | from | Git operations |
-| github | from | GitHub API |
-| secret | from | Secret management |
-| identity | from | Auth identity tokens |
-| metadata | from | Solution metadata access |
-| solution | from | Cross-solution references |
-| cel | transform | CEL expression evaluation |
-| gotmpl | transform | Go template rendering |
-| hcl | transform | HCL format conversion |
-| validation | validation | Rule-based validation |
-| message | action | User-facing messages |
-| directory | action | Directory/file operations |
-| debug | from | Debug output |
-| sleep | from | Delay execution |
+For the list of built-in and official providers and their capabilities, call the
+MCP tool **`list_providers`** (and `get_provider_schema` for a provider's I/O).
+This is authoritative and version-accurate.
 
 ## Key Types (pkg/spec/)
 
@@ -268,7 +212,7 @@ per-mask match count. Regenerate golden files with `--update-snapshots`.
 - `Resolver`: Name, Type, Phases (Resolve/Transform/Validate), When, DependsOn
 - `ValueRef`: Literal | Resolver | Expr | Tmpl
 - `Workflow`: Actions map, ResultSchemaMode
-- `Action`: Provider, Inputs, DependsOn, When, OnError, Retry, ForEach
+- `Action`: Provider, Inputs, DependsOn, When, ContinueOnError, Retry, ForEach
 
 ## Key Packages
 
@@ -277,3 +221,10 @@ per-mask match count. Regenerate golden files with `--update-snapshots`.
 - `pkg/resolver/`: DAG building, phase execution, dependency extraction
 - `pkg/action/`: Action workflow execution
 - `pkg/provider/`: Provider interface and registry
+
+## See Also
+
+- MCP tools: `get_solution_schema`, `explain_kind`, `scaffold_solution`,
+  `lint_solution`, `list_providers`, `run_solution_tests`, `extract_resolver_refs`.
+- Concepts (`explain_concepts name=<...>`): `phase-execution`, `snapshot-masking`,
+  `context-variables`, `authoring-workflow`.

--- a/.github/skills/solution-spec/SKILL.md
+++ b/.github/skills/solution-spec/SKILL.md
@@ -32,8 +32,11 @@ spec:
 
 ## Resolver Structure
 
-Resolvers are the DAG nodes. Map keys are resolver names (DNS-safe). Each has up
-to three phases, each a `with:` list of provider steps.
+Resolvers are the DAG nodes. Map keys are resolver names. A name must not be a
+reserved variable (`_`, `__self`, `__item`, `__index`, `__actions`, `__error`,
+etc.) and should avoid hyphens -- prefer camelCase so it is usable in CEL as
+`_.myResolver` rather than the bracket form `_["my-resolver"]`. Each resolver
+has up to three phases, each a `with:` list of provider steps.
 
 ```yaml
 spec:

--- a/opencode.json
+++ b/opencode.json
@@ -5,6 +5,9 @@
     ".github/copilot-instructions.md",
     ".github/instructions/*.instructions.md"
   ],
+  "skills": {
+    "paths": [".github/skills"]
+  },
   "plugin": [
     "opencode-vibeguard",
     "opencode-notify",


### PR DESCRIPTION
## Summary

The four `.github/skills` authoring skills (`cel-patterns`, `go-template-patterns`, `provider-authoring`, `solution-spec`) duplicated live MCP tool output -- function catalogs, provider tables, raw schema -- which drifts out of sync, and carried some stale content. PR #670 moved the "gap knowledge" into the MCP server (a `context` concept category in `explain_concepts` plus the `list_context_variables` tool), so the skills should now **point at the tools** and keep only the non-duplicative knowledge. This also wires opencode to load the skills (previously only Copilot used them).

Closes one of the #667 downstream follow-ups.

## Part A -- thin the skills

- **cel-patterns**: drop the CEL function catalogs (use `list_cel_functions`); keep the context-variable orientation, common patterns, pitfalls, cost model, and reference-extraction knowledge; cross-link the `context-variables` / `cel-cost-model` concepts.
- **go-template-patterns**: drop the Sprig and custom-function tables (use `list_go_template_functions`); **fix the stale `.__fileExt` / dotted file-var names** to the canonical `__fileExtension` etc. (no leading dot -- the dot is template accessor syntax); keep the dependency-inference model, decision guide, and anti-patterns.
- **provider-authoring**: keep the contributor Go authoring content (the MCP intentionally does not cover writing providers); drop only the drifting "Existing Providers" table (use `list_providers`).
- **solution-spec**: drop the "Built-in Providers" table; **fix the stale `resolve: - provider:` syntax to `resolve.with:`**; correct the `parameter` (`key`), `validation` (`expression`/`message`), and `until` placement so the example lints clean; point schema references at `get_solution_schema` / `explain_kind`; keep the runtime semantics (phase execution, `__actions` context, ValueRef decision guide) and snapshot masking.

Net: -313 lines, mostly deleted mirror tables. Each skill keeps valid frontmatter and its unique knowledge.

## Part B -- wire opencode

- Add `skills.paths: [".github/skills"]` to `opencode.json` so opencode's skill loader picks up the four skills. **Verified all four now appear in opencode's skill tool** (they were not loaded before -- `.github/skills` is not a default opencode skill path).

## Verification

- Every skill YAML example was validated against the current schema with `scafctl lint` -- all clean. (Fixed 4 real errors in the examples during this pass.)
- All 16 referenced MCP tools and 7 referenced concepts confirmed to exist in `main`.
- Files are ASCII-only (per the markdown rule).
- `task lint:changed`: 0 issues.

## Side finding (filed separately as #675)

While validating examples I found that the `resolve-foreach` lint rule wrongly warns that `forEach` on resolve steps is unsupported -- but it is fully supported (verified at runtime, documented in the `foreach` concept, and used in real example solutions). That is a code fix, out of scope here, tracked in #675. The skills correctly document forEach-on-resolve as supported.

## Out of scope

Cross-repo skill distribution (a Ford GitHub repo + git-sync into `~/.agents/skills` + generated Copilot `.github/instructions`) remains a separate future PR, per #667.