### PR TITLE
fix(resolver,providers): raise resolver step caps to 200 and remove cel/debug expression maxLength

### DIFF
--- a/pkg/provider/builtin/celprovider/cel.go
+++ b/pkg/provider/builtin/celprovider/cel.go
@@ -14,7 +14,6 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/schemahelper"
-	"github.com/oakwood-commons/scafctl/pkg/ptrs"
 )
 
 const (
@@ -62,8 +61,7 @@ func NewCelProvider() *CelProvider {
 			},
 			Schema: schemahelper.ObjectSchema([]string{"expression"}, map[string]*jsonschema.Schema{
 				"expression": schemahelper.StringProp("CEL expression to evaluate. Resolver data is available under the '_' variable (e.g., _.name).",
-					schemahelper.WithExample("_.name.upperAscii()"),
-					schemahelper.WithMaxLength(*ptrs.IntPtr(8192))),
+					schemahelper.WithExample("_.name.upperAscii()")),
 				"variables": schemahelper.AnyProp("Additional variables to make available in the CEL expression context",
 					schemahelper.WithExample(map[string]any{"prefix": "Mr.", "suffix": "Jr."})),
 			}),

--- a/pkg/provider/builtin/celprovider/cel_test.go
+++ b/pkg/provider/builtin/celprovider/cel_test.go
@@ -27,6 +27,16 @@ func TestNewCelProvider(t *testing.T) {
 	assert.NotEmpty(t, desc.OutputSchemas[provider.CapabilityTransform].Properties)
 }
 
+// TestCelProvider_ExpressionNoMaxLength verifies the expression input has no
+// maxLength cap. CEL runtime cost limits are the real DoS guard, so a character
+// cap only produces false rejections for large literal expressions.
+func TestCelProvider_ExpressionNoMaxLength(t *testing.T) {
+	desc := NewCelProvider().Descriptor()
+	expr := desc.Schema.Properties["expression"]
+	require.NotNil(t, expr)
+	assert.Nil(t, expr.MaxLength, "expression input must not cap maxLength")
+}
+
 func TestCelProvider_Execute_StringTransform(t *testing.T) {
 	p := NewCelProvider()
 	ctx := provider.WithResolverContext(context.Background(), map[string]any{

--- a/pkg/provider/builtin/debugprovider/debug.go
+++ b/pkg/provider/builtin/debugprovider/debug.go
@@ -76,8 +76,7 @@ func NewDebugProvider() *DebugProvider {
 			},
 			Schema: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 				fieldExpression: schemahelper.StringProp("Optional CEL expression to filter or transform resolver data before output. If not provided, outputs all resolver data. Resolver data is available under the '_' variable (e.g., _.user.name).",
-					schemahelper.WithExample("_.user.name"),
-					schemahelper.WithMaxLength(*ptrs.IntPtr(8192))),
+					schemahelper.WithExample("_.user.name")),
 				fieldLabel: schemahelper.StringProp("Optional label or message to add context to the debug output",
 					schemahelper.WithExample("User data after transformation"),
 					schemahelper.WithMaxLength(*ptrs.IntPtr(500))),

--- a/pkg/provider/builtin/debugprovider/debug_test.go
+++ b/pkg/provider/builtin/debugprovider/debug_test.go
@@ -22,6 +22,16 @@ func TestNewDebugProvider(t *testing.T) {
 	assert.Equal(t, "Debug Provider", p.Descriptor().DisplayName)
 }
 
+// TestDebugProvider_ExpressionNoMaxLength verifies the expression input has no
+// maxLength cap. CEL runtime cost limits are the real DoS guard, so a character
+// cap only produces false rejections for large literal expressions.
+func TestDebugProvider_ExpressionNoMaxLength(t *testing.T) {
+	desc := NewDebugProvider().Descriptor()
+	expr := desc.Schema.Properties[fieldExpression]
+	require.NotNil(t, expr)
+	assert.Nil(t, expr.MaxLength, "expression input must not cap maxLength")
+}
+
 func TestDebugProvider_Execute_AllResolverData(t *testing.T) {
 	p := NewDebugProvider()
 	ctx := logger.WithLogger(context.Background(), logger.Get(0))

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -38,6 +38,22 @@ const (
 	ErrorBehaviorContinue = spec.OnErrorContinue
 )
 
+// Phase step-count caps. These bound the number of provider steps allowed in a
+// resolver phase, guarding against pathological solutions while leaving ample
+// headroom for values assembled from many sequential steps. They must stay in
+// sync with the maxItems struct tags on ResolvePhase.With, TransformPhase.With,
+// and ValidatePhase.With (enforced by a drift-guard test). They are unexported
+// because the tags do the enforcing; the constants exist only to document the
+// value and guard against drift.
+const (
+	// maxResolveSteps is the maximum number of steps in a resolve phase.
+	maxResolveSteps = 200
+	// maxTransformSteps is the maximum number of steps in a transform phase.
+	maxTransformSteps = 200
+	// maxValidateSteps is the maximum number of steps in a validate phase.
+	maxValidateSteps = 200
+)
+
 // Condition is a resolver-specific condition type with custom YAML/JSON unmarshalling.
 // Unlike spec.Condition, this type only wraps the expr field, keeping backward
 // compatibility with existing resolver YAML files.
@@ -236,20 +252,20 @@ type Messages struct {
 
 // ResolvePhase defines how to obtain an initial value
 type ResolvePhase struct {
-	With  []ProviderSource `json:"with" yaml:"with" doc:"Ordered list of value sources" minItems:"1" maxItems:"50"`
+	With  []ProviderSource `json:"with" yaml:"with" doc:"Ordered list of value sources" minItems:"1" maxItems:"200"`
 	Until *Condition       `json:"until,omitempty" yaml:"until,omitempty" doc:"Stop condition (default: first non-null)"`
 	When  *Condition       `json:"when,omitempty" yaml:"when,omitempty" doc:"Phase-level condition"`
 }
 
 // TransformPhase defines how to derive a new value
 type TransformPhase struct {
-	With []ProviderTransform `json:"with" yaml:"with" doc:"Ordered list of transformations" minItems:"1" maxItems:"50"`
+	With []ProviderTransform `json:"with" yaml:"with" doc:"Ordered list of transformations" minItems:"1" maxItems:"200"`
 	When *Condition          `json:"when,omitempty" yaml:"when,omitempty" doc:"Phase-level condition"`
 }
 
 // ValidatePhase defines validation constraints
 type ValidatePhase struct {
-	With []ProviderValidation `json:"with" yaml:"with" doc:"Validation rules" minItems:"1" maxItems:"20"`
+	With []ProviderValidation `json:"with" yaml:"with" doc:"Validation rules" minItems:"1" maxItems:"200"`
 	When *Condition           `json:"when,omitempty" yaml:"when,omitempty" doc:"Phase-level condition"`
 }
 

--- a/pkg/resolver/resolver_test.go
+++ b/pkg/resolver/resolver_test.go
@@ -5,6 +5,8 @@ package resolver
 
 import (
 	"encoding/json"
+	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -13,6 +15,41 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
+
+// TestPhaseStepCaps_TagsMatchConstants guards against drift between the phase
+// step-count constants and the maxItems struct tags they document. The tags
+// must be literals (Go struct tags cannot reference constants), so this test
+// is the single source of truth keeping the two in sync.
+func TestPhaseStepCaps_TagsMatchConstants(t *testing.T) {
+	tests := []struct {
+		name     string
+		typ      reflect.Type
+		field    string
+		expected int
+	}{
+		{"resolve phase", reflect.TypeOf(ResolvePhase{}), "With", maxResolveSteps},
+		{"transform phase", reflect.TypeOf(TransformPhase{}), "With", maxTransformSteps},
+		{"validate phase", reflect.TypeOf(ValidatePhase{}), "With", maxValidateSteps},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			field, ok := tt.typ.FieldByName(tt.field)
+			require.True(t, ok, "field %s not found on %s", tt.field, tt.typ.Name())
+			tag := field.Tag.Get("maxItems")
+			require.NotEmpty(t, tag, "maxItems tag missing on %s.%s", tt.typ.Name(), tt.field)
+			assert.Equal(t, tt.expected, mustAtoi(t, tag),
+				"maxItems tag on %s.%s must match the documented constant", tt.typ.Name(), tt.field)
+		})
+	}
+}
+
+func mustAtoi(t *testing.T, s string) int {
+	t.Helper()
+	n, err := strconv.Atoi(s)
+	require.NoError(t, err, "maxItems tag %q is not an integer", s)
+	return n
+}
 
 func TestResolverType_Constants(t *testing.T) {
 	tests := []struct {

--- a/pkg/schema/validate_test.go
+++ b/pkg/schema/validate_test.go
@@ -146,6 +146,60 @@ func TestValidateSolutionAgainstSchema_ConditionShorthand(t *testing.T) {
 	})
 }
 
+// TestValidateSolutionAgainstSchema_TransformStepCap verifies the resolver
+// transform phase accepts up to the raised step cap (200) and rejects more.
+// This guards the loosened maxItems boundary against regressions.
+func TestValidateSolutionAgainstSchema_TransformStepCap(t *testing.T) {
+	buildSolution := func(n int) map[string]any {
+		steps := make([]any, 0, n)
+		for range n {
+			steps = append(steps, map[string]any{
+				"provider": "cel",
+				"inputs":   map[string]any{"expression": "_"},
+			})
+		}
+		return map[string]any{
+			"apiVersion": "scafctl.io/v1",
+			"kind":       "Solution",
+			"metadata": map[string]any{
+				"name":    "test-solution",
+				"version": "1.0.0",
+			},
+			"spec": map[string]any{
+				"resolvers": map[string]any{
+					"a": map[string]any{
+						"name":        "a",
+						"description": "d",
+						"resolve": map[string]any{
+							"with": []any{map[string]any{
+								"provider": "static",
+								"inputs":   map[string]any{"value": "hi"},
+							}},
+						},
+						"transform": map[string]any{
+							"with": steps,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("at cap validates", func(t *testing.T) {
+		resetSolutionSchemaOnce()
+		violations, err := ValidateSolutionAgainstSchema(buildSolution(200))
+		require.NoError(t, err)
+		assert.Empty(t, violations, "200 transform steps should validate")
+	})
+
+	t.Run("above cap is flagged", func(t *testing.T) {
+		resetSolutionSchemaOnce()
+		violations, err := ValidateSolutionAgainstSchema(buildSolution(201))
+		require.NoError(t, err)
+		assert.NotEmpty(t, violations, "201 transform steps should exceed the cap")
+	})
+}
+
 // conditionSolution builds a minimal solution whose single source carries the
 // supplied extra keys (e.g., a when or continueOnError condition).
 func conditionSolution(sourceExtra map[string]any) map[string]any {


### PR DESCRIPTION
Two coupled authoring-friction fixes (addresses the two local issues on `cel` provider `expression` maxLength and resolver `with` step caps).

## What changed

- **Remove the `maxLength: 8192` cap on the `expression` input** of the `cel` and `debug` providers. The CEL runtime cost limit (`settings.DefaultCELCostLimit`, applied per-solution via `spec.options.cel.costLimit` with `min(solution, global)` semantics) is the real DoS guard, so a character cap only produced false rejections for large literal expressions. Plugin transport already permits 64 MB inputs.
- **Raise the resolver phase step caps from 50/50/20 to 200** on `ResolvePhase.With`, `TransformPhase.With`, and `ValidatePhase.With`. These are sanity guards, not security controls; 200 leaves ample headroom for values assembled from many sequential steps. The two caps are coupled -- splitting a long expression to dodge the char cap runs into the step cap -- so they ship together.

## Why not configurable

The one lever that matters for evaluation-cost DoS (the CEL cost limit) is already configurable. The step caps are static struct tags feeding a cached reflected schema; making them runtime-configurable would require schema post-processing for negligible benefit. Deferred.

## Tests

- `TestCelProvider_ExpressionNoMaxLength`, `TestDebugProvider_ExpressionNoMaxLength` -- assert the `expression` input is uncapped.
- `TestPhaseStepCaps_TagsMatchConstants` -- reflection-based drift guard tying the `maxItems` struct-tag literals to the (unexported) `maxResolveSteps`/`maxTransformSteps`/`maxValidateSteps` constants.
- `TestValidateSolutionAgainstSchema_TransformStepCap` -- 200 steps validate, 201 rejected.

## Verification

- `pkg/resolver`, `pkg/provider/builtin/celprovider`, `pkg/provider/builtin/debugprovider`, `pkg/schema` tests pass.
- Functional: a solution with 60 transform steps + a 12,001-char expression lints clean.
- `task lint:changed` -> 0 issues.

## Notes

- The `message` provider's `maxMessageLength = 8192` is intentionally left unchanged (separate output-formatting concern with a `type: raw` bypass).
- Non-breaking: raising/removing a max only accepts more input.