### PR TITLE
feat(lint): load leniently so lint and validate aggregate all findings

### DIFF
--- a/docs/design/resolvers.md
+++ b/docs/design/resolvers.md
@@ -1672,6 +1672,14 @@ The `dependsOn` field:
 - Cannot reference itself (self-dependency is an error)
 - Participates in circular dependency detection
 
+> **Undefined `dependsOn` targets.** A `dependsOn` entry that names a resolver
+> which does not exist is a hard error on execution paths: `run` and `build`
+> load the solution strictly and fail. Advisory tooling degrades gracefully
+> instead -- `lint` and `validate` load the solution **leniently** and report
+> the problem as a `resolver-undefined-dependency` **error** finding. Loading
+> leniently lets every other finding surface in the same pass rather than being
+> hidden behind the first structural error ("onion peeling").
+
 ### Circular Dependency Detection
 
 Circular dependencies are detected during graph construction and cause immediate failure.

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -916,7 +916,65 @@ a required value is to reference it with `_.name`.
 This is an **info**-level finding because optional access is valid and often
 deliberate; it exists to catch accidental typos in optional references.
 
-## 13. Suppressing Findings
+## 13. Undefined Dependencies
+
+The `resolver-undefined-dependency` rule reports a `dependsOn` entry that names a
+resolver which does not exist (or is empty, or points at the resolver itself).
+
+A `dependsOn` edge is a **hard** dependency used to order the resolver DAG, so an
+undefined target cannot be satisfied. What makes this rule valuable is *how* it
+reports the problem. Structural errors like this used to abort the whole load,
+so lint could surface only the first one and every other finding stayed hidden
+behind it ("onion peeling"). Lint and `validate` now load the solution
+**leniently** and report the undefined dependency as a finding, so it appears
+**alongside** all other findings in a single pass.
+
+```yaml
+# ERROR: dependsOn targets a resolver that is not defined
+spec:
+  resolvers:
+    app:
+      dependsOn: [doesNotExist] # 'doesNotExist' is never defined
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+
+    # A separate, unrelated issue -- this hyphenated name still surfaces in the
+    # same lint run instead of being hidden behind the dependency error.
+    my-service-name:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: world
+```
+
+**Fix**: correct the name to an existing resolver, define the missing resolver,
+or remove the `dependsOn` entry if the dependency is not needed.
+
+This is an **error**-level finding because an undefined `dependsOn` target can
+never be resolved. Execution paths (`run` and `build`) still fail strictly when a
+dependency is undefined -- only advisory tooling (`lint` / `validate`) degrades
+gracefully so it can report the full picture.
+
+For more details:
+
+{{< tabs "linting-tutorial-cmd-14" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl lint rule resolver-undefined-dependency
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl lint rule resolver-undefined-dependency
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+## 14. Suppressing Findings
 
 When a finding is a deliberate, reviewed exception, you can suppress it with an
 inline YAML comment directive instead of disabling the rule globally. Directives
@@ -1006,7 +1064,7 @@ spec:
 > `disable-file`. Targeted suppressions keep the rest of the file linted and make
 > the intent obvious to reviewers.
 
-## 14. Using Lint with the MCP Server
+## 15. Using Lint with the MCP Server
 
 When using AI agents (VS Code Copilot, Claude, Cursor), the MCP server exposes lint functionality through:
 

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -961,7 +961,7 @@ gracefully so it can report the full picture.
 
 For more details:
 
-{{< tabs "linting-tutorial-cmd-14" >}}
+{{< tabs "linting-tutorial-cmd-15" >}}
 {{% tab "Bash" %}}
 ```bash
 scafctl lint rule resolver-undefined-dependency

--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -88,6 +88,7 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 			  Errors (will cause execution failures):
 			    - unused-resolver          Resolver defined but never referenced
 			    - invalid-dependency       Action depends on non-existent action
+			    - resolver-undefined-dependency  Resolver dependsOn references an undefined resolver
 			    - missing-provider         Referenced provider not registered
 			    - invalid-expression       Invalid CEL expression syntax
 			    - invalid-template         Invalid Go template syntax
@@ -186,8 +187,11 @@ func runLint(ctx context.Context, opts *Options) error {
 
 	lgr := logger.FromContext(ctx)
 
-	// Set up getter with catalog resolver for bare name resolution
-	var getterOpts []get.Option
+	// Set up getter with catalog resolver for bare name resolution.
+	// Lint loads leniently: a structural problem such as an undefined dependsOn
+	// target must surface as a finding rather than aborting the load and hiding
+	// every other issue behind the first one ("onion peeling").
+	getterOpts := []get.Option{get.WithLenientValidation()}
 	localCatalog, err := catalog.NewLocalCatalog(*lgr)
 	if err == nil {
 		resolver := catalog.NewSolutionResolver(localCatalog, *lgr,

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -113,6 +113,7 @@ func Solution(sol *solution.Solution, filePath string, registry *provider.Regist
 
 	lintResolvers(sol, result, registry, referencedResolvers)
 	lintTemplateFileDependencies(sol, solutionDir, result, registry)
+	lintResolverDependencies(sol, result)
 	lintResolverCycles(sol, result, registry)
 	lintUndefinedOptionalRefs(sol, result)
 	lintDeferredValidation(sol, result, registry)
@@ -795,6 +796,57 @@ func isNonTrivialGuard(c *resolver.Condition) bool {
 	}
 	expr := strings.TrimSpace(string(*c.Expr))
 	return expr != "" && expr != "true"
+}
+
+// lintResolverDependencies reports explicit dependsOn entries that cannot
+// reference a real resolver: an undefined target, an empty entry, or a
+// self-reference. These are structural errors that would otherwise abort the
+// load; reporting them as findings lets a single lint pass surface every
+// problem instead of failing on the first one ("onion peeling").
+func lintResolverDependencies(sol *solution.Solution, result *Result) {
+	if sol.Spec.Resolvers == nil {
+		return
+	}
+
+	// Build the set of defined resolver names once.
+	defined := make(map[string]bool, len(sol.Spec.Resolvers))
+	for name := range sol.Spec.Resolvers {
+		defined[name] = true
+	}
+
+	// Iterate in sorted order so findings are emitted deterministically.
+	names := make([]string, 0, len(sol.Spec.Resolvers))
+	for name := range sol.Spec.Resolvers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		res := sol.Spec.Resolvers[name]
+		if res == nil {
+			continue
+		}
+		location := fmt.Sprintf("resolvers.%s.dependsOn", name)
+		for _, dep := range res.DependsOn {
+			switch {
+			case dep == "":
+				result.addFinding(SeverityError, "dependency", location,
+					fmt.Sprintf("resolver %q has an empty dependsOn entry", name),
+					"Remove the empty entry or replace it with a valid resolver name",
+					"resolver-undefined-dependency")
+			case dep == name:
+				result.addFinding(SeverityError, "dependency", location,
+					fmt.Sprintf("resolver %q cannot depend on itself", name),
+					"Remove the self-reference from dependsOn",
+					"resolver-undefined-dependency")
+			case !defined[dep]:
+				result.addFinding(SeverityError, "dependency", location,
+					fmt.Sprintf("resolver %q has a dependsOn reference to undefined resolver %q", name, dep),
+					fmt.Sprintf("Define a resolver named %q or fix the typo in dependsOn", dep),
+					"resolver-undefined-dependency")
+			}
+		}
+	}
 }
 
 // lintResolverCycles checks for circular dependencies in the resolver dependency graph.

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -808,10 +808,13 @@ func lintResolverDependencies(sol *solution.Solution, result *Result) {
 		return
 	}
 
-	// Build the set of defined resolver names once.
+	// Build the set of defined resolver names once. A null resolver value is
+	// not a valid dependsOn target (strict validation rejects it and execution
+	// fails), so it does not count as "defined" for dependency resolution — a
+	// dependsOn reference to it is reported as undefined below.
 	defined := make(map[string]bool, len(sol.Spec.Resolvers))
-	for name := range sol.Spec.Resolvers {
-		defined[name] = true
+	for name, res := range sol.Spec.Resolvers {
+		defined[name] = res != nil
 	}
 
 	// Iterate in sorted order so findings are emitted deterministically.

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -851,6 +851,99 @@ func TestLintUndefinedOptionalReference_NoResolvers(t *testing.T) {
 	assert.Contains(t, findings[0].Message, "missing")
 }
 
+func TestLintResolverUndefinedDependency(t *testing.T) {
+	staticProv := newFakeProvider("static", map[string]*jsonschema.Schema{
+		"value": {Type: "string"},
+	})
+
+	newSol := func(deps []string) *solution.Solution {
+		return &solution.Solution{
+			Spec: solution.Spec{
+				Resolvers: map[string]*resolver.Resolver{
+					"base": {
+						Resolve: &resolver.ResolvePhase{
+							With: []resolver.ProviderSource{{
+								Provider: "static",
+								Inputs:   map[string]*spec.ValueRef{"value": {Literal: "b"}},
+							}},
+						},
+					},
+					"app": {
+						DependsOn: deps,
+						Resolve: &resolver.ResolvePhase{
+							With: []resolver.ProviderSource{{
+								Provider: "static",
+								Inputs:   map[string]*spec.ValueRef{"value": {Literal: "a"}},
+							}},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	reg := provider.NewRegistry()
+	_ = reg.Register(staticProv)
+
+	tests := []struct {
+		name          string
+		deps          []string
+		wantFindings  int
+		wantSubstring string
+	}{
+		{name: "defined dependency is not flagged", deps: []string{"base"}, wantFindings: 0},
+		{name: "undefined dependency is flagged", deps: []string{"doesNotExist"}, wantFindings: 1, wantSubstring: "doesNotExist"},
+		{name: "empty dependency is flagged", deps: []string{""}, wantFindings: 1, wantSubstring: "empty"},
+		{name: "self dependency is flagged", deps: []string{"app"}, wantFindings: 1, wantSubstring: "itself"},
+		{name: "multiple undefined deps are all flagged", deps: []string{"missingA", "missingB"}, wantFindings: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Solution(newSol(tt.deps), "test.yaml", reg)
+			findings := filterFindingsByRule(result, "resolver-undefined-dependency")
+			require.Len(t, findings, tt.wantFindings)
+			for _, f := range findings {
+				assert.Equal(t, SeverityError, f.Severity)
+			}
+			if tt.wantSubstring != "" {
+				require.Len(t, findings, 1)
+				assert.Contains(t, findings[0].Message, tt.wantSubstring)
+			}
+		})
+	}
+}
+
+func TestLintResolverUndefinedDependency_NilResolver(t *testing.T) {
+	staticProv := newFakeProvider("static", map[string]*jsonschema.Schema{
+		"value": {Type: "string"},
+	})
+	reg := provider.NewRegistry()
+	_ = reg.Register(staticProv)
+
+	// A nil resolver entry must be skipped without panicking and must not
+	// produce a resolver-undefined-dependency finding.
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"nilResolver": nil,
+				"app": {
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "static",
+							Inputs:   map[string]*spec.ValueRef{"value": {Literal: "a"}},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "resolver-undefined-dependency")
+	assert.Empty(t, findings)
+}
+
 func TestLintNonValidationProvider(t *testing.T) {
 	// "static" has CapabilityFrom, not CapabilityValidation
 	staticProv := newFakeProvider("static", map[string]*jsonschema.Schema{

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -944,6 +944,39 @@ func TestLintResolverUndefinedDependency_NilResolver(t *testing.T) {
 	assert.Empty(t, findings)
 }
 
+func TestLintResolverUndefinedDependency_NilTargetFlagged(t *testing.T) {
+	staticProv := newFakeProvider("static", map[string]*jsonschema.Schema{
+		"value": {Type: "string"},
+	})
+	reg := provider.NewRegistry()
+	_ = reg.Register(staticProv)
+
+	// A dependsOn reference to a resolver whose value is null must be flagged:
+	// a null resolver is not a valid dependency target and execution fails.
+	sol := &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				"nilResolver": nil,
+				"app": {
+					DependsOn: []string{"nilResolver"},
+					Resolve: &resolver.ResolvePhase{
+						With: []resolver.ProviderSource{{
+							Provider: "static",
+							Inputs:   map[string]*spec.ValueRef{"value": {Literal: "a"}},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	result := Solution(sol, "test.yaml", reg)
+	findings := filterFindingsByRule(result, "resolver-undefined-dependency")
+	require.Len(t, findings, 1)
+	assert.Equal(t, SeverityError, findings[0].Severity)
+	assert.Contains(t, findings[0].Message, "nilResolver")
+}
+
 func TestLintNonValidationProvider(t *testing.T) {
 	// "static" has CapabilityFrom, not CapabilityValidation
 	staticProv := newFakeProvider("static", map[string]*jsonschema.Schema{

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -206,6 +206,14 @@ var KnownRules = map[string]RuleMeta{
 		Why:         "Actions with invalid dependencies cannot be scheduled for execution. This usually indicates a typo in the action name.",
 		Fix:         "Check the action names in spec.workflow.actions and ensure all dependsOn references match exactly. Names are case-sensitive.",
 	},
+	"resolver-undefined-dependency": {
+		Rule:        "resolver-undefined-dependency",
+		Severity:    string(SeverityError),
+		Category:    "dependency",
+		Description: "A resolver's dependsOn entry references a resolver that does not exist, is empty, or is a self-reference.",
+		Why:         "An undefined dependsOn target breaks dependency-graph construction. Reporting it as a finding (rather than aborting the load) lets a single lint pass surface every problem at once instead of revealing them one at a time.",
+		Fix:         "Define a resolver with the referenced name, fix the typo, or remove the invalid dependsOn entry. Names are case-sensitive.",
+	},
 	"undefined-optional-reference": {
 		Rule:        "undefined-optional-reference",
 		Severity:    string(SeverityInfo),

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 65 rules — update this when new rules are added
-	assert.Equal(t, 65, len(KnownRules), "expected 65 known lint rules")
+	// We expect exactly 66 rules — update this when new rules are added
+	assert.Equal(t, 66, len(KnownRules), "expected 66 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/solution/get/get.go
+++ b/pkg/solution/get/get.go
@@ -749,6 +749,9 @@ func (o *Getter) FromLocalFileSystem(ctx context.Context, path string) (*solutio
 	o.logger.V(1).Info("Unmarshalling solution data", "path", path, "size", len(data))
 
 	sol := solution.Solution{}
+	// Set the path before loadBytes so the source map built during
+	// unmarshalling records the correct file in finding positions.
+	sol.SetPath(path)
 	err = o.loadBytes(&sol, data)
 	if err != nil {
 		o.logger.Error(err, "Failed to unmarshal solution", "path", path)
@@ -756,7 +759,6 @@ func (o *Getter) FromLocalFileSystem(ctx context.Context, path string) (*solutio
 	}
 
 	o.logger.V(1).Info("Successfully loaded solution from local filesystem", "path", path)
-	sol.SetPath(path)
 
 	// Apply compose if the solution references composed files
 	if len(sol.Compose) > 0 {
@@ -823,6 +825,9 @@ func (o *Getter) FromURL(ctx context.Context, url string) (*solution.Solution, e
 	o.logger.V(1).Info("Unmarshalling solution data", "url", url, "size", len(data))
 
 	sol := solution.Solution{}
+	// Set the path before loadBytes so the source map built during
+	// unmarshalling records the correct source in finding positions.
+	sol.SetPath(url)
 	err = o.loadBytes(&sol, data)
 	if err != nil {
 		o.logger.Error(err, "Failed to unmarshal solution", "url", url)
@@ -830,7 +835,6 @@ func (o *Getter) FromURL(ctx context.Context, url string) (*solution.Solution, e
 	}
 
 	o.logger.Info("Successfully loaded solution from URL", "url", url)
-	sol.SetPath(url)
 	return &sol, nil
 }
 

--- a/pkg/solution/get/get.go
+++ b/pkg/solution/get/get.go
@@ -91,6 +91,7 @@ type Getter struct {
 	discoveryMode     settings.DiscoveryMode
 	customActionFiles []string
 	lastDiscovery     DiscoveryResult
+	lenient           bool
 }
 
 // Option defines a function type that modifies a Getter instance.
@@ -148,6 +149,18 @@ func WithCatalogResolver(resolver CatalogResolver) Option {
 func WithRemoteResolver(resolver RemoteResolver) Option {
 	return func(g *Getter) {
 		g.remoteResolver = resolver
+	}
+}
+
+// WithLenientValidation returns an Option that makes the Getter load solutions
+// leniently: the solution is parsed and defaulted, but the fatal spec Validate()
+// gate is skipped so structural problems (e.g. an undefined dependsOn target) do
+// not abort the load. This is intended for advisory tooling (lint / validate)
+// that must report all problems in a single pass rather than failing on the
+// first one. Execution paths (run / build) must NOT enable this.
+func WithLenientValidation() Option {
+	return func(g *Getter) {
+		g.lenient = true
 	}
 }
 
@@ -248,6 +261,17 @@ type Interface interface {
 	// bundleData is nil when the solution has no bundle or comes from a local file.
 	GetWithBundle(ctx context.Context, path string) (sol *solution.Solution, bundleData []byte, err error)
 	FindSolution() string
+}
+
+// loadBytes parses solution content into sol, honoring the Getter's lenient
+// mode. In lenient mode the fatal spec Validate() gate is skipped so advisory
+// tooling can report structural problems as findings instead of aborting the
+// load; parse errors are still returned in both modes.
+func (o *Getter) loadBytes(sol *solution.Solution, content []byte) error {
+	if o.lenient {
+		return sol.LoadFromBytesLenient(content)
+	}
+	return sol.LoadFromBytes(content)
 }
 
 // Get retrieves a Solution from the specified path, which can be a local file or a URL.
@@ -396,7 +420,7 @@ func (o *Getter) fromCatalogWithBundle(ctx context.Context, nameWithVersion stri
 		}
 
 		sol := solution.Solution{}
-		if err := sol.LoadFromBytes(content); err != nil {
+		if err := o.loadBytes(&sol, content); err != nil {
 			return nil, nil, fmt.Errorf("failed to parse solution from catalog: %w", err)
 		}
 
@@ -411,7 +435,7 @@ func (o *Getter) fromCatalogWithBundle(ctx context.Context, nameWithVersion stri
 	}
 
 	sol := solution.Solution{}
-	if err := sol.LoadFromBytes(content); err != nil {
+	if err := o.loadBytes(&sol, content); err != nil {
 		return nil, nil, fmt.Errorf("failed to parse solution from catalog: %w", err)
 	}
 
@@ -633,7 +657,7 @@ func (o *Getter) fromCatalog(ctx context.Context, nameWithVersion string) (*solu
 	}
 
 	sol := solution.Solution{}
-	if err := sol.LoadFromBytes(content); err != nil {
+	if err := o.loadBytes(&sol, content); err != nil {
 		return nil, fmt.Errorf("failed to parse solution from catalog: %w", err)
 	}
 
@@ -651,7 +675,7 @@ func (o *Getter) fromRemoteRef(ctx context.Context, ref string) (*solution.Solut
 	}
 
 	sol := solution.Solution{}
-	if err := sol.LoadFromBytes(content); err != nil {
+	if err := o.loadBytes(&sol, content); err != nil {
 		return nil, fmt.Errorf("failed to parse solution from remote: %w", err)
 	}
 
@@ -668,7 +692,7 @@ func (o *Getter) fromRemoteRefWithBundle(ctx context.Context, ref string) (*solu
 	}
 
 	sol := solution.Solution{}
-	if err := sol.LoadFromBytes(content); err != nil {
+	if err := o.loadBytes(&sol, content); err != nil {
 		return nil, nil, fmt.Errorf("failed to parse solution from remote: %w", err)
 	}
 
@@ -725,7 +749,7 @@ func (o *Getter) FromLocalFileSystem(ctx context.Context, path string) (*solutio
 	o.logger.V(1).Info("Unmarshalling solution data", "path", path, "size", len(data))
 
 	sol := solution.Solution{}
-	err = sol.LoadFromBytes(data)
+	err = o.loadBytes(&sol, data)
 	if err != nil {
 		o.logger.Error(err, "Failed to unmarshal solution", "path", path)
 		return &solution.Solution{}, fmt.Errorf("failed to load solution from '%s': %w", path, err)
@@ -799,7 +823,7 @@ func (o *Getter) FromURL(ctx context.Context, url string) (*solution.Solution, e
 	o.logger.V(1).Info("Unmarshalling solution data", "url", url, "size", len(data))
 
 	sol := solution.Solution{}
-	err = sol.LoadFromBytes(data)
+	err = o.loadBytes(&sol, data)
 	if err != nil {
 		o.logger.Error(err, "Failed to unmarshal solution", "url", url)
 		return nil, fmt.Errorf("failed to load solution from '%s': %w", url, err)

--- a/pkg/solution/get/get_test.go
+++ b/pkg/solution/get/get_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -339,6 +340,37 @@ func TestFromLocalFileSystem(t *testing.T) {
 		assert.Equal(t, solution.DefaultAPIVersion, sol.APIVersion)
 		assert.Equal(t, solution.SolutionKind, sol.Kind)
 		assert.Equal(t, "private", sol.Catalog.Visibility)
+	})
+
+	t.Run("source map records the file path", func(t *testing.T) {
+		// The path must be set before unmarshalling so the source map built
+		// during parsing records the correct file in finding positions.
+		yamlSol := "apiVersion: scafctl.io/v1\n" +
+			"kind: Solution\n" +
+			"metadata:\n" +
+			"  name: test-solution\n" +
+			"  version: 1.0.0\n"
+		customReadFile := func(name string) ([]byte, error) {
+			return []byte(yamlSol), nil
+		}
+
+		getter := NewGetter(WithReadFile(customReadFile))
+		ctx := context.Background()
+
+		sol, err := getter.FromLocalFileSystem(ctx, "my-solution.yaml")
+		require.NoError(t, err)
+		require.NotNil(t, sol)
+
+		sm := sol.SourceMap()
+		require.NotNil(t, sm)
+		require.Positive(t, sm.Len())
+		pos, ok := sm.Get("metadata.name")
+		require.True(t, ok)
+		// The path is resolved to an absolute path before unmarshalling, so
+		// the recorded file must be non-empty and reference the solution file.
+		assert.NotEmpty(t, pos.File)
+		assert.True(t, strings.HasSuffix(pos.File, "my-solution.yaml"),
+			"expected source file to end with my-solution.yaml, got %q", pos.File)
 	})
 
 	t.Run("validation failure", func(t *testing.T) {

--- a/pkg/solution/get/get_test.go
+++ b/pkg/solution/get/get_test.go
@@ -356,6 +356,47 @@ func TestFromLocalFileSystem(t *testing.T) {
 		assert.Contains(t, err.Error(), "validation")
 	})
 
+	t.Run("lenient load skips spec validation", func(t *testing.T) {
+		// An undefined dependsOn target fails strict load but must succeed
+		// under WithLenientValidation so advisory tooling can inspect it.
+		undefinedDep := `{
+			"apiVersion": "scafctl.io/v1",
+			"kind": "Solution",
+			"metadata": {"name": "lenient", "version": "1.0.0"},
+			"spec": {"resolvers": {"app": {
+				"dependsOn": ["doesNotExist"],
+				"resolve": {"with": [{"provider": "static", "inputs": {"value": "x"}}]}
+			}}}
+		}`
+		customReadFile := func(name string) ([]byte, error) {
+			return []byte(undefinedDep), nil
+		}
+		ctx := context.Background()
+
+		// Strict getter fails.
+		strict := NewGetter(WithReadFile(customReadFile))
+		_, strictErr := strict.FromLocalFileSystem(ctx, "undefined.json")
+		require.Error(t, strictErr)
+
+		// Lenient getter succeeds and returns the parsed solution.
+		lenient := NewGetter(WithReadFile(customReadFile), WithLenientValidation())
+		sol, err := lenient.FromLocalFileSystem(ctx, "undefined.json")
+		require.NoError(t, err)
+		require.NotNil(t, sol)
+		require.Contains(t, sol.Spec.Resolvers, "app")
+	})
+
+	t.Run("lenient load still returns parse errors", func(t *testing.T) {
+		customReadFile := func(name string) ([]byte, error) {
+			return []byte("not valid yaml: ["), nil
+		}
+		getter := NewGetter(WithReadFile(customReadFile), WithLenientValidation())
+		ctx := context.Background()
+
+		_, err := getter.FromLocalFileSystem(ctx, "broken.yaml")
+		require.Error(t, err)
+	})
+
 	t.Run("file read error", func(t *testing.T) {
 		customReadFile := func(name string) ([]byte, error) {
 			return nil, fmt.Errorf("file not found")

--- a/pkg/solution/solution.go
+++ b/pkg/solution/solution.go
@@ -322,6 +322,27 @@ func (s *Solution) LoadFromBytes(bytes []byte) error {
 	return s.Validate()
 }
 
+// LoadFromBytesLenient unmarshals the provided bytes and applies defaults, but
+// deliberately skips the fatal Validate() gate. It is used by advisory tooling
+// (lint / validate) that must degrade gracefully: a structural problem such as
+// an undefined dependsOn target should surface as a reported finding rather than
+// aborting the load and hiding every other issue behind the first one. Parse
+// errors (malformed YAML/JSON) are still returned, since without a parsed
+// solution there is nothing to inspect. Callers that require a fully valid
+// solution (run / build) must use LoadFromBytes instead.
+func (s *Solution) LoadFromBytesLenient(bytes []byte) error {
+	if s == nil {
+		return errors.New("solution is nil")
+	}
+
+	if err := s.UnmarshalFromBytes(bytes); err != nil {
+		return err
+	}
+
+	s.ApplyDefaults()
+	return nil
+}
+
 // GetPath returns the file system path associated with the Solution.
 func (s *Solution) GetPath() string {
 	return s.path

--- a/pkg/solution/solution_test.go
+++ b/pkg/solution/solution_test.go
@@ -424,6 +424,52 @@ bundle:
 	})
 }
 
+func TestSolution_LoadFromBytesLenient(t *testing.T) {
+	// A solution whose dependsOn references an undefined resolver fails the
+	// strict LoadFromBytes but must load successfully in lenient mode so
+	// advisory tooling can report the problem as a finding.
+	data := []byte(`metadata:
+  name: lenient-test
+  version: 1.0.0
+spec:
+  resolvers:
+    app:
+      dependsOn: [doesNotExist]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+`)
+
+	t.Run("strict load fails on undefined dependsOn", func(t *testing.T) {
+		var s Solution
+		err := s.LoadFromBytes(data)
+		require.Error(t, err)
+	})
+
+	t.Run("lenient load parses and defaults without validating spec", func(t *testing.T) {
+		var s Solution
+		require.NoError(t, s.LoadFromBytesLenient(data))
+		assert.Equal(t, DefaultAPIVersion, s.APIVersion)
+		assert.Equal(t, SolutionKind, s.Kind)
+		assert.Equal(t, "lenient-test", s.Metadata.Name)
+		require.Contains(t, s.Spec.Resolvers, "app")
+	})
+
+	t.Run("lenient load still returns parse errors", func(t *testing.T) {
+		var s Solution
+		err := s.LoadFromBytesLenient([]byte("nope"))
+		require.Error(t, err)
+	})
+
+	t.Run("nil receiver", func(t *testing.T) {
+		var s *Solution
+		err := s.LoadFromBytesLenient([]byte("{}"))
+		require.Error(t, err)
+	})
+}
+
 func TestBundle_IsEmpty(t *testing.T) {
 	b := Bundle{}
 	assert.True(t, b.IsEmpty())

--- a/pkg/validate/solution.go
+++ b/pkg/validate/solution.go
@@ -85,10 +85,13 @@ func LoadedSolution(sol *solution.Solution, filePath string, registry *provider.
 
 // newGetter builds a solution getter wired with the local (and any remote)
 // catalog resolver so bare catalog names resolve, mirroring the lint command.
+// It loads leniently so structural problems (e.g. an undefined dependsOn
+// target) surface as lint findings rather than aborting the load; the error
+// severity of those findings still drives a non-zero validation result.
 func newGetter(ctx context.Context) *get.Getter {
 	lgr := logger.FromContext(ctx)
 
-	var getterOpts []get.Option
+	getterOpts := []get.Option{get.WithLenientValidation()}
 	if localCatalog, err := catalog.NewLocalCatalog(*lgr); err == nil {
 		resolver := catalog.NewSolutionResolver(localCatalog, *lgr,
 			catalog.WithResolverRemoteCatalogs(catalog.RemoteCatalogsFromContext(ctx, *lgr)),

--- a/pkg/validate/solution_test.go
+++ b/pkg/validate/solution_test.go
@@ -115,3 +115,58 @@ func TestValidateSolution_MissingFile(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, res)
 }
+
+func TestValidateSolution_UndefinedDependencyAggregates(t *testing.T) {
+	// An undefined dependsOn target used to abort the strict load and hide every
+	// other finding behind it. validate now loads leniently, so it reports the
+	// undefined dependency AND an unrelated finding in the same pass, while still
+	// failing (error-severity finding).
+	dir := t.TempDir()
+	path := filepath.Join(dir, "solution.yaml")
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: undefined-dep
+  version: 1.0.0
+spec:
+  resolvers:
+    app:
+      dependsOn: [doesNotExist]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+    my-service-name:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: world
+`
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+
+	res, err := Solution(context.Background(), path, reg)
+	require.NoError(t, err, "lenient load must not abort on an undefined dependsOn")
+	require.NotNil(t, res)
+	require.NotNil(t, res.Lint)
+
+	var undefinedDep, hyphenated bool
+	for _, f := range res.Lint.Findings {
+		switch f.RuleName {
+		case "resolver-undefined-dependency":
+			undefinedDep = true
+			assert.Equal(t, lint.SeverityError, f.Severity)
+			assert.Contains(t, f.Message, "doesNotExist")
+		case "hyphenated-name":
+			hyphenated = true
+		}
+	}
+	assert.True(t, undefinedDep, "should report the undefined dependency as a finding")
+	assert.True(t, hyphenated, "an unrelated finding must also surface in the same pass")
+	assert.Positive(t, res.Lint.ErrorCount, "error-severity finding drives a non-zero result")
+	assert.False(t, res.Passed(false), "validate must still fail")
+}

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -497,7 +497,7 @@ tasks:
         PASSED=0
         SKIPPED=0
 
-        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml|lint-tmpl-underscore/|lint-stress-test/|lint-resolver-cycle/|lint-missing-template-dependency/|lint-template-nonstandard-ext/|compose-demo/workflow|compose-demo/resolvers|state/github-state"
+        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml|lint-tmpl-underscore/|lint-stress-test/|lint-resolver-cycle/|lint-missing-template-dependency/|lint-template-nonstandard-ext/|lint-undefined-dependency/|compose-demo/workflow|compose-demo/resolvers|state/github-state"
 
         {
           find examples/solutions -name '*.yaml'

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1460,15 +1460,19 @@ func TestIntegration_RunSolution_NullResolver(t *testing.T) {
 
 func TestIntegration_Lint_NullResolver(t *testing.T) {
 	t.Parallel()
-	_, stderr, exitCode := runScafctl(t,
+	stdout, _, exitCode := runScafctl(t,
 		"lint",
 		"-f", "tests/integration/solutions/edge-cases/null-resolver/solution.yaml",
 		"-o", "json",
 	)
 
-	// Lint returns exit code 1 because spec validation rejects the null resolver
-	assert.Equal(t, 1, exitCode)
-	assert.Contains(t, stderr, "null value")
+	// Lint loads leniently, so a null resolver is reported as a null-resolver
+	// finding (exit 2 for error-severity findings) instead of aborting the load.
+	// Unrelated findings surface in the same pass (no "onion peeling").
+	assert.Equal(t, 2, exitCode)
+	assert.Contains(t, stdout, "null-resolver")
+	assert.Contains(t, stdout, "has a null value")
+	assert.Contains(t, stdout, "unused-resolver")
 }
 
 func TestIntegration_RunSolution_DryRun(t *testing.T) {

--- a/tests/integration/solutions/lint-resolver-cycle/solution.yaml
+++ b/tests/integration/solutions/lint-resolver-cycle/solution.yaml
@@ -5,9 +5,11 @@ metadata:
   name: lint-resolver-cycle
   version: 1.0.0
   description: |
-    Tests the resolver-cycle lint rule. Resolver cycles are caught during
-    solution loading (spec validation), so the lint command fails with an
-    error message before producing JSON findings output.
+    Tests the resolver-cycle lint rule. Lint loads the solution leniently, so a
+    resolver cycle is reported as a resolver-cycle finding (exit 2) alongside
+    every other finding in the same pass, instead of aborting the load and
+    hiding the rest behind the first error ("onion peeling"). Execution paths
+    (run resolver) still fail strictly on the cycle.
 
 spec:
   resolvers:
@@ -47,26 +49,29 @@ spec:
 
     cases:
       cycle-detected:
-        description: Lint fails with cycle error during solution load
+        description: Lint reports the cycle as a finding alongside unrelated findings
         command: [lint]
         args: ["-o", "json"]
         tags: [lint, resolver-cycle]
         assertions:
-          - expression: __exitCode != 0
-            message: "Resolver cycle should cause non-zero exit"
+          - expression: __exitCode == 2
+            message: "Resolver cycle is an error finding, so lint exits 2"
           - expression: >
-              __stderr.contains("cycle detected")
-            message: "Error message should mention cycle detected"
+              __output.findings.exists(f, f.ruleName == "resolver-cycle" && f.severity == "error")
+            message: "Cycle should be reported as a resolver-cycle error finding"
           - expression: >
-              __stderr.contains("alpha") && __stderr.contains("beta")
-            message: "Error message should mention the resolvers involved in the cycle"
+              __output.findings.exists(f, f.ruleName == "resolver-cycle" && f.message.contains("alpha") && f.message.contains("beta"))
+            message: "Finding should name the resolvers involved in the cycle"
+          - expression: >
+              __output.findings.exists(f, f.ruleName == "unused-resolver")
+            message: "Unrelated findings must also surface in the same pass (no onion peeling)"
 
-      standalone-not-in-error:
-        description: Standalone resolver should not appear in the cycle error
+      standalone-not-in-cycle:
+        description: Standalone resolver should not be part of the cycle finding
         command: [lint]
         args: ["-o", "json"]
         tags: [lint, resolver-cycle]
         assertions:
           - expression: >
-              !__stderr.contains("standalone")
-            message: "Standalone resolver should not appear in cycle error message"
+              !__output.findings.exists(f, f.ruleName == "resolver-cycle" && f.message.contains("standalone"))
+            message: "Standalone resolver should not appear in the cycle finding"

--- a/tests/integration/solutions/lint-undefined-dependency/solution.yaml
+++ b/tests/integration/solutions/lint-undefined-dependency/solution.yaml
@@ -1,0 +1,73 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: lint-undefined-dependency
+  version: 1.0.0
+  description: |
+    Tests that an undefined dependsOn target degrades gracefully. Instead of a
+    hard LOAD_FAILED that hides every other problem behind the first one
+    ("onion peeling"), lint loads leniently and reports the undefined dependency
+    as a resolver-undefined-dependency error alongside all other findings.
+    Execution paths (run resolver) still fail strictly.
+
+spec:
+  resolvers:
+    # Undefined dependsOn target -> reported as an error finding by lint, but
+    # a hard load failure for run/build.
+    app:
+      dependsOn: [doesNotExist]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+
+    # An unrelated hyphenated name -> a separate warning that must ALSO surface
+    # in the same lint pass, proving lint no longer stops at the first problem.
+    my-service-name:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: world
+
+  testing:
+    config:
+      # The 'app' resolver has an intentional undefined dependsOn target, so the
+      # strict builtins (parse / lint / resolve-defaults) would fail by design.
+      skipBuiltins: true
+
+    cases:
+      lint-reports-all-problems-in-one-pass:
+        description: Lint surfaces the undefined dependency AND unrelated findings together
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [lint, resolver-undefined-dependency]
+        assertions:
+          - expression: __exitCode == 2
+            message: "Lint must fail (exit 2) because the undefined dependency is an error"
+          - expression: >
+              __output.findings.exists(f, f.ruleName == "resolver-undefined-dependency" && f.severity == "error")
+            message: "Should report the undefined dependency as an error finding"
+          - expression: >
+              __output.findings.filter(f, f.ruleName == "resolver-undefined-dependency").size() == 1
+            message: "Should flag exactly one undefined dependency"
+          - expression: >
+              __output.findings.exists(f, f.ruleName == "resolver-undefined-dependency" && f.message.contains("doesNotExist"))
+            message: "Finding should name the undefined resolver"
+          - expression: >
+              __output.findings.exists(f, f.ruleName == "hyphenated-name")
+            message: "Unrelated findings must also surface in the same pass (no onion peeling)"
+
+      run-still-fails-strict:
+        description: Execution paths still fail strictly on the undefined dependency
+        command: [run, resolver]
+        args: ["app", "-o", "json"]
+        tags: [resolver, negative]
+        expectFailure: true
+        assertions:
+          - expression: __exitCode != 0
+            message: "run resolver must fail strictly when a dependsOn target is undefined"
+          - expression: '__stderr.contains("doesNotExist")'
+            message: "The strict failure should name the undefined resolver"


### PR DESCRIPTION
Advisory tooling (lint / validate) previously aborted on the first fatal spec error, hiding every other problem behind it ("onion peeling"). Both commands now load solutions leniently -- parsing and defaulting without the fatal Validate() gate -- so structural problems surface as findings alongside all other issues in a single pass. Execution paths (run / build) still load strictly and fail.

- Add Solution.LoadFromBytesLenient and get.WithLenientValidation to skip the fatal spec gate while still returning parse errors
- Wire lenient loading through the lint and validate commands
- Add resolver-undefined-dependency error rule for dependsOn entries that are undefined, empty, or self-referential (66 known rules); a dependsOn reference to a null resolver is also flagged (the null resolver itself is reported by the null-resolver rule)
- Lint null resolvers now report as findings (exit 2) instead of aborting
- Record the source file in finding positions by setting the solution path before unmarshalling in FromLocalFileSystem and FromURL (previously SourceFile was empty for local YAML)
- Document the behavior in the resolvers design doc and linting tutorial