### PR TITLE
feat(resolver): treat optional CEL refs as soft, non-blocking dependencies

### DIFF
--- a/docs/design/resolvers.md
+++ b/docs/design/resolvers.md
@@ -1612,6 +1612,27 @@ than causing a hard "depends on X but X wasn't present" failure), a bare
 force a resolver dependency, reference it via `_.name` in the `data` expression,
 use `{{ ._.name }}` in the template, or add an explicit `dependsOn` entry.
 
+### Optional (Soft) Dependencies via Optional Access
+
+CEL **optional access** on the `_` map -- `_.?name` or `_[?"name"]` -- is treated
+as a **soft** dependency rather than a hard one. It contributes an ordering edge
+when the target exists (so the referenced resolver runs first), but it never
+blocks loading when the target is absent:
+
+| Accessor | Kind | Behavior when target is undefined |
+|----------|------|-----------------------------------|
+| `_.name`, `_["name"]` | Hard | Load fails (`dag.Build`) -- a typo is caught. |
+| `_.?name`, `_[?"name"]` | Optional (soft) | Edge dropped silently; `.orValue()` supplies the fallback at runtime. |
+
+This mirrors the go-template rule above: unknown **optional** targets are dropped
+as best-effort ordering hints instead of failing the build, so
+`_.?missing.orValue("default")` degrades gracefully. A name that is accessed
+**hard anywhere** remains a strict dependency even if it is also accessed
+optionally elsewhere (the hard occurrence dominates), so genuine typos are still
+caught. The `undefined-optional-reference` lint rule surfaces optional references
+to undefined resolvers as INFO findings. To force a hard dependency, use `_.name`
+or add an explicit `dependsOn` entry.
+
 ### Explicit Dependencies (dependsOn)
 
 When dependencies cannot be auto-extracted (e.g., templates loaded from files), use `dependsOn`:

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -884,7 +884,39 @@ scafctl lint rule missing-template-dependency
 {{% /tab %}}
 {{< /tabs >}}
 
-## 12. Suppressing Findings
+## 12. Undefined Optional References
+
+The `undefined-optional-reference` rule reports **optional** CEL access
+(`_.?name` or `_[?"name"]`) that targets a resolver which is not defined.
+
+Optional access is a **soft** dependency: unlike a hard `_.name` reference (which
+fails the build when `name` is missing so typos are caught), an optional
+reference to an undefined resolver loads successfully and lets `.orValue()`
+supply a fallback at runtime. That is useful on purpose, but it also hides
+genuine typos -- so this rule surfaces them as **info**-level findings.
+
+```yaml
+# INFO: optional reference targets an undefined resolver
+spec:
+  resolvers:
+    app:
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              # 'profil' is a typo for 'profile' -- this silently falls back
+              expression: '_.?profil.orValue("default")'
+```
+
+**Fix**: correct the name, define the resolver, or -- if the fallback is
+intentional -- suppress the finding. A name accessed **hard anywhere** stays a
+strict dependency even when it is also accessed optionally, so the safest fix for
+a required value is to reference it with `_.name`.
+
+This is an **info**-level finding because optional access is valid and often
+deliberate; it exists to catch accidental typos in optional references.
+
+## 13. Suppressing Findings
 
 When a finding is a deliberate, reviewed exception, you can suppress it with an
 inline YAML comment directive instead of disabling the rule globally. Directives
@@ -974,7 +1006,7 @@ spec:
 > `disable-file`. Targeted suppressions keep the rest of the file linted and make
 > the intent obvious to reviewers.
 
-## 13. Using Lint with the MCP Server
+## 14. Using Lint with the MCP Server
 
 When using AI agents (VS Code Copilot, Claude, Cursor), the MCP server exposes lint functionality through:
 

--- a/pkg/celexp/refs.go
+++ b/pkg/celexp/refs.go
@@ -92,6 +92,88 @@ func (e Expression) GetUnderscoreVariables(ctx context.Context) ([]string, error
 	return e.GetVariablesWithPrefix(ctx, "_.")
 }
 
+// GetUnderscoreVariablesByOptionality parses the CEL expression and returns the
+// "_"-scoped references split by access style: hard references (_.name,
+// _["name"]) and optional-only references (_.?name, _[?"name"]). A name that is
+// accessed with hard syntax anywhere in the expression is reported only in hard,
+// never in optional -- a single non-optional use makes the whole dependency hard.
+//
+// This lets dependency inference treat optional access as a soft dependency: it
+// orders the consumer after the target when the target exists, but does not fail
+// loading when the target is absent (the author's .orValue()/optional handling
+// supplies a fallback).
+//
+// Both returned slices are deduplicated and sorted.
+//
+// Example:
+//
+//	expr := celexp.Expression(`_.a + _.?b.orValue("") + _.?a`)
+//	hard, optional, _ := expr.GetUnderscoreVariablesByOptionality(ctx)
+//	// hard == []string{"a"}, optional == []string{"b"}
+//	// (a is hard despite the _.?a use; b is optional-only)
+func (e Expression) GetUnderscoreVariablesByOptionality(ctx context.Context) (hard, optional []string, err error) {
+	env, err := e.parseEnv(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	parsed, issues := env.Parse(string(e))
+	if issues != nil && issues.Err() != nil {
+		return nil, nil, fmt.Errorf("failed to parse CEL expression: %w", issues.Err())
+	}
+
+	parsedExpr, err := cel.AstToParsedExpr(parsed)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to convert AST: %w", err)
+	}
+
+	hardSet := make(map[string]struct{})
+	optionalSet := make(map[string]struct{})
+	walkVariablesWithPrefix(parsedExpr.GetExpr(), "_.", func(name string, opt bool) {
+		if opt {
+			optionalSet[name] = struct{}{}
+		} else {
+			hardSet[name] = struct{}{}
+		}
+	})
+
+	hard = make([]string, 0, len(hardSet))
+	for v := range hardSet {
+		hard = append(hard, v)
+	}
+	sort.Strings(hard)
+
+	// A name accessed with hard syntax anywhere dominates: exclude it from optional.
+	optional = make([]string, 0, len(optionalSet))
+	for v := range optionalSet {
+		if _, isHard := hardSet[v]; !isHard {
+			optional = append(optional, v)
+		}
+	}
+	sort.Strings(optional)
+
+	return hard, optional, nil
+}
+
+// parseEnv builds a CEL environment for parsing, using the registered
+// environment factory (with custom extensions) when available and falling back
+// to a minimal environment with optional types enabled so optional access
+// (_.?name, _[?"name"]) parses in white-box tests.
+func (e Expression) parseEnv(ctx context.Context) (*cel.Env, error) {
+	if factory := getEnvFactory(); factory != nil {
+		env, err := factory(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+		}
+		return env, nil
+	}
+	env, err := cel.NewEnv(cel.OptionalTypes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+	return env, nil
+}
+
 // MapLiteralKeys parses the CEL expression and, if its top-level node is a map
 // literal with constant string keys (e.g. {"a": _.x, "b": proj}), returns the
 // list of those keys and true. For any other expression shape -- a function
@@ -233,8 +315,26 @@ func (e Expression) RequiredVariables(ctx context.Context) ([]string, error) {
 	return result, nil
 }
 
-// extractVariablesWithPrefix recursively walks the AST and collects variable names starting with the given prefix
+// refVisitor receives each discovered prefix-scoped reference along with whether
+// it was reached through optional-access syntax (_.?name or _[?"name"]). The same
+// name may be reported more than once (e.g. both hard and optional); callers
+// reconcile duplicates (a hard occurrence dominates an optional one).
+type refVisitor func(name string, optional bool)
+
+// extractVariablesWithPrefix recursively walks the AST and collects variable
+// names starting with the given prefix into vars, ignoring optionality.
 func extractVariablesWithPrefix(expr *exprpb.Expr, prefix string, vars map[string]struct{}) {
+	walkVariablesWithPrefix(expr, prefix, func(name string, _ bool) {
+		vars[name] = struct{}{}
+	})
+}
+
+// walkVariablesWithPrefix recursively walks the AST and invokes visit for every
+// prefix-scoped reference, distinguishing hard access (_.name, _["name"]) from
+// optional access (_.?name, _[?"name"]). Optionality is only tracked for the
+// explicit optional-access operators; has()-guarded plain access (_.name) is
+// reported as hard.
+func walkVariablesWithPrefix(expr *exprpb.Expr, prefix string, visit refVisitor) {
 	if expr == nil {
 		return
 	}
@@ -264,7 +364,7 @@ func extractVariablesWithPrefix(expr *exprpb.Expr, prefix string, vars map[strin
 			// For "$" style, check if identifier starts with prefix
 			if len(ident) >= len(prefix) && ident[:len(prefix)] == prefix {
 				// Store without the prefix
-				vars[ident[len(prefix):]] = struct{}{}
+				visit(ident[len(prefix):], false)
 			}
 		}
 
@@ -275,16 +375,15 @@ func extractVariablesWithPrefix(expr *exprpb.Expr, prefix string, vars map[strin
 		if useSelect {
 			// For "_." style prefix, check if the operand is the base identifier
 			if operand.GetIdentExpr() != nil && operand.GetIdentExpr().GetName() == baseIdent {
-				// This is a _.something expression - capture it without the prefix
-				field := selectExpr.GetField()
-				vars[field] = struct{}{}
+				// This is a _.something expression - capture it as a hard reference.
+				visit(selectExpr.GetField(), false)
 			} else {
 				// Continue traversing for other variables
-				extractVariablesWithPrefix(operand, prefix, vars)
+				walkVariablesWithPrefix(operand, prefix, visit)
 			}
 		} else {
 			// For "$" style, traverse the operand
-			extractVariablesWithPrefix(operand, prefix, vars)
+			walkVariablesWithPrefix(operand, prefix, visit)
 		}
 
 	case *exprpb.Expr_CallExpr:
@@ -293,34 +392,37 @@ func extractVariablesWithPrefix(expr *exprpb.Expr, prefix string, vars map[strin
 
 		// Handle index and optional access, all of which are parsed as a CallExpr
 		// with args[0] the operand and args[1] the field/key string constant:
-		//   _["resolverName"]  -> function "_[_]"   (bracket index)
+		//   _["resolverName"]  -> function "_[_]"   (bracket index, hard)
 		//   _.?resolverName    -> function "_?._"   (optional select)
 		//   _[?"resolverName"] -> function "_[?_]"  (optional index)
 		if useSelect && len(call.GetArgs()) == 2 {
-			switch call.GetFunction() {
+			fn := call.GetFunction()
+			switch fn {
 			case "_[_]", "_?._", "_[?_]":
 				operand := call.GetArgs()[0]
 				key := call.GetArgs()[1]
 				if operand.GetIdentExpr() != nil && operand.GetIdentExpr().GetName() == baseIdent {
 					// Check if the key is a string constant (e.g., _["resolverName"])
 					if key.GetConstExpr() != nil && key.GetConstExpr().GetStringValue() != "" {
-						vars[key.GetConstExpr().GetStringValue()] = struct{}{}
+						// Only the two optional operators signal optionality; a
+						// plain bracket index (_[_]) is a hard reference.
+						visit(key.GetConstExpr().GetStringValue(), fn != "_[_]")
 					}
 				}
 			}
 		}
 
 		if call.GetTarget() != nil {
-			extractVariablesWithPrefix(call.GetTarget(), prefix, vars)
+			walkVariablesWithPrefix(call.GetTarget(), prefix, visit)
 		}
 		for _, arg := range call.GetArgs() {
-			extractVariablesWithPrefix(arg, prefix, vars)
+			walkVariablesWithPrefix(arg, prefix, visit)
 		}
 
 	case *exprpb.Expr_ListExpr:
 		// Process list elements
 		for _, elem := range expr.GetListExpr().GetElements() {
-			extractVariablesWithPrefix(elem, prefix, vars)
+			walkVariablesWithPrefix(elem, prefix, visit)
 		}
 
 	case *exprpb.Expr_StructExpr:
@@ -328,19 +430,19 @@ func extractVariablesWithPrefix(expr *exprpb.Expr, prefix string, vars map[strin
 		structExpr := expr.GetStructExpr()
 		for _, entry := range structExpr.GetEntries() {
 			if entry.GetMapKey() != nil {
-				extractVariablesWithPrefix(entry.GetMapKey(), prefix, vars)
+				walkVariablesWithPrefix(entry.GetMapKey(), prefix, visit)
 			}
-			extractVariablesWithPrefix(entry.GetValue(), prefix, vars)
+			walkVariablesWithPrefix(entry.GetValue(), prefix, visit)
 		}
 
 	case *exprpb.Expr_ComprehensionExpr:
 		// Process comprehension expressions
 		comp := expr.GetComprehensionExpr()
-		extractVariablesWithPrefix(comp.GetIterRange(), prefix, vars)
-		extractVariablesWithPrefix(comp.GetAccuInit(), prefix, vars)
-		extractVariablesWithPrefix(comp.GetLoopCondition(), prefix, vars)
-		extractVariablesWithPrefix(comp.GetLoopStep(), prefix, vars)
-		extractVariablesWithPrefix(comp.GetResult(), prefix, vars)
+		walkVariablesWithPrefix(comp.GetIterRange(), prefix, visit)
+		walkVariablesWithPrefix(comp.GetAccuInit(), prefix, visit)
+		walkVariablesWithPrefix(comp.GetLoopCondition(), prefix, visit)
+		walkVariablesWithPrefix(comp.GetLoopStep(), prefix, visit)
+		walkVariablesWithPrefix(comp.GetResult(), prefix, visit)
 
 	case *exprpb.Expr_ConstExpr:
 		// Literals don't contain variable references

--- a/pkg/celexp/refs_test.go
+++ b/pkg/celexp/refs_test.go
@@ -329,6 +329,96 @@ func BenchmarkGetUnderscoreVariables_Complex(b *testing.B) {
 	}
 }
 
+func BenchmarkGetUnderscoreVariablesByOptionality_Simple(b *testing.B) {
+	expr := Expression(`_.?platformProfileID.orValue("") + _.moduleSource`)
+	b.ResetTimer()
+	for b.Loop() {
+		_, _, _ = expr.GetUnderscoreVariablesByOptionality(context.Background())
+	}
+}
+
+func BenchmarkGetUnderscoreVariablesByOptionality_Complex(b *testing.B) {
+	expr := Expression(`_.config.enabled && _.?fallbackRole.orValue(_.requiredRole) && _.items.filter(i, i.active).size() > _.?threshold.orValue(0)`)
+	b.ResetTimer()
+	for b.Loop() {
+		_, _, _ = expr.GetUnderscoreVariablesByOptionality(context.Background())
+	}
+}
+
+func TestGetUnderscoreVariablesByOptionality(t *testing.T) {
+	tests := []struct {
+		name         string
+		expression   string
+		wantHard     []string
+		wantOptional []string
+		wantError    bool
+	}{
+		{
+			name:         "all hard",
+			expression:   "_.user.name + _.config.value",
+			wantHard:     []string{"config", "user"},
+			wantOptional: []string{},
+		},
+		{
+			name:         "optional select only",
+			expression:   `_.?platformProfileID.orValue("")`,
+			wantHard:     []string{},
+			wantOptional: []string{"platformProfileID"},
+		},
+		{
+			name:         "optional index only",
+			expression:   `_[?"my-resolver"]`,
+			wantHard:     []string{},
+			wantOptional: []string{"my-resolver"},
+		},
+		{
+			name:         "mixed hard and optional",
+			expression:   `_.?platformProfileID.orValue("") + _.moduleSource`,
+			wantHard:     []string{"moduleSource"},
+			wantOptional: []string{"platformProfileID"},
+		},
+		{
+			name:         "hard dominates when name appears both ways",
+			expression:   `_.a + _.?a.orValue("") + _.?b.orValue("")`,
+			wantHard:     []string{"a"},
+			wantOptional: []string{"b"},
+		},
+		{
+			name:         "hard bracket is not optional",
+			expression:   `_["resolverName"]`,
+			wantHard:     []string{"resolverName"},
+			wantOptional: []string{},
+		},
+		{
+			name:       "unclosed parenthesis",
+			expression: "_.value + (_.other",
+			wantError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expr := Expression(tt.expression)
+			hard, optional, err := expr.GetUnderscoreVariablesByOptionality(context.Background())
+
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			sort.Strings(hard)
+			sort.Strings(optional)
+			sort.Strings(tt.wantHard)
+			sort.Strings(tt.wantOptional)
+
+			assert.Equal(t, tt.wantHard, hard, "hard refs")
+			assert.Equal(t, tt.wantOptional, optional, "optional-only refs")
+		})
+	}
+}
+
 func TestGetVariablesWithPrefix(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -106,6 +106,7 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 			    - missing-description  Action/resolver lacks description
 			    - long-timeout        Timeout exceeds recommended maximum
 			    - unused-finally      Finally actions with no regular actions
+			    - undefined-optional-reference  Optional CEL ref (_.?name) targets an undefined resolver
 
 			SOME OUTPUT FORMATS:
 			  table   Human-readable bordered table

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -113,6 +114,7 @@ func Solution(sol *solution.Solution, filePath string, registry *provider.Regist
 	lintResolvers(sol, result, registry, referencedResolvers)
 	lintTemplateFileDependencies(sol, solutionDir, result, registry)
 	lintResolverCycles(sol, result, registry)
+	lintUndefinedOptionalRefs(sol, result)
 	lintDeferredValidation(sol, result, registry)
 	lintTemplateAccessors(sol, result)
 	lintWorkflow(sol, result, registry)
@@ -1482,6 +1484,64 @@ func hyphensToCamelCase(name string) string {
 // functions are registered during parsing, matching runtime behavior.
 func validateTemplateSyntax(tmpl string) error {
 	return gotmpl.ValidateSyntax(tmpl, "", "")
+}
+
+// lintUndefinedOptionalRefs emits an INFO finding for each optional CEL
+// reference (_.?name / _[?"name"]) whose target resolver is not defined.
+// Optional access never blocks loading -- the value resolves to absent -- so a
+// typo'd optional reference would otherwise pass silently. This surfaces it
+// without failing the lint. A name that is a defined resolver is not reported.
+func lintUndefinedOptionalRefs(sol *solution.Solution, result *Result) {
+	// Note: we intentionally do not early-return when Spec.Resolvers is nil.
+	// The rule flags optional references to *undefined* resolvers, so a
+	// solution with zero defined resolvers should still have its optional
+	// references (e.g. in workflow conditions) checked against an empty set.
+	defined := make(map[string]bool, len(sol.Spec.Resolvers))
+	for name := range sol.Spec.Resolvers {
+		defined[name] = true
+	}
+
+	// Dedupe by resolver name so a name referenced optionally in several places
+	// yields a single finding, located at the first occurrence encountered.
+	seen := make(map[string]bool)
+	report := func(path string, optional map[string]bool) {
+		names := make([]string, 0, len(optional))
+		for n := range optional {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			if defined[n] || seen[n] {
+				continue
+			}
+			// Injected context keys (e.g. __plan) are reachable through the `_`
+			// map but are not resolvers, so an optional access to one is not an
+			// undefined-resolver reference.
+			if strings.HasPrefix(n, "__") {
+				continue
+			}
+			seen[n] = true
+			result.addFinding(SeverityInfo, "dependency", path,
+				fmt.Sprintf("optional reference to resolver '%s' which is not defined; it will always resolve to absent", n),
+				fmt.Sprintf("Define a resolver named '%s' or remove the optional reference if the absence is intentional", n),
+				"undefined-optional-reference")
+		}
+	}
+
+	_ = walk.Walk(sol, &walk.Visitor{
+		ValueRef: func(path string, vr *spec.ValueRef) error {
+			optional := make(map[string]bool)
+			resolver.ExtractOptionalRefsFromValueRef(vr, optional)
+			report(path, optional)
+			return nil
+		},
+		Condition: func(path, _ string, expr *celexp.Expression) error {
+			optional := make(map[string]bool)
+			resolver.ExtractOptionalRefsFromValueRef(&spec.ValueRef{Expr: expr}, optional)
+			report(path, optional)
+			return nil
+		},
+	})
 }
 
 func collectReferencedResolvers(sol *solution.Solution) map[string]bool {

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -693,6 +693,164 @@ func TestLintEmptyValidateWith(t *testing.T) {
 	assert.Contains(t, findings[0].Message, "empty")
 }
 
+func TestLintUndefinedOptionalReference(t *testing.T) {
+	staticProv := newFakeProvider("static", map[string]*jsonschema.Schema{
+		"value": {Type: "string"},
+	})
+	celProv := newFakeProvider("cel", map[string]*jsonschema.Schema{
+		"expression": {Type: "string"},
+	})
+	reg := provider.NewRegistry()
+	_ = reg.Register(staticProv)
+	_ = reg.Register(celProv)
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"profile": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "static",
+							Inputs:   map[string]*spec.ValueRef{"value": {Literal: "p"}},
+						}},
+					},
+				},
+				"app": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "cel",
+							// Optional reference to a defined resolver (profile) must not be
+							// flagged; optional reference to an undefined resolver (missing)
+							// must produce a single INFO finding.
+							Inputs: map[string]*spec.ValueRef{
+								"expression": {Expr: exprPtr(`_.?profile.orValue("") + _.?missing.orValue("")`)},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	result := Solution(sol, "test.yaml", reg)
+
+	findings := filterFindingsByRule(result, "undefined-optional-reference")
+	require.Len(t, findings, 1)
+	assert.Equal(t, SeverityInfo, findings[0].Severity)
+	assert.Contains(t, findings[0].Message, "missing")
+	assert.NotContains(t, findings[0].Message, "profile")
+}
+
+func TestLintUndefinedOptionalReference_HardRefNotFlagged(t *testing.T) {
+	// A hard reference to a defined resolver must never produce an
+	// undefined-optional-reference finding.
+	staticProv := newFakeProvider("static", map[string]*jsonschema.Schema{
+		"value": {Type: "string"},
+	})
+	celProv := newFakeProvider("cel", map[string]*jsonschema.Schema{
+		"expression": {Type: "string"},
+	})
+	reg := provider.NewRegistry()
+	_ = reg.Register(staticProv)
+	_ = reg.Register(celProv)
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"profile": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "static",
+							Inputs:   map[string]*spec.ValueRef{"value": {Literal: "p"}},
+						}},
+					},
+				},
+				"app": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "cel",
+							Inputs: map[string]*spec.ValueRef{
+								"expression": {Expr: exprPtr(`_.profile`)},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	result := Solution(sol, "test.yaml", reg)
+
+	findings := filterFindingsByRule(result, "undefined-optional-reference")
+	assert.Empty(t, findings)
+}
+
+func TestLintUndefinedOptionalReference_InjectedKeyNotFlagged(t *testing.T) {
+	// Optional access to an injected context key (e.g. __plan) reachable through
+	// the `_` map must not be reported as an undefined resolver.
+	staticProv := newFakeProvider("static", map[string]*jsonschema.Schema{
+		"value": {Type: "string"},
+	})
+	celProv := newFakeProvider("cel", map[string]*jsonschema.Schema{
+		"expression": {Type: "string"},
+	})
+	reg := provider.NewRegistry()
+	_ = reg.Register(staticProv)
+	_ = reg.Register(celProv)
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"app": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "cel",
+							Inputs: map[string]*spec.ValueRef{
+								"expression": {Expr: exprPtr(`_[?"__plan"].orValue({})`)},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	result := Solution(sol, "test.yaml", reg)
+
+	findings := filterFindingsByRule(result, "undefined-optional-reference")
+	assert.Empty(t, findings)
+}
+
+func TestLintUndefinedOptionalReference_NoResolvers(t *testing.T) {
+	// A solution with no spec.resolvers block must still have optional
+	// references (here in a workflow action's `when` condition) checked
+	// against the empty defined set, so an undefined optional reference is
+	// reported instead of being silently skipped.
+	reg := provider.NewRegistry()
+	whenExpr := celexp.Expression(`_.?missing.orValue(false)`)
+
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Workflow: &action.Workflow{
+				Actions: map[string]*action.Action{
+					"main": {
+						Name:        "main",
+						Description: "main action",
+						When:        &spec.Condition{Expr: &whenExpr},
+					},
+				},
+			},
+		},
+	}
+
+	result := Solution(sol, "test.yaml", reg)
+
+	findings := filterFindingsByRule(result, "undefined-optional-reference")
+	require.Len(t, findings, 1)
+	assert.Equal(t, SeverityInfo, findings[0].Severity)
+	assert.Contains(t, findings[0].Message, "missing")
+}
+
 func TestLintNonValidationProvider(t *testing.T) {
 	// "static" has CapabilityFrom, not CapabilityValidation
 	staticProv := newFakeProvider("static", map[string]*jsonschema.Schema{

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -206,6 +206,14 @@ var KnownRules = map[string]RuleMeta{
 		Why:         "Actions with invalid dependencies cannot be scheduled for execution. This usually indicates a typo in the action name.",
 		Fix:         "Check the action names in spec.workflow.actions and ensure all dependsOn references match exactly. Names are case-sensitive.",
 	},
+	"undefined-optional-reference": {
+		Rule:        "undefined-optional-reference",
+		Severity:    string(SeverityInfo),
+		Category:    "dependency",
+		Description: "An optional CEL reference (_.?name or _[?\"name\"]) targets a resolver that is not defined.",
+		Why:         "Optional access never blocks loading -- the value simply resolves to absent -- so a typo in an optional reference passes silently and the fallback is always used. This surfaces the undefined target without failing the lint.",
+		Fix:         "Define a resolver with the referenced name, or remove the optional reference if the value is intentionally always absent.",
+	},
 	"empty-workflow": {
 		Rule:        "empty-workflow",
 		Severity:    string(SeverityWarning),

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 64 rules — update this when new rules are added
-	assert.Equal(t, 64, len(KnownRules), "expected 64 known lint rules")
+	// We expect exactly 65 rules — update this when new rules are added
+	assert.Equal(t, 65, len(KnownRules), "expected 65 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/resolver/graph.go
+++ b/pkg/resolver/graph.go
@@ -183,7 +183,7 @@ func extractStrictDependencies(r *Resolver) map[string]bool {
 	}
 
 	if r.When != nil && r.When.Expr != nil {
-		extractDepsFromExpression(string(*r.When.Expr), deps)
+		extractHardDepsFromExpression(string(*r.When.Expr), deps)
 	}
 
 	extractStrictFromResolvePhase(r.Resolve, deps)
@@ -205,20 +205,20 @@ func extractStrictFromResolvePhase(phase *ResolvePhase, deps map[string]bool) {
 		return
 	}
 	if phase.When != nil && phase.When.Expr != nil {
-		extractDepsFromExpression(string(*phase.When.Expr), deps)
+		extractHardDepsFromExpression(string(*phase.When.Expr), deps)
 	}
 	if phase.Until != nil && phase.Until.Expr != nil {
-		extractDepsFromExpression(string(*phase.Until.Expr), deps)
+		extractHardDepsFromExpression(string(*phase.Until.Expr), deps)
 	}
 	for _, source := range phase.With {
 		for _, arg := range source.Args {
 			extractStrictFromValueRef(arg, deps)
 		}
 		if source.When != nil && source.When.Expr != nil {
-			extractDepsFromExpression(string(*source.When.Expr), deps)
+			extractHardDepsFromExpression(string(*source.When.Expr), deps)
 		}
 		if source.ContinueOnError != nil && source.ContinueOnError.Expr != nil {
-			extractDepsFromExpression(string(*source.ContinueOnError.Expr), deps)
+			extractHardDepsFromExpression(string(*source.ContinueOnError.Expr), deps)
 		}
 		if source.ForEach != nil && source.ForEach.In != nil {
 			extractStrictFromValueRef(source.ForEach.In, deps)
@@ -233,17 +233,17 @@ func extractStrictFromTransformPhase(phase *TransformPhase, deps map[string]bool
 		return
 	}
 	if phase.When != nil && phase.When.Expr != nil {
-		extractDepsFromExpression(string(*phase.When.Expr), deps)
+		extractHardDepsFromExpression(string(*phase.When.Expr), deps)
 	}
 	for _, transform := range phase.With {
 		for _, arg := range transform.Args {
 			extractStrictFromValueRef(arg, deps)
 		}
 		if transform.When != nil && transform.When.Expr != nil {
-			extractDepsFromExpression(string(*transform.When.Expr), deps)
+			extractHardDepsFromExpression(string(*transform.When.Expr), deps)
 		}
 		if transform.ContinueOnError != nil && transform.ContinueOnError.Expr != nil {
-			extractDepsFromExpression(string(*transform.ContinueOnError.Expr), deps)
+			extractHardDepsFromExpression(string(*transform.ContinueOnError.Expr), deps)
 		}
 		if transform.ForEach != nil && transform.ForEach.In != nil {
 			extractStrictFromValueRef(transform.ForEach.In, deps)
@@ -265,9 +265,11 @@ func extractStrictFromInputs(inputs map[string]*ValueRef, deps map[string]bool) 
 }
 
 // extractStrictFromValueRef collects only strict references from a ValueRef:
-// direct rslvr references, CEL expressions, and rslvr/expr forms nested inside
-// literal values. tmpl: ValueRefs and {{ .field }} accessors in literal strings
-// are intentionally skipped.
+// direct rslvr references, hard CEL expressions, and rslvr/expr forms nested
+// inside literal values. tmpl: ValueRefs, {{ .field }} accessors in literal
+// strings, and optional CEL access (_.?name, _[?"name"]) are intentionally
+// skipped -- optional access signals the value may be absent, so it must not
+// create a load-blocking strict edge.
 func extractStrictFromValueRef(ref *ValueRef, deps map[string]bool) {
 	if ref == nil {
 		return
@@ -276,7 +278,7 @@ func extractStrictFromValueRef(ref *ValueRef, deps map[string]bool) {
 	case ref.Resolver != nil:
 		deps[*ref.Resolver] = true
 	case ref.Expr != nil:
-		extractDepsFromExpression(string(*ref.Expr), deps)
+		extractHardDepsFromExpression(string(*ref.Expr), deps)
 	case ref.Tmpl != nil:
 		// Template ValueRef: inferred best-effort, not a strict reference.
 	case ref.Literal != nil:
@@ -285,13 +287,13 @@ func extractStrictFromValueRef(ref *ValueRef, deps map[string]bool) {
 }
 
 // extractStrictFromLiteral recursively collects strict references from a literal
-// value: rslvr keys, expr (CEL) keys, and CEL patterns in strings. tmpl keys and
-// {{ .field }} template accessors are skipped.
+// value: rslvr keys, expr (CEL) keys, and hard CEL patterns in strings. tmpl
+// keys, {{ .field }} template accessors, and optional CEL access are skipped.
 func extractStrictFromLiteral(literal any, deps map[string]bool) {
 	switch v := literal.(type) {
 	case string:
 		if strings.Contains(v, "_.") || strings.Contains(v, "_[") {
-			extractDepsFromExpression(v, deps)
+			extractHardDepsFromExpression(v, deps)
 		}
 	case map[string]any:
 		isValueRef := false
@@ -300,7 +302,7 @@ func extractStrictFromLiteral(literal any, deps map[string]bool) {
 			isValueRef = true
 		}
 		if expr, ok := v["expr"].(string); ok {
-			extractDepsFromExpression(expr, deps)
+			extractHardDepsFromExpression(expr, deps)
 			isValueRef = true
 		}
 		if _, ok := v["tmpl"].(string); ok {
@@ -336,6 +338,26 @@ func extractDepsFromExpression(expr string, deps map[string]bool) {
 
 	// Add all found variables to the deps map
 	for _, v := range vars {
+		deps[v] = true
+	}
+}
+
+// extractHardDepsFromExpression extracts only HARD resolver references
+// (_.name, _["name"]) from a CEL expression, ignoring optional access
+// (_.?name, _[?"name"]). Optional access signals the author tolerates the
+// referenced resolver being absent (typically paired with .orValue(...)), so it
+// must not contribute a strict, load-blocking dependency edge. A resolver
+// referenced with hard syntax anywhere in the expression is still returned even
+// if it also appears with optional syntax.
+func extractHardDepsFromExpression(expr string, deps map[string]bool) {
+	celExpr := celexp.Expression(expr)
+	hard, _, err := celExpr.GetUnderscoreVariablesByOptionality(context.TODO())
+	if err != nil {
+		// If parsing fails, skip dependency extraction for this expression.
+		// This is a non-fatal error - the resolver may still be valid.
+		return
+	}
+	for _, v := range hard {
 		deps[v] = true
 	}
 }
@@ -397,6 +419,80 @@ func ExtractRefsFromValueRef(ref *ValueRef, deps map[string]bool) {
 		return
 	}
 	extractDepsFromValueRef(ref, deps)
+}
+
+// ExtractOptionalRefsFromValueRef collects resolver names that a ValueRef
+// references via optional CEL access (_.?name, _[?"name"]), accumulating them
+// into the provided optional set. Optional access is a CEL-only concept, so
+// direct rslvr: references and Go-template (tmpl:) accessors -- which are always
+// hard -- contribute nothing. Within a single CEL expression, a name also
+// accessed with hard syntax is excluded (hard access dominates). Passing a nil
+// ref or optional map is a no-op (optional must be non-nil to collect results).
+func ExtractOptionalRefsFromValueRef(ref *ValueRef, optional map[string]bool) {
+	if optional == nil {
+		return
+	}
+	extractOptionalFromValueRef(ref, optional)
+}
+
+func extractOptionalFromValueRef(ref *ValueRef, optional map[string]bool) {
+	if ref == nil {
+		return
+	}
+	switch {
+	case ref.Expr != nil:
+		addOptionalFromExpression(string(*ref.Expr), optional)
+	case ref.Literal != nil:
+		extractOptionalFromLiteral(ref.Literal, optional)
+	}
+}
+
+// extractOptionalFromLiteral recursively collects optional CEL references from a
+// literal value: expr (CEL) keys and CEL patterns in strings. rslvr keys, tmpl
+// keys, and Go-template accessors carry no optional access and are skipped.
+func extractOptionalFromLiteral(literal any, optional map[string]bool) {
+	switch v := literal.(type) {
+	case string:
+		if strings.Contains(v, "_.") || strings.Contains(v, "_[") {
+			addOptionalFromExpression(v, optional)
+		}
+	case map[string]any:
+		isValueRef := false
+		if expr, ok := v["expr"].(string); ok {
+			addOptionalFromExpression(expr, optional)
+			isValueRef = true
+		}
+		if _, ok := v["rslvr"].(string); ok {
+			isValueRef = true
+		}
+		if _, ok := v["tmpl"].(string); ok {
+			isValueRef = true
+		}
+		if isValueRef {
+			return
+		}
+		for _, mapVal := range v {
+			extractOptionalFromLiteral(mapVal, optional)
+		}
+	case []any:
+		for _, arrVal := range v {
+			extractOptionalFromLiteral(arrVal, optional)
+		}
+	}
+}
+
+// addOptionalFromExpression parses a CEL expression and adds its optional-only
+// resolver references to the optional set. Parse failures are non-fatal and
+// yield no references.
+func addOptionalFromExpression(expr string, optional map[string]bool) {
+	celExpr := celexp.Expression(expr)
+	_, opt, err := celExpr.GetUnderscoreVariablesByOptionality(context.TODO())
+	if err != nil {
+		return
+	}
+	for _, v := range opt {
+		optional[v] = true
+	}
 }
 
 // extractDepsFromLiteral recursively extracts dependencies from literal values

--- a/pkg/resolver/graph_test.go
+++ b/pkg/resolver/graph_test.go
@@ -2009,6 +2009,81 @@ func TestExtractRefsFromValueRef_NilDepsIsNoOp(t *testing.T) {
 	})
 }
 
+func TestExtractOptionalRefsFromValueRef(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		ref  *ValueRef
+		want map[string]bool
+	}{
+		{
+			name: "nil ref is a no-op",
+			ref:  nil,
+			want: map[string]bool{},
+		},
+		{
+			name: "optional select in cel expression",
+			ref:  &ValueRef{Expr: celExpPtr(`_.?platformProfileID.orValue("")`)},
+			want: map[string]bool{"platformProfileID": true},
+		},
+		{
+			name: "optional index in cel expression",
+			ref:  &ValueRef{Expr: celExpPtr(`_[?"my-resolver"].orValue("")`)},
+			want: map[string]bool{"my-resolver": true},
+		},
+		{
+			name: "hard reference contributes no optional",
+			ref:  &ValueRef{Expr: celExpPtr("_.config.host")},
+			want: map[string]bool{},
+		},
+		{
+			name: "hard dominates within one expression",
+			ref:  &ValueRef{Expr: celExpPtr(`_.a + _.?a.orValue("")`)},
+			want: map[string]bool{},
+		},
+		{
+			name: "direct resolver reference is hard",
+			ref:  &ValueRef{Resolver: stringPtr("environment")},
+			want: map[string]bool{},
+		},
+		{
+			name: "template reference is hard",
+			ref:  &ValueRef{Tmpl: tmplPtr("Hello {{ ._.username }}")},
+			want: map[string]bool{},
+		},
+		{
+			name: "optional select nested in literal map expr",
+			ref: &ValueRef{Literal: map[string]any{
+				"ID": map[string]any{"expr": `_.?profile.orValue("")`},
+			}},
+			want: map[string]bool{"profile": true},
+		},
+		{
+			name: "optional select in literal string",
+			ref:  &ValueRef{Literal: `_.?zone.orValue("us")`},
+			want: map[string]bool{"zone": true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			optional := make(map[string]bool)
+			ExtractOptionalRefsFromValueRef(tt.ref, optional)
+			assert.Equal(t, tt.want, optional)
+		})
+	}
+}
+
+func TestExtractOptionalRefsFromValueRef_NilOptionalIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() {
+		ExtractOptionalRefsFromValueRef(&ValueRef{Expr: celExpPtr(`_.?x.orValue("")`)}, nil)
+	})
+}
+
 func TestExtractRefsFromValueRefs_NestedValueRefMaps(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/resolver/phase_test.go
+++ b/pkg/resolver/phase_test.go
@@ -988,6 +988,23 @@ func TestBuildPhases_KeepsUnknownStrictDeps(t *testing.T) {
 				},
 			},
 		},
+		{
+			// Hard access dominates: a name accessed with hard syntax must fail
+			// fast when undefined even if the same name is also accessed
+			// optionally in a sibling expression.
+			name: "hard reference dominates optional access to same undefined name",
+			resolver: &Resolver{
+				Name: "app",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{{
+						Provider: "cel",
+						Inputs: map[string]*ValueRef{
+							"expression": {Expr: exprPtr(`_.missing + _.?missing.orValue("")`)},
+						},
+					}},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -997,6 +1014,84 @@ func TestBuildPhases_KeepsUnknownStrictDeps(t *testing.T) {
 			assert.Contains(t, err.Error(), "missing")
 		})
 	}
+}
+
+func TestBuildPhases_DropsUnknownOptionalDeps(t *testing.T) {
+	// An optional CEL reference (_.?name / _[?"name"]) to a resolver that is not
+	// defined must NOT hard-fail phase building. Optional access signals the
+	// author tolerates the value being absent (typically paired with .orValue),
+	// so an unknown optional target is a soft edge and is dropped rather than
+	// producing a "depends on X but X wasn't present" DAG error.
+	tests := []struct {
+		name     string
+		resolver *Resolver
+	}{
+		{
+			name: "optional select to unknown target",
+			resolver: &Resolver{
+				Name: "app",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{{
+						Provider: "cel",
+						Inputs: map[string]*ValueRef{
+							"expression": {Expr: exprPtr(`_.?missing.orValue("fallback")`)},
+						},
+					}},
+				},
+			},
+		},
+		{
+			name: "optional index to unknown target",
+			resolver: &Resolver{
+				Name: "app",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{{
+						Provider: "cel",
+						Inputs: map[string]*ValueRef{
+							"expression": {Expr: exprPtr(`_[?"missing"].orValue("fallback")`)},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := BuildPhases([]*Resolver{tt.resolver}, nil)
+			require.NoError(t, err)
+			require.Len(t, result.Phases, 1)
+			assert.Equal(t, 1, result.Phases[0].Phase)
+			assert.Len(t, result.Phases[0].Resolvers, 1)
+		})
+	}
+}
+
+func TestBuildPhases_KeepsKnownOptionalDeps(t *testing.T) {
+	// An optional CEL reference to an existing resolver is retained as an
+	// ordering edge: the target is not required to exist, but when it does the
+	// dependent resolver must run after it so the optional value is available.
+	resolvers := []*Resolver{
+		{
+			Name: "app",
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{{
+					Provider: "cel",
+					Inputs: map[string]*ValueRef{
+						"expression": {Expr: exprPtr(`_.?profile.orValue("")`)},
+					},
+				}},
+			},
+		},
+		{Name: "profile"},
+	}
+
+	result, err := BuildPhases(resolvers, nil)
+	require.NoError(t, err)
+	require.Len(t, result.Phases, 2)
+	// profile has no deps -> phase 1; app optionally depends on profile -> phase 2.
+	assert.Equal(t, "profile", result.Phases[0].Resolvers[0].Name)
+	assert.Equal(t, "app", result.Phases[1].Resolvers[0].Name)
 }
 
 func TestExtractStrictDependencies(t *testing.T) {
@@ -1109,6 +1204,37 @@ func TestExtractStrictDependencies(t *testing.T) {
 				},
 			},
 			want: nil,
+		},
+		{
+			name: "optional cel reference is not strict",
+			resolver: &Resolver{
+				Name: "app",
+				When: &Condition{Expr: exprPtr(`_.?gate.orValue(false)`)},
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{{
+						Provider: "cel",
+						Inputs: map[string]*ValueRef{
+							"expr": {Expr: exprPtr(`_.?platformProfileID.orValue("")`)},
+						},
+					}},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "hard reference is strict even when name also appears optionally",
+			resolver: &Resolver{
+				Name: "app",
+				Resolve: &ResolvePhase{
+					With: []ProviderSource{{
+						Provider: "cel",
+						Inputs: map[string]*ValueRef{
+							"expr": {Expr: exprPtr(`_.?opt.orValue("") + _.hard`)},
+						},
+					}},
+				},
+			},
+			want: []string{"hard"},
 		},
 		{
 			name: "self reference is excluded",

--- a/tests/integration/solutions/lint-undefined-optional-reference/solution.yaml
+++ b/tests/integration/solutions/lint-undefined-optional-reference/solution.yaml
@@ -1,0 +1,84 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: lint-undefined-optional-reference
+  version: 1.0.0
+  description: |
+    Tests optional CEL access (_.?name / _[?"name"]) as a SOFT dependency.
+    An optional reference to an undefined resolver must not block loading -- it
+    resolves to absent and .orValue() supplies the fallback -- and the
+    undefined-optional-reference lint rule surfaces it as an INFO finding.
+
+spec:
+  resolvers:
+    # A concrete resolver that IS defined; referenced optionally below.
+    profile:
+      description: A defined resolver referenced optionally
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: prod-profile
+
+    # Optional reference to an UNDEFINED resolver (missingProfile). This must
+    # load successfully and fall back to the .orValue() default rather than
+    # failing on a missing hard dependency.
+    resolvedFromOptional:
+      description: Falls back when an optional reference targets an undefined resolver
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.?missingProfile.orValue("fallback-value")'
+
+    # Optional reference to a DEFINED resolver (profile). This must resolve to
+    # the target's value and must NOT be flagged by the lint rule.
+    resolvedFromDefinedOptional:
+      description: Resolves through an optional reference to a defined resolver
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: '_.?profile.orValue("no-profile")'
+
+  testing:
+    cases:
+      optional-undefined-falls-back:
+        description: Optional access to an undefined resolver loads and uses the fallback
+        command: [run, resolver]
+        args: ["resolvedFromOptional", "-o", "json"]
+        tags: [lint, resolver, optional-dependency, smoke]
+        assertions:
+          - expression: __exitCode == 0
+            message: "Optional reference to an undefined resolver must not block loading"
+          - expression: '__output.resolvedFromOptional == "fallback-value"'
+            message: "Undefined optional reference must fall back to .orValue()"
+
+      optional-defined-resolves:
+        description: Optional access to a defined resolver resolves to its value
+        command: [run, resolver]
+        args: ["resolvedFromDefinedOptional", "-o", "json"]
+        tags: [resolver, optional-dependency]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: '__output.resolvedFromDefinedOptional == "prod-profile"'
+            message: "Optional reference to a defined resolver must resolve to its value"
+
+      undefined-optional-reference-detected:
+        description: Lint reports the undefined optional reference as an INFO finding
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [lint, undefined-optional-reference]
+        assertions:
+          - expression: __exitCode == 0
+            message: "undefined-optional-reference is info-level, must not cause non-zero exit"
+          - expression: >
+              __output.findings.exists(f, f.ruleName == "undefined-optional-reference" && f.severity == "info")
+            message: "Should detect the undefined optional reference as INFO"
+          - expression: >
+              __output.findings.filter(f, f.ruleName == "undefined-optional-reference").size() == 1
+            message: "Should flag only the undefined optional target, not the defined one"
+          - expression: >
+              __output.findings.exists(f, f.ruleName == "undefined-optional-reference" && f.message.contains("missingProfile"))
+            message: "Finding should name the undefined resolver"


### PR DESCRIPTION
Optional CEL access (_.?name, _[?"name"]) signals the author tolerates the referenced resolver being absent, so it must no longer contribute a strict, load-blocking dependency edge. Dependency extraction now splits "_"-scoped references by access style and only hard references (_.name, _["name"]) create strict edges.

- Add GetUnderscoreVariablesByOptionality to split hard vs optional-only CEL references
- Route strict dependency extraction through extractHardDepsFromExpression so optional access is ignored across when/until/args/inputs/literals
- Add ExtractOptionalRefsFromValueRef to collect optional-only refs from ValueRefs and nested literals
- Add undefined-optional-reference lint rule (INFO) that flags optional references to resolvers that are not defined, since they always resolve to absent and would otherwise pass silently
- Document optional-reference dependency behavior and the new lint rule