### PR TITLE
fix(cli): make 'get examples' metadata-driven and fix stale example solutions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ Go-based CLI tool using CEL (Common Expression Language) for dynamic configurati
 ## Key Patterns
 
 - **CLI Output**: Use `writer.FromContext(ctx)` -- never `fmt.Fprintf` directly. See `pkg/terminal/writer/`
-- **Data Output**: Use `kvx.OutputOptions` for structured table/json/yaml/quiet output. See `pkg/terminal/kvx/`. Commands that emit an **array of objects** should attach an interactive display schema via `kvx.WithOutputDisplaySchemaJSON` (a `go:embed`-ed `<cmd>_schema.json` with `x-kvx-list`/`x-kvx-detail` extensions) so `-i` renders a card/detail view; single-object output does not need one. See `.github/instructions/cli-commands.instructions.md`.
+- **Data Output**: Use `kvx.OutputOptions` for structured table/json/yaml/quiet output. See `pkg/terminal/kvx/`. Commands that emit an **array of objects** should attach an interactive display schema via `kvx.WithOutputDisplaySchemaJSON` (a `go:embed`-ed `<cmd>_schema.json` with `x-kvx-list`/`x-kvx-detail` extensions) so `-i` renders a card/detail view; single-object output does not need one. **Before debugging kvx list/`-i` rendering, read the "kvx Rendering" section in `.github/instructions/cli-commands.instructions.md`** -- piping into a shell only shows the flat text fallback (not the TUI), the card view needs `core.LoadObject` to convert struct slices, and you can inspect the real TUI via `tui.RenderSnapshot`.
 - **HTTP Client**: See `pkg/httpc/README.md`
 - **Paths**: Use xdg paths via `pkg/paths`
 - **Configuration**: `pkg/settings` for defaults, `pkg/config/` for app configuration

--- a/.github/instructions/cli-commands.instructions.md
+++ b/.github/instructions/cli-commands.instructions.md
@@ -29,6 +29,173 @@ Commands are **thin wiring only** -- they parse flags, call domain packages, and
 - New or modified RunE functions must have test coverage (integration or unit) -- 0% patch coverage on CLI files is unacceptable
 - Extract complex RunE logic into testable helper functions when direct cobra testing is impractical
 
+## kvx Rendering: how the TUI actually works (READ THIS before debugging list/`-i` output)
+
+kvx (`github.com/oakwood-commons/kvx`) is a **key-value explorer**. Do NOT build a
+custom search/filter engine or a hand-rolled table -- kvx already provides
+responsive tables, an interactive card/detail TUI, search (`/`), filter (`f`),
+and CEL filtering (`-e`/`--where`). Wire the data in correctly and you get all of
+it for free. The rules below are the result of a painful debugging session; heed
+them to avoid repeating it.
+
+### The render paths (what runs when)
+
+`OutputOptions.Write(data)` (from `flags.ToKvxOutputOptions`) branches on format
+and TTY (see `pkg/terminal/kvx/output.go` `Write` -> `writeKvx`):
+
+- **`-o json`/`-o yaml`/`-o quiet`/`-o csv`/`-o toml`** -> structured serialization.
+  Empty results MUST still emit a parseable document (`[]`, not `null`; pass a
+  **non-nil** empty slice). Human "no results" text goes to **stderr** only.
+- **`auto`/`table`/`list`, NON-interactive, real TTY** -> `renderTable` ->
+  `tui.RenderTable` (bordered, responsive: table when it fits, list when narrow --
+  this is `FormatAuto`). The **display schema is also passed here**, so column
+  hints/order apply.
+- **`auto`/`table`, NON-interactive, NOT a TTY** (piped, tests, CI) -> falls back
+  to a plain **text** table (`writeText`). This is the flat `[index]` + key/value
+  block you see when you pipe output or run in a non-TTY shell. **It is NOT the
+  card list and NOT what a user sees in a terminal.** Do not judge the TUI by
+  piped output.
+- **`-i` (interactive), real TTY** -> `runInteractive` -> `tui.Run` -> the full
+  bubbletea TUI (card list + detail drill-down + search/filter).
+- **`-i`, NOT a TTY** -> hard error: `interactive mode requires a terminal`.
+
+Consequence: **you cannot see the real table or the `-i` TUI by piping into a
+shell** (the AI's default shell is non-TTY). Piping only ever shows the flat text
+fallback. Use snapshot rendering (below) to actually see the TUI.
+
+### The `core.LoadObject` requirement (THE bug that wastes hours)
+
+kvx's card/list view only activates when the data is a **homogeneous array of
+objects** in kvx's *generic* form -- `[]interface{}` whose every element is
+`map[string]interface{}` (see `internal/ui/list_view.go` `isHomogeneousObjectArray`
+and `internal/ui/view_mode.go` `updateViewMode`). A typed struct slice
+(`[]MyRow`) or even `[]map[string]any` is **NOT** that type, so the list view
+does not trigger and kvx dumps the whole array as one raw JSON VALUE cell.
+
+The real `View()` path fixes this for you: it calls **`core.LoadObject(data)`**
+first, which converts typed structs into the generic `[]interface{}{map...}`
+form. So in a real command you just pass your `[]MyRow` to `outputOpts.Write` and
+it works. **But any snapshot/test harness that calls `tui.RenderSnapshot`/`tui.Run`
+directly MUST call `core.LoadObject(data)` first** -- otherwise you get the JSON
+blob and will wrongly conclude "the display schema is broken." It isn't; the data
+shape is.
+
+### Verifying the TUI without a terminal: `tui.RenderSnapshot`
+
+To actually SEE the card list / detail / narrow-width behavior from a non-TTY
+context (AI shell, unit test), render a snapshot:
+
+~~~go
+import (
+    "github.com/oakwood-commons/kvx/pkg/core"
+    "github.com/oakwood-commons/kvx/pkg/tui"
+)
+
+items, _ := mydomain.Scan("")            // your []Row
+root, _ := core.LoadObject(items)        // REQUIRED: struct slice -> generic form
+_, ds, _ := tui.ParseSchemaWithDisplay(mySchemaJSON) // parse the embedded schema
+out := tui.RenderSnapshot(root, tui.Config{
+    AppName:       "mytool get things",
+    Width:         120, Height: 30,       // fixed size; try 60 wide to test narrow
+    NoColor:       true,
+    DisplaySchema: ds,
+    StartKeys:     []string{"right"},     // simulate keypresses (drill-in = "right")
+})
+t.Log("\n" + out)                        // inspect the rendered frame
+~~~
+
+Notes:
+- Validate the schema first: `tui.ParseSchemaWithDisplay(schema)` is the function
+  kvx actually uses (via `resolveDisplaySchema`). A non-nil `*DisplaySchema` with
+  a populated `List.TitleField` means `-i` will render the card list. (Do NOT use
+  `tui.ParseDisplaySchema` -- it expects a different `displaySchema`-wrapped
+  document and will error on the `x-kvx-*` root form.)
+- Interactive drill-down from the list to the detail pane is triggered by
+  **`right`** (not `enter`; `enter` opens search/filter). Startup-key simulation
+  for drill-in is finicky in snapshots -- if it stays on the list, the detail
+  config is still correct as long as `x-kvx-detail` parses.
+- These snapshot harnesses are throwaway debugging tools; put them in `temp/` or a
+  clearly-named `zz_*_test.go` you delete, or keep a real snapshot test if the
+  view is worth locking down.
+
+### Display schema field-name alignment (JSON == YAML == schema)
+
+The row struct's field names surface in `-o json`, `-o yaml`, the table columns,
+and the `x-kvx-*` schema. They must all match. **Add explicit `yaml:"..."` tags
+matching the `json:"..."` tags** -- kvx's YAML path uses `yaml.Marshal`, which
+lowercases keys by default (`displayName` -> `displayname`), producing output
+inconsistent with JSON and the schema. (Canonical example: `get provider`'s
+`Summary` struct carries matching json+yaml tags.)
+
+### Cap EVERY visible column's width or the table silently collapses to KV
+
+kvx's non-interactive table is responsive: if the computed column widths do not
+fit the terminal, it **collapses to the flat per-row key/value list** (the same
+`[index]` block as the non-TTY text fallback -- easy to misdiagnose as a TTY
+bug). The trap: a visible column with **no `MaxWidth`** (commonly a
+`description`) makes kvx assume it needs the full content width (60-90+ chars),
+which blows the width budget and collapses the table even on a wide terminal.
+This is exactly why a command can render fine as `get provider` (short columns)
+but collapse as `get examples` (one uncapped long column).
+
+Rules:
+- Give **every** column in `ColumnOrder` a sensible `MaxWidth` in
+  `ColumnHints`. Budget the sum (plus `#` + padding + borders, ~15 cols
+  overhead) to fit a reasonable minimum terminal (target tabling at ~90-100
+  cols; fewer/narrower columns table on narrower terminals).
+- Use the flex column to fill wide terminals instead of leaving dead space:
+  set `{MaxWidth: N, Flex: true}` on the one column that should absorb the
+  remaining width (typically `description`). With `Flex: true`, `MaxWidth`
+  becomes that column's **minimum** (not a cap) and the bordered table expands
+  to the full terminal width; narrow terminals still truncate it with `...`.
+  This gives "cap when space is tight, extend to fill when there's extra"
+  without the uncapped-column collapse. (Do NOT confuse `Flex: true` with
+  `MaxWidth: 0`/no cap -- the latter demands natural content width upfront and
+  collapses the table; `Flex` cooperates with the width allocator.)
+- Prefer **fewer columns** in the default table; move low-value fields (tags,
+  long content) to `{Hidden: true}` and surface them in the `-i` detail view
+  and/or `-o json`/`-o yaml` instead.
+- Verify the threshold with a snapshot at several widths (render `tui.RenderTable`
+  or run under `script -q /dev/null bash -c 'stty cols N; ./bin cmd'` for N in
+  90/100/120) -- do NOT trust a single width, and remember `script`'s default pty
+  is only 80 cols (narrower than most real terminals).
+
+### Drilling into the `-i` detail view (and showing rich content there)
+
+The interactive detail pane is driven by `x-kvx-detail.sections`; drill in from
+the list with **`l`/`right`** (not `enter`). To let a user read a large field
+(e.g. a full file's content) inside `-i` without a second command, add that field
+to the row struct, add a `paragraph`-layout detail section for it in the schema,
+and **hide it from the table** with `{Hidden: true}` (it still ships in
+`-o json`/`-o yaml`). Example: `get examples` embeds each solution's YAML in a
+`content` field, hidden from the table, rendered as a "Solution" detail section
+so drilling into an example shows the actual solution.
+
+### Columns vs. schema slots (two different knobs)- `kvx.WithOutputColumnOrder([...])` + `kvx.WithOutputColumnHints{...}` tune the
+  **non-interactive table** (order, `MaxWidth`, `Priority`, `Hidden`). Use
+  `{Hidden: true}` to keep an internal field (e.g. a fetch-handle `path`) out of
+  the table while still emitting it in json/yaml and the `-i` detail pane.
+- `kvx.WithOutputDisplaySchemaJSON(schema)` drives the **`-i` TUI** via
+  `x-kvx-list` (card: `titleField`, `subtitleField`, `badgeFields`) and
+  `x-kvx-detail` (drill-in sections). An array command typically sets BOTH.
+- Do not force `-o list`/`WithLayout("list")` to "get the card view" -- `auto`
+  already renders responsively and `-i` already renders cards. Forcing list mode
+  is usually a mistake.
+
+### Empty / not-found output discipline (applies to every array command)
+
+- Structured/quiet: always write a parseable empty document (`[]`) to **stdout**;
+  never emit human text on stdout in these modes.
+- Human formats: put "no results"/guidance on **stderr** (`WarnStderrf`/
+  `PlainStderrf`), leaving stdout clean.
+
+### Search/CEL is built in -- don't reinvent it
+
+Interactive `/` search and `f` filter come from kvx. Programmatic filtering is
+`-e`/`--expression` (CEL over the whole result, bound to `_`) and `-w`/`--where`
+(per-item CEL boolean). Wire the CEL provider (the shared `flags.ToKvxOutputOptions`
+path already does) and these work; do not add a bespoke search/filter flag.
+
 ## Embedder Awareness
 
 scafctl is used as a library by external CLIs. Commands must not assume the binary is called "scafctl".

--- a/.github/instructions/go-testing.instructions.md
+++ b/.github/instructions/go-testing.instructions.md
@@ -79,6 +79,19 @@ func BenchmarkMyFeature(b *testing.B) {
 }
 ```
 
+## Testing kvx TUI / `-i` output
+
+CLI commands that render arrays via kvx cannot be visually verified by piping
+(a non-TTY shell only shows the flat text fallback, never the card/detail TUI).
+To assert the real interactive rendering, use kvx's snapshot API: convert the
+data with `core.LoadObject`, parse the display schema with
+`tui.ParseSchemaWithDisplay`, and render a fixed-size frame with
+`tui.RenderSnapshot(root, tui.Config{Width, Height, DisplaySchema, StartKeys})`.
+See the "kvx Rendering" section in
+`.github/instructions/cli-commands.instructions.md` for the full harness and the
+`core.LoadObject` gotcha (struct slices must be converted or the card view won't
+trigger).
+
 ## Reference
 
 See skill: `golang-testing` for testing patterns, benchmarks, fuzzing, and coverage.

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -1080,12 +1080,15 @@ scafctl lint rule <rule-id> -o json
 
 ## Browsing Examples
 
-Discover and download built-in example configurations:
+Discover and view built-in example solutions. Examples are **embedded in the
+binary** (not files on disk), and the listing is driven by each solution's own
+`metadata` (displayName, name, category, tags, description) -- only
+`kind: Solution` examples are listed.
 
 ### List Examples
 
 ~~~bash
-# List all examples
+# List all examples (metadata-driven; prints a tip on how to view one)
 scafctl get examples
 
 # Filter by category
@@ -1093,21 +1096,39 @@ scafctl get examples --category solutions
 scafctl get examples --category resolvers
 scafctl get examples --category actions
 
-# Output as JSON
-scafctl get examples -o json
+# Interactive card + detail view
+scafctl get examples -i
 
-# Output as YAML
+# Output as JSON / YAML
+scafctl get examples -o json
 scafctl get examples -o yaml
 ~~~
 
 ### Get an Example
 
+You can fetch an example by its **path** (always unique) or by its
+**metadata.name** / basename when that is unambiguous:
+
 ~~~bash
-# Print example to stdout
+# By full path (always works)
 scafctl get examples resolvers/hello-world.yaml
+
+# By metadata.name when unique
+scafctl get examples cel-basics
 
 # Save to file
 scafctl get examples resolvers/hello-world.yaml > output.yaml
+~~~
+
+If a name matches more than one example (e.g. `hello-world` exists as an action,
+a resolver, and a solution), the command refuses to guess and lists the
+candidate paths so you can pick one:
+
+~~~bash
+scafctl get examples hello-world
+# error: ambiguous example query: "hello-world" matches
+#        actions/hello-world.yaml, resolvers/hello-world.yaml, ...
+# Pass the full path to disambiguate.
 ~~~
 
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,7 +29,7 @@ scafctl run solution -f examples/actions/hello-world.yaml --log-level info --log
 You can also discover and download examples using the built-in `get examples` command:
 
 ```bash
-# List all available examples
+# List all available examples (metadata-driven; only kind: Solution)
 scafctl get examples
 
 # Filter by category
@@ -37,10 +37,14 @@ scafctl get examples --category resolvers
 scafctl get examples --category actions
 scafctl get examples --category solutions
 
-# Download an example
+# View an example by path (always unique)...
 scafctl get examples resolvers/hello-world.yaml > hello.yaml
 
-# List in JSON format
+# ...or by its metadata.name when unambiguous
+scafctl get examples cel-basics
+
+# Interactive card + detail view, or JSON
+scafctl get examples -i
 scafctl get examples -o json
 ```
 

--- a/examples/auth/token-delegation/delegation-solution.yaml
+++ b/examples/auth/token-delegation/delegation-solution.yaml
@@ -12,7 +12,13 @@ kind: Solution
 
 metadata:
   name: token-delegation-demo
+  displayName: Token Delegation
   version: 1.0.0
+  category: auth
+  tags:
+    - auth
+    - token-delegation
+    - http
   description: |
     Demonstrates token delegation with the HTTP provider.
     Shows OBO, client credentials, and pass-through patterns.
@@ -29,7 +35,7 @@ spec:
               url: "https://graph.microsoft.com/v1.0/me"
               method: GET
               authProvider: entra
-              authScope: "https://graph.microsoft.com/.default"
+              scope: "https://graph.microsoft.com/.default"
 
     # OBO/Client Credentials: Access Key Vault with a different scope
     keyVaultSecret:
@@ -41,7 +47,7 @@ spec:
               url: "https://my-vault.vault.azure.net/secrets/my-secret?api-version=7.4"
               method: GET
               authProvider: entra
-              authScope: "https://vault.azure.net/.default"
+              scope: "https://vault.azure.net/.default"
 
     # Pass-through: Use the caller's GitHub token directly
     githubRepo:

--- a/examples/catalog/bundling-example/solution.yaml
+++ b/examples/catalog/bundling-example/solution.yaml
@@ -21,10 +21,6 @@ bundle:
   # (e.g., files loaded via dynamic CEL expressions)
   include:
     - "configs/**/*.yaml"
-  
-  # Exclude test files from the bundle
-  exclude:
-    - "**/*_test.yaml"
 
 spec:
   resolvers:
@@ -66,7 +62,6 @@ spec:
             inputs:
               path:
                 expr: "'configs/' + _.environment + '.yaml'"
-              format: yaml
 
     # Combine template with config values
     rendered-deployment:

--- a/examples/catalog/hello-world/solution.yaml
+++ b/examples/catalog/hello-world/solution.yaml
@@ -2,8 +2,8 @@ apiVersion: scafctl.io/v1
 kind: Solution
 
 metadata:
-  name: hello-world
-  displayName: Hello World
+  name: hello-world-catalog
+  displayName: Hello World (Catalog)
   category: developer-tools
   tags:
     - catalog

--- a/examples/inspect/usage-view.yaml
+++ b/examples/inspect/usage-view.yaml
@@ -13,6 +13,7 @@ metadata:
   name: registry-index
   displayName: Registry Index
   version: 1.0.0
+  category: inspect
   description: Query and refresh a small registry index.
   tags: [registry, discovery]
   links:

--- a/examples/plugins/auto-fetch-solution.yaml
+++ b/examples/plugins/auto-fetch-solution.yaml
@@ -1,7 +1,8 @@
 # Prerequisites:
 #   1. Build and publish the echo plugin to a catalog:
-#      cd examples/plugins/echo && go build -o echo-provider .
-#      scafctl catalog push provider echo-provider --version 1.0.0 --binary echo-provider
+#      cd examples/plugins/echo && go build -o echo .
+#      scafctl package plugin --name echo --kind provider --version 1.0.0 --platform $(go env GOOS)/$(go env GOARCH)=./echo
+#      scafctl catalog push echo@1.0.0
 #   2. Or run without real plugins to see the resolution flow:
 #      scafctl plugins install -f examples/plugins/auto-fetch-solution.yaml
 #
@@ -24,7 +25,7 @@ metadata:
 
 bundle:
   plugins:
-    - name: echo-provider
+    - name: echo
       kind: provider
       version: "^1.0.0"
       defaults:

--- a/examples/providers/github-api.yaml
+++ b/examples/providers/github-api.yaml
@@ -30,5 +30,5 @@ spec:
               method: GET
               headers:
                 Accept: application/json
-              auth: github
+              authProvider: github
               scope: "read:user"

--- a/examples/providers/github-write-operations.yaml
+++ b/examples/providers/github-write-operations.yaml
@@ -33,210 +33,43 @@ spec:
               owner: cli
               repo: cli
 
-  # Write operations go in workflow actions -- the write-op guard rejects
-  # these in resolver context.
-  workflow:
-    actions:
-      # Write operation examples (commented - uncomment to use)
-      #
-      # Create an issue:
-      # new-issue:
-      #   provider: github
-      #   inputs:
-      #     operation: create_issue
-      #     owner: my-org
-      #     repo: my-repo
-      #     title: "Bug: something is broken"
-      #     body: "Steps to reproduce..."
-      #     labels:
-      #       - bug
-      #       - priority/high
-      #
-      # Create a pull request:
-      # new-pr:
-      #   provider: github
-      #   inputs:
-      #     operation: create_pull_request
-      #     owner: my-org
-      #     repo: my-repo
-      #     title: "feat: add new scaffolding templates"
-      #     body: "This PR adds new templates."
-      #     head: feature-branch
-      #     base: main
-      #     draft: true
-      #
-      # Create a signed commit:
-      # signed-commit:
-      #   provider: github
-      #   inputs:
-      #     operation: create_commit
-      #     owner: my-org
-      #     repo: my-repo
-      #     branch: feature-branch
-      #     message: "feat: add scaffolded project files"
-      #     expected_head_oid: abc123def456789012345678901234567890abcd
-      #     additions:
-      #       - path: src/main.go
-      #         content: "package main"
-      #
-      # Create a release:
-      # new-release:
-      #   provider: github
-      #   inputs:
-      #     operation: create_release
-      #     owner: my-org
-      #     repo: my-repo
-      #     tag_name: v1.0.0
-      #     name: "Release 1.0.0"
-      #     body: "First stable release"
-      #     prerelease: false
-      #     target_commitish: main
-      #
-      # Create a repository (GraphQL, REST fallback for EMU):
-      # new-repo:
-      #   provider: github
-      #   inputs:
-      #     operation: create_repo
-      #     owner: my-org
-      #     repo: my-new-repo
-      #     description: "A new project"
-      #     visibility: private
-      #     auto_init: true
-      #
-      # Create a branch protection ruleset (REST):
-      # branch-ruleset:
-      #   provider: github
-      #   inputs:
-      #     operation: create_ruleset
-      #     owner: my-org
-      #     repo: my-repo
-      #     ruleset_name: main branch protection
-      #     target: branch
-      #     enforcement: active
-      #     include_refs:
-      #       - refs/heads/main
-      #     required_status_checks_contexts:
-      #       - test
-      #       - lint
-      #     required_approving_review_count: 1
-      #     required_linear_history: true
-      #     requires_commit_signatures: true
-      #     allow_force_pushes: false
-      #     allow_deletions: false
-      #
-      # Create a tag protection ruleset (REST):
-      # tag-ruleset:
-      #   provider: github
-      #   inputs:
-      #     operation: create_ruleset
-      #     owner: my-org
-      #     repo: my-repo
-      #     ruleset_name: version tag protection
-      #     target: tag
-      #     enforcement: active
-      #     include_refs:
-      #       - "refs/tags/v*"
-      #     allow_deletions: false
-      #     allow_force_pushes: false
-      #
-      # Enable vulnerability alerts (REST):
-      # vuln-alerts:
-      #   provider: github
-      #   inputs:
-      #     operation: enable_vulnerability_alerts
-      #     owner: my-org
-      #     repo: my-repo
-      #
-      # Enable automated security fixes (REST):
-      # auto-security-fixes:
-      #   provider: github
-      #   inputs:
-      #     operation: enable_automated_security_fixes
-      #     owner: my-org
-      #     repo: my-repo
-      #
-      # ─── v2.1 operations ──────────────────────────────────────────────
-      #
-      # Generic API call (escape hatch for any endpoint):
-      # custom-api-call:
-      #   provider: github
-      #   inputs:
-      #     operation: api_call
-      #     endpoint: /repos/my-org/my-repo/labels
-      #     method: GET
-      #
-      # Create a label:
-      # new-label:
-      #   provider: github
-      #   inputs:
-      #     operation: create_label
-      #     owner: my-org
-      #     repo: my-repo
-      #     label_name: help-wanted
-      #     color: "00ff00"
-      #     label_description: "Extra attention is needed"
-      #
-      # Add reaction to an issue:
-      # react-to-issue:
-      #   provider: github
-      #   inputs:
-      #     operation: add_reaction
-      #     owner: my-org
-      #     repo: my-repo
-      #     number: 42
-      #     reaction_content: "+1"
-      #
-      # Dispatch a workflow:
-      # trigger-ci:
-      #   provider: github
-      #   inputs:
-      #     operation: dispatch_workflow
-      #     owner: my-org
-      #     repo: my-repo
-      #     workflow_id: ci.yml
-      #     ref: main
-      #     workflow_inputs:
-      #       environment: staging
-      #
-      # Create a webhook:
-      # new-webhook:
-      #   provider: github
-      #   inputs:
-      #     operation: create_webhook
-      #     owner: my-org
-      #     repo: my-repo
-      #     webhook_url: https://example.com/webhook
-      #     webhook_events:
-      #       - push
-      #       - pull_request
-      #
-      # Update repository settings:
-      # configure-repo:
-      #   provider: github
-      #   inputs:
-      #     operation: update_repo
-      #     owner: my-org
-      #     repo: my-repo
-      #     description: "Updated description"
-      #     has_wiki: false
-      #     delete_branch_on_merge: true
-      #
-      # Fork a repository:
-      # fork:
-      #   provider: github
-      #   inputs:
-      #     operation: fork_repo
-      #     owner: upstream-org
-      #     repo: upstream-repo
-      #     organization: my-org
-      #     default_branch_only: true
-      #
-      # Add collaborator:
-      # add-user:
-      #   provider: github
-      #   inputs:
-      #     operation: add_collaborator
-      #     owner: my-org
-      #     repo: my-repo
-      #     username: new-contributor
-      #     permission: push
+
+# ---------------------------------------------------------------------------
+# WRITE OPERATIONS REFERENCE
+# ---------------------------------------------------------------------------
+# Write operations (create_issue, create_pull_request, create_commit,
+# create_release, dispatch_workflow, add_collaborator, ...) must run as
+# WORKFLOW ACTIONS, not resolvers -- the github provider's write-op guard
+# rejects mutating operations in resolver context. Add a `workflow.actions`
+# block and set `provider: github` with the desired `operation`. Examples:
+#
+#   workflow:
+#     actions:
+#       new-issue:
+#         provider: github
+#         inputs:
+#           operation: create_issue
+#           owner: my-org
+#           repo: my-repo
+#           title: "Bug: something is broken"
+#           body: "Steps to reproduce..."
+#           labels: [bug, priority/high]
+#
+#       new-pr:
+#         provider: github
+#         inputs:
+#           operation: create_pull_request
+#           owner: my-org
+#           repo: my-repo
+#           title: "feat: add new templates"
+#           head: feature-branch
+#           base: main
+#
+#       new-release:
+#         provider: github
+#         inputs:
+#           operation: create_release
+#           owner: my-org
+#           repo: my-repo
+#           tag_name: v1.0.0
+#           name: "Release 1.0.0"

--- a/examples/providers/http-entra.yaml
+++ b/examples/providers/http-entra.yaml
@@ -29,5 +29,5 @@ spec:
               method: GET
               headers:
                 Accept: application/json
-              auth: entra
+              authProvider: entra
               scope: "https://graph.microsoft.com/.default"

--- a/examples/resolvers/feature-flags.yaml
+++ b/examples/resolvers/feature-flags.yaml
@@ -28,8 +28,7 @@ spec:
             inputs:
               url: https://features.example.com/api/v1/flags
               method: GET
-              timeout: 5s
-          # Fall back to static defaults
+              timeout: 5          # Fall back to static defaults
           - provider: static
             inputs:
               value:

--- a/examples/resolvers/feature-flags.yaml
+++ b/examples/resolvers/feature-flags.yaml
@@ -28,7 +28,8 @@ spec:
             inputs:
               url: https://features.example.com/api/v1/flags
               method: GET
-              timeout: 5          # Fall back to static defaults
+              timeout: 5
+          # Fall back to these static defaults when the HTTP source fails.
           - provider: static
             inputs:
               value:

--- a/examples/resolvers/foreach-filter.yaml
+++ b/examples/resolvers/foreach-filter.yaml
@@ -16,7 +16,6 @@ metadata:
     keepSkipped: true retains nils so output stays index-aligned with input.
 
 spec:
-    - resolver-example
   resolvers:
     # ─────────────────────────────────────────────
     # 1. Source data — all users (active and inactive)

--- a/examples/resolvers/hello-world.yaml
+++ b/examples/resolvers/hello-world.yaml
@@ -3,8 +3,8 @@
 apiVersion: scafctl.io/v1
 kind: Solution
 metadata:
-  name: hello-world
-  displayName: Hello World
+  name: hello-world-resolver
+  displayName: Hello World (Resolver)
   category: resolvers
   tags:
     - resolver-example

--- a/examples/resolvers/plan-aware.yaml
+++ b/examples/resolvers/plan-aware.yaml
@@ -15,8 +15,6 @@ metadata:
     topology: phase, dependsOn list, and dependencyCount.
 
 spec:
-  tags:
-    - resolver-example
   resolvers:
     # Phase 1: no dependencies
     base_url:

--- a/examples/snapshots/snapshot-diff.yaml
+++ b/examples/snapshots/snapshot-diff.yaml
@@ -1,9 +1,9 @@
 # Run: scafctl render solution -f examples/snapshots/snapshot-diff.yaml -r env=staging --snapshot --snapshot-file=/tmp/snap-staging.json
 # Run: scafctl render solution -f examples/snapshots/snapshot-diff.yaml -r env=production --snapshot --snapshot-file=/tmp/snap-prod.json
-# Run: scafctl snapshot diff /tmp/snap-staging.json /tmp/snap-prod.json
-# Run: scafctl snapshot diff /tmp/snap-staging.json /tmp/snap-prod.json --ignore-fields duration,providerCalls
-# Run: scafctl snapshot diff /tmp/snap-staging.json /tmp/snap-prod.json --ignore-unchanged
-# Run: scafctl snapshot diff /tmp/snap-staging.json /tmp/snap-prod.json --format json
+# Run: scafctl diff snapshot /tmp/snap-staging.json /tmp/snap-prod.json
+# Run: scafctl diff snapshot /tmp/snap-staging.json /tmp/snap-prod.json --ignore-fields duration,providerCalls
+# Run: scafctl diff snapshot /tmp/snap-staging.json /tmp/snap-prod.json --ignore-unchanged
+# Run: scafctl diff snapshot /tmp/snap-staging.json /tmp/snap-prod.json -o json
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/examples/soldiff/solution-v1.yaml
+++ b/examples/soldiff/solution-v1.yaml
@@ -1,5 +1,5 @@
-# Run: scafctl solution diff -f examples/soldiff/solution-v1.yaml -f examples/soldiff/solution-v2.yaml
-# Run: scafctl solution diff -f examples/soldiff/solution-v1.yaml -f examples/soldiff/solution-v2.yaml -o json
+# Run: scafctl diff solution -f examples/soldiff/solution-v1.yaml -f examples/soldiff/solution-v2.yaml
+# Run: scafctl diff solution -f examples/soldiff/solution-v1.yaml -f examples/soldiff/solution-v2.yaml -o json
 
 apiVersion: scafctl.io/v1
 kind: Solution
@@ -47,9 +47,7 @@ spec:
     actions:
       deploy:
         description: Deploy the application
-        with:
-          - provider: exec
-            inputs:
-              command: echo
-              args:
-                - "Deploying {{ .app_name }} with {{ .replicas }} replicas to {{ .environment }}"
+        provider: exec
+        inputs:
+          command:
+            expr: "'echo Deploying ' + _.app_name + ' with ' + string(_.replicas) + ' replicas to ' + _.environment"

--- a/examples/soldiff/solution-v1.yaml
+++ b/examples/soldiff/solution-v1.yaml
@@ -4,9 +4,9 @@
 apiVersion: scafctl.io/v1
 kind: Solution
 metadata:
-  name: soldiff-demo
+  name: soldiff-demo-v1
   version: "1.0.0"
-  displayName: Soldiff Demo
+  displayName: Soldiff Demo (v1)
   category: developer-tools
   tags:
     - diff

--- a/examples/soldiff/solution-v2.yaml
+++ b/examples/soldiff/solution-v2.yaml
@@ -3,9 +3,9 @@
 apiVersion: scafctl.io/v1
 kind: Solution
 metadata:
-  name: soldiff-demo
+  name: soldiff-demo-v2
   version: "2.0.0"
-  displayName: Soldiff Demo
+  displayName: Soldiff Demo (v2)
   category: developer-tools
   tags:
     - diff

--- a/examples/soldiff/solution-v2.yaml
+++ b/examples/soldiff/solution-v2.yaml
@@ -1,4 +1,4 @@
-# Run: scafctl solution diff -f examples/soldiff/solution-v1.yaml -f examples/soldiff/solution-v2.yaml
+# Run: scafctl diff solution -f examples/soldiff/solution-v1.yaml -f examples/soldiff/solution-v2.yaml
 
 apiVersion: scafctl.io/v1
 kind: Solution
@@ -57,21 +57,17 @@ spec:
     actions:
       deploy:
         description: Deploy the application with health check
-        with:
-          - provider: exec
-            inputs:
-              command: echo
-              args:
-                - "Deploying {{ .app_name }} with {{ .replicas }} replicas to {{ .environment }}"
+        provider: exec
+        inputs:
+          command:
+            expr: "'echo Deploying ' + _.app_name + ' with ' + string(_.replicas) + ' replicas to ' + _.environment"
 
       # New action added in v2
       verify:
         description: Verify deployment health
         dependsOn:
           - deploy
-        with:
-          - provider: exec
-            inputs:
-              command: echo
-              args:
-                - "Checking health at {{ .health_check_url }}"
+        provider: exec
+        inputs:
+          command:
+            expr: "'echo Checking health at ' + _.health_check_url"

--- a/examples/solutions/entra-groups/solution.yaml
+++ b/examples/solutions/entra-groups/solution.yaml
@@ -3,6 +3,7 @@ kind: Solution
 metadata:
   name: entra-groups
   displayName: Entra Group Membership Check
+  category: identity
   description: >
     Resolves the current user's Entra group memberships via the Microsoft Graph API.
     Bypasses the 200-group JWT overage limit by calling /me/memberOf directly.

--- a/examples/solutions/hello-world/solution.yaml
+++ b/examples/solutions/hello-world/solution.yaml
@@ -5,8 +5,8 @@ apiVersion: scafctl.io/v1
 kind: Solution
 
 metadata:
-  name: hello-world
-  displayName: Hello World
+  name: hello-world-solution
+  displayName: Hello World (Solution)
   description: |
     A minimal hello-world solution that demonstrates the basic structure
     of a scafctl solution. Use this as a starting point for building

--- a/examples/solutions/lint-stress-test/solution.yaml
+++ b/examples/solutions/lint-stress-test/solution.yaml
@@ -11,6 +11,11 @@ kind: Solution
 
 metadata:
   name: lint-stress-test
+  displayName: Lint Stress Test
+  category: solutions
+  tags:
+    - lint
+    - testing
   description: Triggers many lint rules for testing table output
 
 spec:

--- a/examples/solutions/state-immutable/solution.yaml
+++ b/examples/solutions/state-immutable/solution.yaml
@@ -39,7 +39,12 @@ apiVersion: scafctl.io/v1
 kind: Solution
 metadata:
   name: state-immutable-example
+  displayName: State Immutable
   version: 1.0.0
+  category: solutions
+  tags:
+    - state
+    - immutable
   description: Demonstrates immutable resolver state entries
 
 state:

--- a/examples/solutions/state-persist/solution.yaml
+++ b/examples/solutions/state-persist/solution.yaml
@@ -34,7 +34,12 @@ apiVersion: scafctl.io/v1
 kind: Solution
 metadata:
   name: state-persist-example
+  displayName: State Persist
   version: 1.0.0
+  category: solutions
+  tags:
+    - state
+    - persistence
   description: Demonstrates persisted resolvers and the state provider
 
 state:

--- a/examples/solutions/state/github-state.yaml
+++ b/examples/solutions/state/github-state.yaml
@@ -24,7 +24,12 @@ apiVersion: scafctl.io/v1
 kind: Solution
 metadata:
   name: github-state-example
+  displayName: GitHub State Persistence
   version: 1.0.0
+  category: solutions
+  tags:
+    - state
+    - github
   description: |
     GitHub-based state persistence with PR workflow.
     Loads state from main, saves to a feature branch derived from a resolver.

--- a/examples/solutions/state/solution.yaml
+++ b/examples/solutions/state/solution.yaml
@@ -16,7 +16,12 @@ apiVersion: scafctl.io/v1
 kind: Solution
 metadata:
   name: state-example
+  displayName: State Persistence
   version: 1.0.0
+  category: solutions
+  tags:
+    - state
+    - parameters
   description: Demonstrates state persistence across runs via parameter replay
 
 # State configuration -- persists CLI parameters to a local JSON file.

--- a/pkg/cmd/scafctl/get/examples/examples.go
+++ b/pkg/cmd/scafctl/get/examples/examples.go
@@ -107,19 +107,6 @@ func (o *Options) runList(ctx context.Context) error {
 		return err
 	}
 
-	if len(items) == 0 {
-		if o.Category != "" {
-			w.Infof("No examples found in category %q.", o.Category)
-			cats := exampleslib.Categories()
-			if len(cats) > 0 {
-				w.Infof("Available categories: %s", strings.Join(cats, ", "))
-			}
-		} else {
-			w.Infof("No examples available.")
-		}
-		return nil
-	}
-
 	outputOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags,
 		kvx.WithIOStreams(o.IOStreams),
 		kvx.WithOutputContext(ctx),
@@ -138,13 +125,40 @@ func (o *Options) runList(ctx context.Context) error {
 			"description": {Priority: 3},
 		}),
 	)
+
+	structured := kvx.IsStructuredFormat(outputOpts.Format)
+	quiet := kvx.IsQuietFormat(outputOpts.Format)
+
+	if len(items) == 0 {
+		// Structured/quiet consumers must always receive a parseable, empty
+		// document on stdout -- never human text. Emit [] (a non-nil empty
+		// slice so JSON/YAML render "[]", not "null") and put any guidance on
+		// stderr only.
+		if structured {
+			if writeErr := outputOpts.Write([]exampleslib.Example{}); writeErr != nil {
+				return writeErr
+			}
+		}
+		if !structured && !quiet {
+			if o.Category != "" {
+				w.WarnStderrf("No examples found in category %q.", o.Category)
+				if cats := exampleslib.Categories(); len(cats) > 0 {
+					w.PlainStderrf("Available categories: %s", strings.Join(cats, ", "))
+				}
+			} else {
+				w.WarnStderrf("No examples available.")
+			}
+		}
+		return nil
+	}
+
 	if err := outputOpts.Write(items); err != nil {
 		return err
 	}
 
 	// Tip: the list shows metadata, but the content lives in the embedded FS.
 	// Tell the user exactly how to view a solution (the path is the handle).
-	if !kvx.IsStructuredFormat(outputOpts.Format) && !kvx.IsQuietFormat(outputOpts.Format) {
+	if !structured && !quiet {
 		bin := o.CliParams.BinaryName
 		w.PlainStderrf("")
 		w.PlainStderrf("Tip: run '%s get examples <path>' to view a solution (e.g. '%s get examples %s').",

--- a/pkg/cmd/scafctl/get/examples/examples.go
+++ b/pkg/cmd/scafctl/get/examples/examples.go
@@ -126,16 +126,16 @@ func (o *Options) runList(ctx context.Context) error {
 		kvx.WithOutputNoColor(o.CliParams.NoColor),
 		kvx.WithOutputAppName(o.CliParams.BinaryName+" get examples"),
 		kvx.WithOutputDisplaySchemaJSON(examplesSchemaJSON),
-		kvx.WithOutputColumnOrder([]string{"displayName", "name", "category", "tags", "description"}),
+		kvx.WithOutputColumnOrder([]string{"displayName", "name", "category", "path", "tags", "description"}),
 		kvx.WithOutputColumnHints(map[string]tui.ColumnHint{
-			"displayName": {MaxWidth: 30, Priority: 10},
-			"name":        {MaxWidth: 26, Priority: 8},
+			"displayName": {MaxWidth: 28, Priority: 10},
+			"name":        {MaxWidth: 24, Priority: 8},
 			"category":    {MaxWidth: 16, Priority: 7},
-			"tags":        {MaxWidth: 24, Priority: 5},
-			"description": {Priority: 4},
-			// Path is the fetch handle, surfaced in the detail view and the tip
-			// below rather than as a wide table column.
-			"path": {Hidden: true},
+			// Path is the copy/paste handle for `get examples <path>` -- keep it
+			// visible and wide enough that it does not truncate.
+			"path":        {MaxWidth: 48, Priority: 9},
+			"tags":        {MaxWidth: 20, Priority: 4},
+			"description": {Priority: 3},
 		}),
 	)
 	if err := outputOpts.Write(items); err != nil {

--- a/pkg/cmd/scafctl/get/examples/examples.go
+++ b/pkg/cmd/scafctl/get/examples/examples.go
@@ -5,12 +5,14 @@ package examples
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	exampleslib "github.com/oakwood-commons/scafctl/pkg/examples"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
@@ -22,6 +24,9 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
+
+//go:embed examples_schema.json
+var examplesSchemaJSON []byte
 
 // Options holds configuration for the get examples command.
 type Options struct {
@@ -115,11 +120,40 @@ func (o *Options) runList(ctx context.Context) error {
 		return nil
 	}
 
-	outputOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags, kvx.WithIOStreams(o.IOStreams))
-	return outputOpts.Write(items)
+	outputOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags,
+		kvx.WithIOStreams(o.IOStreams),
+		kvx.WithOutputContext(ctx),
+		kvx.WithOutputNoColor(o.CliParams.NoColor),
+		kvx.WithOutputAppName(o.CliParams.BinaryName+" get examples"),
+		kvx.WithOutputDisplaySchemaJSON(examplesSchemaJSON),
+		kvx.WithOutputColumnOrder([]string{"displayName", "name", "category", "tags", "description"}),
+		kvx.WithOutputColumnHints(map[string]tui.ColumnHint{
+			"displayName": {MaxWidth: 30, Priority: 10},
+			"name":        {MaxWidth: 26, Priority: 8},
+			"category":    {MaxWidth: 16, Priority: 7},
+			"tags":        {MaxWidth: 24, Priority: 5},
+			"description": {Priority: 4},
+			// Path is the fetch handle, surfaced in the detail view and the tip
+			// below rather than as a wide table column.
+			"path": {Hidden: true},
+		}),
+	)
+	if err := outputOpts.Write(items); err != nil {
+		return err
+	}
+
+	// Tip: the list shows metadata, but the content lives in the embedded FS.
+	// Tell the user exactly how to view a solution (the path is the handle).
+	if !kvx.IsStructuredFormat(outputOpts.Format) && !kvx.IsQuietFormat(outputOpts.Format) {
+		bin := o.CliParams.BinaryName
+		w.PlainStderrf("")
+		w.PlainStderrf("Tip: run '%s get examples <path>' to view a solution (e.g. '%s get examples %s').",
+			bin, bin, items[0].Path)
+	}
+	return nil
 }
 
-func (o *Options) runGet(ctx context.Context, exPath string) error {
+func (o *Options) runGet(ctx context.Context, query string) error {
 	w := writer.FromContext(ctx)
 	if w == nil {
 		return fmt.Errorf("writer not initialized in context")
@@ -127,6 +161,26 @@ func (o *Options) runGet(ctx context.Context, exPath string) error {
 
 	if o.Category != "" {
 		return exitcode.WithCode(fmt.Errorf("--category can only be used in list mode"), exitcode.InvalidInput)
+	}
+
+	// Resolve the query (path, metadata.name, or basename) to a concrete path.
+	exPath, err := exampleslib.ResolveExample(query)
+	if err != nil {
+		switch {
+		case errors.Is(err, exampleslib.ErrPathTraversal):
+			w.Errorf("Invalid example path: %s", query)
+			return exitcode.WithCode(fmt.Errorf("invalid example path: %w", err), exitcode.InvalidInput)
+		case errors.Is(err, exampleslib.ErrAmbiguousExample):
+			w.Errorf("%v", err)
+			w.PlainStderrf("Pass the full path to disambiguate, e.g. '%s get examples <path>'.", o.CliParams.BinaryName)
+			return exitcode.WithCode(err, exitcode.InvalidInput)
+		case errors.Is(err, exampleslib.ErrExampleNotFound):
+			w.Errorf("Example not found: %s", query)
+			w.PlainStderrf("Run '%s get examples' to list available examples.", o.CliParams.BinaryName)
+			return exitcode.WithCode(err, exitcode.FileNotFound)
+		default:
+			return err
+		}
 	}
 
 	content, err := exampleslib.Read(exPath)

--- a/pkg/cmd/scafctl/get/examples/examples.go
+++ b/pkg/cmd/scafctl/get/examples/examples.go
@@ -107,25 +107,7 @@ func (o *Options) runList(ctx context.Context) error {
 		return err
 	}
 
-	outputOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags,
-		kvx.WithIOStreams(o.IOStreams),
-		kvx.WithOutputContext(ctx),
-		kvx.WithOutputNoColor(o.CliParams.NoColor),
-		kvx.WithOutputAppName(o.CliParams.BinaryName+" get examples"),
-		kvx.WithOutputDisplaySchemaJSON(examplesSchemaJSON),
-		kvx.WithOutputColumnOrder([]string{"displayName", "name", "category", "path", "tags", "description"}),
-		kvx.WithOutputColumnHints(map[string]tui.ColumnHint{
-			"displayName": {MaxWidth: 28, Priority: 10},
-			"name":        {MaxWidth: 24, Priority: 8},
-			"category":    {MaxWidth: 16, Priority: 7},
-			// Path is the copy/paste handle for `get examples <path>` -- keep it
-			// visible and wide enough that it does not truncate.
-			"path":        {MaxWidth: 48, Priority: 9},
-			"tags":        {MaxWidth: 20, Priority: 4},
-			"description": {Priority: 3},
-		}),
-	)
-
+	outputOpts := o.listOutputOpts(ctx)
 	structured := kvx.IsStructuredFormat(outputOpts.Format)
 	quiet := kvx.IsQuietFormat(outputOpts.Format)
 
@@ -157,14 +139,46 @@ func (o *Options) runList(ctx context.Context) error {
 	}
 
 	// Tip: the list shows metadata, but the content lives in the embedded FS.
-	// Tell the user exactly how to view a solution (the path is the handle).
+	// Tell the user how to view a specific example.
 	if !structured && !quiet {
 		bin := o.CliParams.BinaryName
 		w.PlainStderrf("")
-		w.PlainStderrf("Tip: run '%s get examples <path>' to view a solution (e.g. '%s get examples %s').",
-			bin, bin, items[0].Path)
+		w.PlainStderrf("Tip: run '%s get examples <name>' to view an example (e.g. '%s get examples %s').",
+			bin, bin, items[0].Name)
 	}
 	return nil
+}
+
+// listOutputOpts builds the kvx output options for the example listing (shared
+// by the full list and the multi-match filtered list). The display schema drives
+// the interactive (-i) card + detail view; the column hints tune the plain
+// table. name and path are internal fetch handles, not list columns.
+func (o *Options) listOutputOpts(ctx context.Context) *kvx.OutputOptions {
+	return flags.ToKvxOutputOptions(&o.KvxOutputFlags,
+		kvx.WithIOStreams(o.IOStreams),
+		kvx.WithOutputContext(ctx),
+		kvx.WithOutputNoColor(o.CliParams.NoColor),
+		kvx.WithOutputAppName(o.CliParams.BinaryName+" get examples"),
+		kvx.WithOutputDisplaySchemaJSON(examplesSchemaJSON),
+		kvx.WithOutputColumnOrder([]string{"name", "category", "description"}),
+		kvx.WithOutputColumnHints(map[string]tui.ColumnHint{
+			// `name` is the PRIMARY column: it is exactly what the user types in
+			// `get examples <name>` (what you see is what you type, matching
+			// `get provider`). Fixed columns get a MaxWidth so the table fits;
+			// description is a flex column that absorbs the remaining terminal
+			// width (MaxWidth is its minimum, not a cap).
+			"name":        {MaxWidth: 34, Priority: 10},
+			"category":    {MaxWidth: 14, Priority: 8},
+			"description": {MaxWidth: 40, Priority: 6, Flex: true},
+			// displayName/tags/path/content are not table columns; they appear in
+			// the -i detail view and/or -o json/yaml. name/path are the fetch
+			// handles; content powers the -i detail "Solution" section.
+			"displayName": {Hidden: true},
+			"tags":        {Hidden: true},
+			"path":        {Hidden: true},
+			"content":     {Hidden: true},
+		}),
+	)
 }
 
 func (o *Options) runGet(ctx context.Context, query string) error {
@@ -177,17 +191,14 @@ func (o *Options) runGet(ctx context.Context, query string) error {
 		return exitcode.WithCode(fmt.Errorf("--category can only be used in list mode"), exitcode.InvalidInput)
 	}
 
-	// Resolve the query (path, metadata.name, or basename) to a concrete path.
-	exPath, err := exampleslib.ResolveExample(query)
+	// Resolve the query (exact path, metadata.name, or basename) to matching
+	// example(s).
+	matches, err := exampleslib.MatchExamples(query)
 	if err != nil {
 		switch {
 		case errors.Is(err, exampleslib.ErrPathTraversal):
 			w.Errorf("Invalid example path: %s", query)
 			return exitcode.WithCode(fmt.Errorf("invalid example path: %w", err), exitcode.InvalidInput)
-		case errors.Is(err, exampleslib.ErrAmbiguousExample):
-			w.Errorf("%v", err)
-			w.PlainStderrf("Pass the full path to disambiguate, e.g. '%s get examples <path>'.", o.CliParams.BinaryName)
-			return exitcode.WithCode(err, exitcode.InvalidInput)
 		case errors.Is(err, exampleslib.ErrExampleNotFound):
 			w.Errorf("Example not found: %s", query)
 			w.PlainStderrf("Run '%s get examples' to list available examples.", o.CliParams.BinaryName)
@@ -196,6 +207,35 @@ func (o *Options) runGet(ctx context.Context, query string) error {
 			return err
 		}
 	}
+
+	// More than one example matched the name/basename: show the matches as a
+	// filtered list so the user can pick one, rather than guessing or erroring.
+	if len(matches) > 1 {
+		outputOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags,
+			kvx.WithIOStreams(o.IOStreams),
+			kvx.WithOutputContext(ctx),
+			kvx.WithOutputNoColor(o.CliParams.NoColor),
+			kvx.WithOutputAppName(o.CliParams.BinaryName+" get examples"),
+			kvx.WithOutputDisplaySchemaJSON(examplesSchemaJSON),
+			kvx.WithOutputColumnOrder([]string{"displayName", "category", "path"}),
+			kvx.WithOutputColumnHints(map[string]tui.ColumnHint{
+				"displayName": {MaxWidth: 32, Priority: 10},
+				"category":    {MaxWidth: 16, Priority: 8},
+				// Show path here so the user can disambiguate the matches.
+				"path":        {MaxWidth: 48, Priority: 6},
+				"name":        {Hidden: true},
+				"tags":        {Hidden: true},
+				"description": {Hidden: true},
+				"content":     {Hidden: true},
+			}),
+		)
+		if !kvx.IsStructuredFormat(outputOpts.Format) && !kvx.IsQuietFormat(outputOpts.Format) {
+			w.WarnStderrf("%d examples match %q -- pick one by its path:", len(matches), query)
+		}
+		return outputOpts.Write(matches)
+	}
+
+	exPath := matches[0].Path
 
 	content, err := exampleslib.Read(exPath)
 	if err != nil {

--- a/pkg/cmd/scafctl/get/examples/examples_schema.json
+++ b/pkg/cmd/scafctl/get/examples/examples_schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Scafctl Example Solutions",
+  "description": "Schema for scafctl embedded example solutions with display extensions",
+  "type": "array",
+
+  "x-kvx-icon": "📄",
+  "x-kvx-collectionTitle": "Examples",
+
+  "x-kvx-list": {
+    "titleField": "displayName",
+    "subtitleField": "description",
+    "subtitleMaxLines": 1,
+    "badgeFields": ["category", "tags"]
+  },
+
+  "x-kvx-detail": {
+    "titleField": "displayName",
+    "hiddenFields": [],
+    "sections": [
+      {
+        "title": "",
+        "fields": ["name", "category"],
+        "layout": "inline"
+      },
+      {
+        "title": "Description",
+        "fields": ["description"],
+        "layout": "paragraph"
+      },
+      {
+        "title": "Tags",
+        "fields": ["tags"],
+        "layout": "tags"
+      },
+      {
+        "title": "View this example",
+        "fields": ["path"],
+        "layout": "inline"
+      }
+    ]
+  },
+
+  "items": {
+    "type": "object",
+    "required": ["name", "path"],
+    "properties": {
+      "displayName": {
+        "type": "string",
+        "title": "Example",
+        "description": "Human-readable name from the solution's metadata.displayName"
+      },
+      "name": {
+        "type": "string",
+        "title": "Name",
+        "description": "The solution's metadata.name (stable identifier)"
+      },
+      "category": {
+        "type": "string",
+        "title": "Category",
+        "description": "Example category (from metadata.category or the top-level directory)"
+      },
+      "tags": {
+        "type": "array",
+        "items": { "type": "string" },
+        "title": "Tags",
+        "description": "Searchable keywords from metadata.tags"
+      },
+      "description": {
+        "type": "string",
+        "title": "Description",
+        "description": "First line of the solution's metadata.description"
+      },
+      "path": {
+        "type": "string",
+        "title": "Path",
+        "description": "Handle passed to 'get examples <path>' to view the full solution"
+      }
+    }
+  }
+}

--- a/pkg/cmd/scafctl/get/examples/examples_schema.json
+++ b/pkg/cmd/scafctl/get/examples/examples_schema.json
@@ -34,9 +34,14 @@
         "layout": "tags"
       },
       {
-        "title": "View this example",
+        "title": "Path",
         "fields": ["path"],
         "layout": "inline"
+      },
+      {
+        "title": "Solution",
+        "fields": ["content"],
+        "layout": "paragraph"
       }
     ]
   },
@@ -75,6 +80,11 @@
         "type": "string",
         "title": "Path",
         "description": "Handle passed to 'get examples <path>' to view the full solution"
+      },
+      "content": {
+        "type": "string",
+        "title": "Solution",
+        "description": "The full example solution content, shown in the interactive detail view"
       }
     }
   }

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -30,8 +30,9 @@ import (
 var ErrPathTraversal = errors.New("path must not contain '..'")
 
 // ErrAmbiguousExample is returned when a lookup query matches more than one
-// example. The Matches field lists the candidate paths so the caller can guide
-// the user to an unambiguous selection.
+// example. It is a sentinel error: ResolveExample wraps it with the candidate
+// paths in the error string (e.g. `...: "hello-world" matches a.yaml, b.yaml`),
+// so callers detect it with errors.Is and can surface the message to the user.
 var ErrAmbiguousExample = errors.New("ambiguous example query")
 
 // ErrExampleNotFound is returned when a lookup query matches no example.
@@ -182,7 +183,7 @@ func ResolveExample(query string) (string, error) {
 
 	// Security: reject any ".." path segment before touching the filesystem. A
 	// filename that merely contains ".." (e.g. foo..bar) is safe and allowed.
-	if hasDotDotSegment(slashed) {
+	if isUnsafeExamplePath(slashed) {
 		return "", ErrPathTraversal
 	}
 	normalized := path.Clean(slashed)
@@ -238,6 +239,28 @@ func firstLine(s string) string {
 	return ""
 }
 
+// isUnsafeExamplePath reports whether a slash-separated path is unsafe to use as
+// an example lookup: either it contains a ".." traversal segment, or it is an
+// absolute path (leading "/", or a Windows drive/UNC form). The input must be
+// forward-slash separated but NOT path.Clean'd, so a ".." component cannot be
+// normalized away (path.Clean("foo/../x") == "x") before the check runs.
+// Example paths are always relative (e.g. "resolvers/hello-world.yaml"); an
+// absolute input never names an embedded example and is rejected up front to
+// keep the guard complete for any reuse of this resolver logic.
+func isUnsafeExamplePath(p string) bool {
+	if hasDotDotSegment(p) {
+		return true
+	}
+	if strings.HasPrefix(p, "/") {
+		return true // absolute (including UNC "\\\\server" -> "//server")
+	}
+	// Windows drive-letter absolute path, e.g. "C:/x".
+	if len(p) >= 2 && p[1] == ':' {
+		return true
+	}
+	return false
+}
+
 // hasDotDotSegment reports whether a slash-separated path contains a ".."
 // component (a traversal segment), as opposed to merely containing the literal
 // ".." inside a filename (e.g. "foo..bar.yaml", which is safe). The input must
@@ -284,7 +307,7 @@ func Read(exPath string) (string, error) {
 
 	// Security: reject any ".." path segment. A filename containing ".."
 	// (e.g. foo..bar.yaml) is safe and allowed.
-	if hasDotDotSegment(slashed) {
+	if isUnsafeExamplePath(slashed) {
 		return "", ErrPathTraversal
 	}
 	cleanPath := path.Clean(slashed)

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -26,8 +26,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// ErrPathTraversal is returned when a path contains ".." components.
-var ErrPathTraversal = errors.New("path must not contain '..'")
+// ErrPathTraversal is returned when an example lookup path is unsafe: it either
+// contains a ".." traversal component or is an absolute/UNC/drive-letter path.
+// Example paths are always relative (e.g. "resolvers/hello-world.yaml").
+var ErrPathTraversal = errors.New("example path must be relative and must not contain '..'")
 
 // ErrAmbiguousExample is returned when a lookup query matches more than one
 // example. It is a sentinel error: ResolveExample wraps it with the candidate

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -190,6 +190,15 @@ func ResolveExample(query string) (string, error) {
 	}
 	normalized := path.Clean(slashed)
 
+	// Exact-path short-circuit: if the query names a real embedded example file,
+	// return it directly. The listing (Scan) is intentionally solution-only, but
+	// `get examples <path>` must still be able to fetch ANY embedded example file
+	// by exact path (e.g. catalog/native-auth.yaml, which is kind: Config), which
+	// it could before the metadata-driven listing narrowed Scan to solutions.
+	if exampleFileExists(normalized) {
+		return normalized, nil
+	}
+
 	items, err := Scan("")
 	if err != nil {
 		return "", err
@@ -279,6 +288,20 @@ func hasDotDotSegment(p string) bool {
 		}
 	}
 	return false
+}
+
+// exampleFileExists reports whether relPath names a regular file in the
+// embedded examples filesystem. relPath must already be traversal-checked and
+// path.Clean'd (forward slashes). It is used by ResolveExample to allow
+// exact-path fetching of any embedded example file, including non-solution
+// files that the solution-only listing excludes.
+func exampleFileExists(relPath string) bool {
+	examplesFS, root, err := getExamplesFS()
+	if err != nil {
+		return false
+	}
+	info, err := fs.Stat(examplesFS, path.Join(root, relPath))
+	return err == nil && !info.IsDir()
 }
 
 // relFromRoot returns the forward-slash relative path of fpath under root,

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -66,6 +66,10 @@ type Example struct {
 	// Path is the embedded-FS path used as the unambiguous fetch handle for
 	// `get examples <path>` (metadata.name is not unique across examples).
 	Path string `json:"path" yaml:"path"`
+	// Content is the full example file content. It powers the interactive (-i)
+	// detail view so a user can read the solution without leaving the browser.
+	// Omitted from the default table (see the command's column hints).
+	Content string `json:"content,omitempty" yaml:"content,omitempty"`
 }
 
 // exampleMeta is a lightweight view of a solution used only to populate the
@@ -147,6 +151,7 @@ func Scan(category string) ([]Example, error) {
 			Tags:        meta.Metadata.Tags,
 			Description: firstLine(meta.Metadata.Description),
 			Path:        relPath,
+			Content:     string(content),
 		})
 		return nil
 	})
@@ -168,67 +173,83 @@ func Scan(category string) ([]Example, error) {
 	return items, nil
 }
 
-// ResolveExample resolves a user-supplied query to a single example path. The
-// query may be an exact path, a metadata.name, or a file basename. When the
-// query matches exactly one example, its path is returned. When it matches more
-// than one, ErrAmbiguousExample is returned wrapped with the candidate paths so
-// the caller can prompt for a precise path. When nothing matches,
-// ErrExampleNotFound is returned.
-func ResolveExample(query string) (string, error) {
+// MatchExamples resolves a user-supplied query to the example(s) it identifies.
+// The query may be an exact embedded path, a metadata.name, or a file basename.
+// It returns:
+//
+//   - exactly one Example when the query names a single example (by exact path,
+//     or a unique name/basename),
+//   - more than one Example when a name/basename matches several (the caller
+//     should present them as a list to choose from),
+//   - ErrExampleNotFound when nothing matches,
+//   - ErrPathTraversal when the query is an unsafe path.
+//
+// Exact-path matches also resolve non-solution embedded files (e.g. kind:
+// Config) that the solution-only listing excludes; those are returned as a
+// single Example carrying just the Path.
+func MatchExamples(query string) ([]Example, error) {
 	query = strings.TrimSpace(query)
 	if query == "" {
-		return "", ErrExampleNotFound
+		return nil, ErrExampleNotFound
 	}
 	// Slash-normalize WITHOUT cleaning first, so a ".." component cannot be
 	// resolved away before the traversal check (path.Clean("foo/../x") == "x").
 	slashed := strings.ReplaceAll(filepath.ToSlash(query), "\\", "/")
-
-	// Security: reject any ".." path segment before touching the filesystem. A
-	// filename that merely contains ".." (e.g. foo..bar) is safe and allowed.
 	if isUnsafeExamplePath(slashed) {
-		return "", ErrPathTraversal
+		return nil, ErrPathTraversal
 	}
 	normalized := path.Clean(slashed)
 
-	// Exact-path short-circuit: if the query names a real embedded example file,
-	// return it directly. The listing (Scan) is intentionally solution-only, but
-	// `get examples <path>` must still be able to fetch ANY embedded example file
-	// by exact path (e.g. catalog/native-auth.yaml, which is kind: Config), which
-	// it could before the metadata-driven listing narrowed Scan to solutions.
-	if exampleFileExists(normalized) {
-		return normalized, nil
-	}
-
 	items, err := Scan("")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	// 1. Exact path match wins immediately (paths are unique).
+	// 1. Exact path match wins immediately (paths are unique): a listed solution
+	//    is returned with full metadata...
 	for _, it := range items {
 		if it.Path == normalized {
-			return it.Path, nil
+			return []Example{it}, nil
 		}
 	}
+	// ...and any other embedded example file by exact path (non-solution kinds
+	// the listing excludes) is still fetchable.
+	if exampleFileExists(normalized) {
+		return []Example{{Name: normalized, Path: normalized}}, nil
+	}
 
-	// 2. Match by metadata.name or file basename (may be ambiguous).
-	var matches []string
+	// 2. Match by metadata.name or file basename (may match several).
+	var matches []Example
 	for _, it := range items {
 		base := strings.TrimSuffix(path.Base(it.Path), path.Ext(it.Path))
 		if it.Name == query || base == query || base == normalized {
-			matches = append(matches, it.Path)
+			matches = append(matches, it)
 		}
 	}
-
-	switch len(matches) {
-	case 0:
-		return "", fmt.Errorf("%w: %q", ErrExampleNotFound, query)
-	case 1:
-		return matches[0], nil
-	default:
-		sort.Strings(matches)
-		return "", fmt.Errorf("%w: %q matches %s", ErrAmbiguousExample, query, strings.Join(matches, ", "))
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("%w: %q", ErrExampleNotFound, query)
 	}
+	sort.Slice(matches, func(i, j int) bool { return matches[i].Path < matches[j].Path })
+	return matches, nil
+}
+
+// ResolveExample resolves a query to a single example path. It is a thin wrapper
+// over MatchExamples for callers requiring exactly one result: when the query
+// matches more than one example, ErrAmbiguousExample is returned wrapped with
+// the candidate paths.
+func ResolveExample(query string) (string, error) {
+	matches, err := MatchExamples(query)
+	if err != nil {
+		return "", err
+	}
+	if len(matches) > 1 {
+		paths := make([]string, len(matches))
+		for i, m := range matches {
+			paths[i] = m.Path
+		}
+		return "", fmt.Errorf("%w: %q matches %s", ErrAmbiguousExample, query, strings.Join(paths, ", "))
+	}
+	return matches[0].Path, nil
 }
 
 // displayNameOf returns metadata.displayName, falling back to metadata.name.

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -54,18 +54,18 @@ const solutionKind = "Solution"
 type Example struct {
 	// DisplayName is the human-friendly name from metadata.displayName.
 	// Falls back to metadata.name when unset.
-	DisplayName string `json:"displayName,omitempty"`
+	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	// Name is the solution's metadata.name (its stable identifier).
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 	// Category is metadata.category (falls back to the top-level directory).
-	Category string `json:"category,omitempty"`
+	Category string `json:"category,omitempty" yaml:"category,omitempty"`
 	// Tags are metadata.tags.
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 	// Description is metadata.description (first line, trimmed).
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	// Path is the embedded-FS path used as the unambiguous fetch handle for
 	// `get examples <path>` (metadata.name is not unique across examples).
-	Path string `json:"path"`
+	Path string `json:"path" yaml:"path"`
 }
 
 // exampleMeta is a lightweight view of a solution used only to populate the

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -176,13 +176,16 @@ func ResolveExample(query string) (string, error) {
 	if query == "" {
 		return "", ErrExampleNotFound
 	}
-	normalized := path.Clean(strings.ReplaceAll(filepath.ToSlash(query), "\\", "/"))
+	// Slash-normalize WITHOUT cleaning first, so a ".." component cannot be
+	// resolved away before the traversal check (path.Clean("foo/../x") == "x").
+	slashed := strings.ReplaceAll(filepath.ToSlash(query), "\\", "/")
 
-	// Security: reject path traversal (a ".." path segment) before touching
-	// the filesystem. A filename that merely contains ".." (e.g. foo..bar) is safe.
-	if hasDotDotSegment(normalized) {
+	// Security: reject any ".." path segment before touching the filesystem. A
+	// filename that merely contains ".." (e.g. foo..bar) is safe and allowed.
+	if hasDotDotSegment(slashed) {
 		return "", ErrPathTraversal
 	}
+	normalized := path.Clean(slashed)
 
 	items, err := Scan("")
 	if err != nil {
@@ -271,16 +274,18 @@ func Read(exPath string) (string, error) {
 		return "", err
 	}
 
-	// Normalize to forward slashes. embed.FS always uses forward slashes, and a
-	// caller may pass a Windows-style backslash path. filepath.ToSlash is a
-	// no-op for backslashes on non-Windows hosts, so convert explicitly.
-	cleanPath := path.Clean(strings.ReplaceAll(filepath.ToSlash(exPath), "\\", "/"))
+	// Normalize to forward slashes WITHOUT cleaning first: embed.FS uses forward
+	// slashes, a caller may pass Windows-style backslashes, and path.Clean would
+	// resolve a ".." component away (path.Clean("foo/../x") == "x") before the
+	// traversal check. filepath.ToSlash is a no-op for backslashes off Windows.
+	slashed := strings.ReplaceAll(filepath.ToSlash(exPath), "\\", "/")
 
-	// Security: reject a ".." path segment (traversal). A filename containing
-	// ".." (e.g. foo..bar.yaml) is safe and allowed.
-	if hasDotDotSegment(cleanPath) {
+	// Security: reject any ".." path segment. A filename containing ".."
+	// (e.g. foo..bar.yaml) is safe and allowed.
+	if hasDotDotSegment(slashed) {
 		return "", ErrPathTraversal
 	}
+	cleanPath := path.Clean(slashed)
 
 	fullPath := path.Join(root, cleanPath)
 	content, err := fs.ReadFile(examplesFS, fullPath)

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -178,8 +178,9 @@ func ResolveExample(query string) (string, error) {
 	}
 	normalized := path.Clean(strings.ReplaceAll(filepath.ToSlash(query), "\\", "/"))
 
-	// Security: reject path traversal before touching the filesystem.
-	if strings.Contains(normalized, "..") {
+	// Security: reject path traversal (a ".." path segment) before touching
+	// the filesystem. A filename that merely contains ".." (e.g. foo..bar) is safe.
+	if hasDotDotSegment(normalized) {
 		return "", ErrPathTraversal
 	}
 
@@ -234,6 +235,22 @@ func firstLine(s string) string {
 	return ""
 }
 
+// hasDotDotSegment reports whether a slash-separated path contains a ".."
+// component (a traversal segment), as opposed to merely containing the literal
+// ".." inside a filename (e.g. "foo..bar.yaml", which is safe). The input
+// should already be path.Clean'd and use forward slashes.
+func hasDotDotSegment(p string) bool {
+	if p == ".." {
+		return true
+	}
+	for _, seg := range strings.Split(p, "/") {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
+}
+
 // relFromRoot returns the forward-slash relative path of fpath under root,
 // handling both embed.FS (forward slashes) and OS filesystems (native
 // separators) consistently.
@@ -259,8 +276,9 @@ func Read(exPath string) (string, error) {
 	// no-op for backslashes on non-Windows hosts, so convert explicitly.
 	cleanPath := path.Clean(strings.ReplaceAll(filepath.ToSlash(exPath), "\\", "/"))
 
-	// Security: ensure the path doesn't escape
-	if strings.Contains(cleanPath, "..") {
+	// Security: reject a ".." path segment (traversal). A filename containing
+	// ".." (e.g. foo..bar.yaml) is safe and allowed.
+	if hasDotDotSegment(cleanPath) {
 		return "", ErrPathTraversal
 	}
 

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -240,8 +240,10 @@ func firstLine(s string) string {
 
 // hasDotDotSegment reports whether a slash-separated path contains a ".."
 // component (a traversal segment), as opposed to merely containing the literal
-// ".." inside a filename (e.g. "foo..bar.yaml", which is safe). The input
-// should already be path.Clean'd and use forward slashes.
+// ".." inside a filename (e.g. "foo..bar.yaml", which is safe). The input must
+// be forward-slash separated but must NOT have been path.Clean'd: callers invoke
+// this before cleaning, precisely so a ".." component cannot be normalized away
+// (path.Clean("foo/../x") == "x") before the traversal check runs.
 func hasDotDotSegment(p string) bool {
 	if p == ".." {
 		return true

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -22,24 +22,68 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 // ErrPathTraversal is returned when a path contains ".." components.
 var ErrPathTraversal = errors.New("path must not contain '..'")
 
+// ErrAmbiguousExample is returned when a lookup query matches more than one
+// example. The Matches field lists the candidate paths so the caller can guide
+// the user to an unambiguous selection.
+var ErrAmbiguousExample = errors.New("ambiguous example query")
+
+// ErrExampleNotFound is returned when a lookup query matches no example.
+var ErrExampleNotFound = errors.New("example not found")
+
 //go:embed files/*
 var EmbeddedExamples embed.FS
 
-// Example represents an example file in the listing.
+// solutionKind is the only artifact kind surfaced as a runnable example. Config
+// files, auth-handler configs, compose partials, and rendered templates that
+// live under examples/ are intentionally excluded from the listing.
+const solutionKind = "Solution"
+
+// Example represents a runnable example solution in the listing. Fields are
+// sourced from the solution's own metadata block (not the filename), so the
+// listing reflects what the author declared.
 type Example struct {
-	Path        string `json:"path"`
-	Category    string `json:"category"`
-	Name        string `json:"name"`
+	// DisplayName is the human-friendly name from metadata.displayName.
+	// Falls back to metadata.name when unset.
+	DisplayName string `json:"displayName,omitempty"`
+	// Name is the solution's metadata.name (its stable identifier).
+	Name string `json:"name"`
+	// Category is metadata.category (falls back to the top-level directory).
+	Category string `json:"category,omitempty"`
+	// Tags are metadata.tags.
+	Tags []string `json:"tags,omitempty"`
+	// Description is metadata.description (first line, trimmed).
 	Description string `json:"description,omitempty"`
+	// Path is the embedded-FS path used as the unambiguous fetch handle for
+	// `get examples <path>` (metadata.name is not unique across examples).
+	Path string `json:"path"`
 }
 
-// Scan walks the examples filesystem and returns matching examples.
-// If category is empty, returns all examples.
+// exampleMeta is a lightweight view of a solution used only to populate the
+// listing. It deliberately parses just the fields the listing needs so a quirky
+// (but valid) example never breaks scanning.
+type exampleMeta struct {
+	Kind     string `yaml:"kind"`
+	Metadata struct {
+		Name        string   `yaml:"name"`
+		DisplayName string   `yaml:"displayName"`
+		Category    string   `yaml:"category"`
+		Description string   `yaml:"description"`
+		Tags        []string `yaml:"tags"`
+	} `yaml:"metadata"`
+}
+
+// Scan walks the examples filesystem and returns matching example solutions.
+// Only kind: Solution files are returned; non-solution YAML (configs, partials,
+// templates) is skipped. If category is non-empty, only examples in that
+// category are returned. Metadata is read from each solution's own metadata
+// block.
 func Scan(category string) ([]Example, error) {
 	examplesFS, root, err := getExamplesFS()
 	if err != nil {
@@ -55,67 +99,152 @@ func Scan(category string) ([]Example, error) {
 			return nil
 		}
 
-		// Only include YAML files (use path.Ext for forward-slash paths from embed.FS)
 		ext := path.Ext(fpath)
 		if ext != ".yaml" && ext != ".yml" {
 			return nil
 		}
 
-		// Get the relative path from the root.
-		// embed.FS always uses forward slashes, so use strings-based trimming
-		// instead of filepath.Rel which produces OS-native separators on Windows.
-		relPath := strings.TrimPrefix(fpath, root+"/")
-		if relPath == fpath {
-			// Fallback for OS filesystem where paths may use native separators
-			var relErr error
-			relPath, relErr = filepath.Rel(root, fpath)
-			if relErr != nil {
-				return relErr
+		relPath := relFromRoot(fpath, root)
+
+		// Skip intentionally invalid/demo examples that exist to trigger errors
+		// or stress lint rules -- they are not runnable reference examples.
+		if strings.Contains(relPath, "bad-solution") || strings.Contains(relPath, "lint-stress-test") {
+			return nil
+		}
+
+		content, err := fs.ReadFile(examplesFS, fpath)
+		if err != nil {
+			return nil //nolint:nilerr // skip unreadable file, keep scanning
+		}
+
+		var meta exampleMeta
+		if err := yaml.Unmarshal(content, &meta); err != nil {
+			// Not valid YAML (e.g. a Go-template partial) -- not a listable example.
+			return nil //nolint:nilerr
+		}
+		if meta.Kind != solutionKind {
+			return nil
+		}
+
+		// Category from metadata, falling back to the first path component.
+		cat := meta.Metadata.Category
+		if cat == "" {
+			if parts := strings.SplitN(relPath, "/", 2); len(parts) > 1 {
+				cat = parts[0]
 			}
-			relPath = filepath.ToSlash(relPath)
 		}
-
-		// Determine category from the first directory component
-		parts := strings.SplitN(relPath, "/", 2)
-		cat := ""
-		name := relPath
-		if len(parts) > 1 {
-			cat = parts[0]
-			name = parts[1]
-		}
-
-		// Apply category filter
 		if category != "" && cat != category {
 			return nil
 		}
 
-		// Skip intentionally bad examples
-		if strings.Contains(relPath, "bad-solution") {
-			return nil
-		}
-
-		item := Example{
-			Path:        relPath,
+		items = append(items, Example{
+			DisplayName: displayNameOf(meta),
+			Name:        meta.Metadata.Name,
 			Category:    cat,
-			Name:        name,
-			Description: DescriptionFromPath(relPath),
-		}
-		items = append(items, item)
+			Tags:        meta.Metadata.Tags,
+			Description: firstLine(meta.Metadata.Description),
+			Path:        relPath,
+		})
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	// Sort by category then name
+	// Sort by category, then displayName, then path (stable, path is unique).
 	sort.Slice(items, func(i, j int) bool {
 		if items[i].Category != items[j].Category {
 			return items[i].Category < items[j].Category
 		}
-		return items[i].Name < items[j].Name
+		if items[i].DisplayName != items[j].DisplayName {
+			return items[i].DisplayName < items[j].DisplayName
+		}
+		return items[i].Path < items[j].Path
 	})
 
 	return items, nil
+}
+
+// ResolveExample resolves a user-supplied query to a single example path. The
+// query may be an exact path, a metadata.name, or a file basename. When the
+// query matches exactly one example, its path is returned. When it matches more
+// than one, ErrAmbiguousExample is returned wrapped with the candidate paths so
+// the caller can prompt for a precise path. When nothing matches,
+// ErrExampleNotFound is returned.
+func ResolveExample(query string) (string, error) {
+	query = strings.TrimSpace(query)
+	if query == "" {
+		return "", ErrExampleNotFound
+	}
+	normalized := path.Clean(strings.ReplaceAll(filepath.ToSlash(query), "\\", "/"))
+
+	// Security: reject path traversal before touching the filesystem.
+	if strings.Contains(normalized, "..") {
+		return "", ErrPathTraversal
+	}
+
+	items, err := Scan("")
+	if err != nil {
+		return "", err
+	}
+
+	// 1. Exact path match wins immediately (paths are unique).
+	for _, it := range items {
+		if it.Path == normalized {
+			return it.Path, nil
+		}
+	}
+
+	// 2. Match by metadata.name or file basename (may be ambiguous).
+	var matches []string
+	for _, it := range items {
+		base := strings.TrimSuffix(path.Base(it.Path), path.Ext(it.Path))
+		if it.Name == query || base == query || base == normalized {
+			matches = append(matches, it.Path)
+		}
+	}
+
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf("%w: %q", ErrExampleNotFound, query)
+	case 1:
+		return matches[0], nil
+	default:
+		sort.Strings(matches)
+		return "", fmt.Errorf("%w: %q matches %s", ErrAmbiguousExample, query, strings.Join(matches, ", "))
+	}
+}
+
+// displayNameOf returns metadata.displayName, falling back to metadata.name.
+func displayNameOf(m exampleMeta) string {
+	if m.Metadata.DisplayName != "" {
+		return m.Metadata.DisplayName
+	}
+	return m.Metadata.Name
+}
+
+// firstLine returns the first non-empty line of s, trimmed. Multi-line
+// descriptions (block scalars) collapse to their first line for the listing.
+func firstLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if t := strings.TrimSpace(line); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+// relFromRoot returns the forward-slash relative path of fpath under root,
+// handling both embed.FS (forward slashes) and OS filesystems (native
+// separators) consistently.
+func relFromRoot(fpath, root string) string {
+	relPath := strings.TrimPrefix(fpath, root+"/")
+	if relPath == fpath {
+		if rel, err := filepath.Rel(root, fpath); err == nil {
+			relPath = filepath.ToSlash(rel)
+		}
+	}
+	return relPath
 }
 
 // Read returns the contents of an example file.
@@ -125,8 +254,10 @@ func Read(exPath string) (string, error) {
 		return "", err
 	}
 
-	// Normalize to forward slashes (embed.FS always uses forward slashes)
-	cleanPath := path.Clean(filepath.ToSlash(exPath))
+	// Normalize to forward slashes. embed.FS always uses forward slashes, and a
+	// caller may pass a Windows-style backslash path. filepath.ToSlash is a
+	// no-op for backslashes on non-Windows hosts, so convert explicitly.
+	cleanPath := path.Clean(strings.ReplaceAll(filepath.ToSlash(exPath), "\\", "/"))
 
 	// Security: ensure the path doesn't escape
 	if strings.Contains(cleanPath, "..") {
@@ -227,100 +358,4 @@ func findExamplesDir() (string, error) {
 	}
 
 	return "", fmt.Errorf("could not locate examples directory")
-}
-
-// DescriptionFromPath generates a human-readable description from a file path.
-func DescriptionFromPath(exPath string) string {
-	descriptions := map[string]string{
-		// Solutions
-		"solutions/comprehensive/solution.yaml":      "Comprehensive solution demonstrating all features (resolvers, actions, transforms, validation, etc.)",
-		"solutions/email-notifier/solution.yaml":     "Email notification solution with parameters, validation, and action workflow",
-		"solutions/terraform/solution.yaml":          "Terraform infrastructure scaffolding solution",
-		"solutions/k8s-clusters/solution.yaml":       "Kubernetes cluster provisioning solution",
-		"solutions/directory/solution.yaml":          "Directory provider examples (list, read, create, copy)",
-		"solutions/scaffold-demo/solution.yaml":      "Scaffold/template rendering demo solution",
-		"solutions/github-auth/solution.yaml":        "GitHub authentication and API access solution",
-		"solutions/composition/parent.yaml":          "Solution composition - parent that composes children",
-		"solutions/composition/child.yaml":           "Solution composition - child partial solution",
-		"solutions/taskfile/solution.yaml":           "Taskfile-based workflow solution",
-		"solutions/tested-solution/solution.yaml":    "Solution with functional tests defined in spec.testing.cases",
-		"solutions/template-functions/solution.yaml": "Demonstrates custom Go template functions (slugify, where, selectField, cel, toYaml, metadata) plus the CEL strings.slugify function",
-
-		// Actions
-		"actions/hello-world.yaml":              "Simple hello world action",
-		"actions/sequential-chain.yaml":         "Actions executed sequentially using dependsOn",
-		"actions/parallel-with-deps.yaml":       "Parallel actions with dependency ordering",
-		"actions/conditional-execution.yaml":    "Actions with conditional execution (when clauses)",
-		"actions/error-handling.yaml":           "Error handling with continueOnError",
-		"actions/finally-cleanup.yaml":          "Finally block for cleanup actions",
-		"actions/foreach-deploy.yaml":           "ForEach iteration over collections",
-		"actions/retry-backoff.yaml":            "Retry with exponential backoff",
-		"actions/conditional-retry.yaml":        "Retry with conditional retry logic (retryIf)",
-		"actions/complex-workflow.yaml":         "Complex workflow with all action features",
-		"actions/template-render.yaml":          "Template rendering action",
-		"actions/go-template-inline.yaml":       "Inline Go template action",
-		"actions/result-schema-validation.yaml": "Action result schema validation",
-
-		// Resolvers
-		"resolvers/hello-world.yaml":         "Simple static value resolver",
-		"resolvers/parameters.yaml":          "Parameter provider for user input",
-		"resolvers/dependencies.yaml":        "Resolver dependency chain (dependsOn)",
-		"resolvers/env-config.yaml":          "Environment variable resolver",
-		"resolvers/validation.yaml":          "Resolver validation rules",
-		"resolvers/transform-pipeline.yaml":  "Multi-step transform pipeline",
-		"resolvers/cel-basics.yaml":          "CEL expression basics in resolvers",
-		"resolvers/cel-builtins.yaml":        "CEL built-in functions reference",
-		"resolvers/cel-extensions.yaml":      "scafctl custom CEL extensions",
-		"resolvers/cel-transforms.yaml":      "CEL-based transform examples",
-		"resolvers/cel-common-patterns.yaml": "Common CEL patterns and recipes",
-		"resolvers/feature-flags.yaml":       "Feature flag resolver pattern",
-		"resolvers/identity.yaml":            "Identity/auth resolver pattern",
-		"resolvers/secrets.yaml":             "Secrets resolver pattern",
-		"resolvers/error-recovery.yaml":      "Conditional error recovery with continueOnError",
-
-		// Providers
-		"providers/static-hello.yaml":                "Static provider — simple static string value",
-		"providers/exec-ls.yaml":                     "Exec provider — list directory contents",
-		"providers/http-get.yaml":                    "HTTP provider — simple GET request",
-		"providers/http-autoparse.yaml":              "HTTP provider — auto-parse JSON responses",
-		"providers/http-poll.yaml":                   "HTTP provider — polling until a condition is met",
-		"providers/http-entra.yaml":                  "HTTP provider — Microsoft Graph API with Entra auth",
-		"providers/github-api.yaml":                  "HTTP provider — GitHub API with authentication",
-		"providers/http-pagination-cursor.yaml":      "HTTP provider — cursor-based pagination",
-		"providers/http-pagination-link-header.yaml": "HTTP provider — Link header pagination (RFC 8288)",
-		"providers/http-pagination-odata.yaml":       "HTTP provider — OData / Microsoft Graph pagination",
-		"providers/http-pagination-offset.yaml":      "HTTP provider — offset-based pagination",
-		"providers/http-pagination-page-number.yaml": "HTTP provider — page number pagination",
-		"providers/github-provider.yaml":             "GitHub provider — read repository info via GraphQL",
-		"providers/github-write-operations.yaml":     "GitHub provider — write operations reference (issues, PRs, commits, releases)",
-		"providers/hcl-format.yaml":                  "HCL provider — format Terraform content to canonical style",
-		"providers/hcl-validate.yaml":                "HCL provider — validate HCL syntax and return diagnostics",
-		"providers/hcl-parse-variables.yaml":         "HCL provider — parse Terraform variable definitions",
-		"providers/hcl-generate.yaml":                "HCL provider — generate HCL from structured block data",
-		"providers/hcl-generate-json.yaml":           "HCL provider — generate Terraform JSON (.tf.json)",
-		"providers/identity-list.yaml":               "Identity provider — list available auth handlers",
-		"providers/identity-claims.yaml":             "Identity provider — get claims from stored metadata",
-		"providers/identity-status.yaml":             "Identity provider — check authentication status",
-		"providers/identity-groups.yaml":             "Identity provider — get Entra group memberships",
-		"providers/identity-scoped-claims.yaml":      "Identity provider — get claims from a scoped access token",
-		"providers/identity-scoped-status.yaml":      "Identity provider — check scoped token status and metadata",
-		"providers/metadata-full.yaml":               "Metadata provider — returns runtime metadata about scafctl and the current solution",
-		"providers/message-types.yaml":               "Message provider — all six built-in message types (success, warning, error, info, debug, plain)",
-		"providers/message-custom-style.yaml":        "Message provider — custom colors, bold, italic, icons, and newline control",
-		"providers/message-dynamic.yaml":             "Message provider — Go template interpolation and CEL expression messages",
-		"providers/metadata-single-field.yaml":       "Metadata provider — use CEL to extract a single field from runtime metadata",
-		"providers/security-example.yaml":            "Security hardening patterns across providers",
-	}
-
-	if desc, ok := descriptions[exPath]; ok {
-		return desc
-	}
-
-	// Fallback: generate from filename.
-	// Use path.Base/path.Ext (forward-slash) since relPaths are normalized to forward slashes.
-	name := path.Base(exPath)
-	name = strings.TrimSuffix(name, path.Ext(name))
-	name = strings.ReplaceAll(name, "-", " ")
-	name = strings.ReplaceAll(name, "_", " ")
-	return strings.Title(name) + " example" //nolint:staticcheck // strings.Title is fine for simple cases
 }

--- a/pkg/examples/examples_test.go
+++ b/pkg/examples/examples_test.go
@@ -260,6 +260,29 @@ func TestResolveExample_RejectsPathTraversal(t *testing.T) {
 	}
 }
 
+func TestHasDotDotSegment(t *testing.T) {
+	t.Parallel()
+	// Only a ".." path *segment* is traversal; ".." inside a filename is safe.
+	traversal := []string{"..", "../x", "a/../../b", "foo/.."}
+	for _, p := range traversal {
+		assert.True(t, hasDotDotSegment(p), "%q should be flagged as traversal", p)
+	}
+	safe := []string{"foo..bar.yaml", "a/foo..bar/c.yaml", "resolvers/hello-world.yaml", "..bar", "bar..", ""}
+	for _, p := range safe {
+		assert.False(t, hasDotDotSegment(p), "%q should NOT be flagged as traversal", p)
+	}
+}
+
+func TestResolveExample_DotDotInFilenameIsNotTraversal(t *testing.T) {
+	t.Parallel()
+	// A query containing ".." in a segment name (not as a component) must not be
+	// rejected as traversal -- it should simply be "not found".
+	_, err := ResolveExample("foo..bar")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExampleNotFound)
+	assert.NotErrorIs(t, err, ErrPathTraversal)
+}
+
 // ── Example struct tests ──────────────────────────────────────────────────────
 
 func TestExample_Fields(t *testing.T) {

--- a/pkg/examples/examples_test.go
+++ b/pkg/examples/examples_test.go
@@ -136,6 +136,11 @@ func TestRead_PathTraversalVariants(t *testing.T) {
 		"../../secret.yaml",
 		"foo/../../bar.yaml",
 		"../solution.yaml",
+		// Tricky: path.Clean would resolve these ".." components away if the
+		// check ran after cleaning; they must still be rejected.
+		"foo/../bar.yaml",
+		"foo/..",
+		"actions/../secret.yaml",
 	}
 
 	for _, path := range tests {
@@ -253,6 +258,11 @@ func TestResolveExample_RejectsPathTraversal(t *testing.T) {
 		"foo/../../bar.yaml",
 		"..\\..\\windows\\system32",
 		"actions/../../secret",
+		// Tricky: a ".." that path.Clean would resolve away if checked after
+		// cleaning. These must still be rejected.
+		"foo/../bar.yaml",
+		"foo/..",
+		"actions/../secret.yaml",
 	} {
 		_, err := ResolveExample(q)
 		require.Error(t, err, "query %q must be rejected", q)

--- a/pkg/examples/examples_test.go
+++ b/pkg/examples/examples_test.go
@@ -141,6 +141,8 @@ func TestRead_PathTraversalVariants(t *testing.T) {
 		"foo/../bar.yaml",
 		"foo/..",
 		"actions/../secret.yaml",
+		"/etc/passwd",
+		"C:\\Windows\\system32",
 	}
 
 	for _, path := range tests {
@@ -263,6 +265,10 @@ func TestResolveExample_RejectsPathTraversal(t *testing.T) {
 		"foo/../bar.yaml",
 		"foo/..",
 		"actions/../secret.yaml",
+		// Absolute / UNC paths never name an embedded example and are rejected.
+		"/etc/passwd",
+		"\\\\server\\share",
+		"C:\\Windows\\system32",
 	} {
 		_, err := ResolveExample(q)
 		require.Error(t, err, "query %q must be rejected", q)
@@ -280,6 +286,21 @@ func TestHasDotDotSegment(t *testing.T) {
 	safe := []string{"foo..bar.yaml", "a/foo..bar/c.yaml", "resolvers/hello-world.yaml", "..bar", "bar..", ""}
 	for _, p := range safe {
 		assert.False(t, hasDotDotSegment(p), "%q should NOT be flagged as traversal", p)
+	}
+}
+
+func TestIsUnsafeExamplePath(t *testing.T) {
+	t.Parallel()
+	unsafe := []string{
+		"..", "../x", "a/../../b", "foo/..", // traversal
+		"/etc/passwd", "//server/share", "C:/Windows", // absolute / UNC / drive
+	}
+	for _, p := range unsafe {
+		assert.True(t, isUnsafeExamplePath(p), "%q should be unsafe", p)
+	}
+	safe := []string{"resolvers/hello-world.yaml", "foo..bar.yaml", "a/b/c.yaml", "..bar"}
+	for _, p := range safe {
+		assert.False(t, isUnsafeExamplePath(p), "%q should be safe", p)
 	}
 }
 

--- a/pkg/examples/examples_test.go
+++ b/pkg/examples/examples_test.go
@@ -258,6 +258,75 @@ func TestResolveExample_Ambiguous(t *testing.T) {
 	assert.Contains(t, err.Error(), "actions/hello-world.yaml")
 }
 
+func TestMatchExamples_UniqueName(t *testing.T) {
+	t.Parallel()
+	got, err := MatchExamples("hello-world-resolver")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "hello-world-resolver", got[0].Name)
+	assert.Equal(t, "resolvers/hello-world.yaml", got[0].Path)
+}
+
+func TestMatchExamples_MultipleReturnsAll(t *testing.T) {
+	t.Parallel()
+	// "hello-world" is a basename shared by several examples; MatchExamples
+	// returns all of them (the CLI lists them for the user to pick).
+	got, err := MatchExamples("hello-world")
+	require.NoError(t, err)
+	require.Greater(t, len(got), 1)
+	paths := make([]string, len(got))
+	for i, m := range got {
+		paths[i] = m.Path
+	}
+	assert.Contains(t, paths, "actions/hello-world.yaml")
+	assert.Contains(t, paths, "resolvers/hello-world.yaml")
+}
+
+func TestMatchExamples_ExactPath(t *testing.T) {
+	t.Parallel()
+	got, err := MatchExamples("resolvers/cel-basics.yaml")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "resolvers/cel-basics.yaml", got[0].Path)
+}
+
+func TestMatchExamples_NotFoundAndTraversal(t *testing.T) {
+	t.Parallel()
+	_, err := MatchExamples("does-not-exist-xyz")
+	assert.ErrorIs(t, err, ErrExampleNotFound)
+
+	_, err = MatchExamples("../../etc/passwd")
+	assert.ErrorIs(t, err, ErrPathTraversal)
+}
+
+func TestScan_PopulatesContent(t *testing.T) {
+	t.Parallel()
+	// Content carries the full example file so the interactive (-i) detail view
+	// can show the solution without a second command.
+	items, err := Scan("")
+	require.NoError(t, err)
+	require.NotEmpty(t, items)
+	for _, it := range items[:min(5, len(items))] {
+		assert.Contains(t, it.Content, "apiVersion:", "%s: content should be the full solution", it.Path)
+		assert.Contains(t, it.Content, "kind: Solution", it.Path)
+	}
+}
+
+func TestExampleNamesAreUnique(t *testing.T) {
+	t.Parallel()
+	// Regression guard: every listed example must have a unique metadata.name so
+	// `get examples <name>` is unambiguous by name.
+	items, err := Scan("")
+	require.NoError(t, err)
+	seen := make(map[string]string, len(items))
+	for _, it := range items {
+		if prev, dup := seen[it.Name]; dup {
+			t.Errorf("duplicate example name %q: %s and %s", it.Name, prev, it.Path)
+		}
+		seen[it.Name] = it.Path
+	}
+}
+
 func TestResolveExample_NotFound(t *testing.T) {
 	t.Parallel()
 	_, err := ResolveExample("this-does-not-exist-anywhere")

--- a/pkg/examples/examples_test.go
+++ b/pkg/examples/examples_test.go
@@ -230,6 +230,25 @@ func TestResolveExample_ByName(t *testing.T) {
 	assert.Equal(t, "resolvers/cel-basics.yaml", got)
 }
 
+func TestResolveExample_ExactPathToNonSolutionFile(t *testing.T) {
+	t.Parallel()
+	// The listing is solution-only, but exact-path fetch must still resolve any
+	// embedded example file -- including non-solution kinds (e.g. kind: Config).
+	// Regression guard: catalog/native-auth.yaml is not listed by Scan but must
+	// remain fetchable by exact path.
+	got, err := ResolveExample("catalog/native-auth.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, "catalog/native-auth.yaml", got)
+
+	// And it must NOT appear in the (solution-only) listing.
+	items, err := Scan("")
+	require.NoError(t, err)
+	for _, it := range items {
+		assert.NotEqual(t, "catalog/native-auth.yaml", it.Path,
+			"non-solution files must not be listed")
+	}
+}
+
 func TestResolveExample_Ambiguous(t *testing.T) {
 	t.Parallel()
 	// "hello-world" is a basename shared by several examples.

--- a/pkg/examples/examples_test.go
+++ b/pkg/examples/examples_test.go
@@ -52,7 +52,7 @@ func TestScan_ResultsAreSorted(t *testing.T) {
 		prev := items[i-1]
 		curr := items[i]
 		if prev.Category == curr.Category {
-			assert.LessOrEqual(t, prev.Name, curr.Name, "items should be sorted by name within category")
+			assert.LessOrEqual(t, prev.DisplayName, curr.DisplayName, "items should be sorted by displayName within category")
 		} else {
 			assert.Less(t, prev.Category, curr.Category, "items should be sorted by category")
 		}
@@ -170,27 +170,94 @@ func TestCategories_ContainsExpectedCategories(t *testing.T) {
 	}
 }
 
-// ── DescriptionFromPath tests ─────────────────────────────────────────────────
+// ── Metadata-driven Scan tests ────────────────────────────────────────────────
 
-func TestDescriptionFromPath_KnownPath(t *testing.T) {
+func TestScan_OnlyListsSolutions(t *testing.T) {
 	t.Parallel()
-	desc := DescriptionFromPath("solutions/comprehensive/solution.yaml")
-	assert.NotEmpty(t, desc)
-	assert.Contains(t, desc, "Comprehensive")
+	items, err := Scan("")
+	require.NoError(t, err)
+	require.NotEmpty(t, items)
+
+	for _, item := range items {
+		// Names come from metadata.name, never the filename, so no ".yaml".
+		assert.NotContains(t, item.Name, ".yaml", "name must come from metadata, not filename")
+		assert.NotContains(t, item.Name, ".yml")
+		// Non-solution files and intentional bad/stress demos must be excluded.
+		assert.NotContains(t, item.Path, "bad-solution")
+		assert.NotContains(t, item.Path, "lint-stress-test")
+	}
 }
 
-func TestDescriptionFromPath_UnknownPath(t *testing.T) {
+func TestScan_PopulatesMetadata(t *testing.T) {
 	t.Parallel()
-	desc := DescriptionFromPath("unknown/my-custom-example.yaml")
-	assert.Contains(t, desc, "example")
-	assert.Contains(t, desc, "My")
+	items, err := Scan("")
+	require.NoError(t, err)
+
+	var hello *Example
+	for i := range items {
+		if items[i].Path == "actions/hello-world.yaml" {
+			hello = &items[i]
+			break
+		}
+	}
+	require.NotNil(t, hello, "actions/hello-world.yaml should be listed")
+	assert.Equal(t, "hello-world-action", hello.Name)
+	assert.Equal(t, "Hello World Action", hello.DisplayName)
+	assert.Equal(t, "actions", hello.Category)
+	assert.NotEmpty(t, hello.Description)
+	assert.Contains(t, hello.Tags, "action")
 }
 
-func TestDescriptionFromPath_CleansFallbackName(t *testing.T) {
+func TestResolveExample_ExactPath(t *testing.T) {
 	t.Parallel()
-	desc := DescriptionFromPath("category/some-complex_file-name.yaml")
-	assert.NotContains(t, desc, "-")
-	assert.NotContains(t, desc, "_")
+	got, err := ResolveExample("actions/hello-world.yaml")
+	require.NoError(t, err)
+	assert.Equal(t, "actions/hello-world.yaml", got)
+}
+
+func TestResolveExample_ByName(t *testing.T) {
+	t.Parallel()
+	// cel-basics is a unique metadata.name.
+	got, err := ResolveExample("cel-basics")
+	require.NoError(t, err)
+	assert.Equal(t, "resolvers/cel-basics.yaml", got)
+}
+
+func TestResolveExample_Ambiguous(t *testing.T) {
+	t.Parallel()
+	// "hello-world" is a basename shared by several examples.
+	_, err := ResolveExample("hello-world")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrAmbiguousExample)
+	assert.Contains(t, err.Error(), "actions/hello-world.yaml")
+}
+
+func TestResolveExample_NotFound(t *testing.T) {
+	t.Parallel()
+	_, err := ResolveExample("this-does-not-exist-anywhere")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExampleNotFound)
+}
+
+func TestResolveExample_Empty(t *testing.T) {
+	t.Parallel()
+	_, err := ResolveExample("   ")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExampleNotFound)
+}
+
+func TestResolveExample_RejectsPathTraversal(t *testing.T) {
+	t.Parallel()
+	for _, q := range []string{
+		"../../etc/passwd",
+		"foo/../../bar.yaml",
+		"..\\..\\windows\\system32",
+		"actions/../../secret",
+	} {
+		_, err := ResolveExample(q)
+		require.Error(t, err, "query %q must be rejected", q)
+		assert.ErrorIs(t, err, ErrPathTraversal, "query %q must return ErrPathTraversal", q)
+	}
 }
 
 // ── Example struct tests ──────────────────────────────────────────────────────
@@ -204,7 +271,6 @@ func TestExample_Fields(t *testing.T) {
 	for _, item := range items[:min(5, len(items))] {
 		assert.NotEmpty(t, item.Path, "Path should be set")
 		assert.NotEmpty(t, item.Name, "Name should be set")
-		assert.NotEmpty(t, item.Description, "Description should be set")
 	}
 }
 
@@ -226,6 +292,14 @@ func BenchmarkScan_Category(b *testing.B) {
 	}
 }
 
+func BenchmarkResolveExample(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = ResolveExample("cel-basics")
+	}
+}
+
 func BenchmarkRead(b *testing.B) {
 	items, err := Scan("")
 	if err != nil || len(items) == 0 {
@@ -236,21 +310,6 @@ func BenchmarkRead(b *testing.B) {
 	b.ResetTimer()
 	for b.Loop() {
 		_, _ = Read(path)
-	}
-}
-
-func BenchmarkDescriptionFromPath(b *testing.B) {
-	paths := []string{
-		"solutions/comprehensive/solution.yaml",
-		"providers/static-hello.yaml",
-		"unknown/something.yaml",
-	}
-	b.ReportAllocs()
-	b.ResetTimer()
-	idx := 0
-	for b.Loop() {
-		DescriptionFromPath(paths[idx%len(paths)])
-		idx++
 	}
 }
 

--- a/pkg/mcp/tools_examples.go
+++ b/pkg/mcp/tools_examples.go
@@ -23,8 +23,8 @@ func (s *Server) registerExampleTools() {
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithString("category",
-			mcp.Description("Filter by category. Omit to list all examples grouped by category."),
-			mcp.Enum("solutions", "resolvers", "actions", "providers", "exec", "config", "mcp", "snapshots", "catalog", "auth", "eval", "plugins", "telemetry"),
+			mcp.Description("Filter by category (from each example's metadata.category). Omit to list all examples grouped by category."),
+			mcp.Enum(examples.Categories()...),
 		),
 	)
 	s.addTool(listExamplesTool, s.handleListExamples)

--- a/pkg/mcp/tools_examples_test.go
+++ b/pkg/mcp/tools_examples_test.go
@@ -241,6 +241,19 @@ func TestExamplesMetadataDriven(t *testing.T) {
 			assert.NotContains(t, item.Name, ".yaml")
 		}
 	})
+
+	t.Run("every reported category is filterable", func(t *testing.T) {
+		// The list_examples MCP enum is generated from Categories(); every
+		// metadata-derived category must therefore return results when used as
+		// a filter (regression guard against the old hardcoded directory enum).
+		cats := examples.Categories()
+		require.NotEmpty(t, cats)
+		for _, c := range cats {
+			items, err := examples.Scan(c)
+			require.NoError(t, err, "scanning category %q", c)
+			assert.NotEmpty(t, items, "category %q is reported but returns no examples", c)
+		}
+	})
 }
 
 func TestExamplesCategories(t *testing.T) {

--- a/pkg/mcp/tools_examples_test.go
+++ b/pkg/mcp/tools_examples_test.go
@@ -188,10 +188,10 @@ func TestExamplesScan(t *testing.T) {
 		require.NoError(t, err)
 		assert.Greater(t, len(items), 0)
 
-		// Verify items are sorted
+		// Verify items are sorted by category, then displayName.
 		for i := 1; i < len(items); i++ {
 			if items[i].Category == items[i-1].Category {
-				assert.LessOrEqual(t, items[i-1].Name, items[i].Name)
+				assert.LessOrEqual(t, items[i-1].DisplayName, items[i].DisplayName)
 			} else {
 				assert.Less(t, items[i-1].Category, items[i].Category)
 			}
@@ -215,26 +215,31 @@ func TestExamplesScan(t *testing.T) {
 	})
 }
 
-func TestExamplesDescriptionFromPath(t *testing.T) {
-	t.Run("known path returns specific description", func(t *testing.T) {
-		desc := examples.DescriptionFromPath("actions/hello-world.yaml")
-		assert.Equal(t, "Simple hello world action", desc)
+func TestExamplesMetadataDriven(t *testing.T) {
+	t.Run("scan reads description and displayName from solution metadata", func(t *testing.T) {
+		items, err := examples.Scan("")
+		require.NoError(t, err)
+		require.NotEmpty(t, items)
+
+		var hello *examples.Example
+		for i := range items {
+			if items[i].Path == "actions/hello-world.yaml" {
+				hello = &items[i]
+				break
+			}
+		}
+		require.NotNil(t, hello, "actions/hello-world.yaml should be listed")
+		assert.Equal(t, "hello-world-action", hello.Name)
+		assert.Equal(t, "Hello World Action", hello.DisplayName)
+		assert.Equal(t, "The simplest possible workflow with a single action", hello.Description)
 	})
 
-	t.Run("unknown path generates fallback", func(t *testing.T) {
-		desc := examples.DescriptionFromPath("custom/my-custom-thing.yaml")
-		assert.Contains(t, desc, "My Custom Thing")
-		assert.Contains(t, desc, "example")
-	})
-
-	t.Run("dashes replaced with spaces", func(t *testing.T) {
-		desc := examples.DescriptionFromPath("something/some-long-name.yaml")
-		assert.Contains(t, desc, "Some Long Name")
-	})
-
-	t.Run("underscores replaced with spaces", func(t *testing.T) {
-		desc := examples.DescriptionFromPath("something/some_other_name.yaml")
-		assert.Contains(t, desc, "Some Other Name")
+	t.Run("names never contain a file extension", func(t *testing.T) {
+		items, err := examples.Scan("")
+		require.NoError(t, err)
+		for _, item := range items {
+			assert.NotContains(t, item.Name, ".yaml")
+		}
 	})
 }
 

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -8553,6 +8553,29 @@ func TestIntegration_GetExamples_List_FilterCategory(t *testing.T) {
 	assert.Contains(t, stdout, "solutions")
 }
 
+func TestIntegration_GetExamples_List_EmptyStructuredEmitsArray(t *testing.T) {
+	t.Parallel()
+	// An empty result in a structured format must still emit a parseable, empty
+	// document on stdout (not "null", not human text), and any guidance goes to
+	// stderr only.
+	stdout, _, exitCode := runScafctl(t, "get", "examples", "--category", "no-such-category", "-o", "json")
+	assert.Equal(t, 0, exitCode)
+	var items []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &items),
+		"empty structured output must be valid JSON, got: %q", stdout)
+	assert.Empty(t, items)
+}
+
+func TestIntegration_GetExamples_List_EmptyHumanMessageOnStderr(t *testing.T) {
+	t.Parallel()
+	// In the default (human) format, an empty result prints no data on stdout;
+	// the "no examples" guidance is written to stderr.
+	stdout, stderr, exitCode := runScafctl(t, "get", "examples", "--category", "no-such-category")
+	assert.Equal(t, 0, exitCode)
+	assert.Empty(t, strings.TrimSpace(stdout), "stdout should be empty for a human empty result")
+	assert.Contains(t, stderr, "No examples found in category")
+}
+
 func TestIntegration_GetExamples_Get(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "get", "examples", "resolver-demo.yaml")

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -8511,8 +8511,9 @@ func TestIntegration_GetExamples_List(t *testing.T) {
 	stdout, _, exitCode := runScafctl(t, "get", "examples", "-o", "yaml")
 	assert.Equal(t, 0, exitCode)
 	// Listing is metadata-driven: displayName/name/category come from each
-	// solution's metadata block, not the filename. (kvx yaml lowercases keys.)
-	assert.Contains(t, stdout, "displayname:")
+	// solution's metadata block, not the filename. Explicit yaml tags keep the
+	// YAML key casing aligned with the JSON output and the display schema.
+	assert.Contains(t, stdout, "displayName:")
 	assert.Contains(t, stdout, "name:")
 	assert.Contains(t, stdout, "category:")
 	// Names come from metadata.name, so they never carry a file extension.
@@ -8544,6 +8545,21 @@ func TestIntegration_GetExamples_List_OnlySolutions(t *testing.T) {
 		n, _ := it["name"].(string)
 		assert.NotContains(t, n, ".yaml", "name must come from metadata, not filename")
 	}
+}
+
+func TestIntegration_GetExamples_List_JSONYAMLKeyCasingAligned(t *testing.T) {
+	t.Parallel()
+	// JSON and YAML output must use the same camelCase field names (the struct
+	// carries matching json+yaml tags), and both must match the display-schema
+	// field names. Guards against yaml.Marshal lowercasing keys.
+	yamlOut, _, yc := runScafctl(t, "get", "examples", "-o", "yaml")
+	assert.Equal(t, 0, yc)
+	assert.Contains(t, yamlOut, "displayName:")
+	assert.NotContains(t, yamlOut, "displayname:")
+
+	jsonOut, _, jc := runScafctl(t, "get", "examples", "-o", "json")
+	assert.Equal(t, 0, jc)
+	assert.Contains(t, jsonOut, "\"displayName\"")
 }
 
 func TestIntegration_GetExamples_List_FilterCategory(t *testing.T) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -8510,9 +8510,40 @@ func TestIntegration_GetExamples_List(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "get", "examples", "-o", "yaml")
 	assert.Equal(t, 0, exitCode)
-	assert.Contains(t, stdout, "path:")
+	// Listing is metadata-driven: displayName/name/category come from each
+	// solution's metadata block, not the filename. (kvx yaml lowercases keys.)
+	assert.Contains(t, stdout, "displayname:")
+	assert.Contains(t, stdout, "name:")
 	assert.Contains(t, stdout, "category:")
-	assert.Contains(t, stdout, "description:")
+	// Names come from metadata.name, so they never carry a file extension.
+	assert.NotContains(t, stdout, "name: resolver-demo.yaml")
+}
+
+func TestIntegration_GetExamples_List_ShowsViewTip(t *testing.T) {
+	t.Parallel()
+	// The default (table) list prints a tip to stderr telling the user how to
+	// view an example's content, since the path is an embedded-FS handle.
+	_, stderr, exitCode := runScafctl(t, "get", "examples")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stderr, "get examples")
+	assert.Contains(t, stderr, "to view a solution")
+}
+
+func TestIntegration_GetExamples_List_OnlySolutions(t *testing.T) {
+	t.Parallel()
+	// Non-solution files (configs, partials, templates) must not appear.
+	stdout, _, exitCode := runScafctl(t, "get", "examples", "-o", "json")
+	assert.Equal(t, 0, exitCode)
+	var items []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &items))
+	require.NotEmpty(t, items)
+	for _, it := range items {
+		p, _ := it["path"].(string)
+		assert.NotContains(t, p, "bad-solution")
+		assert.NotContains(t, p, "lint-stress-test")
+		n, _ := it["name"].(string)
+		assert.NotContains(t, n, ".yaml", "name must come from metadata, not filename")
+	}
 }
 
 func TestIntegration_GetExamples_List_FilterCategory(t *testing.T) {
@@ -8527,6 +8558,33 @@ func TestIntegration_GetExamples_Get(t *testing.T) {
 	stdout, _, exitCode := runScafctl(t, "get", "examples", "resolver-demo.yaml")
 	assert.Equal(t, 0, exitCode)
 	assert.NotEmpty(t, stdout)
+}
+
+func TestIntegration_GetExamples_Get_ByName(t *testing.T) {
+	t.Parallel()
+	// A unique metadata.name resolves without needing the full path.
+	stdout, _, exitCode := runScafctl(t, "get", "examples", "cel-basics")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "kind: Solution")
+	assert.Contains(t, stdout, "name: cel-basics")
+}
+
+func TestIntegration_GetExamples_Get_AmbiguousName(t *testing.T) {
+	t.Parallel()
+	// "hello-world" is shared by several examples; the lookup must refuse and
+	// list the candidates rather than guessing.
+	_, stderr, exitCode := runScafctl(t, "get", "examples", "hello-world")
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "ambiguous")
+	assert.Contains(t, stderr, "actions/hello-world.yaml")
+}
+
+func TestIntegration_GetExamples_Get_PathTraversalRejected(t *testing.T) {
+	t.Parallel()
+	// A traversal query must be rejected before touching the filesystem.
+	_, stderr, exitCode := runScafctl(t, "get", "examples", "../../etc/passwd")
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "Invalid example path")
 }
 
 func TestIntegration_GetExamples_Get_JSON(t *testing.T) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -8527,7 +8527,7 @@ func TestIntegration_GetExamples_List_ShowsViewTip(t *testing.T) {
 	_, stderr, exitCode := runScafctl(t, "get", "examples")
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stderr, "get examples")
-	assert.Contains(t, stderr, "to view a solution")
+	assert.Contains(t, stderr, "to view an example")
 }
 
 func TestIntegration_GetExamples_List_OnlySolutions(t *testing.T) {
@@ -8617,14 +8617,27 @@ func TestIntegration_GetExamples_Get_NonSolutionByPath(t *testing.T) {
 	assert.NotEmpty(t, stdout)
 }
 
-func TestIntegration_GetExamples_Get_AmbiguousName(t *testing.T) {
+func TestIntegration_GetExamples_Get_MultipleMatchesListed(t *testing.T) {
 	t.Parallel()
-	// "hello-world" is shared by several examples; the lookup must refuse and
-	// list the candidates rather than guessing.
-	_, stderr, exitCode := runScafctl(t, "get", "examples", "hello-world")
-	assert.NotEqual(t, 0, exitCode)
-	assert.Contains(t, stderr, "ambiguous")
-	assert.Contains(t, stderr, "actions/hello-world.yaml")
+	// "hello-world" is a basename shared by several examples. Rather than error,
+	// the command lists the matching examples (with their paths) so the user can
+	// pick one, and exits 0.
+	stdout, stderr, exitCode := runScafctl(t, "get", "examples", "hello-world")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stderr, "examples match")
+	// The matches are rendered as a list including their disambiguating paths.
+	combined := stdout + stderr
+	assert.Contains(t, combined, "actions/hello-world.yaml")
+	assert.Contains(t, combined, "resolvers/hello-world.yaml")
+}
+
+func TestIntegration_GetExamples_Get_UniqueNameShowsContent(t *testing.T) {
+	t.Parallel()
+	// A now-unique name resolves directly to that example's content.
+	stdout, _, exitCode := runScafctl(t, "get", "examples", "hello-world-resolver")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "kind: Solution")
+	assert.Contains(t, stdout, "name: hello-world-resolver")
 }
 
 func TestIntegration_GetExamples_Get_PathTraversalRejected(t *testing.T) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -8592,6 +8592,15 @@ func TestIntegration_GetExamples_Get_ByName(t *testing.T) {
 	assert.Contains(t, stdout, "name: cel-basics")
 }
 
+func TestIntegration_GetExamples_Get_NonSolutionByPath(t *testing.T) {
+	t.Parallel()
+	// The listing is solution-only, but exact-path fetch must still return any
+	// embedded example file, including non-solution kinds (kind: Config here).
+	stdout, _, exitCode := runScafctl(t, "get", "examples", "catalog/native-auth.yaml")
+	assert.Equal(t, 0, exitCode)
+	assert.NotEmpty(t, stdout)
+}
+
 func TestIntegration_GetExamples_Get_AmbiguousName(t *testing.T) {
 	t.Parallel()
 	// "hello-world" is shared by several examples; the lookup must refuse and


### PR DESCRIPTION
## Summary

`get examples` was poorly made and, separately, ~11 example solutions no longer worked against current scafctl. This makes the command **metadata-driven** and repairs the **example data** it surfaces.

Closes #694.

## Part 1 -- Example correctness

Audited all 144 example Solutions against scafctl v0.37.0. **Result: 0 lint errors, 0 load failures** (only the 2 intentional bad demos remain, correctly excluded), and representative examples verified to actually run.

Fixed 11 broken files:

| File | Problem | Fix |
|---|---|---|
| `resolvers/foreach-filter.yaml` | malformed YAML (stray `- resolver-example` under `spec:`) -- scafctl couldn't load it | removed |
| `auth/token-delegation/...`, `providers/http-entra.yaml` | `http` input `authScope` / `auth` removed from schema | `scope` / `authProvider` |
| `providers/github-api.yaml` | `http` input `auth` removed | `authProvider` |
| `resolvers/feature-flags.yaml` | `http.timeout: 5s` (now integer seconds) | `5` |
| `catalog/bundling-example/...` | `bundle.exclude` (never existed) + `file.format` (removed) | removed both |
| `resolvers/plan-aware.yaml` | `spec.tags` invalid | removed |
| `soldiff/solution-v1.yaml` & `v2` | actions used resolver-style `with:`; missing `provider` | `provider: exec` + CEL `expr` inputs |
| `providers/github-write-operations.yaml` | empty `workflow.actions` (all commented) -> schema error | reference comment block |
| `plugins/auto-fetch-solution.yaml` | plugin declared as `echo-provider` but provider is `echo` | aligned to `echo` |

Also fixed stale `# Run:` headers (`solution diff` -> `diff solution`, `snapshot diff` -> `diff snapshot`, `--format` -> `-o`) and added missing `displayName`/`category`/`tags`/`description` to **8 solutions**.

## Part 2 -- Metadata-driven `get examples`

- **Reads real metadata** (displayName, name, category, tags, description) from each solution instead of the filename + a stale 80-entry hardcoded description map (now deleted). No more `.yaml` in names, no duplicate descriptions.
- **Only lists `kind: Solution`** -- the 23 config/partial/template files (and the bad/lint-stress demos) no longer appear as "examples". 144 clean rows.
- **Name-first columns** + an embedded `examples_schema.json` display schema so `-i` renders a card list + detail pane (mirroring `get provider`) and the path column no longer truncates.
- **Discoverability**: a stderr tip after the list tells users how to view an example (`get examples <path>`); the detail view surfaces the path handle. (The listing shows an embedded-FS path, which previously read like a broken local file.)
- **Argument resolution**: `get examples <arg>` resolves by path, `metadata.name`, or basename; refuses to guess on ambiguity (lists the candidate paths, e.g. the four `hello-world` examples) and rejects path traversal before touching the filesystem. Fixes a latent backslash-normalization bug in `Read` (`filepath.ToSlash` is a no-op for backslashes off Windows).

## Tests

- **pkg/examples**: metadata-driven `Scan` (populates from metadata, only Solutions, excludes bad/stress), `ResolveExample` (exact path, by-name, ambiguity, not-found, empty, **path-traversal**), backslash `Read`; benchmarks (`BenchmarkResolveExample` added). Coverage 76.5%.
- **CLI**: integration cases for the view tip, only-solutions/no-extension names, get-by-name, ambiguity, and **path-traversal rejection**. Command coverage 65.8%.
- **MCP**: `tools_examples_test.go` updated to the metadata-driven behavior.

## Docs

`docs/design/cli.md` and `examples/README.md` "Browsing Examples" sections updated for by-name lookup, ambiguity behavior, `-i`, and the view tip.

## Follow-ups (filed, out of scope here)

- #696 -- lint: down-rank `unused-resolver` for workflow-less resolver-only demos (the dominant, benign warning across examples).
- #697 -- chore: rename hyphenated resolver/action names to camelCase across examples.
- #698 -- feat: publish a curated starter-kit subset of examples to the official catalog.
- #699 -- design: unify embedded examples under the catalog list/inspect/pull UX.

## Verification

- go-reviewer: APPROVE (0 critical/high/medium). artifact-auditor: complete; all must-fix items addressed in this PR (removed dead `AllExamples`, added traversal unit + integration tests, updated docs).
- `-race` tests green; `task lint:changed`: 0 issues.

## Note on scope

The example data fixes and the command redesign are one logical change: the command surfaces that metadata, and broken/incomplete example metadata would break the listing. They are kept in one PR for that reason; the stylistic/idiomatic sweeps and catalog-publish work are split into the follow-up issues above.

## Review fixes (Copilot, round 1)

- **Traversal guard scoped to path segments:** the `..` check used a substring match that wrongly rejected safe filenames containing `..` (e.g. `foo..bar.yaml`). Replaced with `hasDotDotSegment()`, which only rejects an actual `..` path component (applied in both `ResolveExample` and `Read`). Added a helper table test and a test asserting a `..`-in-filename query is not-found, not a traversal error.
- **MCP category enum derived from metadata:** the `list_examples` tool's category enum was a stale, hardcoded directory-based list. It is now generated from `examples.Categories()` so it always matches the metadata-driven categories (`developer-tools`, `identity`, `inspect`, ...). Added a test that every reported category is filterable.


## Presentation & interactive refinement (post-feedback)

Follow-up polish from hands-on review of the rendered output:

- **Table leads with the typeable identifier.** The default list shows `name`
  (exactly what you pass to `get examples <name>`) as the primary column, not
  `displayName` -- what you see is what you type, matching `get provider`.
  (Previously the list showed `displayName` while fetch used `name`, a dead
  end.)
- **Table fills the terminal, responsively.** `description` is a **flex** column
  (`MaxWidth` is its minimum, not a cap) so wide terminals use the full width
  and narrow ones truncate; every other visible column is capped so the table
  never silently collapses to the flat key/value fallback (an uncapped column
  had made kvx treat the table as too wide -- the "no table view" symptom).
- **Unique example names.** Renamed duplicate `metadata.name` values
  (`hello-world` x3 -> `-resolver`/`-catalog`/`-solution`, `soldiff-demo` x2 ->
  `-v1`/`-v2`) so every listed name is unambiguous and directly fetchable.
- **Interactive detail shows the solution.** Each example carries its full YAML
  in a `content` field (hidden from the table, present in `-o json`/`-o yaml`),
  rendered as a "Solution" section in the `-i` detail view -- drilling in
  (`l`/`right`) shows the actual solution without a second command.
- Empty structured output emits a valid `[]`; `get examples <name>` with
  multiple basename matches lists the matches (with paths) instead of erroring.

## Docs (AI guidance)

Captured the kvx rendering model so this class of issue does not recur:
`.github/instructions/cli-commands.instructions.md` now documents the render
paths, the `core.LoadObject` requirement for the card view, the "cap every
column / use `Flex` to fill" table rule, `tui.RenderSnapshot` for verifying the
TUI without a terminal, and how to surface rich content in the `-i` detail view
(with pointers added to `copilot-instructions.md` and the go-testing
instructions).
