### PR TITLE
fix(lint): use WithOutputSchemaJSON for non-interactive lint rule output

### DIFF
--- a/pkg/cmd/scafctl/lint/explain_cmd.go
+++ b/pkg/cmd/scafctl/lint/explain_cmd.go
@@ -109,6 +109,23 @@ Examples:
 // explainColumnOrder controls field display order in KVX visual output.
 var explainColumnOrder = []string{"rule", "severity", "category", "description", "why", "fix", "examples"}
 
+// nonInteractiveOutputOptions builds the OutputOptions used for the
+// structured (JSON/YAML/CSV/TOML) and non-interactive visual (auto/table/list)
+// formats. It must use WithOutputSchemaJSON (column display hints), not
+// WithOutputDisplaySchemaJSON (interactive TUI x-kvx-* extensions) -- the
+// latter is reserved for the separate interactive branch in Run, which builds
+// its own OutputOptions using lintRulesSchemaJSON. See issue #672.
+func (o *RuleOptions) nonInteractiveOutputOptions(ctx context.Context) *kvx.OutputOptions {
+	return flags.ToKvxOutputOptions(&o.KvxOutputFlags,
+		kvx.WithIOStreams(o.IOStreams),
+		kvx.WithOutputContext(ctx),
+		kvx.WithOutputNoColor(o.CliParams.NoColor),
+		kvx.WithOutputAppName(o.BinaryName+" lint rule"),
+		kvx.WithOutputSchemaJSON(lintExplainSchemaJSON),
+		kvx.WithOutputColumnOrder(explainColumnOrder),
+	)
+}
+
 // Run executes the lint rule command.
 func (o *RuleOptions) Run(ctx context.Context, ruleName string) error {
 	if o.BinaryName == "" {
@@ -127,14 +144,7 @@ func (o *RuleOptions) Run(ctx context.Context, ruleName string) error {
 		return exitcode.WithCode(err, exitcode.InvalidInput)
 	}
 
-	outputOpts := flags.ToKvxOutputOptions(&o.KvxOutputFlags,
-		kvx.WithIOStreams(o.IOStreams),
-		kvx.WithOutputContext(ctx),
-		kvx.WithOutputNoColor(o.CliParams.NoColor),
-		kvx.WithOutputAppName(o.BinaryName+" lint rule"),
-		kvx.WithOutputDisplaySchemaJSON(lintExplainSchemaJSON),
-		kvx.WithOutputColumnOrder(explainColumnOrder),
-	)
+	outputOpts := o.nonInteractiveOutputOptions(ctx)
 
 	// For structured formats (JSON/YAML/CSV/TOML), emit the full RuleMeta.
 	if kvx.IsStructuredFormat(outputOpts.Format) {

--- a/pkg/cmd/scafctl/lint/lint_test.go
+++ b/pkg/cmd/scafctl/lint/lint_test.go
@@ -388,6 +388,95 @@ func TestExplainRun_CSVOutput(t *testing.T) {
 	assert.Contains(t, output, "empty-solution")
 }
 
+// TestExplainRun_NonInteractiveOptions_UseSchemaJSON is the regression test
+// for issue #672: the non-interactive output path previously wired an
+// interactive display schema (WithOutputDisplaySchemaJSON) instead of a
+// column-hint schema (WithOutputSchemaJSON) when building outputOpts. This
+// calls the exact same nonInteractiveOutputOptions helper that Run() uses
+// and asserts directly on the resulting struct fields, so it fails if the
+// wrong setter is reintroduced there -- unlike output-content assertions,
+// which render identically either way for this schema/data combination
+// because explainColumnOrder already pins ColumnOrder explicitly (bypassing
+// any ColumnOrder/HiddenColumns that DisplaySchemaJSON would otherwise
+// derive).
+func TestExplainRun_NonInteractiveOptions_UseSchemaJSON(t *testing.T) {
+	t.Parallel()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	ctx := testContext(ioStreams)
+
+	opts := &RuleOptions{
+		BinaryName:     "scafctl",
+		IOStreams:      ioStreams,
+		CliParams:      testCliParams(),
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "table"},
+	}
+
+	outputOpts := opts.nonInteractiveOutputOptions(ctx)
+
+	assert.Equal(t, lintExplainSchemaJSON, outputOpts.SchemaJSON,
+		"non-interactive path must use SchemaJSON (column hints), not DisplaySchemaJSON")
+	assert.Empty(t, outputOpts.DisplaySchemaJSON,
+		"non-interactive path must not set DisplaySchemaJSON; that is reserved for the interactive branch")
+}
+
+// TestExplainRun_TableOutput_WithExamples is a smoke test covering table
+// rendering for a rule with a real, non-trivial Examples value
+// (call-not-found). lintExplainSchemaJSON declares "examples" as a JSON
+// array while projectRule() flattens RuleMeta.Examples into a single
+// joined string; this confirms that shape difference does not break
+// non-interactive table rendering or panic. It does not, by itself,
+// discriminate between WithOutputSchemaJSON and WithOutputDisplaySchemaJSON
+// for this schema/data combination -- see
+// TestExplainRun_NonInteractiveOptions_UseSchemaJSON for the assertion that
+// actually regresses issue #672.
+func TestExplainRun_TableOutput_WithExamples(t *testing.T) {
+	t.Parallel()
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := testCliParams()
+	ctx := testContext(ioStreams)
+
+	opts := &RuleOptions{
+		BinaryName:     "scafctl",
+		IOStreams:      ioStreams,
+		CliParams:      cliParams,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "table"},
+	}
+
+	err := opts.Run(ctx, "call-not-found")
+	require.NoError(t, err)
+
+	output := outBuf.String()
+	assert.Contains(t, output, "call-not-found")
+	assert.Contains(t, output, "error")
+	assert.Contains(t, output, "call")
+	assert.Contains(t, output, "getUser")
+}
+
+// TestExplainRun_ListOutput_WithExamples is the list-format counterpart to
+// TestExplainRun_TableOutput_WithExamples, covering issue #672 for the
+// "list" output format as well as "table".
+func TestExplainRun_ListOutput_WithExamples(t *testing.T) {
+	t.Parallel()
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := testCliParams()
+	ctx := testContext(ioStreams)
+
+	opts := &RuleOptions{
+		BinaryName:     "scafctl",
+		IOStreams:      ioStreams,
+		CliParams:      cliParams,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "list"},
+	}
+
+	err := opts.Run(ctx, "call-not-found")
+	require.NoError(t, err)
+
+	output := outBuf.String()
+	assert.Contains(t, output, "call-not-found")
+	assert.Contains(t, output, "error")
+	assert.Contains(t, output, "getUser")
+}
+
 func TestExplainRun_UnknownRule(t *testing.T) {
 	t.Parallel()
 	ioStreams, _, _ := terminal.NewTestIOStreams()


### PR DESCRIPTION
## Summary

Fixes #672.

The `lint rule <name>` command's non-interactive output path (auto/table/list/csv formats) incorrectly attached an interactive display schema (`kvx.WithOutputDisplaySchemaJSON(lintExplainSchemaJSON)`) instead of table column display hints (`kvx.WithOutputSchemaJSON(lintExplainSchemaJSON)`). This caused a schema/value shape mismatch: the schema declares `examples` as an array, but `projectRule()` flattens `Examples` into a single joined string for display.

This is a low-priority display/consistency bug (not a crash) surfaced during PR #669 review.

## Changes

- `pkg/cmd/scafctl/lint/explain_cmd.go`: extracted the `outputOpts` construction (previously inline in `Run()`) into a new `nonInteractiveOutputOptions(ctx)` method, correcting the schema setter to `WithOutputSchemaJSON`. Added a doc comment explaining the invariant (`WithOutputSchemaJSON` for column hints, not `WithOutputDisplaySchemaJSON` for interactive TUI extensions) and referencing this issue. The interactive branch in `Run()` is untouched -- it correctly uses a separate schema (`lintRulesSchemaJSON`) via its own `interactiveOpts`.
- `pkg/cmd/scafctl/lint/lint_test.go`: added three tests:
  - `TestExplainRun_NonInteractiveOptions_UseSchemaJSON` -- a white-box test that calls the real `nonInteractiveOutputOptions` method and asserts `OutputOptions.SchemaJSON` is set to `lintExplainSchemaJSON` while `DisplaySchemaJSON` is empty. Verified this genuinely regresses the bug (fails if the old `WithOutputDisplaySchemaJSON` call is reintroduced).
  - `TestExplainRun_TableOutput_WithExamples` / `TestExplainRun_ListOutput_WithExamples` -- smoke tests exercising table/list rendering for rule `call-not-found`, which has real `Examples` data, confirming no rendering breakage from the schema/value shape mismatch. Doc comments note these do not by themselves discriminate the bug (both schema setters produce identical output for this data shape, since `ColumnOrder` is already pinned explicitly via `WithOutputColumnOrder`).

## Testing

- `go build ./...`, `go vet ./...`, `gofmt`/`goimports` -- clean
- `task lint:changed` -- 0 new issues
- `go test ./pkg/cmd/scafctl/lint/...` -- all pass; package coverage 70.0%, new `nonInteractiveOutputOptions` method 100% covered
- Reviewed by `go-reviewer` agent: APPROVE (0 Critical/High/Medium; 1 pre-existing Low noting the interactive branch has no dedicated test coverage, unrelated to this change)
- Reviewed by `artifact-auditor` agent: no gaps for this scope (docs/CHANGELOG/integration-tests/MCP/benchmarks confirmed not required)

🤖 Generated with [opencode](https://opencode.ai)