### PR TITLE
fix(lint)!: replace false-positive resolve-foreach rule with resolve-foreach-missing-in

### DIFF
--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -436,12 +436,14 @@ func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Re
 				lintNilInputs(step.Inputs, stepLocation, result)
 				lintExpressions(step.Inputs, stepLocation, result)
 
-				// Warn if forEach is used on a resolve step.
-				if step.ForEach != nil {
-					result.addFinding(SeverityWarning, "structure", stepLocation,
-						"forEach on resolve step is not supported; __self is not available during the resolve phase",
-						"Move forEach to a transform step or use a separate resolver to iterate",
-						"resolve-foreach")
+				// forEach on a resolve step is a valid fan-out, but it requires
+				// forEach.in: the resolve phase has no __self to default the
+				// iteration source to, so the executor hard-fails without it.
+				if step.ForEach != nil && step.ForEach.In == nil {
+					result.addFinding(SeverityError, "structure", stepLocation,
+						"forEach on a resolve step requires 'in'; the resolve phase has no __self to iterate over",
+						"Add a forEach.in source, e.g. 'in: {rslvr: urls}' or 'in: {expr: _.items}'",
+						"resolve-foreach-missing-in")
 				}
 			}
 

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -2202,34 +2202,96 @@ func TestLintResolveForEach(t *testing.T) {
 	reg := provider.NewRegistry()
 	_ = reg.Register(prov)
 
-	sol := &solution.Solution{
-		Spec: solution.Spec{
-			Resolvers: map[string]*resolver.Resolver{
-				"test-resolver": {
-					Type: "string",
-					Resolve: &resolver.ResolvePhase{
-						With: []resolver.ProviderSource{
-							{
-								Provider: "http",
-								Inputs:   map[string]*spec.ValueRef{"url": {Literal: "https://example.com"}},
-								ForEach: &resolver.ForEachClause{
-									In:   &spec.ValueRef{Literal: "items"},
-									Item: "item",
-								},
-							},
-						},
+	newResolveForEach := func(withIn bool) *resolver.ForEachClause {
+		fe := &resolver.ForEachClause{Item: "item"}
+		if withIn {
+			expr := celexp.Expression("_.items")
+			fe.In = &spec.ValueRef{Expr: &expr}
+		}
+		return fe
+	}
+	urlsResolver := "urls"
+
+	tests := []struct {
+		name         string
+		sol          *solution.Solution
+		wantFindings int
+	}{
+		{
+			name: "resolve forEach with in is valid (no finding)",
+			sol: &solution.Solution{Spec: solution.Spec{Resolvers: map[string]*resolver.Resolver{
+				"testResolver": {Type: "array", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{
+					Provider: "http",
+					Inputs:   map[string]*spec.ValueRef{"url": {Literal: "https://example.com"}},
+					ForEach:  newResolveForEach(true),
+				}}}},
+			}}},
+			wantFindings: 0,
+		},
+		{
+			name: "resolve forEach missing in is an error",
+			sol: &solution.Solution{Spec: solution.Spec{Resolvers: map[string]*resolver.Resolver{
+				"testResolver": {Type: "array", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{
+					Provider: "http",
+					Inputs:   map[string]*spec.ValueRef{"url": {Literal: "https://example.com"}},
+					ForEach:  newResolveForEach(false),
+				}}}},
+			}}},
+			wantFindings: 1,
+		},
+		{
+			name: "transform forEach without in is fine (defaults to __self)",
+			sol: &solution.Solution{Spec: solution.Spec{Resolvers: map[string]*resolver.Resolver{
+				"testResolver": {Type: "array", Transform: &resolver.TransformPhase{With: []resolver.ProviderTransform{{
+					Provider: "http",
+					Inputs:   map[string]*spec.ValueRef{"url": {Literal: "https://example.com"}},
+					ForEach:  &resolver.ForEachClause{Item: "item"},
+				}}}},
+			}}},
+			wantFindings: 0,
+		},
+		{
+			name: "resolve forEach with rslvr in is valid (no finding)",
+			sol: &solution.Solution{Spec: solution.Spec{Resolvers: map[string]*resolver.Resolver{
+				"testResolver": {Type: "array", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{{
+					Provider: "http",
+					Inputs:   map[string]*spec.ValueRef{"url": {Literal: "https://example.com"}},
+					ForEach:  &resolver.ForEachClause{Item: "item", In: &spec.ValueRef{Resolver: &urlsResolver}},
+				}}}},
+			}}},
+			wantFindings: 0,
+		},
+		{
+			name: "only the resolve step missing in is flagged (mixed steps)",
+			sol: &solution.Solution{Spec: solution.Spec{Resolvers: map[string]*resolver.Resolver{
+				"testResolver": {Type: "array", Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+					{
+						Provider: "http",
+						Inputs:   map[string]*spec.ValueRef{"url": {Literal: "https://example.com"}},
+						ForEach:  newResolveForEach(true), // has in -> ok
 					},
-				},
-			},
+					{
+						Provider: "http",
+						Inputs:   map[string]*spec.ValueRef{"url": {Literal: "https://example.com"}},
+						ForEach:  newResolveForEach(false), // missing in -> flagged
+					},
+				}}},
+			}}},
+			wantFindings: 1,
 		},
 	}
 
-	result := Solution(sol, "test.yaml", reg)
-
-	findings := filterFindingsByRule(result, "resolve-foreach")
-	require.Len(t, findings, 1)
-	assert.Contains(t, findings[0].Message, "forEach on resolve step")
-	assert.Equal(t, SeverityWarning, findings[0].Severity)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Solution(tt.sol, "test.yaml", reg)
+			findings := filterFindingsByRule(result, "resolve-foreach-missing-in")
+			require.Len(t, findings, tt.wantFindings)
+			if tt.wantFindings > 0 {
+				assert.Contains(t, findings[0].Message, "requires 'in'")
+				assert.Equal(t, SeverityError, findings[0].Severity)
+			}
+		})
+	}
 }
 
 func TestLintRedundantDependsOn(t *testing.T) {

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -402,15 +402,15 @@ var KnownRules = map[string]RuleMeta{
 			"validate:\n  with:\n    - provider: validation\n      inputs:\n        expression: size(__self) > 0",
 		},
 	},
-	"resolve-foreach": {
-		Rule:        "resolve-foreach",
-		Severity:    string(SeverityWarning),
+	"resolve-foreach-missing-in": {
+		Rule:        "resolve-foreach-missing-in",
+		Severity:    string(SeverityError),
 		Category:    "structure",
-		Description: "A resolve.with step uses forEach, which is not supported in the resolve phase.",
-		Why:         "During the resolve phase, __self is not yet available because the resolver is still obtaining its initial value. forEach requires an iterable input, and the resolve phase cannot provide one from the current resolver. Use forEach in the transform phase instead.",
-		Fix:         "Move the forEach clause to a transform step, or use a separate resolver to iterate over an array.",
+		Description: "A resolve.with step uses forEach without the required 'in' source.",
+		Why:         "forEach on a resolve step is a valid fan-out (it runs the provider once per element and collects an ordered array). But unlike a transform step -- which defaults forEach.in to __self -- the resolve phase has no __self to default to, so 'in' is mandatory. Without it the executor fails at runtime with 'forEach.in is required on resolve steps'.",
+		Fix:         "Add a forEach.in source that yields the array to iterate, e.g. 'in: {rslvr: urls}', 'in: {expr: _.items}', or a literal list.",
 		Examples: []string{
-			"# Wrong (forEach in resolve):\nresolve:\n  with:\n    - provider: http\n      forEach:\n        in:\n          expr: items\n\n# Correct (forEach in transform):\ntransform:\n  with:\n    - provider: cel\n      forEach:\n        in:\n          expr: __self\n        item: item",
+			"# Wrong (resolve forEach with no 'in'):\nresolve:\n  with:\n    - provider: http\n      forEach:\n        item: url\n\n# Correct (resolve forEach fans out over 'in'):\nresolve:\n  with:\n    - provider: http\n      forEach:\n        item: url\n        in:\n          expr: _.urls",
 		},
 	},
 	"empty-validate-with": {

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -497,7 +497,7 @@ tasks:
         PASSED=0
         SKIPPED=0
 
-        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml|lint-tmpl-underscore/|lint-stress-test/|lint-resolver-cycle/|lint-missing-template-dependency/|lint-template-nonstandard-ext/|lint-undefined-dependency/|compose-demo/workflow|compose-demo/resolvers|state/github-state"
+        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml|lint-tmpl-underscore/|lint-stress-test/|lint-resolver-cycle/|lint-missing-template-dependency/|lint-template-nonstandard-ext/|lint-undefined-dependency/|lint-resolve-foreach-missing-in/|compose-demo/workflow|compose-demo/resolvers|state/github-state"
 
         {
           find examples/solutions -name '*.yaml'

--- a/tests/integration/solutions/lint-resolve-foreach-missing-in/solution.yaml
+++ b/tests/integration/solutions/lint-resolve-foreach-missing-in/solution.yaml
@@ -1,0 +1,81 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: lint-resolve-foreach-missing-in
+  version: 1.0.0
+  description: |
+    Tests the resolve-foreach-missing-in lint rule. A forEach on a resolve step
+    is a valid fan-out, but it requires forEach.in because the resolve phase has
+    no __self to default the iteration source to (the executor hard-fails
+    without it). The rule fires as an error only when in is missing; a resolve
+    forEach that supplies in, and any transform forEach, must not be flagged.
+
+spec:
+  resolvers:
+    urls:
+      description: Source list to fan out over
+      type: array
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: ["https://a.example", "https://b.example"]
+
+    # Valid: resolve forEach WITH in -> no finding
+    fannedOk:
+      description: Fan out over urls with an explicit in source
+      type: array
+      resolve:
+        with:
+          - provider: cel
+            forEach:
+              item: u
+              in:
+                expr: "_.urls"
+            inputs:
+              expression: "u + '-ok'"
+
+    # Invalid: resolve forEach MISSING in -> resolve-foreach-missing-in error
+    fannedBad:
+      description: Fan out on resolve with no in source (invalid)
+      type: array
+      resolve:
+        with:
+          - provider: cel
+            forEach:
+              item: u
+            inputs:
+              expression: "u + '-bad'"
+
+  testing:
+    config:
+      # lint: solution intentionally has a resolve forEach missing in
+      # resolve-defaults: fannedBad cannot resolve (executor requires in)
+      skipBuiltins: [lint, resolve-defaults]
+
+    cases:
+      missing-in-flagged:
+        description: Resolve forEach without in is reported as an error finding
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [lint, resolve-foreach-missing-in]
+        assertions:
+          - expression: __exitCode == 2
+            message: "resolve-foreach-missing-in is an error finding, so lint exits 2"
+          - expression: >
+              __output.findings.exists(f, f.ruleName == "resolve-foreach-missing-in" && f.severity == "error")
+            message: "Missing in on a resolve forEach must be an error finding"
+          - expression: >
+              __output.findings.exists(f, f.ruleName == "resolve-foreach-missing-in" && f.location.contains("fannedBad"))
+            message: "The finding should point at the fannedBad resolver step"
+
+      valid-foreach-not-flagged:
+        description: A resolve forEach that supplies in is not flagged
+        command: [lint]
+        args: ["-o", "json"]
+        tags: [lint, resolve-foreach-missing-in]
+        assertions:
+          - expression: >
+              !__output.findings.exists(f, f.ruleName == "resolve-foreach-missing-in" && f.location.contains("fannedOk"))
+            message: "A resolve forEach with in must not be flagged"


### PR DESCRIPTION
## Summary

The `resolve-foreach` lint rule emitted a **WARNING** claiming forEach on a resolve step is unsupported. That is a false positive: the resolver executor fully supports resolve-phase forEach (it fans out over `forEach.in` and collects an ordered array -- `pkg/resolver/executor.go`), the `foreach` concept documents it as valid, and real solutions rely on it (e.g. HTTP fan-out). The rule contradicted both the runtime and the docs.

This replaces it with a rule that catches the **genuine** failure mode instead: a resolve-phase forEach **requires** `forEach.in`, because the resolve phase has no `__self` to default the iteration source to. The executor hard-fails without it (`forEach.in is required on resolve steps`). The new rule shifts that runtime failure left to lint time.

Closes #675.

## Changes

- **`pkg/lint/lint.go`**: fire only when a resolve step's forEach is missing `in` (`step.ForEach != nil && step.ForEach.In == nil`).
- **`pkg/lint/rules.go`**: rename `resolve-foreach` -> `resolve-foreach-missing-in`, severity **Warning -> Error**, and rewrite Description/Why/Fix/Examples to the correct semantics (this drives `list_lint_rules` / `explain_lint_rule` automatically).
- **`pkg/lint/lint_test.go`**: rewritten table-driven -- with-in (no finding), missing-in (1 Error), transform (no finding, defaults to `__self`), rslvr-form in (no finding), mixed steps (flags only the step missing `in`).
- **`tests/integration/solutions/lint-resolve-foreach-missing-in/solution.yaml`**: new solution integration fixture matching the established `lint-<rule>` pattern; asserts the missing-in error and that a valid resolve forEach is not flagged.
- **`taskfile.yaml`**: add the new fixture to the `lint:solutions` EXCLUDE list, matching the existing intentionally-invalid lint fixtures (its behavior is validated by its functional test cases, but the pass-all solution sweep must skip it).

## Verification

- Unit: 5/5 cases pass; lint pkg coverage 92.8%.
- Integration fixture: 3/3 functional cases pass.
- **Regression check**: scanned all `examples/` and `tests/integration/solutions/` -- none has a resolve forEach missing `in`, so no existing solution newly errors; valid resolve-forEach solutions no longer get the false warning.
- E2E: valid resolve-forEach-with-in lints clean; missing-in errors (exit 2); old rule id removed (`unknown rule "resolve-foreach"`).
- `task lint:changed`: 0 issues.

## BREAKING CHANGE

The lint rule id `resolve-foreach` is renamed to `resolve-foreach-missing-in`, its severity changes from **warning** to **error**, and it now fires **only** when `in` is missing (not on every resolve forEach). Anyone suppressing `resolve-foreach` (e.g. `scafctl-lint-disable: resolve-foreach`) or gating CI on its severity must update. Breaking changes are permitted in this repo; noting it here as required.
