### PR TITLE
fix(state): guard schema version before strict unmarshal on all load paths

### DIFF
--- a/pkg/errexplain/errexplain.go
+++ b/pkg/errexplain/errexplain.go
@@ -181,6 +181,38 @@ func knownPatterns() []pattern {
 			},
 		},
 		{
+			name:  "state-schema-version-unsupported",
+			regex: regexp.MustCompile(`unsupported state schema version: file version (\d+) is newer than supported version (\d+)`),
+			build: func(m []string, _ string) Explanation {
+				return Explanation{
+					Category:  "state",
+					Summary:   fmt.Sprintf("State file schema version %s is newer than this build supports (%s)", m[1], m[2]),
+					RootCause: fmt.Sprintf("The state file was written by a newer version of scafctl (schema version %s), which this build (max %s) cannot safely read", m[1], m[2]),
+					Suggestions: []string{
+						"Upgrade scafctl to a version that supports this state schema",
+						"Do not hand-edit the schemaVersion field to a lower number -- the file layout may be incompatible",
+						"If you must use this build, recreate the state with it (delete the newer state file first, losing its data)",
+					},
+				}
+			},
+		},
+		{
+			name:  "state-schema-version-incompatible",
+			regex: regexp.MustCompile(`incompatible state schema version: file version (\d+) is older than the minimum supported version (\d+)`),
+			build: func(m []string, _ string) Explanation {
+				return Explanation{
+					Category:  "state",
+					Summary:   fmt.Sprintf("State file schema version %s is older than the minimum supported version (%s)", m[1], m[2]),
+					RootCause: fmt.Sprintf("The state file uses an old schema (version %s) whose layout was dropped by a breaking change; the minimum this build can read is version %s", m[1], m[2]),
+					Suggestions: []string{
+						"Delete the state file and recreate it -- the old layout cannot be safely migrated in place",
+						"If the state is backed by a remote store, remove the stale object before the next run",
+						"Back up any values you need from the old file before deleting it, since they will be regenerated",
+					},
+				}
+			},
+		},
+		{
 			name:  "cel-undeclared-ref",
 			regex: regexp.MustCompile(`undeclared reference to '([^']+)'`),
 			build: func(m []string, _ string) Explanation {

--- a/pkg/errexplain/errexplain_test.go
+++ b/pkg/errexplain/errexplain_test.go
@@ -60,6 +60,26 @@ func TestExplain_StateRefUnknown(t *testing.T) {
 	assert.NotEmpty(t, exp.Suggestions)
 }
 
+func TestExplain_StateSchemaVersionUnsupported(t *testing.T) {
+	exp := Explain(`state load: unsupported state schema version: file version 4 is newer than supported version 3; upgrade scafctl`)
+	assert.Equal(t, "state", exp.Category)
+	assert.Contains(t, exp.Summary, "4")
+	assert.Contains(t, exp.Summary, "3")
+	assert.Contains(t, exp.RootCause, "newer version of scafctl")
+	assert.NotEmpty(t, exp.Suggestions)
+	assert.Contains(t, exp.Suggestions[0], "Upgrade scafctl")
+}
+
+func TestExplain_StateSchemaVersionIncompatible(t *testing.T) {
+	exp := Explain(`state load: incompatible state schema version: file version 1 is older than the minimum supported version 2; delete the state file and recreate it`)
+	assert.Equal(t, "state", exp.Category)
+	assert.Contains(t, exp.Summary, "1")
+	assert.Contains(t, exp.Summary, "2")
+	assert.Contains(t, exp.RootCause, "breaking change")
+	assert.NotEmpty(t, exp.Suggestions)
+	assert.Contains(t, exp.Suggestions[0], "Delete the state file")
+}
+
 func TestExplain_CELNoOverload(t *testing.T) {
 	exp := Explain(`found no matching overload for 'size'`)
 	assert.Equal(t, "cel_expression", exp.Category)

--- a/pkg/provider/builtin/fileprovider/file_state.go
+++ b/pkg/provider/builtin/fileprovider/file_state.go
@@ -31,28 +31,15 @@ func (p *FileProvider) executeStateLoad(absPath string) (*provider.Output, error
 		return nil, fmt.Errorf("state load: %w", err)
 	}
 
-	var stateData state.Data
-	if err := json.Unmarshal(data, &stateData); err != nil {
-		return nil, fmt.Errorf("state load: unmarshal: %w", err)
-	}
-
-	if stateData.Parameters == nil {
-		stateData.Parameters = make(map[string]any)
-	}
-	if stateData.Resolvers == nil {
-		stateData.Resolvers = make(map[string]*state.PersistedEntry)
-	}
-	if stateData.Fingerprints == nil {
-		stateData.Fingerprints = make(map[string]*state.FingerprintEntry)
-	}
-	if stateData.Command.Parameters == nil {
-		stateData.Command.Parameters = make(map[string]string)
+	stateData, err := state.DecodeData(data)
+	if err != nil {
+		return nil, fmt.Errorf("state load: %w", err)
 	}
 
 	return &provider.Output{
 		Data: map[string]any{
 			"success": true,
-			"data":    &stateData,
+			"data":    stateData,
 		},
 	}, nil
 }

--- a/pkg/provider/builtin/fileprovider/file_state_test.go
+++ b/pkg/provider/builtin/fileprovider/file_state_test.go
@@ -34,6 +34,19 @@ func TestFileProvider_StateLoad_NotFound(t *testing.T) {
 	assert.NotNil(t, data["data"])
 }
 
+func TestFileProvider_StateLoad_IncompatibleSchemaVersion(t *testing.T) {
+	p := NewFileProvider()
+	absPath := filepath.Join(t.TempDir(), "legacy.json")
+	// Below the minimum floor AND a field whose type no longer matches the
+	// current struct -- the version guard must win over the raw decode error.
+	err := os.WriteFile(absPath, []byte(`{"schemaVersion":1,"metadata":{"solution":{"nested":"object"}}}`), 0o600)
+	require.NoError(t, err)
+
+	_, err = p.executeStateLoad(absPath)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, state.ErrIncompatibleSchemaVersion)
+}
+
 func TestFileProvider_StateRoundTrip(t *testing.T) {
 	p := NewFileProvider()
 	tmpDir := t.TempDir()
@@ -190,7 +203,7 @@ func TestFileProvider_StateLoadInvalidJSON(t *testing.T) {
 
 	_, err := p.executeStateLoad(statePath)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "unmarshal")
+	assert.Contains(t, err.Error(), "read state schema version")
 }
 
 func TestFileProvider_StateSaveMarshal(t *testing.T) {

--- a/pkg/provider/builtin/httpprovider/http_state.go
+++ b/pkg/provider/builtin/httpprovider/http_state.go
@@ -57,15 +57,15 @@ func (p *HTTPProvider) executeStateLoad(ctx context.Context, client *httpc.Clien
 		return nil, fmt.Errorf("state load: unexpected status %d: %s", resp.StatusCode, string(body))
 	}
 
-	var stateData state.Data
-	if err := json.Unmarshal(body, &stateData); err != nil {
-		return nil, fmt.Errorf("state load: unmarshal: %w", err)
+	stateData, err := state.DecodeData(body)
+	if err != nil {
+		return nil, fmt.Errorf("state load: %w", err)
 	}
 
 	return &provider.Output{
 		Data: map[string]any{
 			"success": true,
-			"data":    &stateData,
+			"data":    stateData,
 		},
 	}, nil
 }

--- a/pkg/provider/builtin/httpprovider/http_state_test.go
+++ b/pkg/provider/builtin/httpprovider/http_state_test.go
@@ -109,7 +109,28 @@ func TestHTTPProvider_StateLoad_InvalidJSON(t *testing.T) {
 		"url":       server.URL,
 	})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "unmarshal")
+	assert.Contains(t, err.Error(), "read state schema version")
+}
+
+func TestHTTPProvider_StateLoad_IncompatibleSchemaVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Below the minimum floor AND a field whose type no longer matches the
+		// current struct -- the version guard must win over the type error.
+		_, _ = w.Write([]byte(`{"schemaVersion":1,"metadata":{"solution":{"nested":"object"}}}`))
+	}))
+	defer server.Close()
+
+	p := NewHTTPProvider()
+	ctx := testContext(t)
+
+	_, err := p.Execute(ctx, map[string]any{
+		"operation": "state_load",
+		"url":       server.URL,
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, state.ErrIncompatibleSchemaVersion)
 }
 
 func TestHTTPProvider_StateSave_Success(t *testing.T) {

--- a/pkg/state/decode.go
+++ b/pkg/state/decode.go
@@ -1,0 +1,74 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DecodeData validates the schema version of raw state JSON before unmarshalling
+// it into a *Data. The schema version is peeked from the raw bytes and bounds-
+// checked first, so a state file whose schemaVersion is outside the supported
+// range produces the actionable ErrUnsupportedSchemaVersion /
+// ErrIncompatibleSchemaVersion error rather than a cryptic Go reflection error
+// from a type-incompatible field aborting the strict full-struct decode.
+//
+// All state load paths (file store, backend providers, and provider result
+// extraction) route through this helper so the version guard is enforced
+// consistently across every backend.
+func DecodeData(raw []byte) (*Data, error) {
+	var probe struct {
+		SchemaVersion int `json:"schemaVersion"`
+	}
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		return nil, fmt.Errorf("read state schema version: %w", err)
+	}
+
+	if err := validateSchemaVersion(probe.SchemaVersion); err != nil {
+		return nil, err
+	}
+
+	var sd Data
+	if err := json.Unmarshal(raw, &sd); err != nil {
+		return nil, fmt.Errorf("unmarshal state data: %w", err)
+	}
+
+	normalizeData(&sd)
+	return &sd, nil
+}
+
+// validateSchemaVersion enforces the supported schema-version bounds, returning
+// an actionable error for out-of-range versions. It is applied both when
+// decoding raw JSON (DecodeData) and when a backend provider returns an
+// already-decoded *Data, so the version floor is enforced at every trust
+// boundary.
+func validateSchemaVersion(version int) error {
+	if version > SchemaVersionCurrent {
+		return fmt.Errorf("%w: file version %d is newer than supported version %d; upgrade scafctl",
+			ErrUnsupportedSchemaVersion, version, SchemaVersionCurrent)
+	}
+	if version < SchemaVersionMinimum {
+		return fmt.Errorf("%w: file version %d is older than the minimum supported version %d; delete the state file and recreate it",
+			ErrIncompatibleSchemaVersion, version, SchemaVersionMinimum)
+	}
+	return nil
+}
+
+// normalizeData initializes the nil maps on a decoded *Data so callers can read
+// and write entries without nil-map panics.
+func normalizeData(sd *Data) {
+	if sd.Parameters == nil {
+		sd.Parameters = make(map[string]any)
+	}
+	if sd.Resolvers == nil {
+		sd.Resolvers = make(map[string]*PersistedEntry)
+	}
+	if sd.Fingerprints == nil {
+		sd.Fingerprints = make(map[string]*FingerprintEntry)
+	}
+	if sd.Command.Parameters == nil {
+		sd.Command.Parameters = make(map[string]string)
+	}
+}

--- a/pkg/state/decode_test.go
+++ b/pkg/state/decode_test.go
@@ -1,0 +1,120 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package state
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeData_ValidRoundTrip(t *testing.T) {
+	t.Parallel()
+	raw := fmt.Appendf(nil, `{"schemaVersion":%d,"parameters":{"env":"prod"}}`, SchemaVersionCurrent)
+
+	sd, err := DecodeData(raw)
+	require.NoError(t, err)
+	assert.Equal(t, SchemaVersionCurrent, sd.SchemaVersion)
+	assert.Equal(t, "prod", sd.Parameters["env"])
+	// Nil maps are normalized so callers can write without panicking.
+	assert.NotNil(t, sd.Resolvers)
+	assert.NotNil(t, sd.Fingerprints)
+	assert.NotNil(t, sd.Command.Parameters)
+}
+
+func TestDecodeData_NewerVersionUnsupported(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{"schemaVersion":999,"parameters":{}}`)
+
+	_, err := DecodeData(raw)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedSchemaVersion)
+	assert.Contains(t, err.Error(), "999")
+	assert.Contains(t, err.Error(), "upgrade scafctl")
+}
+
+func TestDecodeData_OlderVersionIncompatible(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{"schemaVersion":1,"parameters":{}}`)
+
+	_, err := DecodeData(raw)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIncompatibleSchemaVersion)
+	assert.Contains(t, err.Error(), "delete the state file")
+}
+
+func TestDecodeData_MissingVersionIncompatible(t *testing.T) {
+	t.Parallel()
+	// A file predating the schemaVersion field decodes to 0, below the minimum.
+	raw := []byte(`{"parameters":{}}`)
+
+	_, err := DecodeData(raw)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIncompatibleSchemaVersion)
+}
+
+// TestDecodeData_OutOfRangeWinsOverTypeMismatch is the crux of the fix: an
+// out-of-range file whose layout is also structurally incompatible with the
+// current struct must surface the actionable version error, NOT a raw Go
+// reflection error from the strict full-struct decode.
+func TestDecodeData_OutOfRangeWinsOverTypeMismatch(t *testing.T) {
+	t.Parallel()
+	// schemaVersion below the floor AND metadata.solution is an object where the
+	// current struct expects a string.
+	raw := []byte(`{"schemaVersion":1,"metadata":{"solution":{"nested":"object"}}}`)
+
+	_, err := DecodeData(raw)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIncompatibleSchemaVersion)
+	assert.NotContains(t, err.Error(), "cannot unmarshal")
+}
+
+func TestDecodeData_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	_, err := DecodeData([]byte(`{not valid json`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "read state schema version")
+}
+
+func TestDecodeData_InRangeTypeMismatchStillRawError(t *testing.T) {
+	t.Parallel()
+	// A file claiming a supported version but malformed still fails at the
+	// strict decode -- the version guard only rescues out-of-range files.
+	raw := fmt.Appendf(nil, `{"schemaVersion":%d,"metadata":{"solution":{"nested":"object"}}}`, SchemaVersionCurrent)
+
+	_, err := DecodeData(raw)
+	require.Error(t, err)
+	assert.NotErrorIs(t, err, ErrIncompatibleSchemaVersion)
+	assert.NotErrorIs(t, err, ErrUnsupportedSchemaVersion)
+	assert.Contains(t, err.Error(), "unmarshal state data")
+}
+
+func TestValidateSchemaVersion(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		version int
+		wantErr error
+	}{
+		{name: "current", version: SchemaVersionCurrent, wantErr: nil},
+		{name: "minimum", version: SchemaVersionMinimum, wantErr: nil},
+		{name: "too new", version: SchemaVersionCurrent + 1, wantErr: ErrUnsupportedSchemaVersion},
+		{name: "too old", version: SchemaVersionMinimum - 1, wantErr: ErrIncompatibleSchemaVersion},
+		{name: "zero", version: 0, wantErr: ErrIncompatibleSchemaVersion},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateSchemaVersion(tt.version)
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -443,6 +443,9 @@ func extractStateData(result *provider.ExecutionResult) (*Data, error) {
 
 	// Direct pointer — returned by in-process providers.
 	if stateData, ok := sd.(*Data); ok {
+		if err := validateSchemaVersion(stateData.SchemaVersion); err != nil {
+			return nil, err
+		}
 		return stateData, nil
 	}
 
@@ -453,11 +456,11 @@ func extractStateData(result *provider.ExecutionResult) (*Data, error) {
 		if err != nil {
 			return nil, fmt.Errorf("marshal state map: %w", err)
 		}
-		var stateData Data
-		if err := json.Unmarshal(b, &stateData); err != nil {
-			return nil, fmt.Errorf("unmarshal state map: %w", err)
+		stateData, err := DecodeData(b)
+		if err != nil {
+			return nil, err
 		}
-		return &stateData, nil
+		return stateData, nil
 	}
 
 	return nil, fmt.Errorf("expected *Data or map[string]any, got %T", sd)

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -446,6 +446,7 @@ func extractStateData(result *provider.ExecutionResult) (*Data, error) {
 		if err := validateSchemaVersion(stateData.SchemaVersion); err != nil {
 			return nil, err
 		}
+		normalizeData(stateData)
 		return stateData, nil
 	}
 

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -714,7 +714,7 @@ func TestExtractStateData(t *testing.T) {
 		// Simulate what happens when a provider returns data as map[string]any
 		// (e.g., after JSON round-trip through a plugin boundary).
 		dataMap := map[string]any{
-			"schemaVersion": float64(1),
+			"schemaVersion": float64(SchemaVersionCurrent),
 			"metadata": map[string]any{
 				"solution": "test-app",
 				"version":  "1.0.0",
@@ -742,10 +742,45 @@ func TestExtractStateData(t *testing.T) {
 			}},
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, 1, result.SchemaVersion)
+		assert.Equal(t, SchemaVersionCurrent, result.SchemaVersion)
 		assert.Equal(t, "test-app", result.Metadata.Solution)
 		assert.Contains(t, result.Parameters, "region")
 		assert.Equal(t, "us-east-1", result.Parameters["region"])
+	})
+
+	t.Run("map fallback out-of-range version", func(t *testing.T) {
+		t.Parallel()
+		// A map-form state whose schemaVersion is below the floor must surface
+		// the actionable version error, not a raw decode error -- even when a
+		// field type no longer matches the current struct.
+		dataMap := map[string]any{
+			"schemaVersion": float64(1),
+			"metadata":      map[string]any{"solution": map[string]any{"nested": "object"}},
+		}
+		_, err := extractStateData(&provider.ExecutionResult{
+			Output: provider.Output{Data: map[string]any{
+				"success": true,
+				"data":    dataMap,
+			}},
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrIncompatibleSchemaVersion)
+	})
+
+	t.Run("direct pointer out-of-range version", func(t *testing.T) {
+		t.Parallel()
+		// An in-process provider (e.g. an embedder's custom backend) returning a
+		// *Data with an out-of-range schema version must also be rejected.
+		bad := NewData()
+		bad.SchemaVersion = SchemaVersionCurrent + 1
+		_, err := extractStateData(&provider.ExecutionResult{
+			Output: provider.Output{Data: map[string]any{
+				"success": true,
+				"data":    bad,
+			}},
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrUnsupportedSchemaVersion)
 	})
 
 	t.Run("unsupported type", func(t *testing.T) {

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -783,6 +783,31 @@ func TestExtractStateData(t *testing.T) {
 		assert.ErrorIs(t, err, ErrUnsupportedSchemaVersion)
 	})
 
+	t.Run("direct pointer normalizes nil maps", func(t *testing.T) {
+		t.Parallel()
+		// An in-process provider that constructs a *Data directly may leave the
+		// maps nil. extractStateData must normalize the direct-pointer path so it
+		// has the same postconditions as the map fallback (which normalizes via
+		// DecodeData); otherwise downstream reads/writes could nil-map panic.
+		bare := &Data{SchemaVersion: SchemaVersionCurrent}
+		require.Nil(t, bare.Resolvers)
+		require.Nil(t, bare.Parameters)
+		require.Nil(t, bare.Fingerprints)
+		require.Nil(t, bare.Command.Parameters)
+
+		result, err := extractStateData(&provider.ExecutionResult{
+			Output: provider.Output{Data: map[string]any{
+				"success": true,
+				"data":    bare,
+			}},
+		})
+		require.NoError(t, err)
+		assert.NotNil(t, result.Resolvers)
+		assert.NotNil(t, result.Parameters)
+		assert.NotNil(t, result.Fingerprints)
+		assert.NotNil(t, result.Command.Parameters)
+	})
+
 	t.Run("unsupported type", func(t *testing.T) {
 		t.Parallel()
 		_, err := extractStateData(&provider.ExecutionResult{

--- a/pkg/state/store.go
+++ b/pkg/state/store.go
@@ -29,35 +29,12 @@ func LoadFromFile(path, baseDir string) (*Data, error) {
 		return nil, fmt.Errorf("read state file: %w", err)
 	}
 
-	var sd Data
-	if err := json.Unmarshal(data, &sd); err != nil {
-		return nil, fmt.Errorf("unmarshal state file: %w", err)
+	sd, err := DecodeData(data)
+	if err != nil {
+		return nil, err
 	}
 
-	if sd.SchemaVersion > SchemaVersionCurrent {
-		return nil, fmt.Errorf("%w: file version %d is newer than supported version %d; upgrade scafctl",
-			ErrUnsupportedSchemaVersion, sd.SchemaVersion, SchemaVersionCurrent)
-	}
-
-	if sd.SchemaVersion < SchemaVersionMinimum {
-		return nil, fmt.Errorf("%w: file version %d is older than the minimum supported version %d; delete the state file and recreate it",
-			ErrIncompatibleSchemaVersion, sd.SchemaVersion, SchemaVersionMinimum)
-	}
-
-	if sd.Parameters == nil {
-		sd.Parameters = make(map[string]any)
-	}
-	if sd.Resolvers == nil {
-		sd.Resolvers = make(map[string]*PersistedEntry)
-	}
-	if sd.Fingerprints == nil {
-		sd.Fingerprints = make(map[string]*FingerprintEntry)
-	}
-	if sd.Command.Parameters == nil {
-		sd.Command.Parameters = make(map[string]string)
-	}
-
-	return &sd, nil
+	return sd, nil
 }
 
 // SaveToFile marshals and writes StateData to a JSON file using atomic write.

--- a/pkg/state/store_test.go
+++ b/pkg/state/store_test.go
@@ -47,7 +47,7 @@ func TestLoadFromFile_InvalidJSON(t *testing.T) {
 
 	_, err := LoadFromFile(path, "")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unmarshal")
+	assert.Contains(t, err.Error(), "read state schema version")
 }
 
 func TestLoadFromFile_NilMapsNormalized(t *testing.T) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1304,6 +1304,92 @@ spec:
 	assert.Contains(t, stateDoc.Resolvers, "region", "immutable region should be locked after a passing run")
 }
 
+// TestIntegration_RunSolution_StateSchemaVersionOutOfRange verifies that when a
+// state file's schemaVersion is outside the supported range, the run fails with
+// the actionable schema-version error rather than a cryptic Go reflection error
+// from the strict full-struct decode. The pre-written state file also carries a
+// type-incompatible field ("resolvers" as a string) so that, without the
+// peek-before-decode guard, the strict unmarshal would surface a
+// "cannot unmarshal" error -- the assertions confirm it does not.
+func TestIntegration_RunSolution_StateSchemaVersionOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: state-schema-version
+  version: 1.0.0
+state:
+  enabled: true
+  backend:
+    provider: file
+    inputs:
+      path: state.json
+spec:
+  resolvers:
+    region:
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+              default: us-east1
+  workflow:
+    actions:
+      notify:
+        provider: message
+        inputs:
+          message: "ACTION_RAN"
+          type: info
+`
+
+	testCases := []struct {
+		name        string
+		schemaVer   int
+		wantMessage string
+		wantHint    string
+	}{
+		{
+			name:        "older than minimum is incompatible",
+			schemaVer:   1,
+			wantMessage: "incompatible state schema version",
+			wantHint:    "delete the state file and recreate it",
+		},
+		{
+			name:        "newer than current is unsupported",
+			schemaVer:   999,
+			wantMessage: "unsupported state schema version",
+			wantHint:    "upgrade scafctl",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			solutionPath := filepath.Join(tmpDir, "solution.yaml")
+			require.NoError(t, os.WriteFile(solutionPath, []byte(solutionContent), 0o600))
+
+			// Pre-write a state file whose schemaVersion is out of range AND whose
+			// "resolvers" field has an incompatible type (string, not an object).
+			// Without the version guard running first, the strict decode would fail
+			// with a "cannot unmarshal" reflection error.
+			statePath := filepath.Join(tmpDir, "state.json")
+			stateJSON := fmt.Sprintf(`{"schemaVersion": %d, "resolvers": "not-a-map"}`, tc.schemaVer)
+			require.NoError(t, os.WriteFile(statePath, []byte(stateJSON), 0o600))
+
+			_, stderr, exitCode := runScafctlInDir(t, tmpDir, "run", "solution", "-f", solutionPath)
+			assert.NotEqual(t, 0, exitCode, "an out-of-range state schema version should fail the run")
+			assert.Contains(t, stderr, tc.wantMessage, "the actionable schema-version error should be surfaced")
+			assert.Contains(t, stderr, tc.wantHint, "the error should include the actionable remediation hint")
+			assert.NotContains(t, stderr, "cannot unmarshal",
+				"the version guard must fire before the strict decode, so no reflection error should leak")
+		})
+	}
+}
+
 // TestIntegration_RunSolution_NoStateFlag verifies that --no-state skips the
 // entire state lifecycle: no state file is written, immutable values are not
 // locked or verified, the action still runs, and a one-line stderr notice is


### PR DESCRIPTION
A state file whose `schemaVersion` is outside the supported range produced a cryptic Go reflection error (`cannot unmarshal ... into Go struct field`) instead of the actionable version error, because the strict full-struct `json.Unmarshal` ran **before** the version guard. The reported bug was also **broader than filed**: the version guard was missing entirely from the runtime file/http backends and from the direct-pointer branch of `extractStateData`, so fixing only the two reported sites would have left the primary reproduction broken.

## What changed

Introduce a single version-guarded decode seam, `state.DecodeData`, that peeks the `schemaVersion`, bounds-checks it, and only then runs the strict decode (industry standard: Terraform state version, k8s apiVersion/kind, Docker schemaVersion, DB migration tools). All **four** state-load boundaries now route through it:

- `pkg/state/store.go` -- `LoadFromFile`
- `pkg/state/manager.go` -- `extractStateData` (map branch via `DecodeData`; direct-pointer branch via `validateSchemaVersion` + `normalizeData`, so both branches share identical postconditions and no nil maps escape either path)
- `pkg/provider/builtin/fileprovider/file_state.go` -- `executeStateLoad`
- `pkg/provider/builtin/httpprovider/http_state.go` -- `executeStateLoad` (also gains nil-map normalization)

The MCP state tools inherit the guard for free (they load via `LoadFromFile`), per the thin-wrapper convention -- no handler change.

## Diagnostics

Add `errexplain` matchers for the two schema-version errors, grouped with the existing state matchers:

- `state-schema-version-unsupported` -> file newer than this build; upgrade scafctl.
- `state-schema-version-incompatible` -> file older than the minimum; delete/recreate the state file.

## Tests / artifacts

- New `pkg/state/decode_test.go`: valid round-trip, **out-of-range wins over type mismatch** (asserts no `cannot unmarshal`), invalid JSON, in-range type mismatch still returns the raw error, and table-driven `validateSchemaVersion`.
- Updated `manager` / `store` / `file` / `http` state tests for the new peek error message and out-of-range cases; added a `manager` subtest asserting the direct-pointer path normalizes nil maps.
- `errexplain` tests for both new matchers.
- End-to-end integration test `TestIntegration_RunSolution_StateSchemaVersionOutOfRange`: points a **real file backend** at an out-of-range state file carrying a type-incompatible field and asserts the actionable error surfaces (both the older-than-minimum and newer-than-current branches) with no `cannot unmarshal` leak.

## Verification

- `go build ./...` clean; affected-package tests pass; `task test:e2e` green.
- `task lint:changed` -> 0 issues.
- Non-breaking: valid in-range state files (including old-but-compatible ones) load unchanged; only out-of-range files now fail with the actionable error instead of a reflection error.

## Follow-up

Per-version migration framework and envelope decode for schema evolution tracked in #704.