### PR TITLE
feat(providers): add multi-key map read mode to state provider

### DIFF
--- a/docs/design/state/persisted-resolvers-state-provider.md
+++ b/docs/design/state/persisted-resolvers-state-provider.md
@@ -208,6 +208,41 @@ Behavior:
 - Dry-run reads the loaded snapshot normally; it is read-only and has no side
   effect.
 
+#### Map mode (`keys` / `all`)
+
+Instead of a single `key`, an author may read many persisted values into one map.
+Specify **exactly one** of `key`, `keys`, or `all`:
+
+```yaml
+resolvers:
+  # Read an explicit set of persisted keys into a map.
+  - name: prior_config
+    from:
+      provider: state
+      operation: get
+      keys: [region, tier, cluster_id]
+
+  # Read the entire persisted snapshot into a map.
+  - name: prior_state
+    from:
+      provider: state
+      operation: get
+      all: true
+```
+
+- The resolver value is the **bare map** (`_.prior_config.region`), keeping the
+  same shape convention as single-key mode returning a bare scalar.
+- Absent keys are **omitted** from the map rather than defaulted, so
+  `has(_.prior_config.tier)` and `_.prior_config.?tier.orValue(d)` stay faithful.
+  This restores the key-absence fidelity that a hand-assembled `cel` map loses.
+- The present-key list (and, in `keys` mode, the requested-but-absent `missing`
+  list) is reported in provider **metadata** (visible via `run provider`), not in
+  the resolver value. Reconstruct the missing set in CEL with
+  `myKeys.filter(k, !has(_.prior_config[k]))`.
+- `default` is only valid with a single `key`; combining it with `keys`/`all` is
+  an error (in map mode absence is expressed by omission).
+- Like `key`, `keys`/`all` create no dependency edges in the resolver graph.
+
 ### Ordering guarantee
 
 The correctness of the feature rests on the run lifecycle: state is loaded into

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -2464,11 +2464,32 @@ without forming a self-cycle.
 
 ### Inputs
 
+Specify **exactly one** of `key`, `keys`, or `all` to choose the read mode.
+
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
 | `operation` | string | ❌ | State operation. Only `get` is supported (the default). |
-| `key` | string | ✅ | Name of the persisted resolver whose prior-run value to read. |
-| `default` | any | ❌ | Value returned when the key has no persisted entry (e.g. on the first run). Returns null when omitted. |
+| `key` | string | ❌ | Single-key mode. Name of the persisted resolver whose prior-run value to read. Returns the value directly. |
+| `keys` | array | ❌ | Map mode. Explicit set of persisted keys to read as a map. Absent keys are **omitted** from the map. |
+| `all` | bool | ❌ | Map mode. When `true`, read the entire persisted snapshot as a map. |
+| `default` | any | ❌ | Only valid with `key`: value returned when the key has no persisted entry (e.g. on the first run). Returns null when omitted. In map mode absent keys are omitted instead, so `default` is rejected. |
+
+### Read modes
+
+- **Single key** (`key`): returns the persisted value directly, or `default`/null
+  when absent. `_.prior_password` is the scalar value.
+- **Explicit set** (`keys`): returns a map of the requested keys to their
+  persisted values. Requested keys with no persisted entry are **omitted** from
+  the map (not defaulted), so `has(_.myState.keyB)` and
+  `_.myState.?keyB.orValue(d)` remain faithful.
+- **Whole snapshot** (`all: true`): returns a map of every persisted resolver's
+  prior-run value.
+
+In map mode the resolver value is the bare map. The set of present keys (and, in
+`keys` mode, the requested-but-absent keys) is reported in provider metadata,
+visible via `scafctl run provider state ...` but not in the resolver value. You
+can reconstruct the missing set in CEL with
+`myKeys.filter(k, !has(_.myState[k]))`.
 
 ### Examples
 
@@ -2492,6 +2513,24 @@ resolvers:
             operation: get
             key: db_password
             default: ""
+
+  # Reads several persisted keys at once as a map (absent keys omitted).
+  prior_config:
+    resolve:
+      with:
+        - provider: state
+          inputs:
+            operation: get
+            keys: [region, tier, cluster_id]
+
+  # Reads the entire persisted snapshot as a map.
+  prior_state:
+    resolve:
+      with:
+        - provider: state
+          inputs:
+            operation: get
+            all: true
 ```
 
 Within a single run, `state.get("db_password")` returns the prior run's value

--- a/examples/solutions/state-persist/solution.yaml
+++ b/examples/solutions/state-persist/solution.yaml
@@ -82,6 +82,34 @@ spec:
               default: ""
 
     # =========================================================================
+    # Map mode -- read several persisted keys at once as a map
+    # =========================================================================
+    # `keys` reads an explicit set of persisted values into one map instead of
+    # one resolver per key. Absent keys are OMITTED (not defaulted), so
+    # has(_.prior_bag.current_token) and _.prior_bag.?ghost.orValue(d) stay
+    # faithful. No `type` is set because the value is a map, not a scalar.
+    prior_bag:
+      description: Reads a set of prior-run persisted keys into a single map
+      resolve:
+        with:
+          - provider: state
+            inputs:
+              operation: get
+              keys: [current_token, ghost_key]
+
+    # =========================================================================
+    # Whole-snapshot mode -- read every persisted value as a map
+    # =========================================================================
+    prior_snapshot:
+      description: Reads the entire prior-run persisted snapshot as a map
+      resolve:
+        with:
+          - provider: state
+            inputs:
+              operation: get
+              all: true
+
+    # =========================================================================
     # Summary -- compares this run's value with the prior run's value
     # =========================================================================
     token_summary:
@@ -92,7 +120,7 @@ spec:
           - provider: static
             inputs:
               value:
-                expr: "'current=' + _.current_token + ' previous=' + _.previous_token"
+                expr: "'current=' + _.current_token + ' previous=' + _.previous_token + ' bag_current=' + _.prior_bag.?current_token.orValue('none') + ' snapshot_keys=' + string(size(_.prior_snapshot))"
 
   workflow:
     actions:

--- a/pkg/provider/builtin/stateprovider/state.go
+++ b/pkg/provider/builtin/stateprovider/state.go
@@ -10,8 +10,11 @@ package stateprovider
 import (
 	"context"
 	"fmt"
+	"regexp"
+	"sort"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/go-logr/logr"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -32,6 +35,10 @@ const (
 // keyPattern matches a persisted resolver key. It mirrors the resolver name
 // grammar so authors cannot pass expressions or path traversals as a key.
 const keyPattern = `^[A-Za-z_][A-Za-z0-9_.\-]*$`
+
+// keyRe is the compiled form of keyPattern. The schema enforces the pattern on
+// the single-key input; map mode ("keys" list) validates each entry at runtime.
+var keyRe = regexp.MustCompile(keyPattern)
 
 // StateProvider reads previously persisted resolver values from the state
 // snapshot carried in the execution context. It performs no I/O and never
@@ -57,27 +64,37 @@ func New() *StateProvider {
 			Capabilities: []provider.Capability{
 				provider.CapabilityFrom,
 			},
-			Schema: schemahelper.ObjectSchema([]string{"key"}, map[string]*jsonschema.Schema{
-				"operation": schemahelper.StringProp("The state operation to perform. Only \"get\" is supported; it reads a persisted value from the loaded snapshot.",
+			Schema: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
+				"operation": schemahelper.StringProp("The state operation to perform. Only \"get\" is supported; it reads persisted value(s) from the loaded snapshot.",
 					schemahelper.WithEnum(OperationGet),
 					schemahelper.WithExample(OperationGet)),
-				"key": schemahelper.StringProp("Name of the persisted resolver whose prior-run value to read. Treated as an opaque string; it never creates a dependency edge in the resolver graph.",
+				"key": schemahelper.StringProp("Name of a single persisted resolver whose prior-run value to read. Returns the value directly. Treated as an opaque string; it never creates a dependency edge in the resolver graph. Mutually exclusive with \"keys\" and \"all\".",
 					schemahelper.WithMaxLength(*ptrs.IntPtr(256)),
 					schemahelper.WithPattern(keyPattern),
 					schemahelper.WithExample("db_password")),
-				"default": schemahelper.AnyProp("Value to return when the key has no persisted entry (e.g. on the first run). When omitted, a missing key returns null.",
+				"keys": schemahelper.ArrayProp("Explicit set of persisted keys to read as a map. Absent keys are OMITTED from the returned map (not defaulted) so has() and optional chaining stay faithful. Mutually exclusive with \"key\" and \"all\".",
+					schemahelper.WithItems(schemahelper.StringProp("A persisted resolver key",
+						schemahelper.WithMaxLength(*ptrs.IntPtr(256)),
+						schemahelper.WithPattern(keyPattern))),
+					schemahelper.WithExample([]any{"keyA", "keyB"})),
+				"all": schemahelper.BoolProp("When true, read the entire persisted snapshot as a map (every persisted resolver's prior-run value). Mutually exclusive with \"key\" and \"keys\".",
+					schemahelper.WithExample(true)),
+				"default": schemahelper.AnyProp("Value to return when the key has no persisted entry (e.g. on the first run). Only valid with \"key\"; in map mode absent keys are omitted instead. When omitted, a missing key returns null.",
 					schemahelper.WithExample("")),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
-				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
-					"value":  schemahelper.AnyProp("The persisted value from the prior run, or the default (or null) when absent", schemahelper.WithExample("prior-value")),
-					"exists": schemahelper.BoolProp("Whether a persisted entry existed for the key", schemahelper.WithExample(true)),
-				}),
+				provider.CapabilityFrom: schemahelper.AnyProp("In single-key mode the persisted value (or the default/null when absent). In map mode (\"keys\"/\"all\") a map of present keys to their persisted values, with absent keys omitted."),
 			},
 			WhatIf: func(_ context.Context, input any) (string, error) {
 				inputs, ok := input.(map[string]any)
 				if !ok {
 					return "", nil
+				}
+				if all, ok := inputs["all"].(bool); ok && all {
+					return "Would read the entire persisted state snapshot as a map", nil
+				}
+				if _, ok := inputs["keys"]; ok {
+					return "Would read the requested persisted state keys as a map", nil
 				}
 				if key, ok := inputs["key"].(string); ok {
 					return fmt.Sprintf("Would read persisted state value for key %q", key), nil
@@ -93,6 +110,22 @@ inputs:
   operation: get
   key: db_password
   default: ""`,
+				},
+				{
+					Name:        "Read a set of persisted keys as a map",
+					Description: "Read several persisted keys at once. Absent keys are omitted, so has(_.myState.keyB) stays faithful.",
+					YAML: `provider: state
+inputs:
+  operation: get
+  keys: [keyA, keyB, keyC]`,
+				},
+				{
+					Name:        "Read the whole persisted snapshot",
+					Description: "Read every persisted resolver value as a single map.",
+					YAML: `provider: state
+inputs:
+  operation: get
+  all: true`,
 				},
 			},
 		},
@@ -129,12 +162,50 @@ func (p *StateProvider) Execute(ctx context.Context, input any) (*provider.Outpu
 		return nil, fmt.Errorf("%s: unsupported operation %q (only %q is supported)", ProviderName, operation, OperationGet)
 	}
 
+	// Determine the read mode. Exactly one of key / keys / all selects a mode.
+	_, hasKey := inputs["key"]
+	rawKeys, hasKeys := inputs["keys"]
+
+	allMode := false
+	if raw, ok := inputs["all"]; ok {
+		b, ok := raw.(bool)
+		if !ok {
+			return nil, fmt.Errorf("%s: all must be a boolean, got %T", ProviderName, raw)
+		}
+		// Only all:true selects the whole-snapshot mode; all:false is inert.
+		allMode = b
+	}
+
+	selectors := 0
+	if hasKey {
+		selectors++
+	}
+	if hasKeys {
+		selectors++
+	}
+	if allMode {
+		selectors++
+	}
+	if selectors != 1 {
+		return nil, fmt.Errorf(`%s: specify exactly one of "key", "keys", or "all"`, ProviderName)
+	}
+
+	def, hasDefault := inputs["default"]
+
+	// Map mode: read a set of keys (or the whole snapshot) into a map, omitting
+	// absent keys so has()/optional chaining remain faithful.
+	if hasKeys || allMode {
+		if hasDefault {
+			return nil, fmt.Errorf(`%s: "default" is only valid with a single "key"; in map mode absent keys are omitted (use has()/optional chaining)`, ProviderName)
+		}
+		return p.executeMapGet(ctx, lgr, rawKeys, allMode)
+	}
+
+	// Single-key mode.
 	key, ok := inputs["key"].(string)
 	if !ok || key == "" {
 		return nil, fmt.Errorf("%s: missing required input: key", ProviderName)
 	}
-
-	def, hasDefault := inputs["default"]
 
 	// Read the value from the loaded snapshot only. When state is disabled or a
 	// persisted entry does not exist, fall back to the default (or null).
@@ -158,4 +229,83 @@ func (p *StateProvider) Execute(ctx context.Context, input any) (*provider.Outpu
 		Data:     value,
 		Metadata: map[string]any{"exists": false},
 	}, nil
+}
+
+// executeMapGet reads either an explicit set of keys or the entire persisted
+// snapshot into a map. Absent keys are omitted from the returned map (rather
+// than defaulted) so that has() and optional chaining against the map stay
+// faithful. The present-key list (and, in keys mode, the requested-but-absent
+// list) is reported in metadata; the resolver value is the bare map.
+func (p *StateProvider) executeMapGet(ctx context.Context, lgr *logr.Logger, rawKeys any, allMode bool) (*provider.Output, error) {
+	stateData, _ := state.FromContext(ctx)
+
+	result := make(map[string]any)
+	presentKeys := []string{}
+	missing := []string{}
+
+	if allMode {
+		if stateData != nil {
+			for k, entry := range stateData.Resolvers {
+				if entry == nil {
+					continue
+				}
+				result[k] = entry.Value
+				presentKeys = append(presentKeys, k)
+			}
+		}
+		sort.Strings(presentKeys)
+	} else {
+		requested, err := toStringKeys(rawKeys)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", ProviderName, err)
+		}
+		for i, k := range requested {
+			if !keyRe.MatchString(k) {
+				return nil, fmt.Errorf("%s: invalid key %q at keys[%d]", ProviderName, k, i)
+			}
+		}
+		for _, k := range requested {
+			if stateData != nil {
+				if entry, exists := stateData.Resolvers[k]; exists && entry != nil {
+					result[k] = entry.Value
+					presentKeys = append(presentKeys, k)
+					continue
+				}
+			}
+			missing = append(missing, k)
+		}
+	}
+
+	metadata := map[string]any{
+		"mode": "map",
+		"keys": presentKeys,
+	}
+	if !allMode {
+		metadata["missing"] = missing
+	}
+	lgr.V(1).Info("provider completed", "provider", ProviderName, "mode", "map", "present", len(presentKeys), "missing", len(missing))
+	return &provider.Output{Data: result, Metadata: metadata}, nil
+}
+
+// toStringKeys normalizes the "keys" input into a []string. It accepts both
+// []string and []any (the shape a CEL list or YAML sequence produces).
+func toStringKeys(raw any) ([]string, error) {
+	switch v := raw.(type) {
+	case []string:
+		return v, nil
+	case []any:
+		out := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("keys[%d] must be a string, got %T", i, item)
+			}
+			out = append(out, s)
+		}
+		return out, nil
+	case nil:
+		return nil, fmt.Errorf(`"keys" must be an array of strings`)
+	default:
+		return nil, fmt.Errorf(`"keys" must be an array of strings, got %T`, raw)
+	}
 }

--- a/pkg/provider/builtin/stateprovider/state_benchmark_test.go
+++ b/pkg/provider/builtin/stateprovider/state_benchmark_test.go
@@ -34,4 +34,22 @@ func BenchmarkStateProvider_Execute(b *testing.B) {
 			_, _ = p.Execute(ctx, inputs)
 		}
 	})
+
+	b.Run("keys_map", func(b *testing.B) {
+		inputs := map[string]any{"keys": []any{"db_password", "absent"}}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_, _ = p.Execute(ctx, inputs)
+		}
+	})
+
+	b.Run("all_map", func(b *testing.B) {
+		inputs := map[string]any{"all": true}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_, _ = p.Execute(ctx, inputs)
+		}
+	})
 }

--- a/pkg/provider/builtin/stateprovider/state_test.go
+++ b/pkg/provider/builtin/stateprovider/state_test.go
@@ -104,7 +104,7 @@ func TestStateProvider_Execute_MissingKeyInput(t *testing.T) {
 
 	_, err := p.Execute(ctx, map[string]any{"operation": OperationGet})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "missing required input: key")
+	assert.Contains(t, err.Error(), `specify exactly one of "key", "keys", or "all"`)
 }
 
 func TestStateProvider_Execute_EmptyKeyInput(t *testing.T) {
@@ -158,4 +158,182 @@ func TestStateProvider_WhatIf(t *testing.T) {
 	msg, err = whatIf(context.Background(), "not-a-map")
 	require.NoError(t, err)
 	assert.Empty(t, msg)
+}
+
+func TestStateProvider_WhatIf_MapModes(t *testing.T) {
+	p := New()
+	whatIf := p.Descriptor().WhatIf
+	require.NotNil(t, whatIf)
+
+	msg, err := whatIf(context.Background(), map[string]any{"all": true})
+	require.NoError(t, err)
+	assert.Contains(t, msg, "entire persisted state snapshot")
+
+	msg, err = whatIf(context.Background(), map[string]any{"keys": []any{"a", "b"}})
+	require.NoError(t, err)
+	assert.Contains(t, msg, "requested persisted state keys")
+
+	// all:false is inert and should not select the snapshot message.
+	msg, err = whatIf(context.Background(), map[string]any{"all": false, "key": "k"})
+	require.NoError(t, err)
+	assert.Contains(t, msg, "k")
+}
+
+func TestStateProvider_Execute_KeysMode_ReturnsMapOmittingAbsent(t *testing.T) {
+	p := New()
+	ctx := ctxWithState(t, map[string]*state.PersistedEntry{
+		"keyA": {Value: "alpha", Type: "string", CreatedAt: time.Now().UTC()},
+		"keyC": {Value: "gamma", Type: "string", CreatedAt: time.Now().UTC()},
+	})
+
+	output, err := p.Execute(ctx, map[string]any{
+		"operation": OperationGet,
+		"keys":      []any{"keyA", "keyB", "keyC"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	got, ok := output.Data.(map[string]any)
+	require.True(t, ok, "map mode must return a map")
+	assert.Equal(t, map[string]any{"keyA": "alpha", "keyC": "gamma"}, got)
+	// keyB is absent, so has()/optional chaining stay faithful.
+	_, exists := got["keyB"]
+	assert.False(t, exists)
+
+	assert.Equal(t, "map", output.Metadata["mode"])
+	assert.Equal(t, []string{"keyA", "keyC"}, output.Metadata["keys"])
+	assert.Equal(t, []string{"keyB"}, output.Metadata["missing"])
+}
+
+func TestStateProvider_Execute_KeysMode_StringSlice(t *testing.T) {
+	p := New()
+	ctx := ctxWithState(t, map[string]*state.PersistedEntry{
+		"keyA": {Value: "alpha", Type: "string", CreatedAt: time.Now().UTC()},
+	})
+
+	output, err := p.Execute(ctx, map[string]any{"keys": []string{"keyA", "keyB"}})
+	require.NoError(t, err)
+	got, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"keyA": "alpha"}, got)
+	assert.Equal(t, []string{"keyB"}, output.Metadata["missing"])
+}
+
+func TestStateProvider_Execute_KeysMode_EmptyListReturnsEmptyMap(t *testing.T) {
+	p := New()
+	ctx := ctxWithState(t, map[string]*state.PersistedEntry{
+		"keyA": {Value: "alpha", Type: "string", CreatedAt: time.Now().UTC()},
+	})
+
+	output, err := p.Execute(ctx, map[string]any{"keys": []any{}})
+	require.NoError(t, err)
+	got, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Empty(t, got)
+}
+
+func TestStateProvider_Execute_AllMode_ReturnsWholeSnapshot(t *testing.T) {
+	p := New()
+	ctx := ctxWithState(t, map[string]*state.PersistedEntry{
+		"keyA": {Value: "alpha", Type: "string", CreatedAt: time.Now().UTC()},
+		"keyC": {Value: "gamma", Type: "string", CreatedAt: time.Now().UTC()},
+	})
+
+	output, err := p.Execute(ctx, map[string]any{"operation": OperationGet, "all": true})
+	require.NoError(t, err)
+	got, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"keyA": "alpha", "keyC": "gamma"}, got)
+	assert.Equal(t, "map", output.Metadata["mode"])
+	assert.Equal(t, []string{"keyA", "keyC"}, output.Metadata["keys"])
+	// all mode reports no "missing" (no requested set).
+	_, hasMissing := output.Metadata["missing"]
+	assert.False(t, hasMissing)
+}
+
+func TestStateProvider_Execute_AllMode_NoStateReturnsEmptyMap(t *testing.T) {
+	p := New()
+
+	output, err := p.Execute(context.Background(), map[string]any{"all": true})
+	require.NoError(t, err)
+	got, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Empty(t, got)
+}
+
+func TestStateProvider_Execute_AllFalseIsInert(t *testing.T) {
+	p := New()
+	ctx := ctxWithState(t, map[string]*state.PersistedEntry{
+		"keyA": {Value: "alpha", Type: "string", CreatedAt: time.Now().UTC()},
+	})
+
+	// all:false does not select map mode; key still drives single-key mode.
+	output, err := p.Execute(ctx, map[string]any{"all": false, "key": "keyA"})
+	require.NoError(t, err)
+	assert.Equal(t, "alpha", output.Data)
+}
+
+func TestStateProvider_Execute_MultipleSelectorsError(t *testing.T) {
+	p := New()
+	ctx := ctxWithState(t, nil)
+
+	tests := []map[string]any{
+		{"key": "keyA", "keys": []any{"keyB"}},
+		{"key": "keyA", "all": true},
+		{"keys": []any{"keyB"}, "all": true},
+	}
+	for _, inputs := range tests {
+		_, err := p.Execute(ctx, inputs)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `specify exactly one of "key", "keys", or "all"`)
+	}
+}
+
+func TestStateProvider_Execute_MapMode_RejectsDefault(t *testing.T) {
+	p := New()
+	ctx := ctxWithState(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{"keys": []any{"keyA"}, "default": ""})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"default" is only valid with a single "key"`)
+
+	_, err = p.Execute(ctx, map[string]any{"all": true, "default": ""})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"default" is only valid with a single "key"`)
+}
+
+func TestStateProvider_Execute_KeysMode_InvalidKeyPattern(t *testing.T) {
+	p := New()
+	ctx := ctxWithState(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{"keys": []any{"ok", "../etc/passwd"}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid key "../etc/passwd" at keys[1]`)
+}
+
+func TestStateProvider_Execute_KeysMode_NonStringEntry(t *testing.T) {
+	p := New()
+	ctx := ctxWithState(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{"keys": []any{"ok", 123}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "keys[1] must be a string")
+}
+
+func TestStateProvider_Execute_KeysMode_WrongType(t *testing.T) {
+	p := New()
+	ctx := ctxWithState(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{"keys": "not-a-list"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"keys" must be an array of strings`)
+}
+
+func TestStateProvider_Execute_NonBoolAll(t *testing.T) {
+	p := New()
+	ctx := ctxWithState(t, nil)
+
+	_, err := p.Execute(ctx, map[string]any{"all": "yes"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "all must be a boolean")
 }

--- a/tests/integration/solutions/state/persist-provider/solution.yaml
+++ b/tests/integration/solutions/state/persist-provider/solution.yaml
@@ -99,6 +99,32 @@ spec:
               default: fallback-value
 
     # -------------------------------------------------------------------------
+    # Map mode (keys) -- reads several persisted keys at once as a map. Absent
+    # keys are OMITTED (not defaulted) so has()/optional chaining stay faithful.
+    # No `type` is set because the value is a map, not a scalar.
+    # -------------------------------------------------------------------------
+    prior_config:
+      description: Reads a set of prior-run persisted keys into a map
+      resolve:
+        with:
+          - provider: state
+            inputs:
+              operation: get
+              keys: [current_token, region, ghost_key]
+
+    # -------------------------------------------------------------------------
+    # Map mode (all) -- reads the entire persisted snapshot as a map.
+    # -------------------------------------------------------------------------
+    prior_all:
+      description: Reads the whole prior-run persisted snapshot as a map
+      resolve:
+        with:
+          - provider: state
+            inputs:
+              operation: get
+              all: true
+
+    # -------------------------------------------------------------------------
     # Summary -- compares this run's value with the prior run's value.
     # -------------------------------------------------------------------------
     token_summary:
@@ -109,7 +135,7 @@ spec:
           - provider: static
             inputs:
               value:
-                expr: "'current=' + _.current_token + ' previous=' + _.previous_token + ' orphan=' + _.orphan_lookup"
+                expr: "'current=' + _.current_token + ' previous=' + _.previous_token + ' orphan=' + _.orphan_lookup + ' cfg_region=' + _.prior_config.?region.orValue('none') + ' snapshot_keys=' + string(size(_.prior_all))"
 
   workflow:
     actions:
@@ -169,6 +195,32 @@ spec:
             message: "current_token should reflect this run's parameter"
           - expression: __output.previous_token == "seeded-alpha"
             message: "previous_token should be the value persisted by the prior run"
+
+      # =====================================================================
+      # Map mode: reads several persisted keys as a map, omitting absent keys,
+      # and reads the whole snapshot via all: true.
+      # =====================================================================
+      map-mode-reads-keys-and-all:
+        description: state provider keys/all modes return maps with absent keys omitted
+        command: [run, resolver]
+        args: ["-o", "json", "-r", "token=bravo"]
+        tags: [state, persist, provider, map]
+        init:
+          - command: >-
+              printf '{"schemaVersion":3,"metadata":{"solution":"test-state-persist-provider","version":"1.0.0","createdAt":"2025-01-01T00:00:00Z","lastUpdatedAt":"2025-01-01T00:00:00Z","runtime":{"engine":{"name":"scafctl","version":"dev"},"cli":{"name":"scafctl","version":"dev"}}},"command":{"subcommand":"run resolver","parameters":{}},"parameters":{},"resolvers":{"current_token":{"value":"seeded-alpha","type":"string","createdAt":"2025-01-01T00:00:00Z"},"region":{"value":"us-east","type":"string","createdAt":"2025-01-01T00:00:00Z"}},"fingerprints":{}}'
+              > $SCAFCTL_SANDBOX_DIR/state.json
+        assertions:
+          - expression: __exitCode == 0
+          - expression: __output.prior_config.current_token == "seeded-alpha"
+            message: "keys mode should return the persisted value for a present key"
+          - expression: __output.prior_config.region == "us-east"
+            message: "keys mode should return every present requested key"
+          - expression: has(__output.prior_config.ghost_key) == false
+            message: "keys mode must OMIT absent keys so has() stays faithful"
+          - expression: __output.prior_all.current_token == "seeded-alpha"
+            message: "all mode should include every persisted key"
+          - expression: __output.prior_all.region == "us-east"
+            message: "all mode should include every persisted key"
 
       # =====================================================================
       # persist: true writes the current value into the state file on save.


### PR DESCRIPTION
Expose N persisted keys as a map from a **single** resolver instead of N+1. The `state` provider gains two mutually-exclusive map selectors alongside the existing single `key`.

## What changed

- **`keys: [a, b, c]`** -- returns a map of only the **present** keys. Absent keys are **omitted** (not defaulted), so `has(_.myState.k)` and `_.myState.?k.orValue(d)` stay faithful.
- **`all: true`** -- returns the entire prior state snapshot as a map.
- Existing single-`key` behavior is unchanged.

## Design decisions

- **The bare map is the resolver value.** `Output.Data` is the map itself; `{mode, keys, missing}` live in `Output.Metadata` only. Metadata is discarded before a resolver's value reaches CEL, so there is **no** `{value, keys, missing}` wrapper to reach through -- `_.myState` **is** the map. This mirrors the pre-existing `exists` flag, which was likewise metadata-only (and never CEL-reachable).
- **`default` is a single-`key` concern.** Combining `default` with `keys`/`all` is an error, since map mode omits (rather than defaults) absent keys.
- **`key` / `keys` / `all` are mutually exclusive** -- specifying zero or more than one is an error.
- **No dependency edges** are inferred for map modes.

## Tests / artifacts

- Unit tests for both map modes, WhatIf, mutual-exclusion and `default`-rejection errors, invalid key patterns, and non-string/wrong-type `keys`. Provider coverage 98.1%, passing with `-race`.
- Benchmarks `keys_map` and `all_map`.
- Provider schema updated (drops required `key`, adds `keys`/`all`, widens the from-capability output schema to `AnyProp`), plus map-mode examples.
- Docs: provider reference + state design doc updated with the read modes.
- Integration: `map-mode-reads-keys-and-all` functional case (asserts present keys returned and `has(__output.prior_config.ghost_key) == false`); example solution gains `prior_bag`/`prior_snapshot` resolvers.

## Verification

- `pkg/provider/...` tests pass; `task test:e2e` green (0 failed); `task lint:changed` -> 0 issues.
- Non-breaking: adds optional inputs; the single-`key` read is untouched.