### PR TITLE
fix(plugin): deliver host-static metadata to pooled plugins in MCP/API servers

### DIFF
--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -1993,7 +1993,7 @@ None. The metadata provider accepts no inputs.
 | `version.buildTime` | string | Timestamp of the build |
 | `args` | string[] | Command-line arguments passed to scafctl |
 | `cwd` | string | Current working directory |
-| `entrypoint` | string | How scafctl was invoked: `"cli"`, `"api"`, or `"unknown"` |
+| `entrypoint` | string | How scafctl was invoked: `"cli"`, `"api"`, `"mcp"`, or `"unknown"` |
 | `command` | string | The command path (e.g. `scafctl/run/solution`) |
 | `solution` | object | Metadata about the currently-running solution |
 | `solution.name` | string | Solution name |

--- a/examples/providers/metadata-single-field.yaml
+++ b/examples/providers/metadata-single-field.yaml
@@ -45,7 +45,7 @@ spec:
               expression: "_.runtime_meta.version.buildVersion"
 
     entrypoint:
-      description: Whether running as CLI or API
+      description: How scafctl was invoked (cli, api, mcp, or unknown)
       type: string
       dependsOn:
         - runtime_meta

--- a/pkg/cmd/scafctl/mcp/serve.go
+++ b/pkg/cmd/scafctl/mcp/serve.go
@@ -228,6 +228,13 @@ func buildMCPPluginPool(ctx context.Context, cfg *config.Config, reg *provider.R
 	// (SSH_AUTH_SOCK, GITHUB_TOKEN, etc.) during interactive sessions.
 	var poolOpts []plugin.PoolOption
 	poolOpts = append(poolOpts, plugin.WithSanitizeEnv(false))
+	// Deliver host-static runtime metadata (build info, entrypoint, command,
+	// args) to pooled plugins so the metadata provider and any other
+	// Settings-driven plugin behave the same under this long-lived host as
+	// under one-shot per-call hosts.
+	poolOpts = append(poolOpts, plugin.WithBaseProviderConfig(
+		prepare.HostStaticProviderConfig(settings.BinaryNameFromContext(ctx), prepare.EntrypointMCP),
+	))
 	// Wire auth host dependencies so plugins can use host auth
 	if authOpts := plugin.AuthClientOptsFromContext(ctx); len(authOpts) > 0 {
 		poolOpts = append(poolOpts, plugin.WithClientOptions(authOpts...))

--- a/pkg/cmd/scafctl/mcp/serve_test.go
+++ b/pkg/cmd/scafctl/mcp/serve_test.go
@@ -5,6 +5,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -14,6 +15,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -139,6 +141,22 @@ func TestBuildMCPPluginPool(t *testing.T) {
 
 		// MCP pools should not sanitize env so host credentials are available
 		assert.False(t, pool.SanitizeEnv(), "MCP pool should not sanitize env")
+	})
+
+	t.Run("wires host-static metadata base config with mcp entrypoint", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		lgr := logr.Discard()
+		pool, _ := buildMCPPluginPool(context.Background(), nil, reg, &lgr)
+		defer pool.Shutdown()
+
+		base := pool.BaseProviderConfig()
+		raw, ok := base.Settings["metadata"]
+		require.True(t, ok, "base config should carry host metadata settings")
+
+		var meta map[string]any
+		require.NoError(t, json.Unmarshal(raw, &meta))
+		assert.Equal(t, prepare.EntrypointMCP, meta["entrypoint"])
+		assert.Contains(t, meta, "buildVersion")
 	})
 
 	t.Run("wires auth client opts when auth registry in context", func(t *testing.T) {

--- a/pkg/cmd/scafctl/serve/serve.go
+++ b/pkg/cmd/scafctl/serve/serve.go
@@ -437,6 +437,13 @@ func buildPluginPool(ctx context.Context, cfg *config.Config, fetcher *plugin.Fe
 		plugin.WithIdleTimeout(5 * time.Minute),
 		plugin.WithMaxPlugins(50),
 		plugin.WithDisableExternal(!cfg.APIServer.Plugins.AllowExternal),
+		// Deliver host-static runtime metadata (build info, entrypoint,
+		// command, args) to pooled plugins so the metadata provider and any
+		// other Settings-driven plugin behave the same under this long-lived
+		// API host as under one-shot per-call hosts.
+		plugin.WithBaseProviderConfig(
+			prepare.HostStaticProviderConfig(settings.BinaryNameFromContext(ctx), prepare.EntrypointAPI),
+		),
 	}
 	if len(allowedPluginNames) > 0 {
 		poolOpts = append(poolOpts, plugin.WithAllowedPlugins(allowedPluginNames))

--- a/pkg/cmd/scafctl/serve/serve_test.go
+++ b/pkg/cmd/scafctl/serve/serve_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -164,6 +165,33 @@ func TestBuildPluginPool_SanitizesEnv(t *testing.T) {
 
 	// API server pools sanitize env by default
 	assert.True(t, pool.SanitizeEnv())
+}
+
+func TestBuildPluginPool_HostStaticMetadata(t *testing.T) {
+	// The API server pool should carry a host-static base config reporting the
+	// "api" entrypoint so pooled plugins receive host runtime metadata.
+	ctx := context.Background()
+	reg := provider.NewRegistry()
+	lgr := logr.Discard()
+	cfg := &config.Config{
+		APIServer: config.APIServerConfig{
+			Plugins: config.APIPluginConfig{
+				AllowExternal: false,
+			},
+		},
+	}
+
+	pool := buildPluginPool(ctx, cfg, nil, reg, &lgr, nil, nil)
+	defer pool.Shutdown()
+
+	base := pool.BaseProviderConfig()
+	raw, ok := base.Settings["metadata"]
+	require.True(t, ok, "base config should carry host metadata settings")
+
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal(raw, &meta))
+	assert.Equal(t, prepare.EntrypointAPI, meta["entrypoint"])
+	assert.Contains(t, meta, "buildVersion")
 }
 
 func TestBuildPluginPool_AllowedPlugins(t *testing.T) {

--- a/pkg/plugin/pool.go
+++ b/pkg/plugin/pool.go
@@ -5,6 +5,7 @@ package plugin
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -191,8 +192,27 @@ func WithSanitizeEnv(sanitize bool) PoolOption {
 // The config must contain only host-static data (constant for the pool's
 // lifetime). Per-solution values vary per request and are delivered on the
 // per-execution path instead, never re-configured on the shared wrapper.
+//
+// The cfg.Settings map is cloned so the long-lived pool never shares the
+// caller's map reference; a caller mutating its map afterward cannot race with
+// or alter what pooled providers observe.
 func WithBaseProviderConfig(cfg ProviderConfig) PoolOption {
-	return func(o *poolOptions) { o.baseConfig = cfg }
+	return func(o *poolOptions) { o.baseConfig = cloneProviderConfig(cfg) }
+}
+
+// cloneProviderConfig returns a copy of cfg with its Settings map cloned so the
+// pool never shares the caller's map reference. The values (json.RawMessage)
+// are treated as immutable and are not deep-copied.
+func cloneProviderConfig(cfg ProviderConfig) ProviderConfig {
+	if cfg.Settings == nil {
+		return cfg
+	}
+	settings := make(map[string]json.RawMessage, len(cfg.Settings))
+	for k, v := range cfg.Settings {
+		settings[k] = v
+	}
+	cfg.Settings = settings
+	return cfg
 }
 
 // PoolStats holds pool metrics.
@@ -798,9 +818,10 @@ func (p *Pool) ClientOptsLen() int {
 
 // BaseProviderConfig returns the host-static ProviderConfig delivered to each
 // pooled provider at load time. See [WithBaseProviderConfig]. This is primarily
-// useful for testing that the base config was wired correctly.
+// useful for testing that the base config was wired correctly. The returned
+// Settings map is a clone so callers cannot mutate the pool's stored config.
 func (p *Pool) BaseProviderConfig() ProviderConfig {
-	return p.opts.baseConfig
+	return cloneProviderConfig(p.opts.baseConfig)
 }
 
 // Shutdown kills all managed plugin processes. Called once on server stop.

--- a/pkg/plugin/pool.go
+++ b/pkg/plugin/pool.go
@@ -200,16 +200,18 @@ func WithBaseProviderConfig(cfg ProviderConfig) PoolOption {
 	return func(o *poolOptions) { o.baseConfig = cloneProviderConfig(cfg) }
 }
 
-// cloneProviderConfig returns a copy of cfg with its Settings map cloned so the
-// pool never shares the caller's map reference. The values (json.RawMessage)
-// are treated as immutable and are not deep-copied.
+// cloneProviderConfig returns a copy of cfg with its Settings map deep-cloned so
+// the pool never shares mutable references with the caller in either direction.
+// Both the map and each json.RawMessage ([]byte) value are copied, so a caller
+// mutating its map entries -- or the bytes of a value returned by
+// BaseProviderConfig -- cannot race with or alter what pooled providers observe.
 func cloneProviderConfig(cfg ProviderConfig) ProviderConfig {
 	if cfg.Settings == nil {
 		return cfg
 	}
 	settings := make(map[string]json.RawMessage, len(cfg.Settings))
 	for k, v := range cfg.Settings {
-		settings[k] = v
+		settings[k] = append(json.RawMessage(nil), v...)
 	}
 	cfg.Settings = settings
 	return cfg
@@ -819,7 +821,8 @@ func (p *Pool) ClientOptsLen() int {
 // BaseProviderConfig returns the host-static ProviderConfig delivered to each
 // pooled provider at load time. See [WithBaseProviderConfig]. This is primarily
 // useful for testing that the base config was wired correctly. The returned
-// Settings map is a clone so callers cannot mutate the pool's stored config.
+// Settings map is a deep clone (map and value bytes), so callers cannot mutate
+// the pool's stored config.
 func (p *Pool) BaseProviderConfig() ProviderConfig {
 	return cloneProviderConfig(p.opts.baseConfig)
 }

--- a/pkg/plugin/pool.go
+++ b/pkg/plugin/pool.go
@@ -89,6 +89,7 @@ type poolOptions struct {
 	disableExternal bool             // reject all non-adopted plugins
 	clientOpts      []ClientOption   // extra options for spawned plugin clients
 	sanitizeEnv     bool             // prepend WithSanitizedEnv() on spawn
+	baseConfig      ProviderConfig   // host-static config delivered to each pooled provider at load
 }
 
 // defaultPoolOptions returns sensible defaults.
@@ -179,6 +180,19 @@ func WithClientOptions(opts ...ClientOption) PoolOption {
 // false so plugins can access host credentials (SSH_AUTH_SOCK, tokens, etc.).
 func WithSanitizeEnv(sanitize bool) PoolOption {
 	return func(o *poolOptions) { o.sanitizeEnv = sanitize }
+}
+
+// WithBaseProviderConfig sets the host-static ProviderConfig delivered to every
+// pooled provider via the one-time ConfigureProvider call at load. Use it to
+// carry host runtime metadata (build info, entrypoint, command, args) and the
+// binary name into long-lived pool-mode hosts so plugins that read
+// ProviderConfig.Settings behave the same as under one-shot per-call hosts.
+//
+// The config must contain only host-static data (constant for the pool's
+// lifetime). Per-solution values vary per request and are delivered on the
+// per-execution path instead, never re-configured on the shared wrapper.
+func WithBaseProviderConfig(cfg ProviderConfig) PoolOption {
+	return func(o *poolOptions) { o.baseConfig = cfg }
 }
 
 // PoolStats holds pool metrics.
@@ -536,8 +550,11 @@ func (p *Pool) spawn(ctx context.Context, entry *poolEntry, cancel context.Cance
 		}
 		// Configure the provider so the plugin receives the host service ID.
 		// Without this call, the plugin cannot dial back to the host for auth
-		// tokens or other host services.
-		if cErr := wrapper.Configure(ctx, ProviderConfig{}); cErr != nil {
+		// tokens or other host services. The base config also carries
+		// host-static runtime metadata (build info, entrypoint, command, args)
+		// so pooled plugins that read ProviderConfig.Settings match per-call
+		// hosts; it is empty by default.
+		if cErr := wrapper.Configure(ctx, p.opts.baseConfig); cErr != nil {
 			p.logger.V(1).Info("failed to configure plugin provider",
 				"plugin", entry.dep.Name, "provider", provName, "error", cErr)
 		}
@@ -777,6 +794,13 @@ func (p *Pool) SanitizeEnv() bool {
 // This is primarily useful for testing that WithClientOptions was wired correctly.
 func (p *Pool) ClientOptsLen() int {
 	return len(p.opts.clientOpts)
+}
+
+// BaseProviderConfig returns the host-static ProviderConfig delivered to each
+// pooled provider at load time. See [WithBaseProviderConfig]. This is primarily
+// useful for testing that the base config was wired correctly.
+func (p *Pool) BaseProviderConfig() ProviderConfig {
+	return p.opts.baseConfig
 }
 
 // Shutdown kills all managed plugin processes. Called once on server stop.

--- a/pkg/plugin/pool_test.go
+++ b/pkg/plugin/pool_test.go
@@ -126,7 +126,9 @@ func TestNewPool_WithBaseProviderConfig(t *testing.T) {
 		p := NewPool(context.Background(), nil, reg, logr.Discard(), WithBaseProviderConfig(base))
 		defer p.Shutdown()
 
-		// Mutating the caller's map after construction must not affect the pool.
+		// Mutating the caller's map (and the underlying value bytes) after
+		// construction must not affect the pool.
+		base.Settings["metadata"][0] = 'X'
 		base.Settings["metadata"] = json.RawMessage(`{"entrypoint":"tampered"}`)
 		base.Settings["injected"] = json.RawMessage(`true`)
 
@@ -135,7 +137,7 @@ func TestNewPool_WithBaseProviderConfig(t *testing.T) {
 		assert.NotContains(t, stored, "injected")
 	})
 
-	t.Run("BaseProviderConfig returns a clone", func(t *testing.T) {
+	t.Run("BaseProviderConfig returns a deep clone", func(t *testing.T) {
 		base := ProviderConfig{
 			BinaryName: "mycli",
 			Settings: map[string]json.RawMessage{
@@ -145,8 +147,9 @@ func TestNewPool_WithBaseProviderConfig(t *testing.T) {
 		p := NewPool(context.Background(), nil, reg, logr.Discard(), WithBaseProviderConfig(base))
 		defer p.Shutdown()
 
-		// Mutating the returned map must not affect the pool's stored config.
+		// Mutating the returned map entry or its bytes must not affect the pool.
 		got := p.BaseProviderConfig()
+		got.Settings["metadata"][0] = 'X'
 		got.Settings["metadata"] = json.RawMessage(`{"entrypoint":"tampered"}`)
 
 		assert.Equal(t, json.RawMessage(`{"entrypoint":"mcp"}`), p.opts.baseConfig.Settings["metadata"])

--- a/pkg/plugin/pool_test.go
+++ b/pkg/plugin/pool_test.go
@@ -115,6 +115,42 @@ func TestNewPool_WithBaseProviderConfig(t *testing.T) {
 		assert.Equal(t, "mycli", p.opts.baseConfig.BinaryName)
 		assert.Equal(t, base.Settings, p.opts.baseConfig.Settings)
 	})
+
+	t.Run("clones the caller's settings map on store", func(t *testing.T) {
+		base := ProviderConfig{
+			BinaryName: "mycli",
+			Settings: map[string]json.RawMessage{
+				"metadata": json.RawMessage(`{"entrypoint":"mcp"}`),
+			},
+		}
+		p := NewPool(context.Background(), nil, reg, logr.Discard(), WithBaseProviderConfig(base))
+		defer p.Shutdown()
+
+		// Mutating the caller's map after construction must not affect the pool.
+		base.Settings["metadata"] = json.RawMessage(`{"entrypoint":"tampered"}`)
+		base.Settings["injected"] = json.RawMessage(`true`)
+
+		stored := p.opts.baseConfig.Settings
+		assert.Equal(t, json.RawMessage(`{"entrypoint":"mcp"}`), stored["metadata"])
+		assert.NotContains(t, stored, "injected")
+	})
+
+	t.Run("BaseProviderConfig returns a clone", func(t *testing.T) {
+		base := ProviderConfig{
+			BinaryName: "mycli",
+			Settings: map[string]json.RawMessage{
+				"metadata": json.RawMessage(`{"entrypoint":"mcp"}`),
+			},
+		}
+		p := NewPool(context.Background(), nil, reg, logr.Discard(), WithBaseProviderConfig(base))
+		defer p.Shutdown()
+
+		// Mutating the returned map must not affect the pool's stored config.
+		got := p.BaseProviderConfig()
+		got.Settings["metadata"] = json.RawMessage(`{"entrypoint":"tampered"}`)
+
+		assert.Equal(t, json.RawMessage(`{"entrypoint":"mcp"}`), p.opts.baseConfig.Settings["metadata"])
+	})
 }
 
 func TestBuildSpawnClientOpts(t *testing.T) {

--- a/pkg/plugin/pool_test.go
+++ b/pkg/plugin/pool_test.go
@@ -5,6 +5,7 @@ package plugin
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -89,6 +90,30 @@ func TestNewPool_WithSanitizeEnv(t *testing.T) {
 		p := NewPool(context.Background(), nil, reg, logr.Discard(), WithSanitizeEnv(true))
 		defer p.Shutdown()
 		assert.True(t, p.SanitizeEnv())
+	})
+}
+
+func TestNewPool_WithBaseProviderConfig(t *testing.T) {
+	reg := provider.NewRegistry()
+
+	t.Run("defaults to empty base config", func(t *testing.T) {
+		p := NewPool(context.Background(), nil, reg, logr.Discard())
+		defer p.Shutdown()
+		assert.Empty(t, p.opts.baseConfig.BinaryName)
+		assert.Nil(t, p.opts.baseConfig.Settings)
+	})
+
+	t.Run("stores the provided base config", func(t *testing.T) {
+		base := ProviderConfig{
+			BinaryName: "mycli",
+			Settings: map[string]json.RawMessage{
+				"metadata": json.RawMessage(`{"entrypoint":"mcp"}`),
+			},
+		}
+		p := NewPool(context.Background(), nil, reg, logr.Discard(), WithBaseProviderConfig(base))
+		defer p.Shutdown()
+		assert.Equal(t, "mycli", p.opts.baseConfig.BinaryName)
+		assert.Equal(t, base.Settings, p.opts.baseConfig.Settings)
 	})
 }
 

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -1324,10 +1324,13 @@ func buildHostMetadataSettings(entrypoint string, sol *solution.Solution) (json.
 // HostStaticProviderConfig instead (see its doc for why).
 //
 // NOTE: os.Args is included in the serialized settings. This means command-line
-// arguments (potentially including sensitive values) are visible to all plugins
-// over the local gRPC socket. This is acceptable because plugins are first-party
-// trusted binaries, but users should avoid passing secrets via CLI flags when
-// running untrusted plugin binaries.
+// arguments (potentially including sensitive values) are visible to every plugin
+// that receives this config over the local gRPC socket. For built-in and other
+// first-party plugins this is acceptable, but scafctl can be configured to allow
+// external (third-party/untrusted) plugins (disabled by default; see the API
+// server's AllowExternal / DisableExternal controls). Operators who enable
+// external plugins are trusting those binaries with the host command line, so
+// avoid passing secrets via CLI flags in that configuration.
 func injectHostMetadataSettings(cfg *plugin.ProviderConfig, sol *solution.Solution) {
 	if cfg == nil {
 		return

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -1260,7 +1260,14 @@ const hostMetadataSettingsKey = "metadata"
 // blob delivered under Settings["metadata"]. A nil solution yields an empty
 // solution object, which is the correct shape for pool-mode hosts that serve
 // many solutions (per-solution metadata is delivered per-execution instead).
+//
+// An empty entrypoint is normalized to EntrypointUnknown so the serialized
+// metadata never reports a blank/invalid entrypoint, regardless of caller.
 func buildHostMetadataSettings(entrypoint string, sol *solution.Solution) (json.RawMessage, error) {
+	if entrypoint == "" {
+		entrypoint = EntrypointUnknown
+	}
+
 	type solutionMeta struct {
 		Name        string   `json:"name"`
 		Version     string   `json:"version"`

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -1237,26 +1237,30 @@ func ResolveOfficialAuthHandlers(
 	return authClients, nil
 }
 
-// injectHostMetadataSettings populates cfg.Settings["metadata"] with host runtime
-// information so that the metadata plugin (and any other plugin that cares) can
-// return version, entrypoint, args, and solution metadata to callers.
-//
-// NOTE: os.Args is included in the serialized settings. This means command-line
-// arguments (potentially including sensitive values) are visible to all plugins
-// over the local gRPC socket. This is acceptable because plugins are first-party
-// trusted binaries, but users should avoid passing secrets via CLI flags when
-// running untrusted plugin binaries.
-func injectHostMetadataSettings(cfg *plugin.ProviderConfig, sol *solution.Solution) {
-	if cfg == nil {
-		return
-	}
+// Entrypoint values reported by the metadata provider's "entrypoint" field.
+// They describe how the host process was invoked. The host derives the value
+// and delivers it to plugins via ProviderConfig.Settings["metadata"].
+const (
+	// EntrypointCLI is a one-shot command-line invocation (scafctl run ...).
+	EntrypointCLI = "cli"
+	// EntrypointAPI is a long-lived HTTP API server (scafctl serve).
+	EntrypointAPI = "api"
+	// EntrypointMCP is a long-lived MCP server (scafctl mcp serve).
+	EntrypointMCP = "mcp"
+	// EntrypointUnknown is used when the host could not be classified.
+	EntrypointUnknown = "unknown"
+)
 
-	// Determine entrypoint from binary name heuristic.
-	entrypoint := "cli"
-	if cfg.BinaryName == "" {
-		entrypoint = "unknown"
-	}
+// hostMetadataSettingsKey is the ProviderConfig.Settings key under which host
+// runtime metadata is delivered to plugins.
+const hostMetadataSettingsKey = "metadata"
 
+// buildHostMetadataSettings serializes host runtime metadata (build info,
+// entrypoint, command, args) plus the given solution metadata into the JSON
+// blob delivered under Settings["metadata"]. A nil solution yields an empty
+// solution object, which is the correct shape for pool-mode hosts that serve
+// many solutions (per-solution metadata is delivered per-execution instead).
+func buildHostMetadataSettings(entrypoint string, sol *solution.Solution) (json.RawMessage, error) {
 	type solutionMeta struct {
 		Name        string   `json:"name"`
 		Version     string   `json:"version"`
@@ -1300,7 +1304,35 @@ func injectHostMetadataSettings(cfg *plugin.ProviderConfig, sol *solution.Soluti
 		Solution:     solMeta,
 	}
 
-	raw, err := json.Marshal(meta)
+	return json.Marshal(meta)
+}
+
+// injectHostMetadataSettings populates cfg.Settings["metadata"] with host runtime
+// information so that the metadata plugin (and any other plugin that cares) can
+// return version, entrypoint, args, and solution metadata to callers.
+//
+// This is the per-call (one-shot) path: the plugin process is spawned for a
+// single solution, so both host-static and per-solution metadata are delivered
+// together via the one-time ConfigureProvider call. Pool-mode hosts must use
+// HostStaticProviderConfig instead (see its doc for why).
+//
+// NOTE: os.Args is included in the serialized settings. This means command-line
+// arguments (potentially including sensitive values) are visible to all plugins
+// over the local gRPC socket. This is acceptable because plugins are first-party
+// trusted binaries, but users should avoid passing secrets via CLI flags when
+// running untrusted plugin binaries.
+func injectHostMetadataSettings(cfg *plugin.ProviderConfig, sol *solution.Solution) {
+	if cfg == nil {
+		return
+	}
+
+	// Determine entrypoint from binary name heuristic.
+	entrypoint := EntrypointCLI
+	if cfg.BinaryName == "" {
+		entrypoint = EntrypointUnknown
+	}
+
+	raw, err := buildHostMetadataSettings(entrypoint, sol)
 	if err != nil {
 		return
 	}
@@ -1308,7 +1340,31 @@ func injectHostMetadataSettings(cfg *plugin.ProviderConfig, sol *solution.Soluti
 	if cfg.Settings == nil {
 		cfg.Settings = make(map[string]json.RawMessage)
 	}
-	cfg.Settings["metadata"] = json.RawMessage(raw)
+	cfg.Settings[hostMetadataSettingsKey] = raw
+}
+
+// HostStaticProviderConfig builds a ProviderConfig that carries host-static
+// metadata (build version/commit/time, entrypoint, command, args) for delivery
+// to pooled plugins at load time.
+//
+// Pool-mode hosts (long-lived MCP/API servers) start a plugin process once and
+// share it across many solutions and concurrent requests, so the one-time
+// ConfigureProvider call cannot safely carry per-solution metadata. The
+// solution object is therefore intentionally left empty here; per-solution
+// metadata is delivered per-execution via ExecuteProviderRequest.SolutionMetadata.
+//
+// Without this, pooled plugins would only ever receive an empty ProviderConfig,
+// causing the metadata provider to report entrypoint "unknown" and empty
+// version/command fields under pool-mode hosts.
+func HostStaticProviderConfig(binaryName, entrypoint string) plugin.ProviderConfig {
+	cfg := plugin.ProviderConfig{BinaryName: binaryName}
+
+	raw, err := buildHostMetadataSettings(entrypoint, nil)
+	if err != nil {
+		return cfg
+	}
+	cfg.Settings = map[string]json.RawMessage{hostMetadataSettingsKey: raw}
+	return cfg
 }
 
 // injectHTTPClientSettings propagates httpClient configuration (e.g.

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -1278,13 +1278,18 @@ func buildHostMetadataSettings(entrypoint string, sol *solution.Solution) (json.
 		Source      string   `json:"source,omitempty"`
 	}
 
-	solMeta := solutionMeta{}
+	// Tags is documented as string[], so default to an empty slice; a nil
+	// slice marshals to JSON null, which breaks consumers expecting an array
+	// (this happens in pool mode and whenever the solution has no tags).
+	solMeta := solutionMeta{Tags: []string{}}
 	if sol != nil && sol.Metadata.Name != "" {
 		solMeta.Name = sol.Metadata.Name
 		solMeta.DisplayName = sol.Metadata.DisplayName
 		solMeta.Description = sol.Metadata.Description
 		solMeta.Category = sol.Metadata.Category
-		solMeta.Tags = sol.Metadata.Tags
+		if sol.Metadata.Tags != nil {
+			solMeta.Tags = sol.Metadata.Tags
+		}
 		solMeta.Source = sol.Metadata.Source
 		if sol.Metadata.Version != nil {
 			solMeta.Version = sol.Metadata.Version.String()

--- a/pkg/solution/prepare/prepare_test.go
+++ b/pkg/solution/prepare/prepare_test.go
@@ -1156,6 +1156,18 @@ func TestHostStaticProviderConfig_APIEntrypoint(t *testing.T) {
 	assert.Equal(t, "api", meta["entrypoint"])
 }
 
+func TestHostStaticProviderConfig_EmptyEntrypointDefaultsToUnknown(t *testing.T) {
+	// An empty entrypoint must serialize as EntrypointUnknown rather than a
+	// blank/invalid value, even though HostStaticProviderConfig is exported and
+	// a caller could pass "".
+	cfg := HostStaticProviderConfig("scafctl", "")
+
+	raw := cfg.Settings["metadata"]
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal(raw, &meta))
+	assert.Equal(t, EntrypointUnknown, meta["entrypoint"])
+}
+
 func TestInjectHTTPClientSettings_NilConfig(t *testing.T) {
 	// Must not panic.
 	injectHTTPClientSettings(context.Background(), nil)

--- a/pkg/solution/prepare/prepare_test.go
+++ b/pkg/solution/prepare/prepare_test.go
@@ -1141,6 +1141,13 @@ func TestHostStaticProviderConfig(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "", solMap["name"])
 
+	// Tags is documented as string[] and must serialize as an array (not null),
+	// even in pool mode where the solution is empty, so consumers can rely on
+	// the shape.
+	tags, ok := solMap["tags"].([]any)
+	require.True(t, ok, "tags must be a JSON array, got %T", solMap["tags"])
+	assert.Empty(t, tags)
+
 	// Host-static build fields are present (keys always serialized).
 	assert.Contains(t, meta, "buildVersion")
 	assert.Contains(t, meta, "command")

--- a/pkg/solution/prepare/prepare_test.go
+++ b/pkg/solution/prepare/prepare_test.go
@@ -1121,6 +1121,41 @@ func TestInjectHostMetadataSettings_NilSolution(t *testing.T) {
 	assert.Equal(t, "", solMap["name"])
 }
 
+func TestHostStaticProviderConfig(t *testing.T) {
+	cfg := HostStaticProviderConfig("mycli", EntrypointMCP)
+
+	assert.Equal(t, "mycli", cfg.BinaryName)
+	require.NotNil(t, cfg.Settings)
+	raw, ok := cfg.Settings["metadata"]
+	require.True(t, ok)
+
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal(raw, &meta))
+
+	// Entrypoint is the one supplied by the host, not derived from BinaryName.
+	assert.Equal(t, "mcp", meta["entrypoint"])
+
+	// Solution metadata is intentionally empty: pool-mode hosts serve many
+	// solutions and deliver per-solution metadata per-execution instead.
+	solMap, ok := meta["solution"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "", solMap["name"])
+
+	// Host-static build fields are present (keys always serialized).
+	assert.Contains(t, meta, "buildVersion")
+	assert.Contains(t, meta, "command")
+	assert.Contains(t, meta, "args")
+}
+
+func TestHostStaticProviderConfig_APIEntrypoint(t *testing.T) {
+	cfg := HostStaticProviderConfig("scafctl", EntrypointAPI)
+
+	raw := cfg.Settings["metadata"]
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal(raw, &meta))
+	assert.Equal(t, "api", meta["entrypoint"])
+}
+
 func TestInjectHTTPClientSettings_NilConfig(t *testing.T) {
 	// Must not panic.
 	injectHTTPClientSettings(context.Background(), nil)

--- a/pkg/solution/prepare/prepare_test.go
+++ b/pkg/solution/prepare/prepare_test.go
@@ -1126,7 +1126,7 @@ func TestHostStaticProviderConfig(t *testing.T) {
 
 	assert.Equal(t, "mycli", cfg.BinaryName)
 	require.NotNil(t, cfg.Settings)
-	raw, ok := cfg.Settings["metadata"]
+	raw, ok := cfg.Settings[hostMetadataSettingsKey]
 	require.True(t, ok)
 
 	var meta map[string]any
@@ -1150,7 +1150,7 @@ func TestHostStaticProviderConfig(t *testing.T) {
 func TestHostStaticProviderConfig_APIEntrypoint(t *testing.T) {
 	cfg := HostStaticProviderConfig("scafctl", EntrypointAPI)
 
-	raw := cfg.Settings["metadata"]
+	raw := cfg.Settings[hostMetadataSettingsKey]
 	var meta map[string]any
 	require.NoError(t, json.Unmarshal(raw, &meta))
 	assert.Equal(t, "api", meta["entrypoint"])
@@ -1162,7 +1162,7 @@ func TestHostStaticProviderConfig_EmptyEntrypointDefaultsToUnknown(t *testing.T)
 	// a caller could pass "".
 	cfg := HostStaticProviderConfig("scafctl", "")
 
-	raw := cfg.Settings["metadata"]
+	raw := cfg.Settings[hostMetadataSettingsKey]
 	var meta map[string]any
 	require.NoError(t, json.Unmarshal(raw, &meta))
 	assert.Equal(t, EntrypointUnknown, meta["entrypoint"])


### PR DESCRIPTION
Fixes a confirmed bug where pool-mode hosts (long-lived MCP/API servers backing `preview_resolvers`, `run_provider`, `dry_run_solution`) start each plugin process once and configure it with an empty `ProviderConfig{}`. Host runtime metadata therefore never reached pooled plugins, so the `metadata` provider reported `entrypoint: "unknown"` with empty `version`/`command`. Per-call CLI hosts (`run resolver`/`run solution`) were unaffected.

This is the **host-static half** of the fix. The per-solution/per-execution settings channel is deferred to the coordinated follow-up (see Deferred below).

## What changed

- **`pkg/plugin/pool.go`** -- add a `baseConfig` pool option, `WithBaseProviderConfig(cfg)`, and a `BaseProviderConfig()` accessor; the one-time `wrapper.Configure` at plugin load now delivers this base config instead of an empty `ProviderConfig{}`. Default is the zero config, so existing callers are unchanged. Concurrency-safe: the base config is read-only and the shared wrapper is never re-configured per request. Both the setter and accessor **deep-clone** the `Settings` map -- the map and each `json.RawMessage` ([]byte) value (via `cloneProviderConfig`) -- so the long-lived pool never shares mutable references with the caller in either direction; a caller mutating its map entries or the bytes returned by `BaseProviderConfig()` cannot race with or alter what pooled providers observe.
- **`pkg/solution/prepare/prepare.go`** -- extract `buildHostMetadataSettings(entrypoint, sol)`; add entrypoint constants (`EntrypointCLI`/`EntrypointAPI`/`EntrypointMCP`/`EntrypointUnknown`) and `hostMetadataSettingsKey`; add exported `HostStaticProviderConfig(binaryName, entrypoint)` for pool-mode base config. The solution object is intentionally empty in the base config -- per-solution metadata already flows per-execution via `ExecuteProviderRequest.SolutionMetadata`, not the one-time Configure on a shared wrapper. `buildHostMetadataSettings` normalizes an empty `entrypoint` to `EntrypointUnknown` so the exported `HostStaticProviderConfig` can never emit a blank/invalid entrypoint, and always serializes `solution.tags` as a JSON array (never `null`) to match the documented `string[]` shape -- in pool mode and whenever a solution has no tags.
- **`pkg/cmd/scafctl/mcp/serve.go` / `pkg/cmd/scafctl/serve/serve.go`** -- wire the base config into the two production pool constructors with `EntrypointMCP` / `EntrypointAPI` and the context binary name.
- **Docs/examples** -- entrypoint value list now includes `"mcp"`; stale `metadata-single-field.yaml` field description corrected.

## Tests / artifacts

- `pkg/plugin`: `TestNewPool_WithBaseProviderConfig` (default-empty + stored config; caller-map and returned-map deep-clone isolation incl. in-place byte mutation, passing under `-race`).
- `pkg/solution/prepare`: `TestHostStaticProviderConfig` / `_APIEntrypoint` / `_EmptyEntrypointDefaultsToUnknown` (empty solution, correct entrypoint, empty-entrypoint normalization, `tags` serialized as an empty array, host-static build fields present).
- `pkg/cmd/scafctl/mcp` + `serve`: wiring assertions that each production pool delivers the correct entrypoint (`mcp`/`api`) and build fields via `BaseProviderConfig()`.

## Verification

- Targeted package tests pass; `task test:e2e` green (178 ok, 0 failed); `task lint:changed` -> 0 issues.
- Non-breaking: default base config is the zero `ProviderConfig{}`; per-call delivery is untouched.

## Deferred (coordinated follow-up)

The per-solution portion (populating `solution{}` for pooled plugins) needs an execution-scoped settings channel plus an SDK-side merge, which is additive and gated on an SDK release:

- Host side: oakwood-commons/scafctl#706 (per-execution provider `settings` + `SolutionMeta.source`).
- SDK side: oakwood-commons/scafctl-plugin-sdk#74 (proto field + write-once merge of Configure + per-execution settings).

This PR is the confirmed host-static prerequisite for that work (delivered once at pool load).