### PR TITLE
docs(ai): point AI-guidance files at the MCP reference tools

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,28 @@ Go-based CLI tool using CEL (Common Expression Language) for dynamic configurati
 - **Configuration**: `pkg/settings` for defaults, `pkg/config/` for app configuration
 - **CEL**: Use `celexp.EvaluateExpression()`. Prefer `expression` field over `expr`
 
+## MCP Tools Are the Source of Truth
+
+scafctl ships an MCP server whose tools return live, version-accurate facts about
+the solution spec, functions, providers, and lint rules. When authoring or
+reasoning about solutions -- or writing docs/skills -- **consult these tools
+instead of relying on (or hand-maintaining) inline catalogs**, which drift:
+
+- **Spec / fields**: `get_solution_schema`, `explain_kind` (solution, resolver,
+  action, workflow, spec, provider, schema, retry).
+- **Functions**: `list_cel_functions`, `list_go_template_functions`.
+- **Providers**: `list_providers`, `list_official_providers`, `get_provider_schema`.
+- **Lint**: `list_lint_rules`, `explain_lint_rule`.
+- **Concepts / runtime**: `explain_concepts` -- including the `context` category
+  (`context-variables`, `phase-execution`, `cel-cost-model`,
+  `template-dependency-inference`, `snapshot-masking`, `authoring-workflow`) --
+  and `list_context_variables` for the injected-variable-per-phase matrix.
+- **Validate before shipping**: `validate_expression`, `evaluate_cel`,
+  `evaluate_go_template`, `lint_solution`, `extract_resolver_refs`.
+
+Prose in the skills (`.github/skills/`) should POINT at these tools, not mirror
+their output.
+
 ## Conventions
 
 - **Commits**: Use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,8 +14,8 @@ Go-based CLI tool using CEL (Common Expression Language) for dynamic configurati
 
 ## MCP Tools Are the Source of Truth
 
-scafctl ships an MCP server whose tools return live, version-accurate facts about
-the solution spec, functions, providers, and lint rules. When authoring or
+scafctl ships an MCP server whose tools return facts about the solution spec,
+functions, providers, and lint rules straight from the code. When authoring or
 reasoning about solutions -- or writing docs/skills -- **consult these tools
 instead of relying on (or hand-maintaining) inline catalogs**, which drift:
 
@@ -33,6 +33,12 @@ instead of relying on (or hand-maintaining) inline catalogs**, which drift:
 
 Prose in the skills (`.github/skills/`) should POINT at these tools, not mirror
 their output.
+
+**Caveat:** the MCP server reflects the **built binary** (`dist/scafctl`), not
+your uncommitted working tree. If you just changed a function, provider, spec
+field, or lint rule, **rebuild and restart the server** before querying it --
+otherwise the tool output can omit the very change you are authoring. When in
+doubt, the source code is the ultimate authority.
 
 ## Conventions
 

--- a/.github/instructions/cel-extensions.instructions.md
+++ b/.github/instructions/cel-extensions.instructions.md
@@ -9,6 +9,9 @@ CEL extensions are custom functions that extend the CEL expression language
 with scafctl-specific capabilities. They are registered at startup and
 available in all CEL evaluation contexts (resolvers, conditions, transforms).
 
+Before adding a function, check the live catalog with the MCP tool
+**`list_cel_functions`** so you do not duplicate an existing one.
+
 ## File Layout
 
 ```
@@ -154,9 +157,17 @@ func BenchmarkGroupByFunc(b *testing.B) {
 
 ## Documentation
 
-After adding a function, update the cel-patterns skill:
-`.github/skills/cel-patterns/SKILL.md` -- add the function under the correct
-namespace heading in "Custom scafctl Functions".
+The authoritative catalog of implemented CEL functions is the MCP tool
+**`list_cel_functions`** (filter with `custom_only: true` for scafctl
+extensions) -- it is generated from the registry, so it never drifts. Do **not**
+hand-maintain a per-function catalog in the skills or docs.
 
-Only document implemented functions. Never add planned/aspirational functions
-to the skill file.
+After adding a function:
+
+- Register it in `Custom()` (`pkg/celexp/ext/ext.go`) so `list_cel_functions`
+  picks it up automatically.
+- Only update the `cel-patterns` skill if it carries **narrative** about the new
+  function (a pattern, pitfall, or cost note) -- not a mirror of the function
+  signature, which the tool already provides.
+
+Only expose implemented functions. Never register planned/aspirational functions.

--- a/.github/instructions/docs-examples.instructions.md
+++ b/.github/instructions/docs-examples.instructions.md
@@ -14,5 +14,6 @@ applyTo: "{docs,examples,pkg/docs,pkg/examples}/**"
   invoke MCP tools, so keep committed reference material complete. Use the MCP
   tools (`get_solution_schema` / `explain_kind`, `list_cel_functions` /
   `list_go_template_functions`, `list_providers` / `get_provider_schema`,
-  `list_lint_rules`, `explain_concepts`, `list_context_variables`) to **verify or
+  `list_lint_rules` / `explain_lint_rule`, `explain_concepts`,
+  `list_context_variables`) to **verify or
   generate** that reference rather than as the sole reader-facing source.

--- a/.github/instructions/docs-examples.instructions.md
+++ b/.github/instructions/docs-examples.instructions.md
@@ -10,3 +10,8 @@ applyTo: "{docs,examples,pkg/docs,pkg/examples}/**"
 - Always create documentation, tutorials, and examples for new features, providers, and commands
 - Always update documentation, tutorials, and examples when features, providers, or commands change
 - Always update MCP server tools (if applicable) when features, providers, or commands change
+- For spec fields, functions, providers, and lint rules, **link readers to the
+  live MCP tools** (`get_solution_schema` / `explain_kind`, `list_cel_functions`
+  / `list_go_template_functions`, `list_providers` / `get_provider_schema`,
+  `list_lint_rules`, `explain_concepts`, `list_context_variables`) rather than
+  re-documenting schema or catalogs inline, which drifts out of sync.

--- a/.github/instructions/docs-examples.instructions.md
+++ b/.github/instructions/docs-examples.instructions.md
@@ -10,8 +10,9 @@ applyTo: "{docs,examples,pkg/docs,pkg/examples}/**"
 - Always create documentation, tutorials, and examples for new features, providers, and commands
 - Always update documentation, tutorials, and examples when features, providers, or commands change
 - Always update MCP server tools (if applicable) when features, providers, or commands change
-- For spec fields, functions, providers, and lint rules, **link readers to the
-  live MCP tools** (`get_solution_schema` / `explain_kind`, `list_cel_functions`
-  / `list_go_template_functions`, `list_providers` / `get_provider_schema`,
-  `list_lint_rules`, `explain_concepts`, `list_context_variables`) rather than
-  re-documenting schema or catalogs inline, which drifts out of sync.
+- Reader-facing docs must stand alone -- website and checkout readers cannot
+  invoke MCP tools, so keep committed reference material complete. Use the MCP
+  tools (`get_solution_schema` / `explain_kind`, `list_cel_functions` /
+  `list_go_template_functions`, `list_providers` / `get_provider_schema`,
+  `list_lint_rules`, `explain_concepts`, `list_context_variables`) to **verify or
+  generate** that reference rather than as the sole reader-facing source.

--- a/.github/instructions/mcp-tools.instructions.md
+++ b/.github/instructions/mcp-tools.instructions.md
@@ -16,3 +16,13 @@ MCP tool handlers are **thin wrappers** -- they parse tool inputs, call domain p
 - Return `mcp.NewToolResultText()` or `mcp.NewToolResultError()` -- never panic
 - Always add Huma-style parameter descriptions and constraints
 - Tool descriptions and server name must use the configured binary name (`s.name`), not hardcoded "scafctl"
+
+## Before Adding a Tool
+
+Confirm the capability is not already covered. The server already exposes broad
+reference tools -- `explain_concepts`, `explain_kind`, `get_solution_schema`,
+`list_providers` / `get_provider_schema`, `list_cel_functions` /
+`list_go_template_functions`, `list_lint_rules` / `explain_lint_rule`, and
+`list_context_variables`. If a new tool would surface spec / CEL / template /
+provider knowledge, prefer extending or pointing at those existing tools over a
+bespoke handler.

--- a/.github/instructions/providers.instructions.md
+++ b/.github/instructions/providers.instructions.md
@@ -23,6 +23,10 @@ Implement both methods:
 - Place mocks in `mock.go`
 - Always include benchmark tests (`*_benchmark_test.go`)
 - Register in `pkg/provider/builtin/builtin.go`
+
+Verify provider names and input/output schemas against the live catalog with the
+MCP tools `list_providers` / `list_official_providers` / `get_provider_schema`
+rather than a hand-maintained list.
 - Add struct tags with Huma validation on all Descriptor fields
 
 ## Package naming

--- a/.github/instructions/providers.instructions.md
+++ b/.github/instructions/providers.instructions.md
@@ -23,11 +23,8 @@ Implement both methods:
 - Place mocks in `mock.go`
 - Always include benchmark tests (`*_benchmark_test.go`)
 - Register in `pkg/provider/builtin/builtin.go`
-
-Verify provider names and input/output schemas against the live catalog with the
-MCP tools `list_providers` / `list_official_providers` / `get_provider_schema`
-rather than a hand-maintained list.
 - Add struct tags with Huma validation on all Descriptor fields
+- Verify provider names and input/output schemas against the live catalog with the MCP tools `list_providers` / `list_official_providers` / `get_provider_schema` (rebuild the server first if you just changed a provider) rather than a hand-maintained list
 
 ## Package naming
 


### PR DESCRIPTION
## Summary

Following #670 (a `context` concept category + the `list_context_variables` MCP tool) and #676 (thinned the four skills to point at MCP tools instead of duplicating them), this sweeps the rest of this repo's AI-guidance files so they reference the **live MCP reference tools** rather than relying on -- or directing authors to hand-maintain -- inline catalogs that drift out of sync.

Docs-only; no code touched. References #667.

## Changes

- **`cel-extensions.instructions.md`** (the one real fix): the "Documentation" section told contributors to hand-maintain a per-function catalog in the `cel-patterns` skill -- which #676 removed. Reworded to register the function in `ext.go` (so `list_cel_functions` picks it up) and only touch the skill for narrative; also added a "check `list_cel_functions` first" pointer before adding a function.
- **`copilot-instructions.md`** (highest-value cross-link): added an **"MCP Tools Are the Source of Truth"** section enumerating the reference tools -- `get_solution_schema`/`explain_kind`, `list_cel_functions`/`list_go_template_functions`, `list_providers`/`get_provider_schema`, `list_lint_rules`/`explain_lint_rule`, `explain_concepts` (incl. the `context` category), and `list_context_variables` -- so agents consult them instead of trusting inline catalogs.
- **`providers.instructions.md`**, **`mcp-tools.instructions.md`**, **`docs-examples.instructions.md`**: short cross-links to the relevant reference tools rather than hand-maintained lists.

## Audit note

An audit of all 12 `.github/instructions/*.instructions.md` files, `copilot-instructions.md`, and `AGENTS.md` found the rest **clean** -- no stale `resolve: - provider:` syntax, no `.__fileExt`/dotted file-var names, no wrong provider inputs, and no drift-prone mirror tables (the Go-authoring convention tables are legitimate rules, not duplicated reference). So the actionable surface was small; this is the whole of it.

## Verification

- All 5 changed files are ASCII-only (markdown rule) with valid frontmatter.
- Every referenced MCP tool and concept confirmed to exist in `main`.
- `task lint:changed`: 0 issues.

## Out of scope (kept separate)

- The `resolve-foreach` lint-rule bug (code + tests) -- tracked in #675.
- Cross-repo skill distribution (a Ford GitHub repo + git-sync + generated Copilot instructions) -- a future follow-up on #667.