### PR TITLE
fix(catalog)!: stop masking rejected credentials as an empty catalog in catalog list

### DIFF
--- a/docs/tutorials/catalog-tutorial.md
+++ b/docs/tutorials/catalog-tutorial.md
@@ -300,8 +300,9 @@ This shows only artifacts with the name `greeting`.
 > expired token), `catalog list` falls back to anonymous access. When that
 > anonymous listing is **empty**, the command does **not** report an empty
 > catalog -- it exits non-zero with an actionable error naming the registry and
-> the `auth login` fix command, so a rejected credential is never mistaken for a
-> genuinely empty catalog. When anonymous access still returns some artifacts,
+> the login command to fix it (`auth login <handler>`, or `catalog login
+> <registry>` when no auth handler applies), so a rejected credential is never
+> mistaken for a genuinely empty catalog. When anonymous access still returns some artifacts,
 > those are listed (exit 0) with a warning that the listing is incomplete. In
 > `-o json` mode the results array on stdout is unchanged; a
 > `{"degraded":true,"authError":{...}}` marker is written to stderr so

--- a/docs/tutorials/catalog-tutorial.md
+++ b/docs/tutorials/catalog-tutorial.md
@@ -304,9 +304,9 @@ This shows only artifacts with the name `greeting`.
 > <registry>` when no auth handler applies), so a rejected credential is never
 > mistaken for a genuinely empty catalog. When anonymous access still returns some artifacts,
 > those are listed (exit 0) with a warning that the listing is incomplete. In
-> `-o json` mode the results array on stdout is unchanged; a
-> `{"degraded":true,"authError":{...}}` marker is written to stderr so
-> programmatic consumers can detect the degraded state.
+> any structured output mode (`-o json`, `-o yaml`, etc.) the results on stdout
+> are unchanged; a `{"degraded":true,"authError":{...}}` marker is written to
+> stderr so programmatic consumers can detect the degraded state.
 
 ### Step 3: Inspect a Specific Artifact
 

--- a/docs/tutorials/catalog-tutorial.md
+++ b/docs/tutorials/catalog-tutorial.md
@@ -294,6 +294,19 @@ scafctl catalog list --name greeting -o yaml
 
 This shows only artifacts with the name `greeting`.
 
+> [!NOTE]
+> **Private registries and rejected credentials.** If a catalog points at a
+> private OCI registry and your stored credentials are rejected (for example an
+> expired token), `catalog list` falls back to anonymous access. When that
+> anonymous listing is **empty**, the command does **not** report an empty
+> catalog -- it exits non-zero with an actionable error naming the registry and
+> the `auth login` fix command, so a rejected credential is never mistaken for a
+> genuinely empty catalog. When anonymous access still returns some artifacts,
+> those are listed (exit 0) with a warning that the listing is incomplete. In
+> `-o json` mode the results array on stdout is unchanged; a
+> `{"degraded":true,"authError":{...}}` marker is written to stderr so
+> programmatic consumers can detect the degraded state.
+
 ### Step 3: Inspect a Specific Artifact
 
 {{< tabs "catalog-tutorial-cmd-9" >}}

--- a/docs/tutorials/catalog-tutorial.md
+++ b/docs/tutorials/catalog-tutorial.md
@@ -302,7 +302,11 @@ This shows only artifacts with the name `greeting`.
 > catalog -- it exits non-zero with an actionable error naming the registry and
 > the login command to fix it (`auth login <handler>`, or `catalog login
 > <registry>` when no auth handler applies), so a rejected credential is never
-> mistaken for a genuinely empty catalog. When anonymous access still returns some artifacts,
+> mistaken for a genuinely empty catalog. This fatal behavior only applies when
+> the raw anonymous listing was itself empty: if it returned artifacts that your
+> filters (`--pre-release`, a version constraint, or `--catalog`) then removed,
+> the empty final result is attributed to filtering, so the command exits 0 with
+> the degraded warning rather than failing. When anonymous access still returns some artifacts,
 > those are listed (exit 0) with a warning that the listing is incomplete. In
 > any structured output mode (`-o json`, `-o yaml`, etc.) the results on stdout
 > are unchanged; a `{"degraded":true,"authError":{...}}` marker is written to

--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -152,7 +152,7 @@ func (e *AuthDegradedError) Error() string {
 			source = "stored credentials"
 		}
 	}
-	return fmt.Sprintf("authentication required for registry %q: %s were rejected; fell back to anonymous access", e.Registry, source)
+	return fmt.Sprintf("authentication required for registry %q: rejected %s; fell back to anonymous access", e.Registry, source)
 }
 
 // staleCredentialReporter is the subset of RemoteCatalog needed to build an

--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -124,3 +124,69 @@ var ErrEnumerationNotSupported = errors.New("registry does not support repositor
 func IsEnumerationNotSupported(err error) bool {
 	return errors.Is(err, ErrEnumerationNotSupported)
 }
+
+// AuthDegradedError indicates that stored credentials for a registry were
+// rejected and the catalog silently fell back to anonymous access. The listing
+// it produced is therefore degraded/incomplete rather than authoritatively
+// empty. The message is data-only (registry and credential source); callers
+// (e.g. the CLI) are responsible for adding a binary-name-specific fix hint,
+// since the binary name is context-driven.
+type AuthDegradedError struct {
+	// Registry is the registry host whose credentials were rejected.
+	Registry string
+	// Handler is the auth handler that provided the rejected credentials
+	// (may be empty when credentials came from another source).
+	Handler string
+	// CredentialSource is a human-readable description of the rejected
+	// credential source (may be empty).
+	CredentialSource string
+}
+
+// Error implements the error interface with a data-only message.
+func (e *AuthDegradedError) Error() string {
+	source := e.CredentialSource
+	if source == "" {
+		if e.Handler != "" {
+			source = fmt.Sprintf("%s auth handler credentials", e.Handler)
+		} else {
+			source = "stored credentials"
+		}
+	}
+	return fmt.Sprintf("authentication required for registry %q: %s were rejected; fell back to anonymous access", e.Registry, source)
+}
+
+// staleCredentialReporter is the subset of RemoteCatalog needed to build an
+// AuthDegradedError. It lets NewAuthDegradedError be tested without a full
+// RemoteCatalog and keeps the dependency direction clean.
+type staleCredentialReporter interface {
+	HasStaleCredentials() bool
+	Registry() string
+	AuthHandlerUsed() string
+	CredentialSource() string
+}
+
+// NewAuthDegradedError builds an AuthDegradedError from a catalog that fell
+// back to anonymous access. It returns nil when the catalog's credentials are
+// not stale, so callers can write:
+//
+//	if degraded := catalog.NewAuthDegradedError(rc); degraded != nil { ... }
+func NewAuthDegradedError(rc staleCredentialReporter) *AuthDegradedError {
+	if rc == nil || !rc.HasStaleCredentials() {
+		return nil
+	}
+	return &AuthDegradedError{
+		Registry:         rc.Registry(),
+		Handler:          rc.AuthHandlerUsed(),
+		CredentialSource: rc.CredentialSource(),
+	}
+}
+
+// IsAuthDegraded reports whether err (or any error it wraps) is an
+// AuthDegradedError, returning the typed value when it is.
+func IsAuthDegraded(err error) (*AuthDegradedError, bool) {
+	var e *AuthDegradedError
+	if errors.As(err, &e) {
+		return e, true
+	}
+	return nil, false
+}

--- a/pkg/catalog/errors_test.go
+++ b/pkg/catalog/errors_test.go
@@ -156,17 +156,17 @@ func TestAuthDegradedError_Error(t *testing.T) {
 		{
 			name: "with explicit credential source",
 			err:  &AuthDegradedError{Registry: "reg.example.com", CredentialSource: "github auth handler token"},
-			want: `authentication required for registry "reg.example.com": github auth handler token were rejected; fell back to anonymous access`,
+			want: `authentication required for registry "reg.example.com": rejected github auth handler token; fell back to anonymous access`,
 		},
 		{
 			name: "handler only (no source)",
 			err:  &AuthDegradedError{Registry: "reg.example.com", Handler: "github"},
-			want: `authentication required for registry "reg.example.com": github auth handler credentials were rejected; fell back to anonymous access`,
+			want: `authentication required for registry "reg.example.com": rejected github auth handler credentials; fell back to anonymous access`,
 		},
 		{
 			name: "no source or handler",
 			err:  &AuthDegradedError{Registry: "reg.example.com"},
-			want: `authentication required for registry "reg.example.com": stored credentials were rejected; fell back to anonymous access`,
+			want: `authentication required for registry "reg.example.com": rejected stored credentials; fell back to anonymous access`,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/catalog/errors_test.go
+++ b/pkg/catalog/errors_test.go
@@ -133,3 +133,90 @@ func TestIsEnumerationNotSupported(t *testing.T) {
 		assert.False(t, IsEnumerationNotSupported(errors.New("other error")))
 	})
 }
+
+// fakeStaleReporter implements staleCredentialReporter for testing.
+type fakeStaleReporter struct {
+	stale   bool
+	reg     string
+	handler string
+	source  string
+}
+
+func (f fakeStaleReporter) HasStaleCredentials() bool { return f.stale }
+func (f fakeStaleReporter) Registry() string          { return f.reg }
+func (f fakeStaleReporter) AuthHandlerUsed() string   { return f.handler }
+func (f fakeStaleReporter) CredentialSource() string  { return f.source }
+
+func TestAuthDegradedError_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *AuthDegradedError
+		want string
+	}{
+		{
+			name: "with explicit credential source",
+			err:  &AuthDegradedError{Registry: "reg.example.com", CredentialSource: "github auth handler token"},
+			want: `authentication required for registry "reg.example.com": github auth handler token were rejected; fell back to anonymous access`,
+		},
+		{
+			name: "handler only (no source)",
+			err:  &AuthDegradedError{Registry: "reg.example.com", Handler: "github"},
+			want: `authentication required for registry "reg.example.com": github auth handler credentials were rejected; fell back to anonymous access`,
+		},
+		{
+			name: "no source or handler",
+			err:  &AuthDegradedError{Registry: "reg.example.com"},
+			want: `authentication required for registry "reg.example.com": stored credentials were rejected; fell back to anonymous access`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.err.Error())
+		})
+	}
+}
+
+func TestNewAuthDegradedError(t *testing.T) {
+	t.Run("nil when not stale", func(t *testing.T) {
+		assert.Nil(t, NewAuthDegradedError(fakeStaleReporter{stale: false, reg: "reg"}))
+	})
+	t.Run("nil reporter", func(t *testing.T) {
+		assert.Nil(t, NewAuthDegradedError(nil))
+	})
+	t.Run("builds from stale reporter", func(t *testing.T) {
+		e := NewAuthDegradedError(fakeStaleReporter{
+			stale: true, reg: "reg.example.com", handler: "github", source: "github auth handler token",
+		})
+		if assert.NotNil(t, e) {
+			assert.Equal(t, "reg.example.com", e.Registry)
+			assert.Equal(t, "github", e.Handler)
+			assert.Equal(t, "github auth handler token", e.CredentialSource)
+		}
+	})
+}
+
+func TestIsAuthDegraded(t *testing.T) {
+	t.Run("direct", func(t *testing.T) {
+		base := &AuthDegradedError{Registry: "r"}
+		got, ok := IsAuthDegraded(base)
+		assert.True(t, ok)
+		assert.Same(t, base, got)
+	})
+	t.Run("wrapped", func(t *testing.T) {
+		base := &AuthDegradedError{Registry: "r"}
+		wrapped := fmt.Errorf("listing failed: %w", base)
+		got, ok := IsAuthDegraded(wrapped)
+		assert.True(t, ok)
+		assert.Same(t, base, got)
+	})
+	t.Run("unrelated error", func(t *testing.T) {
+		got, ok := IsAuthDegraded(errors.New("nope"))
+		assert.False(t, ok)
+		assert.Nil(t, got)
+	})
+	t.Run("nil", func(t *testing.T) {
+		got, ok := IsAuthDegraded(nil)
+		assert.False(t, ok)
+		assert.Nil(t, got)
+	})
+}

--- a/pkg/cmd/scafctl/catalog/list.go
+++ b/pkg/cmd/scafctl/catalog/list.go
@@ -538,6 +538,7 @@ func listRemoteArtifacts(ctx context.Context, opts *ListOptions, kind catalog.Ar
 
 func writeArtifactList(ctx context.Context, w *writer.Writer, artifacts []catalog.ArtifactInfo, showAll bool, outputOpts *kvx.OutputOptions, degraded *catalog.AuthDegradedError) error {
 	structured := kvx.IsStructuredFormat(outputOpts.Format)
+	quiet := kvx.IsQuietFormat(outputOpts.Format)
 
 	// Handle empty results.
 	if len(artifacts) == 0 {
@@ -545,9 +546,15 @@ func writeArtifactList(ctx context.Context, w *writer.Writer, artifacts []catalo
 		// catalog" case: the listing is not authoritatively empty, credentials
 		// were rejected. Fail loudly instead of printing "No artifacts found".
 		if degraded != nil {
-			renderDegradedSignal(ctx, w, degraded, structured)
+			// For structured output, still write an empty array to stdout so
+			// JSON/YAML consumers get a parseable document even on non-zero
+			// exit; the degraded/authError marker goes to stderr.
+			if structured {
+				_ = outputOpts.Write([]ArtifactListItem{})
+			}
+			renderDegradedSignal(ctx, w, degraded, structured, quiet)
 			return exitcode.WithCode(
-				fmt.Errorf("%w; run %s", degraded, authLoginHint(ctx, degraded.Registry)),
+				fmt.Errorf("%w; run %s", degraded, authLoginHint(ctx, degraded.Registry, degraded.Handler)),
 				exitcode.CatalogError,
 			)
 		}
@@ -562,7 +569,7 @@ func writeArtifactList(ctx context.Context, w *writer.Writer, artifacts []catalo
 	// from anonymous access, but some content may be hidden. Print the results
 	// (exit 0) and warn that the listing is incomplete.
 	if degraded != nil {
-		renderDegradedSignal(ctx, w, degraded, structured)
+		renderDegradedSignal(ctx, w, degraded, structured, quiet)
 	}
 
 	// Sort by name, then version descending
@@ -633,27 +640,37 @@ func writeArtifactList(ctx context.Context, w *writer.Writer, artifacts []catalo
 
 // authLoginHint returns the "<bin> auth login <handler>" (or "<bin> catalog
 // login <registry>") fix command for a degraded registry, using the binary
-// name from context.
-func authLoginHint(ctx context.Context, registry string) string {
+// name from context. It prefers the handler that actually supplied the rejected
+// credentials (which RemoteCatalog gives precedence over credential-store
+// entries), falling back to inferring a handler from the registry host only
+// when no handler was recorded.
+func authLoginHint(ctx context.Context, registry, handler string) string {
 	bin := settings.BinaryNameFromContext(ctx)
-	var customHandlers []appconfig.CustomOAuth2Config
-	if cfg := appconfig.FromContext(ctx); cfg != nil {
-		customHandlers = cfg.Auth.CustomOAuth2
+	if handler == "" {
+		var customHandlers []appconfig.CustomOAuth2Config
+		if cfg := appconfig.FromContext(ctx); cfg != nil {
+			customHandlers = cfg.Auth.CustomOAuth2
+		}
+		handler = catalog.InferAuthHandler(registry, customHandlers)
 	}
-	if handler := catalog.InferAuthHandler(registry, customHandlers); handler != "" {
+	if handler != "" {
 		return fmt.Sprintf("%s auth login %s", bin, handler)
 	}
 	return fmt.Sprintf("%s catalog login %s", bin, registry)
 }
 
-// renderDegradedSignal emits the human-facing degraded warning (always) and,
-// for structured output, a machine-readable {"degraded":true,...} marker on
-// stderr so -o json consumers can detect the condition without changing the
-// stdout array contract.
-func renderDegradedSignal(ctx context.Context, w *writer.Writer, degraded *catalog.AuthDegradedError, structured bool) {
-	w.WarnStderrf("Catalog listing is incomplete: %s were rejected for %s — showing anonymous results only.",
+// renderDegradedSignal emits the human-facing degraded warning and, for
+// structured output, a machine-readable {"degraded":true,...} marker on stderr
+// so -o json consumers can detect the condition without changing the stdout
+// array contract. It emits nothing when quiet output is requested (quiet
+// suppresses all output; the exit code still conveys the failure).
+func renderDegradedSignal(ctx context.Context, w *writer.Writer, degraded *catalog.AuthDegradedError, structured, quiet bool) {
+	if quiet {
+		return
+	}
+	w.WarnStderrf("Catalog listing is incomplete: rejected %s for %s — showing anonymous results only.",
 		credentialSourceDescription(degraded), degraded.Registry)
-	w.PlainStderrf("  To fix: %s", authLoginHint(ctx, degraded.Registry))
+	w.PlainStderrf("  To fix: %s", authLoginHint(ctx, degraded.Registry, degraded.Handler))
 
 	if structured {
 		marker := map[string]any{

--- a/pkg/cmd/scafctl/catalog/list.go
+++ b/pkg/cmd/scafctl/catalog/list.go
@@ -549,14 +549,18 @@ func writeArtifactList(ctx context.Context, w *writer.Writer, artifacts []catalo
 			// For structured output, still write an empty array to stdout so
 			// JSON/YAML consumers get a parseable document even on non-zero
 			// exit; the degraded/authError marker goes to stderr.
+			var writeErr error
 			if structured {
-				_ = outputOpts.Write([]ArtifactListItem{})
+				writeErr = outputOpts.Write([]ArtifactListItem{})
 			}
 			renderDegradedSignal(ctx, w, degraded, structured, quiet)
-			return exitcode.WithCode(
-				fmt.Errorf("%w; run %s", degraded, authLoginHint(ctx, degraded.Registry, degraded.Handler)),
-				exitcode.CatalogError,
-			)
+			authErr := fmt.Errorf("%w; run %s", degraded, authLoginHint(ctx, degraded.Registry, degraded.Handler))
+			// Surface a stdout write failure alongside the auth-degraded error
+			// (the degraded state remains the primary signal / exit code).
+			if writeErr != nil {
+				authErr = fmt.Errorf("%w (failed to write empty result: %w)", authErr, writeErr)
+			}
+			return exitcode.WithCode(authErr, exitcode.CatalogError)
 		}
 		if structured {
 			return outputOpts.Write([]ArtifactListItem{})

--- a/pkg/cmd/scafctl/catalog/list.go
+++ b/pkg/cmd/scafctl/catalog/list.go
@@ -5,6 +5,7 @@ package catalog
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -235,6 +236,11 @@ func runList(ctx context.Context, opts *ListOptions, outputOpts *kvx.OutputOptio
 		return exitcode.WithCode(err, exitcode.CatalogError)
 	}
 
+	// aggregateDegraded records the first remote catalog (if any) that fell back
+	// to anonymous access due to rejected credentials. It is only rendered as an
+	// error when the combined result is empty (see writeArtifactList).
+	var aggregateDegraded *catalog.AuthDegradedError
+
 	// Determine which remote catalogs to query.
 	// --catalog: only the named catalog (used as post-filter below).
 	// --all: all configured catalogs.
@@ -267,7 +273,7 @@ func runList(ctx context.Context, opts *ListOptions, outputOpts *kvx.OutputOptio
 				CliParams: opts.CliParams,
 				IOStreams: opts.IOStreams,
 			}
-			remoteArtifacts, remoteErr := listRemoteArtifacts(ctx, remoteOpts, kind)
+			remoteArtifacts, remoteDegraded, remoteErr := listRemoteArtifacts(ctx, remoteOpts, kind)
 			if remoteErr != nil {
 				if catalog.IsEnumerationNotSupported(remoteErr) {
 					w.Verbosef("Catalog %q does not support enumeration, skipping.", catCfg.Name)
@@ -285,6 +291,13 @@ func runList(ctx context.Context, opts *ListOptions, outputOpts *kvx.OutputOptio
 					}
 				}
 				continue
+			}
+			// Remember the first catalog that degraded to anonymous access. If
+			// the aggregate result ends up empty, this makes the emptiness
+			// attributable to a rejected credential rather than a truly empty
+			// catalog.
+			if remoteDegraded != nil && aggregateDegraded == nil {
+				aggregateDegraded = remoteDegraded
 			}
 			artifacts = append(artifacts, remoteArtifacts...)
 		}
@@ -314,7 +327,7 @@ func runList(ctx context.Context, opts *ListOptions, outputOpts *kvx.OutputOptio
 		artifacts = filterArtifactsByCatalog(artifacts, opts.Catalog)
 	}
 
-	return writeArtifactList(w, artifacts, opts.AllVersions || opts.VersionConstraint != "", outputOpts)
+	return writeArtifactList(ctx, w, artifacts, opts.AllVersions || opts.VersionConstraint != "", outputOpts, aggregateDegraded)
 }
 
 // runListFromRemoteRef lists artifacts from a full OCI reference
@@ -407,7 +420,7 @@ func runListFromRemoteRef(ctx context.Context, opts *ListOptions, outputOpts *kv
 		w.Verbosef("After version filter %q: %d artifact(s)", opts.VersionConstraint, len(artifacts))
 	}
 
-	return writeArtifactList(w, artifacts, opts.AllVersions || opts.VersionConstraint != "", outputOpts)
+	return writeArtifactList(ctx, w, artifacts, opts.AllVersions || opts.VersionConstraint != "", outputOpts, catalog.NewAuthDegradedError(remoteCatalog))
 }
 
 func runListRemote(ctx context.Context, opts *ListOptions, kind catalog.ArtifactKind, outputOpts *kvx.OutputOptions) error {
@@ -417,7 +430,7 @@ func runListRemote(ctx context.Context, opts *ListOptions, kind catalog.Artifact
 		w.Verbose("Enumerating all artifacts in catalog (this may take a moment)...")
 	}
 
-	artifacts, err := listRemoteArtifacts(ctx, opts, kind)
+	artifacts, degraded, err := listRemoteArtifacts(ctx, opts, kind)
 	if err != nil {
 		if catalog.IsEnumerationNotSupported(err) {
 			if opts.Name == "" {
@@ -466,13 +479,13 @@ func runListRemote(ctx context.Context, opts *ListOptions, kind catalog.Artifact
 		}
 	}
 
-	return writeArtifactList(w, artifacts, opts.AllVersions || opts.VersionConstraint != "", outputOpts)
+	return writeArtifactList(ctx, w, artifacts, opts.AllVersions || opts.VersionConstraint != "", outputOpts, degraded)
 }
 
 // listRemoteArtifacts fetches artifacts from a configured remote catalog.
 // This is shared between runListRemote (explicit --catalog) and the
 // unified all-catalogs search in runList.
-func listRemoteArtifacts(ctx context.Context, opts *ListOptions, kind catalog.ArtifactKind) ([]catalog.ArtifactInfo, error) {
+func listRemoteArtifacts(ctx context.Context, opts *ListOptions, kind catalog.ArtifactKind) ([]catalog.ArtifactInfo, *catalog.AuthDegradedError, error) {
 	lgr := logger.FromContext(ctx)
 	w := writer.FromContext(ctx)
 
@@ -480,7 +493,7 @@ func listRemoteArtifacts(ctx context.Context, opts *ListOptions, kind catalog.Ar
 
 	catalogURL, err := catalog.ResolveCatalogURL(ctx, opts.Catalog)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	registry, repository := catalog.ParseCatalogURL(catalogURL)
@@ -508,27 +521,48 @@ func listRemoteArtifacts(ctx context.Context, opts *ListOptions, kind catalog.Ar
 		Logger:            *lgr,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to create remote catalog: %w", err)
+		return nil, nil, fmt.Errorf("failed to create remote catalog: %w", err)
 	}
 
 	result, listErr := remoteCatalog.List(ctx, kind, opts.Name)
 
-	// Warn the user about stale credentials so they can fix the issue.
-	warnStaleCredentials(ctx, w, remoteCatalog)
+	// If stored credentials were rejected the catalog fell back to anonymous
+	// access, so the listing is degraded/incomplete rather than authoritative.
+	// Surface that as a typed value so the render layer can decide whether it is
+	// a fatal error (empty result) or a non-fatal warning (partial result).
+	degraded := catalog.NewAuthDegradedError(remoteCatalog)
 	verboseCredentialSource(w, remoteCatalog)
 
-	return result, listErr
+	return result, degraded, listErr
 }
 
-func writeArtifactList(w *writer.Writer, artifacts []catalog.ArtifactInfo, showAll bool, outputOpts *kvx.OutputOptions) error {
-	// Handle empty results: structured formats get an empty array,
-	// table/interactive formats get a human-friendly message.
+func writeArtifactList(ctx context.Context, w *writer.Writer, artifacts []catalog.ArtifactInfo, showAll bool, outputOpts *kvx.OutputOptions, degraded *catalog.AuthDegradedError) error {
+	structured := kvx.IsStructuredFormat(outputOpts.Format)
+
+	// Handle empty results.
 	if len(artifacts) == 0 {
-		if kvx.IsStructuredFormat(outputOpts.Format) {
+		// Empty + degraded is the "auth failure masquerading as an empty
+		// catalog" case: the listing is not authoritatively empty, credentials
+		// were rejected. Fail loudly instead of printing "No artifacts found".
+		if degraded != nil {
+			renderDegradedSignal(ctx, w, degraded, structured)
+			return exitcode.WithCode(
+				fmt.Errorf("%w; run %s", degraded, authLoginHint(ctx, degraded.Registry)),
+				exitcode.CatalogError,
+			)
+		}
+		if structured {
 			return outputOpts.Write([]ArtifactListItem{})
 		}
 		w.Infof("No artifacts found in catalog.")
 		return nil
+	}
+
+	// Non-empty + degraded is a partial success: real results were returned
+	// from anonymous access, but some content may be hidden. Print the results
+	// (exit 0) and warn that the listing is incomplete.
+	if degraded != nil {
+		renderDegradedSignal(ctx, w, degraded, structured)
 	}
 
 	// Sort by name, then version descending
@@ -595,4 +629,55 @@ func writeArtifactList(w *writer.Writer, artifacts []catalog.ArtifactInfo, showA
 	}
 
 	return outputOpts.Write(items)
+}
+
+// authLoginHint returns the "<bin> auth login <handler>" (or "<bin> catalog
+// login <registry>") fix command for a degraded registry, using the binary
+// name from context.
+func authLoginHint(ctx context.Context, registry string) string {
+	bin := settings.BinaryNameFromContext(ctx)
+	var customHandlers []appconfig.CustomOAuth2Config
+	if cfg := appconfig.FromContext(ctx); cfg != nil {
+		customHandlers = cfg.Auth.CustomOAuth2
+	}
+	if handler := catalog.InferAuthHandler(registry, customHandlers); handler != "" {
+		return fmt.Sprintf("%s auth login %s", bin, handler)
+	}
+	return fmt.Sprintf("%s catalog login %s", bin, registry)
+}
+
+// renderDegradedSignal emits the human-facing degraded warning (always) and,
+// for structured output, a machine-readable {"degraded":true,...} marker on
+// stderr so -o json consumers can detect the condition without changing the
+// stdout array contract.
+func renderDegradedSignal(ctx context.Context, w *writer.Writer, degraded *catalog.AuthDegradedError, structured bool) {
+	w.WarnStderrf("Catalog listing is incomplete: %s were rejected for %s — showing anonymous results only.",
+		credentialSourceDescription(degraded), degraded.Registry)
+	w.PlainStderrf("  To fix: %s", authLoginHint(ctx, degraded.Registry))
+
+	if structured {
+		marker := map[string]any{
+			"degraded": true,
+			"authError": map[string]any{
+				"registry":         degraded.Registry,
+				"handler":          degraded.Handler,
+				"credentialSource": degraded.CredentialSource,
+			},
+		}
+		if data, err := json.Marshal(marker); err == nil {
+			w.PlainStderrf("%s", string(data))
+		}
+	}
+}
+
+// credentialSourceDescription returns a human-readable description of the
+// rejected credential source for a degraded error.
+func credentialSourceDescription(degraded *catalog.AuthDegradedError) string {
+	if degraded.CredentialSource != "" {
+		return "your " + degraded.CredentialSource
+	}
+	if degraded.Handler != "" {
+		return fmt.Sprintf("your %s auth handler credentials", degraded.Handler)
+	}
+	return "your stored credentials"
 }

--- a/pkg/cmd/scafctl/catalog/list.go
+++ b/pkg/cmd/scafctl/catalog/list.go
@@ -303,6 +303,11 @@ func runList(ctx context.Context, opts *ListOptions, outputOpts *kvx.OutputOptio
 		}
 	}
 
+	// Raw count across local + all remote catalogs, before user filters. Used
+	// to distinguish a genuinely empty (auth-degraded) listing from one emptied
+	// by pre-release/version/catalog filtering.
+	rawResultCount := len(artifacts)
+
 	// Filter pre-release versions unless --pre-release flag is set.
 	if !opts.PreRelease {
 		before := len(artifacts)
@@ -327,7 +332,7 @@ func runList(ctx context.Context, opts *ListOptions, outputOpts *kvx.OutputOptio
 		artifacts = filterArtifactsByCatalog(artifacts, opts.Catalog)
 	}
 
-	return writeArtifactList(ctx, w, artifacts, opts.AllVersions || opts.VersionConstraint != "", outputOpts, aggregateDegraded)
+	return writeArtifactList(ctx, w, artifacts, opts.AllVersions || opts.VersionConstraint != "", outputOpts, aggregateDegraded, rawResultCount)
 }
 
 // runListFromRemoteRef lists artifacts from a full OCI reference
@@ -393,6 +398,7 @@ func runListFromRemoteRef(ctx context.Context, opts *ListOptions, outputOpts *kv
 	w.Verbosef("Listing tags for %s...", remoteRef.Name)
 
 	artifacts, err := remoteCatalog.List(ctx, kind, remoteRef.Name)
+	rawResultCount := len(artifacts)
 	if err != nil {
 		w.Errorf("failed to list remote artifacts: %v", err)
 		hintOnAuthError(ctx, w, registry, err)
@@ -420,7 +426,7 @@ func runListFromRemoteRef(ctx context.Context, opts *ListOptions, outputOpts *kv
 		w.Verbosef("After version filter %q: %d artifact(s)", opts.VersionConstraint, len(artifacts))
 	}
 
-	return writeArtifactList(ctx, w, artifacts, opts.AllVersions || opts.VersionConstraint != "", outputOpts, catalog.NewAuthDegradedError(remoteCatalog))
+	return writeArtifactList(ctx, w, artifacts, opts.AllVersions || opts.VersionConstraint != "", outputOpts, catalog.NewAuthDegradedError(remoteCatalog), rawResultCount)
 }
 
 func runListRemote(ctx context.Context, opts *ListOptions, kind catalog.ArtifactKind, outputOpts *kvx.OutputOptions) error {
@@ -431,6 +437,7 @@ func runListRemote(ctx context.Context, opts *ListOptions, kind catalog.Artifact
 	}
 
 	artifacts, degraded, err := listRemoteArtifacts(ctx, opts, kind)
+	rawResultCount := len(artifacts)
 	if err != nil {
 		if catalog.IsEnumerationNotSupported(err) {
 			if opts.Name == "" {
@@ -479,7 +486,7 @@ func runListRemote(ctx context.Context, opts *ListOptions, kind catalog.Artifact
 		}
 	}
 
-	return writeArtifactList(ctx, w, artifacts, opts.AllVersions || opts.VersionConstraint != "", outputOpts, degraded)
+	return writeArtifactList(ctx, w, artifacts, opts.AllVersions || opts.VersionConstraint != "", outputOpts, degraded, rawResultCount)
 }
 
 // listRemoteArtifacts fetches artifacts from a configured remote catalog.
@@ -536,16 +543,20 @@ func listRemoteArtifacts(ctx context.Context, opts *ListOptions, kind catalog.Ar
 	return result, degraded, listErr
 }
 
-func writeArtifactList(ctx context.Context, w *writer.Writer, artifacts []catalog.ArtifactInfo, showAll bool, outputOpts *kvx.OutputOptions, degraded *catalog.AuthDegradedError) error {
+func writeArtifactList(ctx context.Context, w *writer.Writer, artifacts []catalog.ArtifactInfo, showAll bool, outputOpts *kvx.OutputOptions, degraded *catalog.AuthDegradedError, rawResultCount int) error {
 	structured := kvx.IsStructuredFormat(outputOpts.Format)
 	quiet := kvx.IsQuietFormat(outputOpts.Format)
 
 	// Handle empty results.
 	if len(artifacts) == 0 {
-		// Empty + degraded is the "auth failure masquerading as an empty
-		// catalog" case: the listing is not authoritatively empty, credentials
-		// were rejected. Fail loudly instead of printing "No artifacts found".
-		if degraded != nil {
+		// Empty + degraded is treated as fatal ONLY when the raw listing itself
+		// was empty (rawResultCount == 0) -- i.e. rejected credentials produced
+		// a genuinely empty anonymous listing. If the raw listing had artifacts
+		// but user filters (pre-release, version constraint, --catalog) removed
+		// them all, the emptiness is due to filtering, not the auth failure, so
+		// we do not fail the command; we still surface the degraded warning.
+		fatalDegraded := degraded != nil && rawResultCount == 0
+		if fatalDegraded {
 			// For structured output, still write an empty array to stdout so
 			// JSON/YAML consumers get a parseable document even on non-zero
 			// exit; the degraded/authError marker goes to stderr.
@@ -561,6 +572,11 @@ func writeArtifactList(ctx context.Context, w *writer.Writer, artifacts []catalo
 				authErr = fmt.Errorf("%w (failed to write empty result: %w)", authErr, writeErr)
 			}
 			return exitcode.WithCode(authErr, exitcode.CatalogError)
+		}
+		// Non-fatal: emptiness came from filtering a degraded-but-non-empty
+		// listing (still warn), or there was no degradation at all.
+		if degraded != nil {
+			renderDegradedSignal(ctx, w, degraded, structured, quiet, false /* non-fatal */)
 		}
 		if structured {
 			return outputOpts.Write([]ArtifactListItem{})

--- a/pkg/cmd/scafctl/catalog/list.go
+++ b/pkg/cmd/scafctl/catalog/list.go
@@ -553,7 +553,7 @@ func writeArtifactList(ctx context.Context, w *writer.Writer, artifacts []catalo
 			if structured {
 				writeErr = outputOpts.Write([]ArtifactListItem{})
 			}
-			renderDegradedSignal(ctx, w, degraded, structured, quiet)
+			renderDegradedSignal(ctx, w, degraded, structured, quiet, true /* fatal/empty */)
 			authErr := fmt.Errorf("%w; run %s", degraded, authLoginHint(ctx, degraded.Registry, degraded.Handler))
 			// Surface a stdout write failure alongside the auth-degraded error
 			// (the degraded state remains the primary signal / exit code).
@@ -573,7 +573,7 @@ func writeArtifactList(ctx context.Context, w *writer.Writer, artifacts []catalo
 	// from anonymous access, but some content may be hidden. Print the results
 	// (exit 0) and warn that the listing is incomplete.
 	if degraded != nil {
-		renderDegradedSignal(ctx, w, degraded, structured, quiet)
+		renderDegradedSignal(ctx, w, degraded, structured, quiet, false /* partial/non-empty */)
 	}
 
 	// Sort by name, then version descending
@@ -663,17 +663,26 @@ func authLoginHint(ctx context.Context, registry, handler string) string {
 	return fmt.Sprintf("%s catalog login %s", bin, registry)
 }
 
-// renderDegradedSignal emits the human-facing degraded warning and, for
-// structured output, a machine-readable {"degraded":true,...} marker on stderr
-// so -o json consumers can detect the condition without changing the stdout
-// array contract. It emits nothing when quiet output is requested (quiet
-// suppresses all output; the exit code still conveys the failure).
-func renderDegradedSignal(ctx context.Context, w *writer.Writer, degraded *catalog.AuthDegradedError, structured, quiet bool) {
+// renderDegradedSignal emits a human-facing message about the degraded listing
+// and, for structured output, a machine-readable {"degraded":true,...} marker on
+// stderr so -o json consumers can detect the condition without changing the
+// stdout array contract. When fatal is true (an empty result on rejected
+// credentials) it emits an error-framed line, since the command exits non-zero
+// and the returned Cobra error is silenced; otherwise it emits an
+// incomplete-listing warning for a partial (non-empty) result. It emits nothing
+// when quiet output is requested (quiet suppresses all output; the exit code
+// still conveys the failure).
+func renderDegradedSignal(ctx context.Context, w *writer.Writer, degraded *catalog.AuthDegradedError, structured, quiet, fatal bool) {
 	if quiet {
 		return
 	}
-	w.WarnStderrf("Catalog listing is incomplete: rejected %s for %s — showing anonymous results only.",
-		credentialSourceDescription(degraded), degraded.Registry)
+	if fatal {
+		w.Errorf("Cannot list catalog %s: rejected %s, and anonymous access found nothing.",
+			degraded.Registry, credentialSourceDescription(degraded))
+	} else {
+		w.WarnStderrf("Catalog listing is incomplete: rejected %s for %s — showing anonymous results only.",
+			credentialSourceDescription(degraded), degraded.Registry)
+	}
 	w.PlainStderrf("  To fix: %s", authLoginHint(ctx, degraded.Registry, degraded.Handler))
 
 	if structured {

--- a/pkg/cmd/scafctl/catalog/list_test.go
+++ b/pkg/cmd/scafctl/catalog/list_test.go
@@ -702,14 +702,12 @@ func BenchmarkWriteArtifactList(b *testing.B) {
 
 // staleDegraded builds an AuthDegradedError from a real RemoteCatalog marked
 // stale, exercising the same NewAuthDegradedError path the command uses.
-func staleDegraded(t *testing.T, registry, source string) *catalogpkg.AuthDegradedError {
+func staleDegraded(t *testing.T) *catalogpkg.AuthDegradedError {
 	t.Helper()
-	rc, err := catalogpkg.NewRemoteCatalog(catalogpkg.RemoteCatalogConfig{Registry: registry})
+	rc, err := catalogpkg.NewRemoteCatalog(catalogpkg.RemoteCatalogConfig{Registry: "ghcr.io"})
 	require.NoError(t, err)
 	rc.SetStaleForTesting()
-	if source != "" {
-		rc.SetCredentialSourceForTest(source)
-	}
+	rc.SetCredentialSourceForTest("github auth handler token")
 	d := catalogpkg.NewAuthDegradedError(rc)
 	require.NotNil(t, d)
 	return d
@@ -720,7 +718,7 @@ func TestWriteArtifactList_EmptyStale_FailsLoudly(t *testing.T) {
 	outputOpts := kvx.NewOutputOptions(ioStreams)
 	w := writer.New(ioStreams, &settings.Run{})
 
-	degraded := staleDegraded(t, "ghcr.io", "github auth handler token")
+	degraded := staleDegraded(t)
 	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
 
 	require.Error(t, err, "empty result on stale credentials must return an error")
@@ -754,7 +752,7 @@ func TestWriteArtifactList_NonEmptyStale_WarnsButSucceeds(t *testing.T) {
 		},
 		Catalog: "remote",
 	}}
-	degraded := staleDegraded(t, "ghcr.io", "github auth handler token")
+	degraded := staleDegraded(t)
 
 	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, degraded)
 	require.NoError(t, err, "partial (non-empty) result must still succeed")
@@ -769,7 +767,7 @@ func TestWriteArtifactList_EmptyStaleJSON_MarkerOnStderr(t *testing.T) {
 	outputOpts.Format = "json"
 	w := writer.New(ioStreams, &settings.Run{})
 
-	degraded := staleDegraded(t, "ghcr.io", "github auth handler token")
+	degraded := staleDegraded(t)
 	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
 
 	require.Error(t, err)
@@ -819,4 +817,55 @@ func TestWriteArtifactList_EmptyStale_GenericSourceAndRegistry(t *testing.T) {
 	assert.Contains(t, errBuf.String(), "stored credentials")
 	assert.Contains(t, errBuf.String(), "private.example.com")
 	assert.Contains(t, errBuf.String(), "catalog login private.example.com")
+}
+
+// TestWriteArtifactList_PrefersRecordedHandler verifies the fix hint uses the
+// handler that actually supplied the rejected credentials, even when the
+// registry host is not one InferAuthHandler recognizes.
+func TestWriteArtifactList_PrefersRecordedHandler(t *testing.T) {
+	ioStreams, _, errBuf := terminal.NewTestIOStreams()
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	w := writer.New(ioStreams, &settings.Run{})
+
+	// Non-inferable registry, but a handler was recorded on the error.
+	degraded := &catalogpkg.AuthDegradedError{Registry: "private.example.com", Handler: "corp-sso"}
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
+
+	require.Error(t, err)
+	assert.Contains(t, errBuf.String(), "auth login corp-sso",
+		"should recommend logging in with the recorded handler, not catalog login")
+	assert.NotContains(t, errBuf.String(), "catalog login")
+}
+
+// TestWriteArtifactList_QuietSuppressesDegradedOutput verifies that quiet output
+// emits no degraded warning while still returning the failing exit code.
+func TestWriteArtifactList_QuietSuppressesDegradedOutput(t *testing.T) {
+	ioStreams, outBuf, errBuf := terminal.NewTestIOStreams()
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	outputOpts.Format = kvx.OutputFormatQuiet
+	w := writer.New(ioStreams, &settings.Run{})
+
+	degraded := staleDegraded(t)
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
+
+	require.Error(t, err, "exit code still conveys the failure")
+	assert.Equal(t, exitcode.CatalogError, exitcode.GetCode(err))
+	assert.Empty(t, errBuf.String(), "quiet output must suppress the degraded warning")
+	assert.Empty(t, outBuf.String(), "quiet output must suppress stdout")
+}
+
+// TestWriteArtifactList_EmptyStaleStructured_WritesEmptyArray verifies the
+// structured (json/yaml) empty+stale path writes a parseable empty array to
+// stdout (so consumers can parse stdout) while the marker goes to stderr.
+func TestWriteArtifactList_EmptyStaleStructured_WritesEmptyArray(t *testing.T) {
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	outputOpts.Format = "json"
+	w := writer.New(ioStreams, &settings.Run{})
+
+	degraded := staleDegraded(t)
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
+
+	require.Error(t, err)
+	assert.Contains(t, outBuf.String(), "[]", "stdout should contain a parseable empty array")
 }

--- a/pkg/cmd/scafctl/catalog/list_test.go
+++ b/pkg/cmd/scafctl/catalog/list_test.go
@@ -295,7 +295,7 @@ func TestWriteArtifactList_LatestOnly(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(w, artifacts, false, outputOpts)
+	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, nil)
 	require.NoError(t, err)
 }
 
@@ -331,7 +331,7 @@ func TestWriteArtifactList_AllVersions(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(w, artifacts, true, outputOpts)
+	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil)
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -364,7 +364,7 @@ func TestWriteArtifactList_TagFallsBackToVersion(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(w, artifacts, true, outputOpts)
+	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil)
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -395,7 +395,7 @@ func TestWriteArtifactList_PreservesDigest(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(w, artifacts, true, outputOpts)
+	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil)
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -429,7 +429,7 @@ func TestWriteArtifactList_SortsByNameThenVersionDescending(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(w, artifacts, true, outputOpts)
+	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil)
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -458,7 +458,7 @@ func TestWriteArtifactList_CatalogColumn(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(w, artifacts, true, outputOpts)
+	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil)
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -491,7 +491,7 @@ func TestWriteArtifactList_CrossCatalogDedup(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(w, artifacts, true, outputOpts)
+	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil)
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -531,7 +531,7 @@ func TestWriteArtifactList_LatestOnlyAfterDedup(t *testing.T) {
 
 	w := writer.New(ioStreams, &settings.Run{})
 	// showAll=false → only latest version per name+kind
-	err := writeArtifactList(w, artifacts, false, outputOpts)
+	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, nil)
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -550,7 +550,7 @@ func TestWriteArtifactList_EmptyRespectsQuiet(t *testing.T) {
 
 	// With quiet=true, the "No artifacts found" message should be suppressed.
 	w := writer.New(ioStreams, &settings.Run{IsQuiet: true})
-	err := writeArtifactList(w, nil, false, outputOpts)
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, nil)
 	require.NoError(t, err)
 	assert.Empty(t, errBuf.String(), "quiet mode should suppress info messages")
 }
@@ -625,7 +625,7 @@ func TestWriteArtifactList_NameWithoutAllVersions_ShowsLatestOnly(t *testing.T) 
 	// showAll=false simulates --name without --all-versions.
 	// Previously --name implied --all-versions; now it does not.
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(w, artifacts, false, outputOpts)
+	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, nil)
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -667,7 +667,7 @@ func TestWriteArtifactList_LatestOnly_AssertsSingleResult(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(w, artifacts, false, outputOpts)
+	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, nil)
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -696,6 +696,127 @@ func BenchmarkWriteArtifactList(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		_ = writeArtifactList(w, artifacts, false, outputOpts)
+		_ = writeArtifactList(context.Background(), w, artifacts, false, outputOpts, nil)
 	}
+}
+
+// staleDegraded builds an AuthDegradedError from a real RemoteCatalog marked
+// stale, exercising the same NewAuthDegradedError path the command uses.
+func staleDegraded(t *testing.T, registry, source string) *catalogpkg.AuthDegradedError {
+	t.Helper()
+	rc, err := catalogpkg.NewRemoteCatalog(catalogpkg.RemoteCatalogConfig{Registry: registry})
+	require.NoError(t, err)
+	rc.SetStaleForTesting()
+	if source != "" {
+		rc.SetCredentialSourceForTest(source)
+	}
+	d := catalogpkg.NewAuthDegradedError(rc)
+	require.NotNil(t, d)
+	return d
+}
+
+func TestWriteArtifactList_EmptyStale_FailsLoudly(t *testing.T) {
+	ioStreams, outBuf, errBuf := terminal.NewTestIOStreams()
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	w := writer.New(ioStreams, &settings.Run{})
+
+	degraded := staleDegraded(t, "ghcr.io", "github auth handler token")
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
+
+	require.Error(t, err, "empty result on stale credentials must return an error")
+	assert.Equal(t, exitcode.CatalogError, exitcode.GetCode(err))
+	assert.NotContains(t, outBuf.String(), "No artifacts found in catalog.",
+		"must not assert emptiness when credentials were rejected")
+	assert.Contains(t, errBuf.String(), "ghcr.io")
+	assert.Contains(t, errBuf.String(), "auth login")
+}
+
+func TestWriteArtifactList_EmptyNoStale_Unchanged(t *testing.T) {
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	w := writer.New(ioStreams, &settings.Run{})
+
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, nil)
+	require.NoError(t, err)
+	assert.Contains(t, outBuf.String(), "No artifacts found in catalog.")
+}
+
+func TestWriteArtifactList_NonEmptyStale_WarnsButSucceeds(t *testing.T) {
+	ioStreams, outBuf, errBuf := terminal.NewTestIOStreams()
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	w := writer.New(ioStreams, &settings.Run{})
+
+	artifacts := []catalogpkg.ArtifactInfo{{
+		Reference: catalogpkg.Reference{
+			Name:    "demo-app",
+			Kind:    catalogpkg.ArtifactKindSolution,
+			Version: semver.MustParse("1.0.0"),
+		},
+		Catalog: "remote",
+	}}
+	degraded := staleDegraded(t, "ghcr.io", "github auth handler token")
+
+	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, degraded)
+	require.NoError(t, err, "partial (non-empty) result must still succeed")
+	assert.Contains(t, outBuf.String(), "demo-app")
+	assert.Contains(t, errBuf.String(), "incomplete")
+	assert.Contains(t, errBuf.String(), "auth login")
+}
+
+func TestWriteArtifactList_EmptyStaleJSON_MarkerOnStderr(t *testing.T) {
+	ioStreams, outBuf, errBuf := terminal.NewTestIOStreams()
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	outputOpts.Format = "json"
+	w := writer.New(ioStreams, &settings.Run{})
+
+	degraded := staleDegraded(t, "ghcr.io", "github auth handler token")
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
+
+	require.Error(t, err)
+	assert.Equal(t, exitcode.CatalogError, exitcode.GetCode(err))
+	// stdout must not contain a bare empty array masquerading as success.
+	assert.NotContains(t, outBuf.String(), "No artifacts found")
+	// The structured degraded marker goes to stderr, preserving stdout's contract.
+	assert.Contains(t, errBuf.String(), `"degraded":true`)
+	assert.Contains(t, errBuf.String(), `"authError"`)
+}
+
+// TestWriteArtifactList_EmptyStale_HandlerOnly covers the credential-source
+// fallback when only an auth handler (no explicit source string) is known.
+func TestWriteArtifactList_EmptyStale_HandlerOnly(t *testing.T) {
+	ioStreams, _, errBuf := terminal.NewTestIOStreams()
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	w := writer.New(ioStreams, &settings.Run{})
+
+	// Handler set but no explicit credential source -> "<handler> auth handler
+	// credentials" wording.
+	degraded := &catalogpkg.AuthDegradedError{Registry: "ghcr.io", Handler: "github"}
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
+
+	require.Error(t, err)
+	assert.Equal(t, exitcode.CatalogError, exitcode.GetCode(err))
+	assert.Contains(t, errBuf.String(), "auth handler credentials")
+	assert.Contains(t, errBuf.String(), "auth login github")
+}
+
+// TestWriteArtifactList_EmptyStale_GenericSourceAndRegistry covers the generic
+// "stored credentials" wording and the catalog-login fallback for a registry
+// with no inferable auth handler.
+func TestWriteArtifactList_EmptyStale_GenericSourceAndRegistry(t *testing.T) {
+	ioStreams, _, errBuf := terminal.NewTestIOStreams()
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	w := writer.New(ioStreams, &settings.Run{})
+
+	// An arbitrary private registry with no known handler and no source.
+	rc, err := catalogpkg.NewRemoteCatalog(catalogpkg.RemoteCatalogConfig{Registry: "private.example.com"})
+	require.NoError(t, err)
+	rc.SetStaleForTesting()
+	degraded := catalogpkg.NewAuthDegradedError(rc)
+	require.NotNil(t, degraded)
+
+	wErr := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
+	require.Error(t, wErr)
+	assert.Contains(t, errBuf.String(), "stored credentials")
+	assert.Contains(t, errBuf.String(), "private.example.com")
+	assert.Contains(t, errBuf.String(), "catalog login private.example.com")
 }

--- a/pkg/cmd/scafctl/catalog/list_test.go
+++ b/pkg/cmd/scafctl/catalog/list_test.go
@@ -725,6 +725,11 @@ func TestWriteArtifactList_EmptyStale_FailsLoudly(t *testing.T) {
 	assert.Equal(t, exitcode.CatalogError, exitcode.GetCode(err))
 	assert.NotContains(t, outBuf.String(), "No artifacts found in catalog.",
 		"must not assert emptiness when credentials were rejected")
+	// The fatal path emits an explicit error line to stderr (Cobra silences the
+	// returned error), not just a partial-listing warning.
+	assert.Contains(t, errBuf.String(), "Cannot list catalog")
+	assert.NotContains(t, errBuf.String(), "showing anonymous results only",
+		"empty result should use the fatal error framing, not the partial warning")
 	assert.Contains(t, errBuf.String(), "ghcr.io")
 	assert.Contains(t, errBuf.String(), "auth login")
 }
@@ -772,7 +777,8 @@ func TestWriteArtifactList_EmptyStaleJSON_MarkerOnStderr(t *testing.T) {
 
 	require.Error(t, err)
 	assert.Equal(t, exitcode.CatalogError, exitcode.GetCode(err))
-	// stdout must not contain a bare empty array masquerading as success.
+	// stdout stays a parseable JSON array (an empty [] here); the degraded
+	// signal is on stderr, not asserted as an authoritative empty catalog.
 	assert.NotContains(t, outBuf.String(), "No artifacts found")
 	// The structured degraded marker goes to stderr, preserving stdout's contract.
 	assert.Contains(t, errBuf.String(), `"degraded":true`)

--- a/pkg/cmd/scafctl/catalog/list_test.go
+++ b/pkg/cmd/scafctl/catalog/list_test.go
@@ -295,7 +295,7 @@ func TestWriteArtifactList_LatestOnly(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, nil)
+	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, nil, len(artifacts))
 	require.NoError(t, err)
 }
 
@@ -331,7 +331,7 @@ func TestWriteArtifactList_AllVersions(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil)
+	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil, len(artifacts))
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -364,7 +364,7 @@ func TestWriteArtifactList_TagFallsBackToVersion(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil)
+	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil, len(artifacts))
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -395,7 +395,7 @@ func TestWriteArtifactList_PreservesDigest(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil)
+	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil, len(artifacts))
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -429,7 +429,7 @@ func TestWriteArtifactList_SortsByNameThenVersionDescending(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil)
+	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil, len(artifacts))
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -458,7 +458,7 @@ func TestWriteArtifactList_CatalogColumn(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil)
+	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil, len(artifacts))
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -491,7 +491,7 @@ func TestWriteArtifactList_CrossCatalogDedup(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil)
+	err := writeArtifactList(context.Background(), w, artifacts, true, outputOpts, nil, len(artifacts))
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -531,7 +531,7 @@ func TestWriteArtifactList_LatestOnlyAfterDedup(t *testing.T) {
 
 	w := writer.New(ioStreams, &settings.Run{})
 	// showAll=false → only latest version per name+kind
-	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, nil)
+	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, nil, len(artifacts))
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -550,7 +550,7 @@ func TestWriteArtifactList_EmptyRespectsQuiet(t *testing.T) {
 
 	// With quiet=true, the "No artifacts found" message should be suppressed.
 	w := writer.New(ioStreams, &settings.Run{IsQuiet: true})
-	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, nil)
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, nil, 0)
 	require.NoError(t, err)
 	assert.Empty(t, errBuf.String(), "quiet mode should suppress info messages")
 }
@@ -625,7 +625,7 @@ func TestWriteArtifactList_NameWithoutAllVersions_ShowsLatestOnly(t *testing.T) 
 	// showAll=false simulates --name without --all-versions.
 	// Previously --name implied --all-versions; now it does not.
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, nil)
+	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, nil, len(artifacts))
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -667,7 +667,7 @@ func TestWriteArtifactList_LatestOnly_AssertsSingleResult(t *testing.T) {
 	}
 
 	w := writer.New(ioStreams, &settings.Run{})
-	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, nil)
+	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, nil, len(artifacts))
 	require.NoError(t, err)
 
 	var items []ArtifactListItem
@@ -696,7 +696,7 @@ func BenchmarkWriteArtifactList(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		_ = writeArtifactList(context.Background(), w, artifacts, false, outputOpts, nil)
+		_ = writeArtifactList(context.Background(), w, artifacts, false, outputOpts, nil, len(artifacts))
 	}
 }
 
@@ -719,7 +719,7 @@ func TestWriteArtifactList_EmptyStale_FailsLoudly(t *testing.T) {
 	w := writer.New(ioStreams, &settings.Run{})
 
 	degraded := staleDegraded(t)
-	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded, 0)
 
 	require.Error(t, err, "empty result on stale credentials must return an error")
 	assert.Equal(t, exitcode.CatalogError, exitcode.GetCode(err))
@@ -734,12 +734,36 @@ func TestWriteArtifactList_EmptyStale_FailsLoudly(t *testing.T) {
 	assert.Contains(t, errBuf.String(), "auth login")
 }
 
+// When the raw anonymous listing returned artifacts (rawResultCount > 0) but
+// user filters (pre-release, version constraint, --catalog) removed them all,
+// the empty final set is due to filtering, NOT the auth failure. This must be
+// non-fatal (exit 0) even though credentials were rejected: we still warn that
+// the listing was degraded, but we do not claim the auth failure emptied the
+// catalog.
+func TestWriteArtifactList_EmptyStaleButFilteredOut_NonFatal(t *testing.T) {
+	ioStreams, outBuf, errBuf := terminal.NewTestIOStreams()
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	w := writer.New(ioStreams, &settings.Run{})
+
+	degraded := staleDegraded(t)
+	// rawResultCount = 3: the anonymous listing had results, but filters left
+	// nothing in `artifacts`.
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded, 3)
+
+	require.NoError(t, err, "filter-emptied listing must not be treated as a fatal auth failure")
+	assert.NotContains(t, errBuf.String(), "Cannot list catalog",
+		"must not use the fatal empty-catalog framing when emptiness came from filtering")
+	assert.Contains(t, errBuf.String(), "Catalog listing is incomplete",
+		"should still surface the degraded/partial warning")
+	assert.Contains(t, outBuf.String(), "No artifacts found in catalog.")
+}
+
 func TestWriteArtifactList_EmptyNoStale_Unchanged(t *testing.T) {
 	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
 	outputOpts := kvx.NewOutputOptions(ioStreams)
 	w := writer.New(ioStreams, &settings.Run{})
 
-	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, nil)
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, nil, 0)
 	require.NoError(t, err)
 	assert.Contains(t, outBuf.String(), "No artifacts found in catalog.")
 }
@@ -759,7 +783,7 @@ func TestWriteArtifactList_NonEmptyStale_WarnsButSucceeds(t *testing.T) {
 	}}
 	degraded := staleDegraded(t)
 
-	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, degraded)
+	err := writeArtifactList(context.Background(), w, artifacts, false, outputOpts, degraded, len(artifacts))
 	require.NoError(t, err, "partial (non-empty) result must still succeed")
 	assert.Contains(t, outBuf.String(), "demo-app")
 	assert.Contains(t, errBuf.String(), "incomplete")
@@ -773,7 +797,7 @@ func TestWriteArtifactList_EmptyStaleJSON_MarkerOnStderr(t *testing.T) {
 	w := writer.New(ioStreams, &settings.Run{})
 
 	degraded := staleDegraded(t)
-	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded, 0)
 
 	require.Error(t, err)
 	assert.Equal(t, exitcode.CatalogError, exitcode.GetCode(err))
@@ -795,7 +819,7 @@ func TestWriteArtifactList_EmptyStale_HandlerOnly(t *testing.T) {
 	// Handler set but no explicit credential source -> "<handler> auth handler
 	// credentials" wording.
 	degraded := &catalogpkg.AuthDegradedError{Registry: "ghcr.io", Handler: "github"}
-	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded, 0)
 
 	require.Error(t, err)
 	assert.Equal(t, exitcode.CatalogError, exitcode.GetCode(err))
@@ -818,7 +842,7 @@ func TestWriteArtifactList_EmptyStale_GenericSourceAndRegistry(t *testing.T) {
 	degraded := catalogpkg.NewAuthDegradedError(rc)
 	require.NotNil(t, degraded)
 
-	wErr := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
+	wErr := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded, 0)
 	require.Error(t, wErr)
 	assert.Contains(t, errBuf.String(), "stored credentials")
 	assert.Contains(t, errBuf.String(), "private.example.com")
@@ -835,7 +859,7 @@ func TestWriteArtifactList_PrefersRecordedHandler(t *testing.T) {
 
 	// Non-inferable registry, but a handler was recorded on the error.
 	degraded := &catalogpkg.AuthDegradedError{Registry: "private.example.com", Handler: "corp-sso"}
-	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded, 0)
 
 	require.Error(t, err)
 	assert.Contains(t, errBuf.String(), "auth login corp-sso",
@@ -852,7 +876,7 @@ func TestWriteArtifactList_QuietSuppressesDegradedOutput(t *testing.T) {
 	w := writer.New(ioStreams, &settings.Run{})
 
 	degraded := staleDegraded(t)
-	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded, 0)
 
 	require.Error(t, err, "exit code still conveys the failure")
 	assert.Equal(t, exitcode.CatalogError, exitcode.GetCode(err))
@@ -870,7 +894,7 @@ func TestWriteArtifactList_EmptyStaleStructured_WritesEmptyArray(t *testing.T) {
 	w := writer.New(ioStreams, &settings.Run{})
 
 	degraded := staleDegraded(t)
-	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded)
+	err := writeArtifactList(context.Background(), w, nil, false, outputOpts, degraded, 0)
 
 	require.Error(t, err)
 	assert.Contains(t, outBuf.String(), "[]", "stdout should contain a parseable empty array")


### PR DESCRIPTION
## Summary

`catalog list` had a fail-open bug: when stored credentials for a private OCI registry are rejected, it silently fell back to anonymous access, printed `No artifacts found in catalog.`, and **exited 0** -- so a user (or a script checking the exit code) could not distinguish an auth failure from a genuinely empty catalog. In `-o json` mode it returned a bare `[]` with no signal at all.

Closes #682.

## Fix

- **`pkg/catalog/errors.go`** -- new typed `AuthDegradedError` (+ `NewAuthDegradedError`, `IsAuthDegraded`). The domain owns the error and its data-only message; the CLI renders it and adds the binary-name-specific fix hint (kept out of `pkg/cmd` per the business-logic-placement rule).
- **`pkg/cmd/scafctl/catalog/list.go`** -- thread the stale-credential state out of `listRemoteArtifacts` through the aggregate (`runList`), single-remote (`runListRemote`), and ref (`runListFromRemoteRef`) paths, and rework `writeArtifactList` into four branches:
  - **empty + stale** -> non-zero exit (`exitcode.CatalogError`) + actionable error naming the registry and the `auth login` fix; the misleading `No artifacts found` line is suppressed. This is gated on the **raw** (pre-filter) anonymous result being empty: a `rawResultCount` is threaded through all three render paths, so a listing that returned artifacts anonymously but had them all removed by user filters (`--pre-release`, a version constraint, `--catalog`) stays **non-fatal** (exit 0, degraded warning) -- the emptiness is attributed to filtering, not the auth failure.
  - **non-empty + stale** -> print the (partial) results and exit 0, with a warning that the listing is incomplete. Partial success must not fail.
  - **`-o json`** (either stale case) -> emit a `{"degraded":true,"authError":{...}}` marker to **stderr** so machine consumers detect it. In structured mode stdout still receives a parseable array (an empty `[]` in the empty+stale case), so consumers can always parse stdout even on the non-zero exit.
  - no-stale cases unchanged.

All three options requested in the issue are delivered (non-zero exit + error, degraded message, structured marker).

## Tests

- Domain: `AuthDegradedError`/`New`/`Is` (100%).
- CLI: `writeArtifactList` branch tests via `SetStaleForTesting` -- empty+stale (fatal), empty+no-stale, non-empty+stale, the json stderr marker, the handler-only / generic credential-source fallbacks, and `EmptyStaleButFilteredOut_NonFatal` (raw listing non-empty but filtered to empty -> exit 0 with degraded warning, not the fatal framing).

The degraded path is only reachable through a real OCI stale-credential handshake (the client sends credentials only after a challenge, then they're rejected). Simulating that end-to-end was brittle; the fix is tested at the `writeArtifactList` seam, which drives the identical `NewAuthDegradedError` -> render logic deterministically. Both the go-reviewer and artifact-auditor agreed this is the right test boundary.

## MCP

The MCP catalog-list tools use the **local** catalog only (`handleCatalogList` -> `NewLocalCatalog(...).List`), so they cannot hit the remote stale-credential path and are unchanged.

## Verification

- go-reviewer: APPROVE (0 critical/high/medium).
- artifact-auditor: complete, no must-fix.
- `-race` tests green; `task lint:changed`: 0 issues; new-code coverage 90-100%.

## BREAKING CHANGE

`catalog list` now exits **non-zero** (`CatalogError`) when the result is empty **and** stored credentials were rejected (previously exit 0), and in `-o json` mode emits a `degraded`/`authError` marker on **stderr**. Scripts that treated an empty listing as success, or that only read stdout, must account for this. Breaking changes are permitted in this repo; noting it here as required.

