### PR TITLE
test(auth): fix flaky diagnose backend assertion and clarify BackendReporter doc

### DIFF
--- a/pkg/auth/diagnose/diagnose_test.go
+++ b/pkg/auth/diagnose/diagnose_test.go
@@ -357,7 +357,7 @@ func TestRunSecretsStoreCheck(t *testing.T) {
 
 // TestProbeSecretsStore_ReadOnly exercises the real probeSecretsStore against a
 // seeded env-backend master key and asserts it is read-only: it reports the key
-// as found via the env backend and never writes a master.key file to the data dir.
+// as found and never writes a master.key file to the data dir.
 func TestProbeSecretsStore_ReadOnly(t *testing.T) {
 	dataHome := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", dataHome)
@@ -372,7 +372,12 @@ func TestProbeSecretsStore_ReadOnly(t *testing.T) {
 
 	require.NoError(t, res.err, "seeded env key should probe without a hard error")
 	assert.True(t, res.found, "seeded env key should be found")
-	assert.Equal(t, secrets.KeyringBackendEnv, res.backend, "env backend should satisfy the read")
+	// The default keyring prefers the OS backend ahead of the env backend, so on a
+	// host that already has a master key in the OS keyring the probe resolves "os";
+	// otherwise it falls through to the seeded env key. Either is a correct, read-only
+	// result -- the invariant under test is the read-only proof below.
+	assert.Contains(t, []string{secrets.KeyringBackendOS, secrets.KeyringBackendEnv}, res.backend,
+		"os or env backend should satisfy the read")
 
 	// Read-only proof: no master.key file was created under the isolated data dir.
 	masterKey := filepath.Join(dataHome, "scafctl", "master.key")

--- a/pkg/secrets/keyring.go
+++ b/pkg/secrets/keyring.go
@@ -411,15 +411,17 @@ func (k *chainKeyring) Delete(service, account string) error {
 }
 
 // BackendReporter is implemented by keyrings that can report which backend
-// last satisfied a Get (e.g. the default chain keyring). Callers can type-assert
-// a Keyring to BackendReporter to learn the resolved backend without mutating.
+// last satisfied a Get or Set (e.g. the default chain keyring). Callers can
+// type-assert a Keyring to BackendReporter to learn the resolved backend
+// without mutating.
 type BackendReporter interface {
 	// Backend returns the backend identifier (os/env/file) that last satisfied
-	// a successful Get, or an empty string if no Get has succeeded yet.
+	// a successful Get or Set, or an empty string if none has succeeded yet.
 	Backend() string
 }
 
-// Backend returns the backend identifier for the keyring that last satisfied a Get.
+// Backend returns the backend identifier for the keyring that last satisfied a
+// Get or Set.
 func (k *chainKeyring) Backend() string {
 	return k.resolvedBackend
 }


### PR DESCRIPTION
## Problem

Two follow-up review nits from PR #689 (issue #684 `auth diagnose` secrets-store
check) were replied-and-resolved on GitHub as "fixed", but the fix commit was
never included in the squash merge -- so `main` still carries the old code.
This PR re-lands both.

## Fix

- **Flaky test** -- `TestProbeSecretsStore_ReadOnly` hard-asserted the resolved
  backend was the env backend, but `NewDefaultKeyring()` prefers the OS keyring
  ahead of env. On a host that already has a `scafctl`/`master-key` entry in its
  OS keyring the probe correctly resolves `os`, flaking the test. The assertion
  is relaxed to accept `os` or `env`; the read-only proof (no `master.key`
  written) stays strict, since that is the real invariant under test.

- **Doc accuracy** -- `BackendReporter` / `chainKeyring.Backend()` docs said the
  reported backend was the one that last satisfied a `Get`, but `resolvedBackend`
  is assigned on both the `Get` and `Set` paths. The contract is clarified to
  "Get or Set".

## Tests

Test + doc-comment only, no behavior change. `go build ./...` clean;
`go test ./pkg/auth/diagnose/... ./pkg/secrets/...` pass; `task lint:changed`
reports 0 issues.
