### PR TITLE
feat(providers): add multi-key map read mode to parameter provider

### DIFF
--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -2167,12 +2167,31 @@ Access CLI parameters passed via `-r` flags.
 
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
-| `key` | string | ❌ | Parameter name (exact match). Provide either `key` or `keys`; `key` takes precedence over `keys` when both are set. |
-| `keys` | array of string | ❌ | Ordered list of parameter names (aliases) for a single logical parameter. The first name provided via CLI wins. Evaluated after `key`. |
-| `default` | any | ❌ | Value returned when the parameter is not provided. |
-| `type` | string | ❌ | How the value is coerced. One of `auto` (default), `string`, `raw`, `int`, `float`, `bool`, `json`, `csv`, `fetch`. See the table below. |
+| `key` | string | ❌ | Single-key (scalar) mode. Parameter name (exact match). Provide either `key` or `keys`; `key` takes precedence over `keys` when both are set. Mutually exclusive with `all` and with `as: map`. |
+| `keys` | array of string | ❌ | Ordered list of parameter names. Default meaning: aliases for a single logical parameter (first provided via CLI wins), evaluated after `key`. With `as: map` it is instead a distinct set of parameter names read into a map. |
+| `as` | string | ❌ | Read-mode discriminator for `keys`. Only `map` is supported: it reinterprets `keys` as a distinct set of parameter names read into a map (instead of first-match-wins aliases). |
+| `all` | bool | ❌ | Map mode. When `true`, read every supplied CLI parameter as a map. Mutually exclusive with `key`, `keys`, and `as`. |
+| `default` | any | ❌ | Value returned when the parameter is not provided. Only valid in single-key/alias mode; in map mode absent keys are omitted instead, so combining `default` with `all` or `as: map` is an error. |
+| `type` | string | ❌ | How the value is coerced. One of `auto` (default), `string`, `raw`, `int`, `float`, `bool`, `json`, `csv`, `fetch`. See the table below. Only valid in single-key/alias mode; in map mode each value uses `auto` inference. |
 
-At least one of `key` or `keys` must be provided.
+Specify one read mode: a single `key` / alias `keys`, `keys` + `as: map`, or `all: true`.
+
+### Read modes
+
+- **Single key** (`key`): returns the parameter value directly, or `default`/an
+  error when absent. `_.environment` is the scalar value.
+- **Aliases** (`keys`, no `as`): resolves one logical value from the first
+  provided alias (first-match-wins), falling back to `default`.
+- **Explicit set** (`keys` + `as: map`): returns a map of the requested
+  parameter names to their values. Requested keys not supplied via CLI are
+  **omitted** from the map (not defaulted), so `has(_.myBag.keyB)` and
+  `_.myBag.?keyB.orValue(d)` remain faithful. Each value uses `auto` inference.
+- **All supplied** (`all: true`): returns a map of every CLI-supplied
+  parameter to its `auto`-inferred value.
+
+In map mode the resolver value is the bare map. The set of present keys (and, in
+`keys` mode, the requested-but-absent keys) is reported in provider metadata,
+visible via `scafctl run provider parameter ...` but not in the resolver value.
 
 #### `type` values
 
@@ -2190,11 +2209,10 @@ At least one of `key` or `keys` must be provided.
 
 ### Output
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `value` | any | Parameter value |
-| `found` | bool | Whether parameter was provided |
-| `type` | string | Detected type of value |
+In single-key/alias mode the output is the parameter value (typed per the
+parsing rules), or the default when absent. In map mode (`keys` + `as: map`, or
+`all: true`) the output is a map of present parameter names to their
+auto-inferred values, with absent keys omitted.
 
 ### Examples
 
@@ -2219,6 +2237,26 @@ resolve:
       inputs:
         keys: [environment, e, env]
         default: dev
+```
+
+```yaml
+# Read a set of distinct parameters at once into a map (opt in with as: map).
+# Absent keys are omitted, so has(_.featureBag.keyB) stays faithful.
+resolve:
+  with:
+    - provider: parameter
+      inputs:
+        keys: [keyA, keyB, keyC]
+        as: map
+```
+
+```yaml
+# Read every supplied CLI parameter into a single map.
+resolve:
+  with:
+    - provider: parameter
+      inputs:
+        all: true
 ```
 
 ```yaml

--- a/examples/README.md
+++ b/examples/README.md
@@ -130,6 +130,7 @@ Resolvers demonstrate dynamic value computation, validation, and transformation.
 |---------|-------------|-----|
 | [hello-world.yaml](resolvers/hello-world.yaml) | Simplest resolver | `scafctl run resolver -f examples/resolvers/hello-world.yaml` |
 | [parameters.yaml](resolvers/parameters.yaml) | CLI parameters with defaults | `scafctl run resolver -f examples/resolvers/parameters.yaml -r name=Alice` |
+| [parameters-all.yaml](resolvers/parameters-all.yaml) | Read every supplied CLI parameter into a map (`all: true`) | `scafctl run resolver -f examples/resolvers/parameters-all.yaml -r name=Alice -r team=platform` |
 | [dependencies.yaml](resolvers/dependencies.yaml) | Resolver dependencies & phases | `scafctl run resolver -f examples/resolvers/dependencies.yaml` |
 | [env-config.yaml](resolvers/env-config.yaml) | Environment-based configuration | `scafctl run resolver -f examples/resolvers/env-config.yaml -r env=production` |
 | [validation.yaml](resolvers/validation.yaml) | Input validation patterns | `scafctl run resolver -f examples/resolvers/validation.yaml` |

--- a/examples/resolvers/parameters-all.yaml
+++ b/examples/resolvers/parameters-all.yaml
@@ -1,0 +1,42 @@
+# Run: scafctl run resolver -f parameters-all.yaml -r name=Alice -r count=5
+# Run: scafctl run resolver -f parameters-all.yaml -r team=platform -r owner=alice
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: parameters-all-example
+  displayName: Parameters (all mode) Example
+  category: resolvers
+  tags:
+    - resolver-example
+  description: |
+    The parameter provider "all: true" read mode collects EVERY supplied CLI
+    parameter into a single map. Because the solution declares that it consumes
+    arbitrary parameters, unknown-key typo validation is intentionally relaxed:
+    any -r key=value pair is a legitimate input.
+
+spec:
+  resolvers:
+    # Read EVERY supplied CLI parameter into a single map.
+    # Absent keys simply do not appear -- the map only contains what was passed.
+    #   scafctl run resolver -f parameters-all.yaml -r name=Alice -r count=5
+    allParams:
+      description: Every supplied CLI parameter as a map
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              all: true
+
+    # Downstream resolver that consumes the all-params map. Use optional chaining
+    # (?key.orValue) or has() for values that may be absent.
+    summary:
+      description: Summary derived from the all-params map
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: |
+                'count=' + string(_.allParams.size()) +
+                ' name=' + _.allParams.?name.orValue('(none)')

--- a/examples/resolvers/parameters.yaml
+++ b/examples/resolvers/parameters.yaml
@@ -16,7 +16,9 @@ metadata:
   description: |
     CLI parameter usage with default values and type coercion.
     Demonstrates positional args, -r flag, @file loading, @- stdin,
-    and raw stdin piping into individual parameters.
+    raw stdin piping into individual parameters, alias keys, and the
+    map read mode (keys + as: map). For the "read every supplied
+    parameter" mode (all: true), see parameters-all.yaml.
 
 spec:
   resolvers:
@@ -113,3 +115,30 @@ spec:
               # Create array of greetings
               expression: |
                 lists.range(_.count).map(i, _.greeting + ' (#' + string(i + 1) + ')')
+
+    # Read a set of DISTINCT parameters at once into a map (opt in with as: map).
+    # This differs from alias "keys" (first-match-wins): here every listed name
+    # is its own entry. Absent keys are OMITTED from the map (not defaulted), so
+    # has()/optional chaining against the map stay faithful.
+    #   scafctl run resolver -f parameters.yaml -r tier=gold -r region=us-west-2
+    featureBag:
+      description: A distinct set of parameters read into a map
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              keys: [tier, region, cluster]
+              as: map
+
+    # Downstream resolver that consumes the map. Because absent keys are omitted,
+    # use optional chaining (?key.orValue) or has() for values that may be absent.
+    tierSummary:
+      description: Summary derived from the featureBag map
+      type: string
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: |
+                'tier=' + _.featureBag.?tier.orValue('default') +
+                ' keys=' + string(_.featureBag.size())

--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -354,10 +354,15 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 
 	// Validate parameter keys
 	if len(params) > 0 {
-		paramKeys := extractParameterKeys(sol.Spec.ResolversToSlice())
-		if len(paramKeys) > 0 {
-			if err := flags.ValidateInputKeys(params, paramKeys, "solution"); err != nil {
-				return o.exitWithCode(ctx, err, exitcode.InvalidInput)
+		solResolvers := sol.Spec.ResolversToSlice()
+		// Skip typo detection when a resolver reads every supplied parameter
+		// (all: true) -- any -r key is valid in that case.
+		if !resolversAcceptAllParameters(solResolvers) {
+			paramKeys := extractParameterKeys(solResolvers)
+			if len(paramKeys) > 0 {
+				if err := flags.ValidateInputKeys(params, paramKeys, "solution"); err != nil {
+					return o.exitWithCode(ctx, err, exitcode.InvalidInput)
+				}
 			}
 		}
 	}

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -1038,17 +1038,45 @@ func extractParameterKeys(resolvers []*resolver.Resolver) []string {
 				}
 			}
 			if keysRef, ok := src.Inputs["keys"]; ok && keysRef != nil {
-				if list, ok := keysRef.Literal.([]any); ok {
+				switch list := keysRef.Literal.(type) {
+				case []any:
 					for _, item := range list {
 						if s, ok := item.(string); ok {
 							add(s)
 						}
+					}
+				case []string:
+					for _, s := range list {
+						add(s)
 					}
 				}
 			}
 		}
 	}
 	return keys
+}
+
+// resolversAcceptAllParameters reports whether any resolver reads every
+// supplied CLI parameter via the parameter provider's "all: true" map mode.
+// When true, callers must not typo-check -r keys against a fixed key list --
+// any key is valid.
+func resolversAcceptAllParameters(resolvers []*resolver.Resolver) bool {
+	for _, r := range resolvers {
+		if r.Resolve == nil {
+			continue
+		}
+		for _, src := range r.Resolve.With {
+			if src.Provider != "parameter" {
+				continue
+			}
+			if allRef, ok := src.Inputs["all"]; ok && allRef != nil {
+				if b, ok := allRef.Literal.(bool); ok && b {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // mockedResolversEnvSuffix is the suffix appended to the binary-name-derived

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -1060,6 +1060,11 @@ func extractParameterKeys(resolvers []*resolver.Resolver) []string {
 // supplied CLI parameter via the parameter provider's "all: true" map mode.
 // When true, callers must not typo-check -r keys against a fixed key list --
 // any key is valid.
+//
+// A non-literal "all" input (set via a resolver reference, CEL expression, or
+// Go template) cannot be evaluated statically, so it is treated conservatively
+// as "could be true": validation is skipped rather than risk falsely rejecting
+// valid -r keys when map mode activates at runtime.
 func resolversAcceptAllParameters(resolvers []*resolver.Resolver) bool {
 	for _, r := range resolvers {
 		if r.Resolve == nil {
@@ -1069,10 +1074,20 @@ func resolversAcceptAllParameters(resolvers []*resolver.Resolver) bool {
 			if src.Provider != "parameter" {
 				continue
 			}
-			if allRef, ok := src.Inputs["all"]; ok && allRef != nil {
-				if b, ok := allRef.Literal.(bool); ok && b {
+			allRef, ok := src.Inputs["all"]
+			if !ok || allRef == nil {
+				continue
+			}
+			if b, ok := allRef.Literal.(bool); ok {
+				if b {
 					return true
 				}
+				continue
+			}
+			// Non-literal "all" (rslvr/expr/tmpl): could resolve to true at
+			// runtime, so fail open and skip typo validation.
+			if allRef.Resolver != nil || allRef.Expr != nil || allRef.Tmpl != nil {
+				return true
 			}
 		}
 	}

--- a/pkg/cmd/scafctl/run/common_test.go
+++ b/pkg/cmd/scafctl/run/common_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -222,12 +223,40 @@ func TestResolversAcceptAllParameters(t *testing.T) {
 			}},
 			want: false,
 		},
+		{
+			name: "non-literal all via resolver ref treated as could-be-true",
+			resolvers: []*resolver.Resolver{{
+				Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*resolver.ValueRef{"all": {Resolver: refString("useAll")}}},
+				}},
+			}},
+			want: true,
+		},
+		{
+			name: "non-literal all via expression treated as could-be-true",
+			resolvers: []*resolver.Resolver{{
+				Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*resolver.ValueRef{"all": {Expr: refExpr("true")}}},
+				}},
+			}},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, resolversAcceptAllParameters(tt.resolvers))
 		})
 	}
+}
+
+// refString returns a pointer to s for building ValueRef.Resolver in tests.
+func refString(s string) *string { return &s }
+
+// refExpr returns a pointer to a celexp.Expression for building ValueRef.Expr
+// in tests.
+func refExpr(s string) *celexp.Expression {
+	e := celexp.Expression(s)
+	return &e
 }
 
 func TestBuildParamFlagHint(t *testing.T) {

--- a/pkg/cmd/scafctl/run/common_test.go
+++ b/pkg/cmd/scafctl/run/common_test.go
@@ -139,11 +139,93 @@ func TestExtractParameterKeys(t *testing.T) {
 			}},
 			want: []string{"env", "region"},
 		},
+		{
+			name: "keys as map contributes its distinct keys",
+			resolvers: []*resolver.Resolver{{
+				Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*resolver.ValueRef{
+						"keys": listRef("keyA", "keyB"),
+						"as":   strRef("map"),
+					}},
+				}},
+			}},
+			want: []string{"keyA", "keyB"},
+		},
+		{
+			name: "keys as []string literal",
+			resolvers: []*resolver.Resolver{{
+				Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*resolver.ValueRef{
+						"keys": {Literal: []string{"keyA", "keyB"}},
+					}},
+				}},
+			}},
+			want: []string{"keyA", "keyB"},
+		},
+		{
+			name: "all mode contributes no named keys",
+			resolvers: []*resolver.Resolver{{
+				Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*resolver.ValueRef{"all": {Literal: true}}},
+				}},
+			}},
+			want: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := extractParameterKeys(tt.resolvers)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolversAcceptAllParameters(t *testing.T) {
+	tests := []struct {
+		name      string
+		resolvers []*resolver.Resolver
+		want      bool
+	}{
+		{
+			name: "all true",
+			resolvers: []*resolver.Resolver{{
+				Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*resolver.ValueRef{"all": {Literal: true}}},
+				}},
+			}},
+			want: true,
+		},
+		{
+			name: "all false is inert",
+			resolvers: []*resolver.Resolver{{
+				Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*resolver.ValueRef{"all": {Literal: false}}},
+				}},
+			}},
+			want: false,
+		},
+		{
+			name: "named-key resolver only",
+			resolvers: []*resolver.Resolver{{
+				Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*resolver.ValueRef{"key": {Literal: "env"}}},
+				}},
+			}},
+			want: false,
+		},
+		{
+			name: "all on non-parameter provider ignored",
+			resolvers: []*resolver.Resolver{{
+				Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+					{Provider: "static", Inputs: map[string]*resolver.ValueRef{"all": {Literal: true}}},
+				}},
+			}},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolversAcceptAllParameters(tt.resolvers))
 		})
 	}
 }

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -570,10 +570,14 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 
 	// Validate parameter keys against parameter provider 'key' inputs (early typo detection)
 	if len(params) > 0 {
-		paramKeys := extractParameterKeys(allResolvers)
-		if len(paramKeys) > 0 {
-			if err := flags.ValidateInputKeys(params, paramKeys, "solution"); err != nil {
-				return o.exitWithCode(ctx, err, exitcode.InvalidInput)
+		// Skip typo detection when a resolver reads every supplied parameter
+		// (all: true) -- any -r key is valid in that case.
+		if !resolversAcceptAllParameters(allResolvers) {
+			paramKeys := extractParameterKeys(allResolvers)
+			if len(paramKeys) > 0 {
+				if err := flags.ValidateInputKeys(params, paramKeys, "solution"); err != nil {
+					return o.exitWithCode(ctx, err, exitcode.InvalidInput)
+				}
 			}
 		}
 	}

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -458,10 +458,15 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 
 	// Validate parameter keys against parameter provider 'key' inputs (early typo detection)
 	if len(params) > 0 {
-		paramKeys := extractParameterKeys(sol.Spec.ResolversToSlice())
-		if len(paramKeys) > 0 {
-			if err := flags.ValidateInputKeys(params, paramKeys, "solution"); err != nil {
-				return o.exitWithCode(ctx, err, exitcode.InvalidInput)
+		solResolvers := sol.Spec.ResolversToSlice()
+		// Skip typo detection when a resolver reads every supplied parameter
+		// (all: true) -- any -r key is valid in that case.
+		if !resolversAcceptAllParameters(solResolvers) {
+			paramKeys := extractParameterKeys(solResolvers)
+			if len(paramKeys) > 0 {
+				if err := flags.ValidateInputKeys(params, paramKeys, "solution"); err != nil {
+					return o.exitWithCode(ctx, err, exitcode.InvalidInput)
+				}
 			}
 		}
 	}

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -264,6 +264,7 @@ func DescriptionFromPath(exPath string) string {
 		// Resolvers
 		"resolvers/hello-world.yaml":         "Simple static value resolver",
 		"resolvers/parameters.yaml":          "Parameter provider for user input",
+		"resolvers/parameters-all.yaml":      "Parameter provider all-mode (every CLI param into a map)",
 		"resolvers/dependencies.yaml":        "Resolver dependency chain (dependsOn)",
 		"resolvers/env-config.yaml":          "Environment variable resolver",
 		"resolvers/validation.yaml":          "Resolver validation rules",

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -203,9 +203,10 @@ func parameterSourceHasDefault(step resolver.ProviderSource) bool {
 // into map mode, where a 'default' is neither valid nor needed: absent keys are
 // simply omitted from the returned map, so the read always produces a value.
 const (
-	parameterAllInput = "all"
-	parameterAsInput  = "as"
-	parameterAsMap    = "map"
+	parameterAllInput  = "all"
+	parameterAsInput   = "as"
+	parameterAsMap     = "map"
+	parameterKeysInput = "keys"
 )
 
 // parameterSourceIsMapMode reports whether a parameter provider source reads a
@@ -221,7 +222,12 @@ func parameterSourceIsMapMode(step resolver.ProviderSource) bool {
 	}
 	if asRef, ok := step.Inputs[parameterAsInput]; ok && asRef != nil {
 		if s, ok := asRef.Literal.(string); ok && s == parameterAsMap {
-			return true
+			// "as: map" only selects map mode when the required "keys" input is
+			// present; without it the provider rejects the config ("as: map"
+			// requires "keys"), so it is not a valid map-mode read.
+			if _, hasKeys := step.Inputs[parameterKeysInput]; hasKeys {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -199,6 +199,34 @@ func parameterSourceHasDefault(step resolver.ProviderSource) bool {
 	return ok
 }
 
+// parameterMapModeInputs are the input keys that switch the parameter provider
+// into map mode, where a 'default' is neither valid nor needed: absent keys are
+// simply omitted from the returned map, so the read always produces a value.
+const (
+	parameterAllInput = "all"
+	parameterAsInput  = "as"
+	parameterAsMap    = "map"
+)
+
+// parameterSourceIsMapMode reports whether a parameter provider source reads a
+// map instead of a single scalar -- either "all: true" (every supplied
+// parameter) or "keys" + "as: map" (a distinct key set). Map-mode reads never
+// fail on a missing parameter (absent keys are omitted), so they act as a
+// guaranteed producer and do not need a 'default'.
+func parameterSourceIsMapMode(step resolver.ProviderSource) bool {
+	if allRef, ok := step.Inputs[parameterAllInput]; ok && allRef != nil {
+		if b, ok := allRef.Literal.(bool); ok && b {
+			return true
+		}
+	}
+	if asRef, ok := step.Inputs[parameterAsInput]; ok && asRef != nil {
+		if s, ok := asRef.Literal.(string); ok && s == parameterAsMap {
+			return true
+		}
+	}
+	return false
+}
+
 // parameterTypeInput is the input key the parameter provider reads to select an
 // explicit type instead of automatic inference.
 const parameterTypeInput = "type"
@@ -476,7 +504,9 @@ func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Re
 						continue
 					}
 					if step.Provider == parameterProviderName {
-						if parameterSourceHasDefault(step) {
+						if parameterSourceHasDefault(step) || parameterSourceIsMapMode(step) {
+							// A 'default' fallback, or a map-mode read (absent keys
+							// omitted), always produces a value.
 							hasGuaranteedFallback = true
 						} else {
 							unconditionalParamWithoutDefault = true

--- a/pkg/lint/lint_extra_test.go
+++ b/pkg/lint/lint_extra_test.go
@@ -1084,6 +1084,31 @@ func TestLintResolvers_ParameterMissingDefault_MapModeKeys(t *testing.T) {
 		"map mode (keys + as: map) omits absent keys, so no default is required")
 }
 
+func TestLintResolvers_ParameterMissingDefault_AsMapWithoutKeys(t *testing.T) {
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("parameter", nil)))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"bag": {
+			Description: "as: map without keys is invalid, not map mode",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*spec.ValueRef{
+						"as": {Literal: "map"},
+					}},
+				},
+			},
+		},
+	}
+
+	result := &Result{}
+	lintResolvers(sol, result, reg, map[string]bool{"bag": true})
+
+	assert.Len(t, filterByRule(result.Findings), 1,
+		"as: map without keys is not map mode, so the missing-default warning still fires")
+}
+
 func TestLintResolvers_ParameterMissingDefault_HasUnconditionalFallback(t *testing.T) {
 	exprCond := celexp.Expression("_.useParam == true")
 

--- a/pkg/lint/lint_extra_test.go
+++ b/pkg/lint/lint_extra_test.go
@@ -1033,6 +1033,57 @@ func TestLintResolvers_ParameterMissingDefault_HasDefault(t *testing.T) {
 		"should not warn when the parameter source declares a default")
 }
 
+func TestLintResolvers_ParameterMissingDefault_MapModeAll(t *testing.T) {
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("parameter", nil)))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"everything": {
+			Description: "reads all parameters (map mode, no default needed)",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*spec.ValueRef{
+						"all": {Literal: true},
+					}},
+				},
+			},
+		},
+	}
+
+	result := &Result{}
+	lintResolvers(sol, result, reg, map[string]bool{"everything": true})
+
+	assert.Empty(t, filterByRule(result.Findings),
+		"map mode (all: true) always produces a value, so no default is required")
+}
+
+func TestLintResolvers_ParameterMissingDefault_MapModeKeys(t *testing.T) {
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(newFakeProvider("parameter", nil)))
+
+	sol := &solution.Solution{}
+	sol.Spec.Resolvers = map[string]*resolver.Resolver{
+		"bag": {
+			Description: "reads a distinct key set as a map (no default needed)",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{Provider: "parameter", Inputs: map[string]*spec.ValueRef{
+						"keys": {Literal: []any{"keyA", "keyB"}},
+						"as":   {Literal: "map"},
+					}},
+				},
+			},
+		},
+	}
+
+	result := &Result{}
+	lintResolvers(sol, result, reg, map[string]bool{"bag": true})
+
+	assert.Empty(t, filterByRule(result.Findings),
+		"map mode (keys + as: map) omits absent keys, so no default is required")
+}
+
 func TestLintResolvers_ParameterMissingDefault_HasUnconditionalFallback(t *testing.T) {
 	exprCond := celexp.Expression("_.useParam == true")
 

--- a/pkg/mcp/resources.go
+++ b/pkg/mcp/resources.go
@@ -467,7 +467,12 @@ func parameterSourceIsMapMode(src resolver.ProviderSource) bool {
 	}
 	if asRef, ok := src.Inputs["as"]; ok && asRef != nil {
 		if s, ok := asRef.Literal.(string); ok && s == "map" {
-			return true
+			// "as: map" only selects map mode when the required "keys" input is
+			// present; without it the provider rejects the config ("as: map"
+			// requires "keys"), so it is not a valid map-mode read.
+			if _, hasKeys := src.Inputs["keys"]; hasKeys {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/mcp/resources.go
+++ b/pkg/mcp/resources.go
@@ -451,10 +451,51 @@ func isParameterResolver(r *resolver.Resolver) bool {
 	return false
 }
 
+// parameterSourceIsMapMode reports whether a parameter provider source reads a
+// map instead of a single scalar -- "all: true" (every supplied parameter) or
+// "keys" + "as: map" (a distinct key set). In map mode the resolver name is not
+// a single CLI parameter name, and the read always produces a value (absent
+// keys are omitted), so such resolvers are neither required nor scalar-typed.
+func parameterSourceIsMapMode(src resolver.ProviderSource) bool {
+	if src.Provider != "parameter" {
+		return false
+	}
+	if allRef, ok := src.Inputs["all"]; ok && allRef != nil {
+		if b, ok := allRef.Literal.(bool); ok && b {
+			return true
+		}
+	}
+	if asRef, ok := src.Inputs["as"]; ok && asRef != nil {
+		if s, ok := asRef.Literal.(string); ok && s == "map" {
+			return true
+		}
+	}
+	return false
+}
+
+// resolverHasMapModeParameter reports whether any of a resolver's resolve
+// sources is a map-mode parameter read.
+func resolverHasMapModeParameter(r *resolver.Resolver) bool {
+	if r == nil || r.Resolve == nil {
+		return false
+	}
+	for _, src := range r.Resolve.With {
+		if parameterSourceIsMapMode(src) {
+			return true
+		}
+	}
+	return false
+}
+
 // isRequiredParameter checks if a resolver's only source is the "parameter" provider
 // (meaning there's no fallback chain and the parameter is effectively required).
 func isRequiredParameter(r *resolver.Resolver) bool {
 	if r.Resolve == nil {
+		return false
+	}
+	// Map-mode parameter reads always produce a value (absent keys are omitted),
+	// so they are never required.
+	if resolverHasMapModeParameter(r) {
 		return false
 	}
 	// If there's only one source and it's a parameter, it's required
@@ -469,10 +510,16 @@ func isRequiredParameter(r *resolver.Resolver) bool {
 func buildResolverProperty(r *resolver.Resolver) map[string]any {
 	prop := map[string]any{}
 
-	// Map resolver type to JSON Schema type
-	jsonType := resolverTypeToJSONSchemaType(r.Type)
-	if jsonType != "" {
-		prop["type"] = jsonType
+	// Map-mode parameter reads produce a map/object regardless of the resolver's
+	// declared scalar type, so present them as an object property.
+	if resolverHasMapModeParameter(r) {
+		prop["type"] = "object"
+	} else {
+		// Map resolver type to JSON Schema type
+		jsonType := resolverTypeToJSONSchemaType(r.Type)
+		if jsonType != "" {
+			prop["type"] = jsonType
+		}
 	}
 
 	// Add description

--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -753,3 +753,92 @@ func TestServerRegistersProviderResources(t *testing.T) {
 	require.True(t, ok)
 	assert.Contains(t, textContent.Text, "[]")
 }
+
+func paramSource(inputs map[string]*resolver.ValueRef) resolver.ProviderSource {
+	return resolver.ProviderSource{Provider: "parameter", Inputs: inputs}
+}
+
+func TestResolverHasMapModeParameter(t *testing.T) {
+	tests := []struct {
+		name string
+		r    *resolver.Resolver
+		want bool
+	}{
+		{
+			name: "all true",
+			r: &resolver.Resolver{Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+				paramSource(map[string]*resolver.ValueRef{"all": {Literal: true}}),
+			}}},
+			want: true,
+		},
+		{
+			name: "keys as map",
+			r: &resolver.Resolver{Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+				paramSource(map[string]*resolver.ValueRef{
+					"keys": {Literal: []any{"a", "b"}},
+					"as":   {Literal: "map"},
+				}),
+			}}},
+			want: true,
+		},
+		{
+			name: "single key scalar",
+			r: &resolver.Resolver{Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+				paramSource(map[string]*resolver.ValueRef{"key": {Literal: "env"}}),
+			}}},
+			want: false,
+		},
+		{
+			name: "alias keys without as map",
+			r: &resolver.Resolver{Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+				paramSource(map[string]*resolver.ValueRef{"keys": {Literal: []any{"a", "b"}}}),
+			}}},
+			want: false,
+		},
+		{
+			name: "all false is inert",
+			r: &resolver.Resolver{Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+				paramSource(map[string]*resolver.ValueRef{"all": {Literal: false}}),
+			}}},
+			want: false,
+		},
+		{
+			name: "nil resolve",
+			r:    &resolver.Resolver{},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolverHasMapModeParameter(tt.r))
+		})
+	}
+}
+
+func TestIsRequiredParameter_MapModeNotRequired(t *testing.T) {
+	r := &resolver.Resolver{Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+		paramSource(map[string]*resolver.ValueRef{"all": {Literal: true}}),
+	}}}
+	assert.False(t, isRequiredParameter(r),
+		"map-mode parameter reads always produce a value, so they are not required")
+
+	// A plain single-key parameter with no fallback remains required.
+	scalar := &resolver.Resolver{Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+		paramSource(map[string]*resolver.ValueRef{"key": {Literal: "env"}}),
+	}}}
+	assert.True(t, isRequiredParameter(scalar))
+}
+
+func TestBuildResolverProperty_MapModeIsObject(t *testing.T) {
+	r := &resolver.Resolver{
+		Type: "string", // declared scalar type is overridden by map mode
+		Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+			paramSource(map[string]*resolver.ValueRef{
+				"keys": {Literal: []any{"a", "b"}},
+				"as":   {Literal: "map"},
+			}),
+		}},
+	}
+	prop := buildResolverProperty(r)
+	assert.Equal(t, "object", prop["type"])
+}

--- a/pkg/mcp/resources_test.go
+++ b/pkg/mcp/resources_test.go
@@ -796,6 +796,13 @@ func TestResolverHasMapModeParameter(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "as map without keys is invalid, not map mode",
+			r: &resolver.Resolver{Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+				paramSource(map[string]*resolver.ValueRef{"as": {Literal: "map"}}),
+			}}},
+			want: false,
+		},
+		{
 			name: "all false is inert",
 			r: &resolver.Resolver{Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
 				paramSource(map[string]*resolver.ValueRef{"all": {Literal: false}}),

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -780,6 +780,12 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 			), nil
 		}
 		if rslvr.Resolve != nil && len(rslvr.Resolve.With) > 0 && rslvr.Resolve.With[0].Provider == "parameter" {
+			// Map-mode parameter reads (all: true, or keys + as: map) do not map
+			// the resolver name to a single CLI parameter, and always produce a
+			// value, so there is nothing to elicit for them.
+			if resolverHasMapModeParameter(rslvr) {
+				continue
+			}
 			if _, provided := params[name]; !provided {
 				missingParamNames = append(missingParamNames, name)
 				if rslvr.Description != "" {

--- a/pkg/provider/builtin/parameterprovider/parameter.go
+++ b/pkg/provider/builtin/parameterprovider/parameter.go
@@ -863,6 +863,9 @@ func resolveMapMode(inputs map[string]any) (mapMode, allMode bool, err error) {
 		asMap = true
 	}
 
+	if allMode && asMap {
+		return false, false, fmt.Errorf(`%s: "all" is mutually exclusive with "as"`, ProviderName)
+	}
 	if asMap && !hasKeys {
 		return false, false, fmt.Errorf(`%s: "as: map" requires "keys"`, ProviderName)
 	}

--- a/pkg/provider/builtin/parameterprovider/parameter.go
+++ b/pkg/provider/builtin/parameterprovider/parameter.go
@@ -927,6 +927,11 @@ func (p *ParameterProvider) executeMapGet(ctx context.Context, lgr *logr.Logger,
 				return nil, fmt.Errorf("%s: invalid key %q at keys[%d]", ProviderName, k, i)
 			}
 		}
+		// De-duplicate the requested keys (preserving first-seen order) so the
+		// "distinct set" semantics hold: the output map already collapses
+		// duplicates, and this keeps metadata.keys/metadata.missing free of
+		// duplicate entries when a caller repeats a key.
+		requested = dedupePreserveOrder(requested)
 		for _, k := range requested {
 			raw, exists := params[k]
 			if !exists {
@@ -974,4 +979,19 @@ func toStringKeys(raw any) ([]string, error) {
 	default:
 		return nil, fmt.Errorf(`"keys" must be an array of strings, got %T`, raw)
 	}
+}
+
+// dedupePreserveOrder returns keys with duplicates removed, keeping the first
+// occurrence of each value in its original position.
+func dedupePreserveOrder(keys []string) []string {
+	seen := make(map[string]struct{}, len(keys))
+	out := make([]string, 0, len(keys))
+	for _, k := range keys {
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, k)
+	}
+	return out
 }

--- a/pkg/provider/builtin/parameterprovider/parameter.go
+++ b/pkg/provider/builtin/parameterprovider/parameter.go
@@ -11,10 +11,13 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/go-logr/logr"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/oakwood-commons/scafctl/pkg/httpc"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
@@ -84,6 +87,37 @@ var paramTypeEnum = func() []any {
 	return enum
 }()
 
+// Input key names for the parameter provider's inputs.
+const (
+	// InputKey is a single exact parameter name (scalar read).
+	InputKey = "key"
+	// InputKeys is an ordered list of parameter names. By default it is an alias
+	// list (first-match-wins) for one logical value; with "as: map" it is a
+	// distinct set of names read into a map.
+	InputKeys = "keys"
+	// InputAs is the read-mode discriminator for "keys". The only supported value
+	// is AsMap.
+	InputAs = "as"
+	// InputAll selects the whole-supplied-parameter-set map read.
+	InputAll = "all"
+	// InputDefault is the scalar fallback value; invalid in map mode.
+	InputDefault = "default"
+	// InputType selects an explicit scalar coercion; invalid in map mode.
+	InputType = "type"
+	// AsMap is the "as" value that reinterprets "keys" as a distinct set of
+	// parameter names read into a map (instead of first-match-wins aliases).
+	AsMap = "map"
+)
+
+// keyPattern matches a valid parameter name. It mirrors the resolver name
+// grammar so authors cannot pass expressions or path traversals as a key.
+const keyPattern = `^[A-Za-z_][A-Za-z0-9_.\-]*$`
+
+// keyRe is the compiled form of keyPattern. The schema enforces the pattern on
+// the single-key/alias inputs; map mode ("keys" + "as: map") validates each
+// entry at runtime.
+var keyRe = regexp.MustCompile(keyPattern)
+
 // HTTPClient defines the interface for HTTP operations
 type HTTPClient interface {
 	Get(ctx context.Context, url string) (*http.Response, error)
@@ -152,27 +186,28 @@ func NewParameterProvider(opts ...Option) *ParameterProvider {
 				provider.CapabilityFrom,
 			},
 			Schema: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
-				"key": schemahelper.StringProp("Name of the parameter to retrieve (exact match). Provide either key or keys; key takes precedence over keys when both are set.",
+				"key": schemahelper.StringProp("Single-key (scalar) read. Name of the parameter to retrieve (exact match). Provide either key or keys; key takes precedence over keys when both are set. Mutually exclusive with \"all\" and with \"as: map\".",
 					schemahelper.WithMaxLength(*ptrs.IntPtr(256)),
-					schemahelper.WithPattern(`^[A-Za-z_][A-Za-z0-9_.\-]*$`),
+					schemahelper.WithPattern(keyPattern),
 					schemahelper.WithExample("env")),
-				"keys": schemahelper.ArrayProp("Ordered list of parameter names (aliases) for a single logical parameter. The first name that was provided via CLI wins. Evaluated after key. Use this to accept a parameter under any of several flag names (e.g. environment, e, env).",
+				"keys": schemahelper.ArrayProp("Ordered list of parameter names. Default meaning: aliases for a single logical parameter (the first name provided via CLI wins), evaluated after key. With \"as: map\" it is instead a distinct set of parameter names read into a map, with absent keys OMITTED (not defaulted).",
 					schemahelper.WithItems(schemahelper.StringProp("Parameter name (exact match)",
 						schemahelper.WithMaxLength(*ptrs.IntPtr(256)),
-						schemahelper.WithPattern(`^[A-Za-z_][A-Za-z0-9_.\-]*$`))),
+						schemahelper.WithPattern(keyPattern))),
 					schemahelper.WithMaxItems(50)),
-				"default": schemahelper.AnyProp("Default value to return when the parameter is not provided via CLI. Must be a literal value -- ValueRef expressions are resolved by the executor before Execute is called, so a ValueRef default would be evaluated even when the parameter exists.",
+				"as": schemahelper.StringProp("Read-mode discriminator for \"keys\". Omitted (default): \"keys\" is an alias list (first-match-wins) for one logical value. \"map\": \"keys\" is a distinct set of parameter names read into a map, with absent keys OMITTED (not defaulted) so has() and optional chaining stay faithful.",
+					schemahelper.WithEnum(AsMap),
+					schemahelper.WithExample(AsMap)),
+				"all": schemahelper.BoolProp("When true, read every supplied CLI parameter as a map. Mutually exclusive with \"key\", \"keys\", and \"as\".",
+					schemahelper.WithExample(true)),
+				"default": schemahelper.AnyProp("Default value to return when the parameter is not provided via CLI. Only valid in single-key/alias mode; in map mode absent keys are omitted instead, so combining \"default\" with \"all\" or \"as: map\" is an error. Must be a literal value -- ValueRef expressions are resolved by the executor before Execute is called, so a ValueRef default would be evaluated even when the parameter exists.",
 					schemahelper.WithExample("fallback")),
-				"type": schemahelper.StringProp("Controls how the parameter value is coerced. \"auto\" (default) infers booleans, numbers, JSON, and file:// sources, falling back to the literal string. \"string\" coerces to a string (stripping surrounding quotes). \"raw\" returns the value untouched. \"int\", \"float\", \"bool\", \"json\", and \"csv\" force that specific coercion and error if the value does not match. Comma-separated values are split into a string list only when type is \"csv\". http:// and https:// values are NOT fetched under \"auto\"; use \"fetch\" to perform an SSRF-guarded HTTP GET, or the http provider for anything beyond a plain GET.",
+				"type": schemahelper.StringProp("Controls how the parameter value is coerced. Only valid in single-key/alias mode; in map mode each value is returned with the provider's standard \"auto\" inference. \"auto\" (default) infers booleans, numbers, JSON, and file:// sources, falling back to the literal string. \"string\" coerces to a string (stripping surrounding quotes). \"raw\" returns the value untouched. \"int\", \"float\", \"bool\", \"json\", and \"csv\" force that specific coercion and error if the value does not match. Comma-separated values are split into a string list only when type is \"csv\". http:// and https:// values are NOT fetched under \"auto\"; use \"fetch\" to perform an SSRF-guarded HTTP GET, or the http provider for anything beyond a plain GET.",
 					schemahelper.WithEnum(paramTypeEnum...),
 					schemahelper.WithExample(TypeString)),
 			}),
 			OutputSchemas: map[provider.Capability]*jsonschema.Schema{
-				provider.CapabilityFrom: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
-					"value":  schemahelper.AnyProp("The parameter value (typed based on parsing rules)", schemahelper.WithExample("prod")),
-					"exists": schemahelper.BoolProp("Whether the value came from a CLI-provided parameter (false when using the default value)", schemahelper.WithExample(true)),
-					"type":   schemahelper.StringProp("Detected type of the value", schemahelper.WithExample("string")),
-				}),
+				provider.CapabilityFrom: schemahelper.AnyProp("In single-key/alias mode the parameter value (typed per the parsing rules), or the default when absent. In map mode (\"keys\" + \"as: map\", or \"all: true\") a map of present parameter names to their auto-inferred values, with absent keys omitted."),
 			},
 			Examples: []provider.Example{
 				{
@@ -197,6 +232,21 @@ inputs:
 inputs:
   keys: [environment, e, env]
   default: development`,
+				},
+				{
+					Name:        "Read a set of parameters as a map",
+					Description: "Read several distinct parameters at once into a map (opt in with as: map). Absent keys are omitted, so has(_.myBag.keyB) stays faithful.",
+					YAML: `provider: parameter
+inputs:
+  keys: [keyA, keyB, keyC]
+  as: map`,
+				},
+				{
+					Name:        "Read all supplied parameters as a map",
+					Description: "Read every CLI-supplied parameter into a single map.",
+					YAML: `provider: parameter
+inputs:
+  all: true`,
 				},
 				{
 					Name:        "Get array parameter",
@@ -281,6 +331,24 @@ func (p *ParameterProvider) Execute(ctx context.Context, input any) (*provider.O
 	}
 
 	lgr.V(1).Info("executing provider", "provider", ProviderName)
+
+	// Determine the read mode. Map mode ("all: true", or "keys" + "as: map")
+	// returns a map instead of a single scalar and is mutually exclusive with
+	// the single-key / alias-keys scalar reads, so it must be resolved before
+	// the scalar candidate-key path below.
+	mapMode, allMode, err := resolveMapMode(inputs)
+	if err != nil {
+		return nil, err
+	}
+	if mapMode {
+		if _, has := inputs[InputDefault]; has {
+			return nil, fmt.Errorf(`%s: "default" is only valid with a single "key"/alias "keys"; in map mode absent keys are omitted (use has()/optional chaining)`, ProviderName)
+		}
+		if _, has := inputs[InputType]; has {
+			return nil, fmt.Errorf(`%s: "type" is only valid with a single "key"/alias "keys"; map mode returns each value with the provider's standard auto inference`, ProviderName)
+		}
+		return p.executeMapGet(ctx, lgr, inputs[InputKeys], allMode)
+	}
 
 	// Build the ordered list of parameter names to look up. "key" (when set)
 	// takes precedence, followed by each name in "keys" in declared order.
@@ -759,4 +827,148 @@ func firstProvided(candidates []string, params map[string]any) (string, any, boo
 		}
 	}
 	return "", nil, false
+}
+
+// resolveMapMode inspects the selector inputs and reports whether the caller
+// requested a map read and, if so, whether it is the whole-parameter-set
+// ("all: true") variant. It enforces that the map selectors are mutually
+// exclusive with each other and with the scalar "key"/alias-"keys" reads.
+//
+// Selection:
+//   - all: true             -> map mode (every supplied parameter)
+//   - keys: [...] + as: map  -> map mode (an explicit distinct-key set)
+//   - key / keys (no as)     -> scalar mode (single value / first-match alias)
+func resolveMapMode(inputs map[string]any) (mapMode, allMode bool, err error) {
+	_, hasKey := inputs[InputKey]
+	_, hasKeys := inputs[InputKeys]
+
+	if raw, present := inputs[InputAll]; present {
+		b, ok := raw.(bool)
+		if !ok {
+			return false, false, fmt.Errorf("%s: all must be a boolean, got %T", ProviderName, raw)
+		}
+		// Only all:true selects the whole-parameter-set mode; all:false is inert.
+		allMode = b
+	}
+
+	asMap := false
+	if raw, present := inputs[InputAs]; present {
+		s, ok := raw.(string)
+		if !ok {
+			return false, false, fmt.Errorf("%s: as must be a string, got %T", ProviderName, raw)
+		}
+		if s != AsMap {
+			return false, false, fmt.Errorf("%s: unsupported as %q (only %q is supported)", ProviderName, s, AsMap)
+		}
+		asMap = true
+	}
+
+	if asMap && !hasKeys {
+		return false, false, fmt.Errorf(`%s: "as: map" requires "keys"`, ProviderName)
+	}
+	if allMode && (hasKey || hasKeys) {
+		return false, false, fmt.Errorf(`%s: "all" is mutually exclusive with "key" and "keys"`, ProviderName)
+	}
+	if asMap && hasKey {
+		return false, false, fmt.Errorf(`%s: "as: map" is mutually exclusive with "key"`, ProviderName)
+	}
+
+	mapMode = allMode || (hasKeys && asMap)
+	return mapMode, allMode, nil
+}
+
+// executeMapGet reads either an explicit set of parameter names ("keys" +
+// "as: map") or every supplied parameter ("all: true") into a map. Absent keys
+// are omitted from the returned map (rather than defaulted) so that has() and
+// optional chaining against the map stay faithful. Each present value is
+// returned with the provider's standard auto inference. The present-key list
+// (and, in keys mode, the requested-but-absent list) is reported in metadata;
+// the resolver value is the bare map.
+func (p *ParameterProvider) executeMapGet(ctx context.Context, lgr *logr.Logger, rawKeys any, allMode bool) (*provider.Output, error) {
+	params, ok := provider.ParametersFromContext(ctx)
+	if !ok {
+		params = make(map[string]any)
+	}
+
+	// Dry-run does not read actual parameter values; mirror the scalar dry-run
+	// path by returning a placeholder (an empty map, since absent keys are
+	// omitted) rather than the real supplied values.
+	if provider.DryRunFromContext(ctx) {
+		return &provider.Output{
+			Data:     map[string]any{},
+			Metadata: map[string]any{"dryRun": true, "mode": "map"},
+		}, nil
+	}
+
+	result := make(map[string]any)
+	presentKeys := []string{}
+	missing := []string{}
+
+	if allMode {
+		for k, raw := range params {
+			v, err := p.resolveValue(ctx, raw, TypeAuto)
+			if err != nil {
+				return nil, fmt.Errorf("%s: failed to parse parameter %q: %w", ProviderName, k, err)
+			}
+			result[k] = v
+			presentKeys = append(presentKeys, k)
+		}
+		sort.Strings(presentKeys)
+	} else {
+		requested, err := toStringKeys(rawKeys)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", ProviderName, err)
+		}
+		for i, k := range requested {
+			if !keyRe.MatchString(k) {
+				return nil, fmt.Errorf("%s: invalid key %q at keys[%d]", ProviderName, k, i)
+			}
+		}
+		for _, k := range requested {
+			raw, exists := params[k]
+			if !exists {
+				missing = append(missing, k)
+				continue
+			}
+			v, err := p.resolveValue(ctx, raw, TypeAuto)
+			if err != nil {
+				return nil, fmt.Errorf("%s: failed to parse parameter %q: %w", ProviderName, k, err)
+			}
+			result[k] = v
+			presentKeys = append(presentKeys, k)
+		}
+	}
+
+	metadata := map[string]any{
+		"mode": "map",
+		"keys": presentKeys,
+	}
+	if !allMode {
+		metadata["missing"] = missing
+	}
+	lgr.V(1).Info("provider completed", "provider", ProviderName, "mode", "map", "present", len(presentKeys), "missing", len(missing))
+	return &provider.Output{Data: result, Metadata: metadata}, nil
+}
+
+// toStringKeys normalizes the "keys" input into a []string. It accepts both
+// []string and []any (the shape a CEL list or YAML sequence produces).
+func toStringKeys(raw any) ([]string, error) {
+	switch v := raw.(type) {
+	case []string:
+		return v, nil
+	case []any:
+		out := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("keys[%d] must be a string, got %T", i, item)
+			}
+			out = append(out, s)
+		}
+		return out, nil
+	case nil:
+		return nil, fmt.Errorf(`"keys" must be an array of strings`)
+	default:
+		return nil, fmt.Errorf(`"keys" must be an array of strings, got %T`, raw)
+	}
 }

--- a/pkg/provider/builtin/parameterprovider/parameter_benchmark_test.go
+++ b/pkg/provider/builtin/parameterprovider/parameter_benchmark_test.go
@@ -42,6 +42,41 @@ func BenchmarkParameterProvider_Execute(b *testing.B) {
 			_, _ = p.Execute(ctx, inputs)
 		}
 	})
+
+	b.Run("keys_map", func(b *testing.B) {
+		ctx := provider.WithParameters(context.Background(), map[string]any{
+			"env":    "production",
+			"region": "us-east-1",
+			"tier":   "gold",
+		})
+		inputs := map[string]any{
+			"keys": []any{"env", "region", "missing"},
+			"as":   "map",
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_, _ = p.Execute(ctx, inputs)
+		}
+	})
+
+	b.Run("all_map", func(b *testing.B) {
+		ctx := provider.WithParameters(context.Background(), map[string]any{
+			"env":    "production",
+			"region": "us-east-1",
+			"tier":   "gold",
+		})
+		inputs := map[string]any{
+			"all": true,
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_, _ = p.Execute(ctx, inputs)
+		}
+	})
 }
 
 func BenchmarkParameterProvider_Execute_TypedCoercion(b *testing.B) {

--- a/pkg/provider/builtin/parameterprovider/parameter_test.go
+++ b/pkg/provider/builtin/parameterprovider/parameter_test.go
@@ -1083,3 +1083,296 @@ func TestParameterProvider_Execute_DryRun_WithDefault_IgnoresDefault(t *testing.
 	assert.Equal(t, "[DRY-RUN] Not retrieved", output.Data)
 	assert.True(t, output.Metadata["dryRun"].(bool))
 }
+
+// --- Map mode ("keys" + "as: map", or "all: true") -------------------------
+
+func TestParameterProvider_Execute_MapMode_Keys(t *testing.T) {
+	t.Parallel()
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{
+		"keyA": "alpha",
+		"keyC": "gamma",
+		"keyD": "delta", // present but not requested -> excluded
+	})
+
+	output, err := p.Execute(ctx, map[string]any{
+		"keys": []any{"keyA", "keyB", "keyC"},
+		"as":   "map",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+
+	result, ok := output.Data.(map[string]any)
+	require.True(t, ok, "map mode returns a bare map")
+	// Present keys are returned; absent keyB is omitted (not defaulted).
+	assert.Equal(t, map[string]any{"keyA": "alpha", "keyC": "gamma"}, result)
+	_, hasB := result["keyB"]
+	assert.False(t, hasB, "absent keys must be omitted so has() stays faithful")
+	// keyD is present in params but was not requested -> excluded.
+	_, hasD := result["keyD"]
+	assert.False(t, hasD, "unrequested params must not leak into the map")
+
+	assert.Equal(t, "map", output.Metadata["mode"])
+	assert.Equal(t, []string{"keyA", "keyC"}, output.Metadata["keys"])
+	assert.Equal(t, []string{"keyB"}, output.Metadata["missing"])
+}
+
+func TestParameterProvider_Execute_MapMode_Keys_StringSlice(t *testing.T) {
+	t.Parallel()
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{"a": "1"})
+
+	output, err := p.Execute(ctx, map[string]any{
+		"keys": []string{"a", "b"},
+		"as":   "map",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	result, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, int64(1), result["a"], "values use the provider's auto inference")
+	assert.Equal(t, []string{"b"}, output.Metadata["missing"])
+}
+
+func TestParameterProvider_Execute_MapMode_Keys_AutoInference(t *testing.T) {
+	t.Parallel()
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{
+		"flag":  "true",
+		"count": "3",
+		"name":  "svc",
+	})
+
+	output, err := p.Execute(ctx, map[string]any{
+		"keys": []any{"flag", "count", "name"},
+		"as":   "map",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	result, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, true, result["flag"])
+	assert.Equal(t, int64(3), result["count"])
+	assert.Equal(t, "svc", result["name"])
+}
+
+func TestParameterProvider_Execute_MapMode_Keys_EmptyList(t *testing.T) {
+	t.Parallel()
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{"a": "1"})
+
+	output, err := p.Execute(ctx, map[string]any{
+		"keys": []any{},
+		"as":   "map",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	result, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Empty(t, result)
+	assert.Equal(t, []string{}, output.Metadata["keys"])
+	assert.Equal(t, []string{}, output.Metadata["missing"])
+}
+
+func TestParameterProvider_Execute_MapMode_All(t *testing.T) {
+	t.Parallel()
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{
+		"flag":  "true",
+		"count": "3",
+		"name":  "svc",
+	})
+
+	output, err := p.Execute(ctx, map[string]any{"all": true})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	result, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"flag": true, "count": int64(3), "name": "svc"}, result)
+	assert.Equal(t, "map", output.Metadata["mode"])
+	// present keys are sorted; no "missing" key in all mode.
+	assert.Equal(t, []string{"count", "flag", "name"}, output.Metadata["keys"])
+	_, hasMissing := output.Metadata["missing"]
+	assert.False(t, hasMissing, "all mode has no notion of missing keys")
+}
+
+func TestParameterProvider_Execute_MapMode_All_Empty(t *testing.T) {
+	t.Parallel()
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{})
+
+	output, err := p.Execute(ctx, map[string]any{"all": true})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	result, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Empty(t, result)
+	assert.Equal(t, []string{}, output.Metadata["keys"])
+}
+
+func TestParameterProvider_Execute_MapMode_AllFalseIsInert(t *testing.T) {
+	t.Parallel()
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{"env": "prod"})
+
+	// all: false must not select map mode; the scalar key read wins.
+	output, err := p.Execute(ctx, map[string]any{"key": "env", "all": false})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, "prod", output.Data)
+	assert.Equal(t, true, output.Metadata["exists"])
+}
+
+func TestParameterProvider_Execute_MapMode_DryRun(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		inputs map[string]any
+	}{
+		{"keys as map", map[string]any{"keys": []any{"a", "b"}, "as": "map"}},
+		{"all", map[string]any{"all": true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := NewParameterProvider()
+			ctx := provider.WithDryRun(provider.WithParameters(context.Background(), map[string]any{
+				"a": "1",
+				"b": "2",
+			}), true)
+
+			output, err := p.Execute(ctx, tt.inputs)
+
+			require.NoError(t, err)
+			require.NotNil(t, output)
+			// Dry-run returns an empty placeholder map (absent keys are omitted).
+			assert.Equal(t, map[string]any{}, output.Data)
+			assert.Equal(t, true, output.Metadata["dryRun"])
+			assert.Equal(t, "map", output.Metadata["mode"])
+		})
+	}
+}
+
+func TestParameterProvider_Execute_MapMode_MutualExclusionAndValidation(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		inputs  map[string]any
+		wantErr string
+	}{
+		{
+			name:    "as map without keys",
+			inputs:  map[string]any{"as": "map"},
+			wantErr: `"as: map" requires "keys"`,
+		},
+		{
+			name:    "all with key",
+			inputs:  map[string]any{"all": true, "key": "env"},
+			wantErr: `"all" is mutually exclusive with "key" and "keys"`,
+		},
+		{
+			name:    "all with keys",
+			inputs:  map[string]any{"all": true, "keys": []any{"a"}},
+			wantErr: `"all" is mutually exclusive with "key" and "keys"`,
+		},
+		{
+			name:    "as map with key",
+			inputs:  map[string]any{"key": "env", "keys": []any{"a"}, "as": "map"},
+			wantErr: `"as: map" is mutually exclusive with "key"`,
+		},
+		{
+			name:    "unsupported as value",
+			inputs:  map[string]any{"keys": []any{"a"}, "as": "list"},
+			wantErr: `unsupported as "list"`,
+		},
+		{
+			name:    "as not a string",
+			inputs:  map[string]any{"keys": []any{"a"}, "as": 42},
+			wantErr: "as must be a string",
+		},
+		{
+			name:    "all not a bool",
+			inputs:  map[string]any{"all": "yes"},
+			wantErr: "all must be a boolean",
+		},
+		{
+			name:    "default rejected in keys map mode",
+			inputs:  map[string]any{"keys": []any{"a"}, "as": "map", "default": "x"},
+			wantErr: `"default" is only valid with a single "key"/alias "keys"`,
+		},
+		{
+			name:    "default rejected in all mode",
+			inputs:  map[string]any{"all": true, "default": "x"},
+			wantErr: `"default" is only valid with a single "key"/alias "keys"`,
+		},
+		{
+			name:    "type rejected in keys map mode",
+			inputs:  map[string]any{"keys": []any{"a"}, "as": "map", "type": "string"},
+			wantErr: `"type" is only valid with a single "key"/alias "keys"`,
+		},
+		{
+			name:    "type rejected in all mode",
+			inputs:  map[string]any{"all": true, "type": "string"},
+			wantErr: `"type" is only valid with a single "key"/alias "keys"`,
+		},
+		{
+			name:    "invalid key pattern in map mode",
+			inputs:  map[string]any{"keys": []any{"ok", "_.bad expr"}, "as": "map"},
+			wantErr: "invalid key",
+		},
+		{
+			name:    "non-string key element in map mode",
+			inputs:  map[string]any{"keys": []any{"ok", 42}, "as": "map"},
+			wantErr: "keys[1] must be a string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := NewParameterProvider()
+			ctx := provider.WithParameters(context.Background(), map[string]any{"a": "1"})
+			output, err := p.Execute(ctx, tt.inputs)
+			require.Error(t, err)
+			assert.Nil(t, output)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestToStringKeys(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		raw     any
+		want    []string
+		wantErr string
+	}{
+		{"string slice", []string{"a", "b"}, []string{"a", "b"}, ""},
+		{"any slice of strings", []any{"a", "b"}, []string{"a", "b"}, ""},
+		{"empty any slice", []any{}, []string{}, ""},
+		{"nil", nil, nil, `"keys" must be an array of strings`},
+		{"wrong type", "a", nil, `"keys" must be an array of strings, got string`},
+		{"non-string element", []any{"a", 1}, nil, "keys[1] must be a string"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := toStringKeys(tt.raw)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/provider/builtin/parameterprovider/parameter_test.go
+++ b/pkg/provider/builtin/parameterprovider/parameter_test.go
@@ -1178,6 +1178,28 @@ func TestParameterProvider_Execute_MapMode_Keys_EmptyList(t *testing.T) {
 	assert.Equal(t, []string{}, output.Metadata["missing"])
 }
 
+func TestParameterProvider_Execute_MapMode_Keys_Duplicates(t *testing.T) {
+	t.Parallel()
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{"a": "1"})
+
+	output, err := p.Execute(ctx, map[string]any{
+		// "a" (present) and "b" (absent) are each repeated; the distinct-set
+		// semantics must collapse them in both the map and the metadata.
+		"keys": []any{"a", "b", "a", "b"},
+		"as":   "map",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	result, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, map[string]any{"a": int64(1)}, result)
+	// Duplicates are removed (first-seen order preserved) from metadata too.
+	assert.Equal(t, []string{"a"}, output.Metadata["keys"])
+	assert.Equal(t, []string{"b"}, output.Metadata["missing"])
+}
+
 func TestParameterProvider_Execute_MapMode_All(t *testing.T) {
 	t.Parallel()
 	p := NewParameterProvider()

--- a/pkg/provider/builtin/parameterprovider/parameter_test.go
+++ b/pkg/provider/builtin/parameterprovider/parameter_test.go
@@ -1283,6 +1283,11 @@ func TestParameterProvider_Execute_MapMode_MutualExclusionAndValidation(t *testi
 			wantErr: `"all" is mutually exclusive with "key" and "keys"`,
 		},
 		{
+			name:    "all with as map",
+			inputs:  map[string]any{"all": true, "as": "map"},
+			wantErr: `"all" is mutually exclusive with "as"`,
+		},
+		{
 			name:    "as map with key",
 			inputs:  map[string]any{"key": "env", "keys": []any{"a"}, "as": "map"},
 			wantErr: `"as: map" is mutually exclusive with "key"`,

--- a/pkg/resolver/detail/help.go
+++ b/pkg/resolver/detail/help.go
@@ -142,9 +142,15 @@ func FormatResolverInputHelp(sol *solution.Solution) string {
 		}
 	}
 
-	// Sort each group by name for deterministic output
+	// Sort each group for deterministic output. Parameter resolvers sort by the
+	// rendered PARAMETER cell, then by resolver name as a tiebreaker so that
+	// resolvers producing the same cell (e.g. two "(all)" resolvers, or the same
+	// key list) keep a stable order regardless of map-iteration order.
 	slices.SortFunc(paramResolvers, func(a, b ResolverInfo) int {
-		return strings.Compare(parameterCell(a), parameterCell(b))
+		if c := strings.Compare(parameterCell(a), parameterCell(b)); c != 0 {
+			return c
+		}
+		return strings.Compare(a.Name, b.Name)
 	})
 	slices.SortFunc(computedResolvers, func(a, b ResolverInfo) int {
 		return strings.Compare(a.Name, b.Name)

--- a/pkg/resolver/detail/help.go
+++ b/pkg/resolver/detail/help.go
@@ -53,17 +53,34 @@ func ExtractResolverInfo(sol *solution.Solution) []ResolverInfo {
 		}
 
 		if r.Resolve != nil {
+			// seen de-duplicates parameter key names across all parameter
+			// sources of this resolver, mirroring the distinct, non-empty key
+			// set the parameter provider actually reads (empty names are
+			// ignored, duplicates collapsed).
+			seen := make(map[string]struct{})
+			addKey := func(name string) {
+				if name == "" {
+					return
+				}
+				if _, dup := seen[name]; dup {
+					return
+				}
+				seen[name] = struct{}{}
+				info.ParameterKeys = append(info.ParameterKeys, name)
+			}
 			for i, src := range r.Resolve.With {
 				if src.Provider == "parameter" {
 					// Single-key / alias "keys" reads, and the distinct-key set
 					// of a "keys" + "as: map" read, all name CLI parameters.
 					if keyRef, ok := src.Inputs["key"]; ok && keyRef != nil {
-						if s, ok := keyRef.Literal.(string); ok && s != "" {
-							info.ParameterKeys = append(info.ParameterKeys, s)
+						if s, ok := keyRef.Literal.(string); ok {
+							addKey(s)
 						}
 					}
 					if keysRef, ok := src.Inputs["keys"]; ok && keysRef != nil {
-						info.ParameterKeys = append(info.ParameterKeys, literalStringList(keysRef.Literal)...)
+						for _, s := range literalStringList(keysRef.Literal) {
+							addKey(s)
+						}
 					}
 					// "all: true" reads every supplied parameter.
 					if allRef, ok := src.Inputs["all"]; ok && allRef != nil {

--- a/pkg/resolver/detail/help.go
+++ b/pkg/resolver/detail/help.go
@@ -13,11 +13,24 @@ import (
 
 // ResolverInfo describes a single resolver for help text rendering.
 type ResolverInfo struct {
-	Name         string
-	Type         string
-	Description  string
-	HasDefault   bool
-	ParameterKey string // The parameter key if this resolver uses the "parameter" provider.
+	Name        string
+	Type        string
+	Description string
+	HasDefault  bool
+	// ParameterKeys holds the CLI parameter names this resolver reads via the
+	// "parameter" provider: a single "key", the alias list "keys", or the
+	// distinct-key set of a "keys" + "as: map" read. Empty when the resolver
+	// does not read named CLI parameters.
+	ParameterKeys []string
+	// AcceptsAllParameters is true when the resolver reads every supplied CLI
+	// parameter via the parameter provider's "all: true" map mode.
+	AcceptsAllParameters bool
+}
+
+// AcceptsParameters reports whether the resolver reads CLI parameters (named
+// keys or the whole supplied set).
+func (r ResolverInfo) AcceptsParameters() bool {
+	return len(r.ParameterKeys) > 0 || r.AcceptsAllParameters
 }
 
 // ExtractResolverInfo builds a list of ResolverInfo from a solution's resolvers.
@@ -42,10 +55,20 @@ func ExtractResolverInfo(sol *solution.Solution) []ResolverInfo {
 		if r.Resolve != nil {
 			for i, src := range r.Resolve.With {
 				if src.Provider == "parameter" {
-					// Extract the key input (literal string value)
+					// Single-key / alias "keys" reads, and the distinct-key set
+					// of a "keys" + "as: map" read, all name CLI parameters.
 					if keyRef, ok := src.Inputs["key"]; ok && keyRef != nil {
-						if s, ok := keyRef.Literal.(string); ok {
-							info.ParameterKey = s
+						if s, ok := keyRef.Literal.(string); ok && s != "" {
+							info.ParameterKeys = append(info.ParameterKeys, s)
+						}
+					}
+					if keysRef, ok := src.Inputs["keys"]; ok && keysRef != nil {
+						info.ParameterKeys = append(info.ParameterKeys, literalStringList(keysRef.Literal)...)
+					}
+					// "all: true" reads every supplied parameter.
+					if allRef, ok := src.Inputs["all"]; ok && allRef != nil {
+						if b, ok := allRef.Literal.(bool); ok && b {
+							info.AcceptsAllParameters = true
 						}
 					}
 					// If there are more sources after this one, the resolver
@@ -61,6 +84,25 @@ func ExtractResolverInfo(sol *solution.Solution) []ResolverInfo {
 	}
 
 	return infos
+}
+
+// literalStringList normalizes a "keys" literal (a []string or []any of
+// strings) into a []string, ignoring non-string entries.
+func literalStringList(raw any) []string {
+	switch v := raw.(type) {
+	case []string:
+		return v
+	case []any:
+		out := make([]string, 0, len(v))
+		for _, item := range v {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
 }
 
 // FormatResolverInputHelp generates a human-readable help section describing
@@ -93,7 +135,7 @@ func FormatResolverInputHelp(sol *solution.Solution) string {
 	var paramResolvers []ResolverInfo
 	var computedResolvers []ResolverInfo
 	for _, info := range infos {
-		if info.ParameterKey != "" {
+		if info.AcceptsParameters() {
 			paramResolvers = append(paramResolvers, info)
 		} else {
 			computedResolvers = append(computedResolvers, info)
@@ -102,7 +144,7 @@ func FormatResolverInputHelp(sol *solution.Solution) string {
 
 	// Sort each group by name for deterministic output
 	slices.SortFunc(paramResolvers, func(a, b ResolverInfo) int {
-		return strings.Compare(a.ParameterKey, b.ParameterKey)
+		return strings.Compare(parameterCell(a), parameterCell(b))
 	})
 	slices.SortFunc(computedResolvers, func(a, b ResolverInfo) int {
 		return strings.Compare(a.Name, b.Name)
@@ -114,7 +156,7 @@ func FormatResolverInputHelp(sol *solution.Solution) string {
 	maxNameLen := len("RESOLVER")
 
 	for _, info := range infos {
-		paramKey := info.ParameterKey
+		paramKey := parameterCell(info)
 		if paramKey == "" {
 			paramKey = "-"
 		}
@@ -154,7 +196,7 @@ func FormatResolverInputHelp(sol *solution.Solution) string {
 		}
 
 		line := fmt.Sprintf("  %-*s  %-*s  %-*s  %s",
-			maxParamLen, info.ParameterKey,
+			maxParamLen, parameterCell(info),
 			maxTypeLen, typeStr,
 			maxNameLen, info.Name,
 			desc)
@@ -184,4 +226,17 @@ func FormatResolverInputHelp(sol *solution.Solution) string {
 	}
 
 	return sb.String()
+}
+
+// parameterCell renders the PARAMETER column for a resolver: "(all)" when it
+// reads every supplied parameter, the comma-joined key list when it reads
+// named parameters, or "-" when it reads none.
+func parameterCell(info ResolverInfo) string {
+	if info.AcceptsAllParameters {
+		return "(all)"
+	}
+	if len(info.ParameterKeys) > 0 {
+		return strings.Join(info.ParameterKeys, ",")
+	}
+	return "-"
 }

--- a/pkg/resolver/detail/help_test.go
+++ b/pkg/resolver/detail/help_test.go
@@ -180,6 +180,42 @@ func TestExtractResolverInfo_ParameterKeysAsMap(t *testing.T) {
 	assert.True(t, infos[0].AcceptsParameters())
 }
 
+func TestExtractResolverInfo_ParameterKeysDedupeAndEmpty(t *testing.T) {
+	t.Parallel()
+
+	// A resolver that reads a "key", then falls back to an alias "keys" list
+	// containing duplicates (including the earlier "key") and an empty string.
+	// Help output should reflect the provider's distinct, non-empty key set.
+	sol := buildTestSolution(map[string]*resolver.Resolver{
+		"environment": {
+			Name: "environment",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "parameter",
+						Inputs: map[string]*spec.ValueRef{
+							"key": {Literal: "env"},
+						},
+					},
+					{
+						Provider: "parameter",
+						Inputs: map[string]*spec.ValueRef{
+							"keys": {Literal: []any{"env", "", "e", "e"}},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	infos := ExtractResolverInfo(sol)
+	require.Len(t, infos, 1)
+	// "env" (from key) is not repeated by the "keys" list, "" is dropped, and
+	// the duplicate "e" collapses to a single entry.
+	assert.Equal(t, []string{"env", "e"}, infos[0].ParameterKeys)
+	assert.True(t, infos[0].AcceptsParameters())
+}
+
 func TestExtractResolverInfo_ParameterAll(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/resolver/detail/help_test.go
+++ b/pkg/resolver/detail/help_test.go
@@ -63,7 +63,7 @@ func TestExtractResolverInfo_ParameterResolver(t *testing.T) {
 	assert.Equal(t, "environment", infos[0].Name)
 	assert.Equal(t, "string", infos[0].Type)
 	assert.Equal(t, "Target deployment environment", infos[0].Description)
-	assert.Equal(t, "env", infos[0].ParameterKey)
+	assert.Equal(t, []string{"env"}, infos[0].ParameterKeys)
 	assert.True(t, infos[0].HasDefault)
 }
 
@@ -90,7 +90,7 @@ func TestExtractResolverInfo_ParameterNoDefault(t *testing.T) {
 
 	infos := ExtractResolverInfo(sol)
 	require.Len(t, infos, 1)
-	assert.Equal(t, "token", infos[0].ParameterKey)
+	assert.Equal(t, []string{"token"}, infos[0].ParameterKeys)
 	assert.False(t, infos[0].HasDefault)
 }
 
@@ -118,8 +118,129 @@ func TestExtractResolverInfo_ComputedResolver(t *testing.T) {
 	infos := ExtractResolverInfo(sol)
 	require.Len(t, infos, 1)
 	assert.Equal(t, "greeting", infos[0].Name)
-	assert.Empty(t, infos[0].ParameterKey)
+	assert.Empty(t, infos[0].ParameterKeys)
+	assert.False(t, infos[0].AcceptsAllParameters)
+	assert.False(t, infos[0].AcceptsParameters())
 	assert.False(t, infos[0].HasDefault)
+}
+
+func TestExtractResolverInfo_ParameterAliasKeys(t *testing.T) {
+	t.Parallel()
+
+	sol := buildTestSolution(map[string]*resolver.Resolver{
+		"environment": {
+			Name: "environment",
+			Type: spec.TypeString,
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "parameter",
+						Inputs: map[string]*spec.ValueRef{
+							"keys": {Literal: []any{"environment", "e", "env"}},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	infos := ExtractResolverInfo(sol)
+	require.Len(t, infos, 1)
+	// Alias "keys" resolvers accept CLI parameters (previously mis-classified
+	// as computed because only "key" was inspected).
+	assert.Equal(t, []string{"environment", "e", "env"}, infos[0].ParameterKeys)
+	assert.True(t, infos[0].AcceptsParameters())
+	assert.False(t, infos[0].AcceptsAllParameters)
+}
+
+func TestExtractResolverInfo_ParameterKeysAsMap(t *testing.T) {
+	t.Parallel()
+
+	sol := buildTestSolution(map[string]*resolver.Resolver{
+		"bag": {
+			Name: "bag",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "parameter",
+						Inputs: map[string]*spec.ValueRef{
+							"keys": {Literal: []string{"keyA", "keyB"}},
+							"as":   {Literal: "map"},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	infos := ExtractResolverInfo(sol)
+	require.Len(t, infos, 1)
+	assert.Equal(t, []string{"keyA", "keyB"}, infos[0].ParameterKeys)
+	assert.True(t, infos[0].AcceptsParameters())
+}
+
+func TestExtractResolverInfo_ParameterAll(t *testing.T) {
+	t.Parallel()
+
+	sol := buildTestSolution(map[string]*resolver.Resolver{
+		"everything": {
+			Name: "everything",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "parameter",
+						Inputs: map[string]*spec.ValueRef{
+							"all": {Literal: true},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	infos := ExtractResolverInfo(sol)
+	require.Len(t, infos, 1)
+	assert.Empty(t, infos[0].ParameterKeys)
+	assert.True(t, infos[0].AcceptsAllParameters)
+	assert.True(t, infos[0].AcceptsParameters())
+}
+
+func TestFormatResolverInputHelp_MapModeResolvers(t *testing.T) {
+	t.Parallel()
+
+	sol := buildTestSolution(map[string]*resolver.Resolver{
+		"bag": {
+			Name: "bag",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "parameter",
+						Inputs: map[string]*spec.ValueRef{
+							"keys": {Literal: []any{"keyA", "keyB"}},
+							"as":   {Literal: "map"},
+						},
+					},
+				},
+			},
+		},
+		"everything": {
+			Name: "everything",
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "parameter",
+						Inputs: map[string]*spec.ValueRef{
+							"all": {Literal: true},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	out := FormatResolverInputHelp(sol)
+	assert.Contains(t, out, "keyA,keyB")
+	assert.Contains(t, out, "(all)")
 }
 
 func TestFormatResolverInputHelp_EmptyResolvers(t *testing.T) {

--- a/pkg/resolver/detail/help_test.go
+++ b/pkg/resolver/detail/help_test.go
@@ -5,6 +5,7 @@ package detail
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
@@ -241,6 +242,52 @@ func TestFormatResolverInputHelp_MapModeResolvers(t *testing.T) {
 	out := FormatResolverInputHelp(sol)
 	assert.Contains(t, out, "keyA,keyB")
 	assert.Contains(t, out, "(all)")
+}
+
+// TestFormatResolverInputHelp_MapModeStableOrdering verifies that resolvers
+// which render the same PARAMETER cell (here two "(all)" resolvers) keep a
+// deterministic order via the resolver-name tiebreaker, despite map iteration
+// being randomized.
+func TestFormatResolverInputHelp_MapModeStableOrdering(t *testing.T) {
+	t.Parallel()
+
+	allSource := func(name string) *resolver.Resolver {
+		return &resolver.Resolver{
+			Name: name,
+			Resolve: &resolver.ResolvePhase{
+				With: []resolver.ProviderSource{
+					{
+						Provider: "parameter",
+						Inputs: map[string]*spec.ValueRef{
+							"all": {Literal: true},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	sol := buildTestSolution(map[string]*resolver.Resolver{
+		"zzz_all": allSource("zzz_all"),
+		"aaa_all": allSource("aaa_all"),
+		"mmm_all": allSource("mmm_all"),
+	})
+
+	first := FormatResolverInputHelp(sol)
+	// The three "(all)" resolvers must appear in resolver-name order.
+	aaaIdx := strings.Index(first, "aaa_all")
+	mmmIdx := strings.Index(first, "mmm_all")
+	zzzIdx := strings.Index(first, "zzz_all")
+	require.NotEqual(t, -1, aaaIdx)
+	require.NotEqual(t, -1, mmmIdx)
+	require.NotEqual(t, -1, zzzIdx)
+	assert.Less(t, aaaIdx, mmmIdx, "aaa_all should sort before mmm_all")
+	assert.Less(t, mmmIdx, zzzIdx, "mmm_all should sort before zzz_all")
+
+	// Output must be identical across repeated invocations (map order is random).
+	for range 20 {
+		assert.Equal(t, first, FormatResolverInputHelp(sol))
+	}
 }
 
 func TestFormatResolverInputHelp_EmptyResolvers(t *testing.T) {

--- a/tests/integration/solutions/providers/parameter/solution.yaml
+++ b/tests/integration/solutions/providers/parameter/solution.yaml
@@ -137,6 +137,26 @@ spec:
               type: int
               default: 3
 
+    # Map mode: read a distinct set of parameters into a map (as: map). Absent
+    # keys are omitted (not defaulted), and each value uses auto inference.
+    mapBag:
+      description: A distinct set of parameters read into a map
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              keys: [keyA, keyB, keyC]
+              as: map
+
+    # Map mode: read every supplied CLI parameter into a map.
+    allBag:
+      description: Every supplied CLI parameter read into a map
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              all: true
+
   testing:
     config:
       # resolve-defaults: resolvers use parameter provider requiring external -r flag input
@@ -266,4 +286,35 @@ spec:
         assertions:
           - expression: __exitCode != 0
             message: "type int should fail the run when the value cannot be parsed as an integer"
+
+      map-mode-reads-keys-and-all:
+        description: Verify map mode (keys + as:map, and all:true) returns maps with absent keys omitted
+        extends: [_base]
+        args: ["-o", "json", "-r", "name=x", "-r", "count=1", "-r", "enabled=false", "-r", "config={}", "-r", "tags=a", "-r", "keyA=alpha", "-r", "keyC=gamma"]
+        assertions:
+          # keys + as:map: present keys are returned...
+          - expression: __output.mapBag.keyA == "alpha"
+            message: "map mode should return present requested keys"
+          - expression: __output.mapBag.keyC == "gamma"
+            message: "map mode should return all present requested keys"
+          # ...and absent requested keys are omitted (not defaulted).
+          - expression: has(__output.mapBag.keyB) == false
+            message: "absent requested keys must be omitted so has() stays faithful"
+          # all:true reads every supplied parameter, including keyA/keyC above.
+          - expression: __output.allBag.keyA == "alpha"
+            message: "all mode should include every supplied parameter"
+          - expression: __output.allBag.name == "x"
+            message: "all mode should include unrelated supplied parameters too"
+
+      map-mode-empty-keys-and-all:
+        description: Verify map mode returns empty maps when no requested/any params are supplied
+        extends: [_base]
+        args: ["-o", "json", "-r", "name=x", "-r", "count=1", "-r", "enabled=false", "-r", "config={}", "-r", "tags=a"]
+        assertions:
+          # None of keyA/keyB/keyC supplied -> empty map.
+          - expression: __output.mapBag.size() == 0
+            message: "map mode with no requested keys supplied should be an empty map"
+          # all mode still reflects the supplied params (name, count, ...).
+          - expression: has(__output.allBag.name)
+            message: "all mode should reflect the supplied parameters"
 


### PR DESCRIPTION
Read multiple CLI parameters into a single map from one resolver, mirroring the state-provider map mode (#695). The `parameter` provider gains two map selectors alongside the existing single-`key` read.

## What changed

- **`keys: [a, b, c]` + `as: map`** -- returns a map of only the **present** keys. Absent keys are **omitted** (not defaulted), so `has(_.bag.k)` and `_.bag.?k.orValue(d)` stay faithful. The `as: map` discriminator is required because `parameter`'s `keys` already means first-match **aliases** (unlike `state`, where bare `keys` is map mode). Duplicate names in `keys` are de-duplicated (first-seen order) so the distinct-set semantics hold in both the map and the reported metadata.
- **`all: true`** -- returns every supplied CLI parameter as a map. `all: false` is inert (does not trigger map mode).
- Each value uses **auto** inference; per-key explicit `type` and `default` are **rejected** in map mode. **Mutual exclusion:** `all` is mutually exclusive with `key`, `keys`, and `as`; `as: map` is mutually exclusive with `key`. `key` + `keys` remain valid together in scalar mode (first-match aliases, `key` wins).
- **The bare map is the resolver value** (`Output.Data`); `{mode, keys, missing}` live in `Output.Metadata` only and never reach CEL.

## Consumer fixes

- **Lint** `parameter-missing-default` treats map mode as a guaranteed fallback (map mode always yields a value, so no missing-default warning).
- **MCP** reports map-mode resolvers as object-typed and not-required, and skips them in missing-parameter elicitation (resolver name != param name).
- **Map-mode detection requires `keys` for `as: map`.** Both the Lint and MCP map-mode detectors only treat `as: map` as map mode when the required `keys` input is present, matching the provider (which rejects `as: map` without `keys`). This prevents an invalid bare-`as: map` source from suppressing the missing-default warning or being mis-classified as object-typed/not-required.
- **Resolver help** surfaces multiple parameter keys and `(all)` for all-mode. Help keys are de-duplicated and empty names dropped across all parameter sources, matching the provider's distinct, non-empty key set.
- **`run resolver`/`solution`/`action`** skip unknown `-r` key typo validation **solution-wide** when any resolver reads all params -- any key is then a legitimate input. A non-literal `all` input (set via `rslvr`/`expr`/`tmpl`) is treated conservatively as \"could be true\" and also skips validation, so valid keys are not falsely rejected when map mode activates at runtime; only a literal `false` stays inert. (This is inherent to `all: true`; the dedicated `parameters-all.yaml` example documents it.)

## Artifacts

- Unit tests for `resolveMapMode`/`executeMapGet`/`toStringKeys` (mutual exclusion, validation, auto inference, dry-run, duplicate-key de-duplication), plus consumer tests for lint (including `as: map` without `keys` still warns), MCP (including the as:map-without-keys table case), resolver help (dedupe/empty filtering), CLI key extraction, and non-literal-`all` validation skip. Benchmarks `keys_map` and `all_map`. Provider coverage 94.5% (new funcs 100%/91.9%/100%).
- Provider schema widened (`as`/`all` inputs, `AnyProp` from-capability output) with map-mode examples.
- Docs: provider reference `parameter` section documents the read modes.
- Examples: `parameters.yaml` (keys + as: map) and new `parameters-all.yaml` (all: true).
- Integration: `map-mode-reads-keys-and-all` / `map-mode-empty-keys-and-all` functional cases assert present keys returned and absent keys omitted (`has(__output.mapBag.keyB) == false`).

## Verification

- Affected-package tests pass; full integration suite green; `task lint:changed` -> 0 issues.
- Non-breaking: adds optional inputs; the single-`key` read is untouched.
- Note: pre-existing (unrelated) parallel `-race` failures in `pkg/cmd/scafctl/run` (redaction/progress/color global state) are **not** introduced by this PR -- they reproduce on `main` with this branch's changes stashed.