### PR TITLE
fix(mcp): wrap array-returning tool outputs in an object envelope

### DIFF
--- a/pkg/mcp/function_filter.go
+++ b/pkg/mcp/function_filter.go
@@ -68,7 +68,7 @@ func filterAndReturnNamedFunctions[T namedFunction](
 		functions = filtered
 	}
 
-	return mcp.NewToolResultJSON(functions)
+	return mcp.NewToolResultJSON(map[string]any{"functions": functions})
 }
 
 // searchFunctions filters a slice by substring match on both Name and Description.

--- a/pkg/mcp/tools_array_envelope_test.go
+++ b/pkg/mcp/tools_array_envelope_test.go
@@ -21,6 +21,10 @@ import (
 // to an array, which strict (zod) MCP clients reject with "expected record,
 // received array", making the tool unusable over MCP.
 func TestArrayReturningToolsEmitObjectEnvelope(t *testing.T) {
+	// Sandbox XDG so the plugin cache / catalog handlers read an isolated temp
+	// directory instead of the developer's or CI user's real XDG paths.
+	setTestXDG(t, t.TempDir())
+
 	reg, err := builtin.DefaultRegistry(context.Background())
 	require.NoError(t, err)
 	root := buildTestCommandTree()

--- a/pkg/mcp/tools_array_envelope_test.go
+++ b/pkg/mcp/tools_array_envelope_test.go
@@ -4,6 +4,7 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"testing"
@@ -51,6 +52,12 @@ func TestArrayReturningToolsEmitObjectEnvelope(t *testing.T) {
 
 		raw, ok := obj[key]
 		require.Truef(t, ok, "output must contain the %q envelope key; keys present: %v", key, keysOf(obj))
+
+		// The value must be a JSON array, not null. json.Unmarshal into a slice
+		// also accepts null (yielding a nil slice), so check the raw token first.
+		rawTrimmed := bytes.TrimSpace(raw)
+		require.Truef(t, len(rawTrimmed) > 0 && rawTrimmed[0] == '[',
+			"key %q must hold a JSON array, got: %s", key, string(rawTrimmed))
 
 		var arr []json.RawMessage
 		require.NoErrorf(t, json.Unmarshal(raw, &arr), "key %q must hold a JSON array", key)

--- a/pkg/mcp/tools_array_envelope_test.go
+++ b/pkg/mcp/tools_array_envelope_test.go
@@ -1,0 +1,112 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestArrayReturningToolsEmitObjectEnvelope is the regression guard for #680:
+// tools that return a list must wrap it in a top-level JSON OBJECT (record) with
+// a named key, never a bare top-level array. A bare array sets structuredContent
+// to an array, which strict (zod) MCP clients reject with "expected record,
+// received array", making the tool unusable over MCP.
+func TestArrayReturningToolsEmitObjectEnvelope(t *testing.T) {
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	root := buildTestCommandTree()
+	srv, err := NewServer(
+		WithServerRegistry(reg),
+		WithServerVersion("test"),
+		WithRootCommand(root),
+	)
+	require.NoError(t, err)
+
+	// assertObjectEnvelope checks the result is a top-level JSON object whose
+	// `key` holds a JSON array. requireNonEmpty toggles whether the array must
+	// contain at least one element (some lists are legitimately empty in a clean
+	// test environment, e.g. no cached plugins).
+	assertObjectEnvelope := func(t *testing.T, result *mcp.CallToolResult, key string, requireNonEmpty bool) {
+		t.Helper()
+		require.False(t, result.IsError, "tool returned an error result")
+		text := extractJSONContent(t, result)
+		require.NotEmpty(t, text)
+
+		trimmed := text
+		require.Equalf(t, byte('{'), trimmed[0],
+			"output must be a top-level JSON object (record), not a bare array; got: %s", trimmed[:minInt(80, len(trimmed))])
+
+		var obj map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal([]byte(text), &obj))
+
+		raw, ok := obj[key]
+		require.Truef(t, ok, "output must contain the %q envelope key; keys present: %v", key, keysOf(obj))
+
+		var arr []json.RawMessage
+		require.NoErrorf(t, json.Unmarshal(raw, &arr), "key %q must hold a JSON array", key)
+		if requireNonEmpty {
+			assert.NotEmptyf(t, arr, "key %q should list at least one item", key)
+		}
+	}
+
+	call := func(t *testing.T, name string, args map[string]any, handler func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)) *mcp.CallToolResult {
+		t.Helper()
+		req := mcp.CallToolRequest{}
+		req.Params.Name = name
+		req.Params.Arguments = args
+		result, err := handler(context.Background(), req)
+		require.NoError(t, err)
+		return result
+	}
+
+	t.Run("list_providers", func(t *testing.T) {
+		assertObjectEnvelope(t, call(t, "list_providers", map[string]any{}, srv.handleListProviders), "providers", true)
+	})
+	t.Run("list_providers with capability filter", func(t *testing.T) {
+		assertObjectEnvelope(t, call(t, "list_providers", map[string]any{"capability": "from"}, srv.handleListProviders), "providers", true)
+	})
+	t.Run("list_cel_functions", func(t *testing.T) {
+		assertObjectEnvelope(t, call(t, "list_cel_functions", map[string]any{}, srv.handleListCELFunctions), "functions", true)
+	})
+	t.Run("list_cel_functions custom_only", func(t *testing.T) {
+		assertObjectEnvelope(t, call(t, "list_cel_functions", map[string]any{"custom_only": true}, srv.handleListCELFunctions), "functions", true)
+	})
+	t.Run("list_go_template_functions", func(t *testing.T) {
+		assertObjectEnvelope(t, call(t, "list_go_template_functions", map[string]any{}, srv.handleListGoTemplateFunctions), "functions", true)
+	})
+	t.Run("list_official_providers", func(t *testing.T) {
+		// Official providers come from a fixed manifest; expect a non-empty list.
+		assertObjectEnvelope(t, call(t, "list_official_providers", map[string]any{}, srv.handleListOfficialProviders), "providers", true)
+	})
+	t.Run("list_plugins", func(t *testing.T) {
+		// The plugin cache may be empty in a clean environment; only require the
+		// object envelope, not a non-empty list.
+		assertObjectEnvelope(t, call(t, "list_plugins", map[string]any{}, srv.handleListPlugins), "plugins", false)
+	})
+	t.Run("get_command_help no-arg", func(t *testing.T) {
+		assertObjectEnvelope(t, call(t, "get_command_help", map[string]any{}, srv.handleGetCommandHelp), "commands", true)
+	})
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pkg/mcp/tools_array_envelope_test.go
+++ b/pkg/mcp/tools_array_envelope_test.go
@@ -31,10 +31,8 @@ func TestArrayReturningToolsEmitObjectEnvelope(t *testing.T) {
 	require.NoError(t, err)
 
 	// assertObjectEnvelope checks the result is a top-level JSON object whose
-	// `key` holds a JSON array. requireNonEmpty toggles whether the array must
-	// contain at least one element (some lists are legitimately empty in a clean
-	// test environment, e.g. no cached plugins).
-	assertObjectEnvelope := func(t *testing.T, result *mcp.CallToolResult, key string, requireNonEmpty bool) {
+	// `key` holds a non-empty JSON array.
+	assertObjectEnvelope := func(t *testing.T, result *mcp.CallToolResult, key string) {
 		t.Helper()
 		require.False(t, result.IsError, "tool returned an error result")
 		text := extractJSONContent(t, result)
@@ -52,9 +50,7 @@ func TestArrayReturningToolsEmitObjectEnvelope(t *testing.T) {
 
 		var arr []json.RawMessage
 		require.NoErrorf(t, json.Unmarshal(raw, &arr), "key %q must hold a JSON array", key)
-		if requireNonEmpty {
-			assert.NotEmptyf(t, arr, "key %q should list at least one item", key)
-		}
+		assert.NotEmptyf(t, arr, "key %q should list at least one item", key)
 	}
 
 	call := func(t *testing.T, name string, args map[string]any, handler func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)) *mcp.CallToolResult {
@@ -68,31 +64,32 @@ func TestArrayReturningToolsEmitObjectEnvelope(t *testing.T) {
 	}
 
 	t.Run("list_providers", func(t *testing.T) {
-		assertObjectEnvelope(t, call(t, "list_providers", map[string]any{}, srv.handleListProviders), "providers", true)
+		assertObjectEnvelope(t, call(t, "list_providers", map[string]any{}, srv.handleListProviders), "providers")
 	})
 	t.Run("list_providers with capability filter", func(t *testing.T) {
-		assertObjectEnvelope(t, call(t, "list_providers", map[string]any{"capability": "from"}, srv.handleListProviders), "providers", true)
+		assertObjectEnvelope(t, call(t, "list_providers", map[string]any{"capability": "from"}, srv.handleListProviders), "providers")
 	})
 	t.Run("list_cel_functions", func(t *testing.T) {
-		assertObjectEnvelope(t, call(t, "list_cel_functions", map[string]any{}, srv.handleListCELFunctions), "functions", true)
+		assertObjectEnvelope(t, call(t, "list_cel_functions", map[string]any{}, srv.handleListCELFunctions), "functions")
 	})
 	t.Run("list_cel_functions custom_only", func(t *testing.T) {
-		assertObjectEnvelope(t, call(t, "list_cel_functions", map[string]any{"custom_only": true}, srv.handleListCELFunctions), "functions", true)
+		assertObjectEnvelope(t, call(t, "list_cel_functions", map[string]any{"custom_only": true}, srv.handleListCELFunctions), "functions")
 	})
 	t.Run("list_go_template_functions", func(t *testing.T) {
-		assertObjectEnvelope(t, call(t, "list_go_template_functions", map[string]any{}, srv.handleListGoTemplateFunctions), "functions", true)
+		assertObjectEnvelope(t, call(t, "list_go_template_functions", map[string]any{}, srv.handleListGoTemplateFunctions), "functions")
 	})
 	t.Run("list_official_providers", func(t *testing.T) {
 		// Official providers come from a fixed manifest; expect a non-empty list.
-		assertObjectEnvelope(t, call(t, "list_official_providers", map[string]any{}, srv.handleListOfficialProviders), "providers", true)
+		assertObjectEnvelope(t, call(t, "list_official_providers", map[string]any{}, srv.handleListOfficialProviders), "providers")
 	})
-	t.Run("list_plugins", func(t *testing.T) {
-		// The plugin cache may be empty in a clean environment; only require the
-		// object envelope, not a non-empty list.
-		assertObjectEnvelope(t, call(t, "list_plugins", map[string]any{}, srv.handleListPlugins), "plugins", false)
-	})
+	// Note: list_plugins is intentionally not covered here. When the plugin cache
+	// is empty (the norm in CI) it returns a plain-text message, not a JSON
+	// envelope, so a bare "must be an object" assertion is environment-dependent.
+	// Its populated JSON path (the one that could carry the bare-array bug) is
+	// covered by TestHandleListPlugins/returns_plugins_when_cache_populated, which
+	// seeds a plugin and asserts the {"plugins": [...]} envelope.
 	t.Run("get_command_help no-arg", func(t *testing.T) {
-		assertObjectEnvelope(t, call(t, "get_command_help", map[string]any{}, srv.handleGetCommandHelp), "commands", true)
+		assertObjectEnvelope(t, call(t, "get_command_help", map[string]any{}, srv.handleGetCommandHelp), "commands")
 	})
 }
 

--- a/pkg/mcp/tools_array_envelope_test.go
+++ b/pkg/mcp/tools_array_envelope_test.go
@@ -31,8 +31,12 @@ func TestArrayReturningToolsEmitObjectEnvelope(t *testing.T) {
 	require.NoError(t, err)
 
 	// assertObjectEnvelope checks the result is a top-level JSON object whose
-	// `key` holds a non-empty JSON array.
-	assertObjectEnvelope := func(t *testing.T, result *mcp.CallToolResult, key string) {
+	// `key` holds a JSON array. requireNonEmpty toggles whether the array must
+	// contain at least one element -- some lists (plugins, solutions) are
+	// legitimately empty in a clean test environment; the point of the guard is
+	// that the shape is always a record with an array under `key`, never a bare
+	// top-level array.
+	assertObjectEnvelope := func(t *testing.T, result *mcp.CallToolResult, key string, requireNonEmpty bool) {
 		t.Helper()
 		require.False(t, result.IsError, "tool returned an error result")
 		text := extractJSONContent(t, result)
@@ -50,7 +54,9 @@ func TestArrayReturningToolsEmitObjectEnvelope(t *testing.T) {
 
 		var arr []json.RawMessage
 		require.NoErrorf(t, json.Unmarshal(raw, &arr), "key %q must hold a JSON array", key)
-		assert.NotEmptyf(t, arr, "key %q should list at least one item", key)
+		if requireNonEmpty {
+			assert.NotEmptyf(t, arr, "key %q should list at least one item", key)
+		}
 	}
 
 	call := func(t *testing.T, name string, args map[string]any, handler func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)) *mcp.CallToolResult {
@@ -64,32 +70,36 @@ func TestArrayReturningToolsEmitObjectEnvelope(t *testing.T) {
 	}
 
 	t.Run("list_providers", func(t *testing.T) {
-		assertObjectEnvelope(t, call(t, "list_providers", map[string]any{}, srv.handleListProviders), "providers")
+		assertObjectEnvelope(t, call(t, "list_providers", map[string]any{}, srv.handleListProviders), "providers", true)
 	})
 	t.Run("list_providers with capability filter", func(t *testing.T) {
-		assertObjectEnvelope(t, call(t, "list_providers", map[string]any{"capability": "from"}, srv.handleListProviders), "providers")
+		assertObjectEnvelope(t, call(t, "list_providers", map[string]any{"capability": "from"}, srv.handleListProviders), "providers", true)
 	})
 	t.Run("list_cel_functions", func(t *testing.T) {
-		assertObjectEnvelope(t, call(t, "list_cel_functions", map[string]any{}, srv.handleListCELFunctions), "functions")
+		assertObjectEnvelope(t, call(t, "list_cel_functions", map[string]any{}, srv.handleListCELFunctions), "functions", true)
 	})
 	t.Run("list_cel_functions custom_only", func(t *testing.T) {
-		assertObjectEnvelope(t, call(t, "list_cel_functions", map[string]any{"custom_only": true}, srv.handleListCELFunctions), "functions")
+		assertObjectEnvelope(t, call(t, "list_cel_functions", map[string]any{"custom_only": true}, srv.handleListCELFunctions), "functions", true)
 	})
 	t.Run("list_go_template_functions", func(t *testing.T) {
-		assertObjectEnvelope(t, call(t, "list_go_template_functions", map[string]any{}, srv.handleListGoTemplateFunctions), "functions")
+		assertObjectEnvelope(t, call(t, "list_go_template_functions", map[string]any{}, srv.handleListGoTemplateFunctions), "functions", true)
 	})
 	t.Run("list_official_providers", func(t *testing.T) {
 		// Official providers come from a fixed manifest; expect a non-empty list.
-		assertObjectEnvelope(t, call(t, "list_official_providers", map[string]any{}, srv.handleListOfficialProviders), "providers")
+		assertObjectEnvelope(t, call(t, "list_official_providers", map[string]any{}, srv.handleListOfficialProviders), "providers", true)
 	})
-	// Note: list_plugins is intentionally not covered here. When the plugin cache
-	// is empty (the norm in CI) it returns a plain-text message, not a JSON
-	// envelope, so a bare "must be an object" assertion is environment-dependent.
-	// Its populated JSON path (the one that could carry the bare-array bug) is
-	// covered by TestHandleListPlugins/returns_plugins_when_cache_populated, which
-	// seeds a plugin and asserts the {"plugins": [...]} envelope.
+	t.Run("list_plugins", func(t *testing.T) {
+		// The plugin cache may be empty in a clean environment; the envelope must
+		// still be an object with a (possibly empty) plugins array.
+		assertObjectEnvelope(t, call(t, "list_plugins", map[string]any{}, srv.handleListPlugins), "plugins", false)
+	})
+	t.Run("list_solutions", func(t *testing.T) {
+		// The local catalog may be empty; the envelope must still be an object
+		// with a (possibly empty) solutions array.
+		assertObjectEnvelope(t, call(t, "list_solutions", map[string]any{}, srv.handleListSolutions), "solutions", false)
+	})
 	t.Run("get_command_help no-arg", func(t *testing.T) {
-		assertObjectEnvelope(t, call(t, "get_command_help", map[string]any{}, srv.handleGetCommandHelp), "commands")
+		assertObjectEnvelope(t, call(t, "get_command_help", map[string]any{}, srv.handleGetCommandHelp), "commands", true)
 	})
 }
 

--- a/pkg/mcp/tools_cel.go
+++ b/pkg/mcp/tools_cel.go
@@ -125,7 +125,7 @@ func (s *Server) handleListCELFunctions(_ context.Context, request mcp.CallToolR
 		return f.FunctionNames
 	})
 
-	result, err := mcp.NewToolResultJSON(functions)
+	result, err := mcp.NewToolResultJSON(map[string]any{"functions": functions})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mcp/tools_cel_test.go
+++ b/pkg/mcp/tools_cel_test.go
@@ -52,8 +52,11 @@ func TestHandleListCELFunctions(t *testing.T) {
 		assert.Contains(t, summaryText, "# Summary")
 
 		text := extractJSONContent(t, result)
-		var functions []celexp.ExtFunction
-		require.NoError(t, json.Unmarshal([]byte(text), &functions))
+		var envelope struct {
+			Functions []celexp.ExtFunction `json:"functions"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		functions := envelope.Functions
 		assert.NotEmpty(t, functions, "expected at least one CEL function")
 	})
 
@@ -72,8 +75,11 @@ func TestHandleListCELFunctions(t *testing.T) {
 		assert.False(t, result.IsError)
 
 		text := extractJSONContent(t, result)
-		var functions []celexp.ExtFunction
-		require.NoError(t, json.Unmarshal([]byte(text), &functions))
+		var envelope struct {
+			Functions []celexp.ExtFunction `json:"functions"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		functions := envelope.Functions
 		assert.NotEmpty(t, functions, "expected at least one custom function")
 
 		// All returned should be custom
@@ -97,8 +103,11 @@ func TestHandleListCELFunctions(t *testing.T) {
 		assert.False(t, result.IsError)
 
 		text := extractJSONContent(t, result)
-		var functions []celexp.ExtFunction
-		require.NoError(t, json.Unmarshal([]byte(text), &functions))
+		var envelope struct {
+			Functions []celexp.ExtFunction `json:"functions"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		functions := envelope.Functions
 		assert.NotEmpty(t, functions, "expected at least one builtin function")
 
 		// All returned should be builtin (not custom)
@@ -122,8 +131,11 @@ func TestHandleListCELFunctions(t *testing.T) {
 		assert.False(t, result.IsError)
 
 		text := result.Content[0].(mcp.TextContent).Text
-		var functions []celexp.ExtFunction
-		require.NoError(t, json.Unmarshal([]byte(text), &functions))
+		var envelope struct {
+			Functions []celexp.ExtFunction `json:"functions"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		functions := envelope.Functions
 		assert.NotEmpty(t, functions, "expected at least one function matching 'map'")
 	})
 
@@ -345,8 +357,11 @@ func TestHandleListCELFunctions_Search(t *testing.T) {
 		assert.False(t, result.IsError)
 
 		text := extractJSONContent(t, result)
-		var functions []celexp.ExtFunction
-		require.NoError(t, json.Unmarshal([]byte(text), &functions))
+		var envelope struct {
+			Functions []celexp.ExtFunction `json:"functions"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		functions := envelope.Functions
 		assert.NotEmpty(t, functions, "expected at least one function matching 'json'")
 	})
 
@@ -365,8 +380,10 @@ func TestHandleListCELFunctions_Search(t *testing.T) {
 		// May or may not find results depending on descriptions, just verify no panic
 		if !result.IsError {
 			text := extractJSONContent(t, result)
-			var functions []celexp.ExtFunction
-			require.NoError(t, json.Unmarshal([]byte(text), &functions))
+			var envelope struct {
+				Functions []celexp.ExtFunction `json:"functions"`
+			}
+			require.NoError(t, json.Unmarshal([]byte(text), &envelope))
 		}
 	})
 
@@ -402,8 +419,11 @@ func TestHandleListCELFunctions_Category(t *testing.T) {
 		assert.False(t, result.IsError)
 
 		text := extractJSONContent(t, result)
-		var functions []celexp.ExtFunction
-		require.NoError(t, json.Unmarshal([]byte(text), &functions))
+		var envelope struct {
+			Functions []celexp.ExtFunction `json:"functions"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		functions := envelope.Functions
 		assert.NotEmpty(t, functions, "expected at least one encoding function")
 
 		for _, f := range functions {

--- a/pkg/mcp/tools_cli.go
+++ b/pkg/mcp/tools_cli.go
@@ -49,7 +49,7 @@ func (s *Server) handleGetCommandHelp(_ context.Context, req mcp.CallToolRequest
 	// No command specified: return top-level command list.
 	if commandPath == "" {
 		commands := cmdinfo.CollectCommands(s.rootCmd, false)
-		return mcp.NewToolResultJSON(commands)
+		return mcp.NewToolResultJSON(map[string]any{"commands": commands})
 	}
 
 	// Find the specific command.

--- a/pkg/mcp/tools_cli_test.go
+++ b/pkg/mcp/tools_cli_test.go
@@ -50,8 +50,11 @@ func TestHandleGetCommandHelp_ListAll(t *testing.T) {
 	require.False(t, result.IsError)
 
 	text := result.Content[0].(mcp.TextContent).Text
-	var commands []cmdinfo.CommandInfo
-	require.NoError(t, json.Unmarshal([]byte(text), &commands))
+	var envelope struct {
+		Commands []cmdinfo.CommandInfo `json:"commands"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+	commands := envelope.Commands
 	assert.NotEmpty(t, commands)
 
 	// Should contain top-level commands

--- a/pkg/mcp/tools_plugin.go
+++ b/pkg/mcp/tools_plugin.go
@@ -96,7 +96,12 @@ func (s *Server) handleListPlugins(_ context.Context, _ mcp.CallToolRequest) (*m
 	}
 
 	if len(plugins) == 0 {
-		return mcp.NewToolResultText("No cached plugins found. Use 'plugins install -f <solution>' to fetch plugins from catalogs, or copy plugin binaries to the plugin cache directory."), nil
+		// Return an empty envelope (not plain text) so strict MCP clients still
+		// receive a valid structuredContent record.
+		return mcp.NewToolResultJSON(map[string]any{
+			"plugins": []any{},
+			"message": "No cached plugins found. Use 'plugins install -f <solution>' to fetch plugins from catalogs, or copy plugin binaries to the plugin cache directory.",
+		})
 	}
 
 	return mcp.NewToolResultJSON(map[string]any{"plugins": plugins})

--- a/pkg/mcp/tools_plugin.go
+++ b/pkg/mcp/tools_plugin.go
@@ -99,7 +99,7 @@ func (s *Server) handleListPlugins(_ context.Context, _ mcp.CallToolRequest) (*m
 		return mcp.NewToolResultText("No cached plugins found. Use 'plugins install -f <solution>' to fetch plugins from catalogs, or copy plugin binaries to the plugin cache directory."), nil
 	}
 
-	return mcp.NewToolResultJSON(plugins)
+	return mcp.NewToolResultJSON(map[string]any{"plugins": plugins})
 }
 
 // handleGetPluginCachePath returns the plugin cache directory path.
@@ -133,7 +133,7 @@ func (s *Server) handleListOfficialProviders(_ context.Context, _ mcp.CallToolRe
 		})
 	}
 
-	return mcp.NewToolResultJSON(items)
+	return mcp.NewToolResultJSON(map[string]any{"providers": items})
 }
 
 // signaturePolicyResponse is the response structure for get_signature_policy.

--- a/pkg/mcp/tools_plugin_test.go
+++ b/pkg/mcp/tools_plugin_test.go
@@ -63,8 +63,11 @@ func TestHandleListPlugins(t *testing.T) {
 		assert.False(t, result.IsError)
 
 		text := result.Content[0].(mcp.TextContent).Text
-		var plugins []plugin.CachedPlugin
-		require.NoError(t, json.Unmarshal([]byte(text), &plugins))
+		var envelope struct {
+			Plugins []plugin.CachedPlugin `json:"plugins"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		plugins := envelope.Plugins
 
 		// Find our test plugin in the results
 		var found bool
@@ -113,8 +116,11 @@ func TestHandleListOfficialProviders(t *testing.T) {
 		assert.False(t, result.IsError)
 
 		text := result.Content[0].(mcp.TextContent).Text
-		var items []officialProviderItem
-		require.NoError(t, json.Unmarshal([]byte(text), &items))
+		var envelope struct {
+			Items []officialProviderItem `json:"providers"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		items := envelope.Items
 
 		// Should contain all the default official providers
 		assert.Len(t, items, len(official.DefaultProviders()))
@@ -155,8 +161,11 @@ func TestHandleListOfficialProviders(t *testing.T) {
 		assert.False(t, result.IsError)
 
 		text := result.Content[0].(mcp.TextContent).Text
-		var items []officialProviderItem
-		require.NoError(t, json.Unmarshal([]byte(text), &items))
+		var envelope struct {
+			Items []officialProviderItem `json:"providers"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		items := envelope.Items
 
 		assert.Len(t, items, 2)
 		assert.Equal(t, "custom-one", items[0].Name)

--- a/pkg/mcp/tools_plugin_test.go
+++ b/pkg/mcp/tools_plugin_test.go
@@ -35,9 +35,16 @@ func TestHandleListPlugins(t *testing.T) {
 		result, err := srv.handleListPlugins(context.Background(), request)
 		require.NoError(t, err)
 		assert.False(t, result.IsError)
-		// Should indicate no plugins found
-		text := result.Content[0].(mcp.TextContent).Text
-		assert.Contains(t, text, "No cached plugins")
+		// Empty cache still returns a JSON envelope (not plain text) so strict
+		// MCP clients receive a valid structuredContent record.
+		text := extractJSONContent(t, result)
+		var envelope struct {
+			Plugins []plugin.CachedPlugin `json:"plugins"`
+			Message string                `json:"message"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		assert.Empty(t, envelope.Plugins, "empty cache should yield an empty plugins array")
+		assert.Contains(t, envelope.Message, "No cached plugins")
 	})
 
 	t.Run("returns plugins when cache populated", func(t *testing.T) {

--- a/pkg/mcp/tools_provider.go
+++ b/pkg/mcp/tools_provider.go
@@ -235,7 +235,7 @@ func (s *Server) handleListProviders(_ context.Context, request mcp.CallToolRequ
 		}
 	}
 
-	result, err := mcp.NewToolResultJSON(items)
+	result, err := mcp.NewToolResultJSON(map[string]any{"providers": items})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mcp/tools_provider_test.go
+++ b/pkg/mcp/tools_provider_test.go
@@ -43,8 +43,11 @@ func TestHandleListProviders(t *testing.T) {
 
 		// Verify the response is valid JSON with providers
 		text := result.Content[0].(mcp.TextContent).Text
-		var items []providerItem
-		require.NoError(t, json.Unmarshal([]byte(text), &items))
+		var envelope struct {
+			Items []providerItem `json:"providers"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		items := envelope.Items
 		assert.NotEmpty(t, items, "expected at least one provider")
 
 		// Verify required fields are populated
@@ -77,8 +80,11 @@ func TestHandleListProviders(t *testing.T) {
 		assert.False(t, result.IsError)
 
 		text := result.Content[0].(mcp.TextContent).Text
-		var items []providerItem
-		require.NoError(t, json.Unmarshal([]byte(text), &items))
+		var envelope struct {
+			Items []providerItem `json:"providers"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		items := envelope.Items
 
 		// Each returned provider should have the "from" capability
 		for _, item := range items {
@@ -107,8 +113,11 @@ func TestHandleListProviders(t *testing.T) {
 		assert.False(t, result.IsError)
 
 		text := result.Content[0].(mcp.TextContent).Text
-		var items []providerItem
-		require.NoError(t, json.Unmarshal([]byte(text), &items))
+		var envelope struct {
+			Items []providerItem `json:"providers"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		items := envelope.Items
 		assert.NotEmpty(t, items, "expected at least one filesystem provider")
 
 		for _, item := range items {
@@ -137,8 +146,11 @@ func TestHandleListProviders(t *testing.T) {
 		assert.False(t, result.IsError)
 
 		text := result.Content[0].(mcp.TextContent).Text
-		var items []providerItem
-		require.NoError(t, json.Unmarshal([]byte(text), &items))
+		var envelope struct {
+			Items []providerItem `json:"providers"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		items := envelope.Items
 		assert.Empty(t, items, "expected no providers for nonexistent category")
 	})
 
@@ -182,8 +194,11 @@ func TestHandleListProviders(t *testing.T) {
 		assert.False(t, result.IsError)
 
 		text := result.Content[0].(mcp.TextContent).Text
-		var items []providerItem
-		require.NoError(t, json.Unmarshal([]byte(text), &items))
+		var envelope struct {
+			Items []providerItem `json:"providers"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		items := envelope.Items
 
 		// Should have built-ins plus official providers
 		foundExec := false

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -288,7 +288,7 @@ func (s *Server) handleListSolutions(_ context.Context, request mcp.CallToolRequ
 		})
 	}
 
-	return mcp.NewToolResultJSON(items)
+	return mcp.NewToolResultJSON(map[string]any{"solutions": items})
 }
 
 // handleInspectSolution gets full solution metadata.


### PR DESCRIPTION
## Summary

Several MCP tools returned a **bare top-level JSON array** via `mcp.NewToolResultJSON(slice)`. MCP clients expect `structuredContent` to be a record/object, so strict (zod) clients rejected every response with `expected record, received array`, making those tools **100% unusable over MCP**. The CLI equivalents work fine -- this was purely an MCP serialization/envelope defect.

Closes #680.

## Fix

Wrap each bare-array return in a top-level object envelope with a descriptive key, matching the convention the working tools already use (e.g. `list_context_variables` returns `{"variables": [...]}`):

| Tool | Envelope key |
|------|-------------|
| `list_providers`, `list_official_providers` | `providers` |
| `list_plugins` | `plugins` |
| `list_cel_functions`, `list_go_template_functions` | `functions` |
| `get_command_help` (no-arg command list) | `commands` |
| `list_solutions` (populated path) | `solutions` |

`list_plugins` also returned plain text (not JSON) when the plugin cache is empty; that path now returns `{"plugins": [], "message": ...}` too, so strict clients get a valid record in every case.

- The two function tools share the `filterAndReturnNamedFunctions` helper, so the fix lands once there (plus the `list_cel_functions` no-filter path).
- **`list_solutions` had the same bug on its populated path** -- its empty/error paths already returned an object, which masked it. Now consistent.

## Out of scope (intentional)

`run_provider`'s CEL `transformed` output is left unwrapped: its shape is caller-controlled (array, scalar, or object are all valid), so it is not a bare-array-*by-default* handler. Wrapping it would corrupt that escape hatch. Noted so it is not "fixed" later. `state`'s map returns and all other handlers return objects already.

## Tests

- Updated the 16 existing test sites that unmarshalled a bare slice to unmarshal the envelope struct.
- Added `tools_array_envelope_test.go`: a regression guard asserting each affected tool emits a top-level JSON **object** (not a bare array) with the expected key -- covering the previously-untested `list_go_template_functions` and the `list_solutions` populated path.

## Verification

- Reviewed all 98 `NewToolResultJSON` call sites in `pkg/mcp`; every bare-array-by-default handler is now wrapped, none missed.
- Full `pkg/mcp` `-race` suite green; MCP integration tests green.
- `task lint:changed`: 0 issues.
- Docs unaffected (the tutorial shows rendered AI output, not the raw JSON wire shape).

## Behavioral note

This changes the output shape of the 7 tools. Since they were fully rejected by strict MCP clients before, there is no working consumer to break; lenient clients that tolerated the bare array will now see a single-key envelope.
