### PR TITLE
feat(host): deliver per-execution provider Settings and SolutionMeta.source (pool-mode fix)

### DIFF
--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -2002,6 +2002,7 @@ None. The metadata provider accepts no inputs.
 | `solution.description` | string | Solution description |
 | `solution.category` | string | Solution category |
 | `solution.tags` | string[] | Solution tags |
+| `solution.source` | string | Solution provenance: the local file path when run from a file, otherwise the author-declared `metadata.source` (e.g. a catalog or repository reference). Empty when neither is available. |
 | `os` | string | Operating system (`runtime.GOOS`): `darwin`, `linux`, `windows`, etc. |
 | `arch` | string | CPU architecture (`runtime.GOARCH`): `amd64`, `arm64`, etc. |
 | `shell` | string | Detected shell name (e.g. `bash`, `zsh`, `fish`, `pwsh`, `powershell`, `cmd.exe`). On Unix, reads `$SHELL`. On Windows, detects PowerShell via `PSModulePath` and parent process inspection, then falls back to Git Bash (`$SHELL`) and finally `%ComSpec%`. Empty if not detected. |

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/oakwood-commons/httpc v0.2.0
 	github.com/oakwood-commons/kvx v0.16.0
 	github.com/oakwood-commons/oauth-helpers v0.2.0
-	github.com/oakwood-commons/scafctl-plugin-sdk v0.16.0
+	github.com/oakwood-commons/scafctl-plugin-sdk v0.17.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -628,8 +628,8 @@ github.com/oakwood-commons/kvx v0.16.0 h1:O6n5XE6ubFonZoiWc/s8o7zuMBZdf2GWYsVBr6
 github.com/oakwood-commons/kvx v0.16.0/go.mod h1:PJktDsEq9PS88UDCkoIT+fgiSXs7dXWcq76Lhk5BmZY=
 github.com/oakwood-commons/oauth-helpers v0.2.0 h1:IIu8AitRWCNp51oRvfBU0D7JGM3Tt3QXUejLwEFZk+Q=
 github.com/oakwood-commons/oauth-helpers v0.2.0/go.mod h1:+VhuszKORoPc9H0HwvS92I/U0828up8XejsUpXS7FvE=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.16.0 h1:qCpABo7SSpHmgZ0KX8UXwDLT8L9CE9Qg2vrCXJROXv0=
-github.com/oakwood-commons/scafctl-plugin-sdk v0.16.0/go.mod h1:oC2LqrVwXEQBgR2rIp+PbSF0mLfkC1a2G5KJb6CzdgE=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.17.0 h1:UCle89jbLDQG16TkMKWWh5z9vLf5nR6CQDVgmkuCuK4=
+github.com/oakwood-commons/scafctl-plugin-sdk v0.17.0/go.mod h1:AMyK1Qw2rGsEBohcgIJ0ju2eAgaVXsHExaL7Uha4+00=
 github.com/oklog/run v1.2.0 h1:O8x3yXwah4A73hJdlrwo/2X6J62gE5qTMusH0dvz60E=
 github.com/oklog/run v1.2.0/go.mod h1:mgDbKRSwPhJfesJ4PntqFUbKQRZ50NgmZTSPlFA0YFk=
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -997,6 +997,7 @@ func solutionMetaFromSolution(sol *solution.Solution) *provider.SolutionMeta {
 		Description: sol.Metadata.Description,
 		Category:    sol.Metadata.Category,
 		Tags:        sol.Metadata.Tags,
+		Source:      sol.Provenance(),
 	}
 	if sol.Metadata.Version != nil {
 		meta.Version = sol.Metadata.Version.String()

--- a/pkg/cmd/scafctl/run/common_test.go
+++ b/pkg/cmd/scafctl/run/common_test.go
@@ -33,6 +33,29 @@ func TestBuildPluginFetcher_WithDefaultContext(t *testing.T) {
 	assert.NotNil(t, fetcher)
 }
 
+func TestSolutionMetaFromSolution_Source(t *testing.T) {
+	t.Run("uses solution path as provenance source", func(t *testing.T) {
+		sol := &solution.Solution{}
+		sol.Metadata.Name = "demo"
+		sol.SetPath("/path/to/solution.yaml")
+		sol.Metadata.Source = "github.com/acme/solutions//demo"
+
+		meta := solutionMetaFromSolution(sol)
+		require.NotNil(t, meta)
+		assert.Equal(t, "demo", meta.Name)
+		assert.Equal(t, "/path/to/solution.yaml", meta.Source)
+	})
+
+	t.Run("falls back to metadata source when no path", func(t *testing.T) {
+		sol := &solution.Solution{}
+		sol.Metadata.Source = "github.com/acme/solutions//demo"
+
+		meta := solutionMetaFromSolution(sol)
+		require.NotNil(t, meta)
+		assert.Equal(t, "github.com/acme/solutions//demo", meta.Source)
+	})
+}
+
 func TestBuildPluginFetcher_WithConfig(t *testing.T) {
 	cfg := &config.Config{}
 	ctx := config.WithConfig(context.Background(), cfg)

--- a/pkg/plugin/grpc.go
+++ b/pkg/plugin/grpc.go
@@ -216,6 +216,7 @@ func unmarshalSolutionMeta(ctx context.Context, meta *proto.SolutionMeta) contex
 		Description: meta.Description,
 		Category:    meta.Category,
 		Tags:        meta.Tags,
+		Source:      meta.Source,
 	})
 }
 
@@ -715,6 +716,7 @@ func marshalSolutionMeta(ctx context.Context) *proto.SolutionMeta {
 		Description: meta.Description,
 		Category:    meta.Category,
 		Tags:        meta.Tags,
+		Source:      meta.Source,
 	}
 }
 
@@ -783,6 +785,18 @@ func buildExecuteProviderRequest(ctx context.Context, providerName string, input
 
 	// Solution metadata
 	req.SolutionMetadata = marshalSolutionMeta(ctx)
+
+	// Per-execution provider settings. Pool-mode hosts configure pooled plugins
+	// once with host-static settings; this channel delivers the per-solution
+	// settings (merged over the configure-time values on the plugin side) so
+	// Settings-driven plugins report correct per-solution values on every call.
+	// Bytes are deep-copied so the request never aliases the shared context map.
+	if execSettings, ok := provider.ExecutionSettingsFromContext(ctx); ok && len(execSettings) > 0 {
+		req.Settings = make(map[string][]byte, len(execSettings))
+		for k, v := range execSettings {
+			req.Settings[k] = append([]byte(nil), v...)
+		}
+	}
 
 	// Auth profile
 	if profile := auth.ProfileFromContext(ctx); profile != "" {

--- a/pkg/plugin/grpc_new_test.go
+++ b/pkg/plugin/grpc_new_test.go
@@ -234,6 +234,7 @@ func TestBuildExecuteProviderRequest_RoundTrip(t *testing.T) {
 	ctx = provider.WithSolutionMetadata(ctx, &provider.SolutionMeta{
 		Name:    "test-sol",
 		Version: "2.0.0",
+		Source:  "/path/to/solution.yaml",
 	})
 	ctx = auth.WithProfile(ctx, "work")
 
@@ -255,6 +256,7 @@ func TestBuildExecuteProviderRequest_RoundTrip(t *testing.T) {
 	require.NotNil(t, req.SolutionMetadata)
 	assert.Equal(t, "test-sol", req.SolutionMetadata.Name)
 	assert.Equal(t, "2.0.0", req.SolutionMetadata.Version)
+	assert.Equal(t, "/path/to/solution.yaml", req.SolutionMetadata.Source)
 
 	var params map[string]any
 	require.NoError(t, json.Unmarshal(req.Parameters, &params))
@@ -281,6 +283,66 @@ func TestBuildExecuteProviderRequest_AuthProfile(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, req.AuthProfile)
 	})
+}
+
+func TestBuildExecuteProviderRequest_ExecutionSettings(t *testing.T) {
+	t.Run("populates settings from context", func(t *testing.T) {
+		settings := map[string]json.RawMessage{
+			"metadata": json.RawMessage(`{"solution":{"name":"demo"}}`),
+		}
+		ctx := provider.WithExecutionSettings(context.Background(), settings)
+
+		req, err := buildExecuteProviderRequest(ctx, "test", []byte(`{}`))
+		require.NoError(t, err)
+		require.Contains(t, req.Settings, "metadata")
+		assert.JSONEq(t, `{"solution":{"name":"demo"}}`, string(req.Settings["metadata"]))
+	})
+
+	t.Run("deep-copies bytes so request does not alias context map", func(t *testing.T) {
+		orig := json.RawMessage(`{"solution":{"name":"demo"}}`)
+		settings := map[string]json.RawMessage{"metadata": orig}
+		ctx := provider.WithExecutionSettings(context.Background(), settings)
+
+		req, err := buildExecuteProviderRequest(ctx, "test", []byte(`{}`))
+		require.NoError(t, err)
+		require.Contains(t, req.Settings, "metadata")
+
+		// Mutating the request bytes must not affect the source map.
+		req.Settings["metadata"][0] = 'X'
+		assert.Equal(t, `{"solution":{"name":"demo"}}`, string(orig),
+			"source settings bytes must not be aliased by the request")
+	})
+
+	t.Run("no settings key when context has none", func(t *testing.T) {
+		req, err := buildExecuteProviderRequest(context.Background(), "test", []byte(`{}`))
+		require.NoError(t, err)
+		assert.Nil(t, req.Settings)
+	})
+
+	t.Run("empty settings map yields no settings", func(t *testing.T) {
+		ctx := provider.WithExecutionSettings(context.Background(), map[string]json.RawMessage{})
+		req, err := buildExecuteProviderRequest(ctx, "test", []byte(`{}`))
+		require.NoError(t, err)
+		assert.Nil(t, req.Settings)
+	})
+}
+
+func TestSolutionMeta_SourceRoundTrip(t *testing.T) {
+	// marshalSolutionMeta (host client -> proto) and unmarshalSolutionMeta
+	// (proto -> plugin-side context) must preserve Source in both directions.
+	ctx := provider.WithSolutionMetadata(context.Background(), &provider.SolutionMeta{
+		Name:   "demo",
+		Source: "github.com/acme/solutions//demo",
+	})
+
+	protoMeta := marshalSolutionMeta(ctx)
+	require.NotNil(t, protoMeta)
+	assert.Equal(t, "github.com/acme/solutions//demo", protoMeta.Source)
+
+	rtCtx := unmarshalSolutionMeta(context.Background(), protoMeta)
+	meta, ok := provider.SolutionMetadataFromContext(rtCtx)
+	require.True(t, ok)
+	assert.Equal(t, "github.com/acme/solutions//demo", meta.Source)
 }
 
 func TestApplyRequestContext_AuthProfile(t *testing.T) {

--- a/pkg/provider/context.go
+++ b/pkg/provider/context.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 
 	sdkprovider "github.com/oakwood-commons/scafctl-plugin-sdk/provider"
 )
@@ -151,4 +152,26 @@ func WithSolutionDirectory(ctx context.Context, dir string) context.Context {
 func SolutionDirectoryFromContext(ctx context.Context) (string, bool) {
 	dir, ok := ctx.Value(solutionDirectoryKey).(string)
 	return dir, ok
+}
+
+// executionSettingsKey is a scafctl-only context key carrying the per-execution
+// host settings that the host serializes into ExecuteProviderRequest.settings.
+const executionSettingsKey scafctlContextKey = "scafctl.provider.executionSettings"
+
+// WithExecutionSettings returns a new context carrying the per-execution host
+// settings map that the host serializes into ExecuteProviderRequest.settings on
+// each provider execution. This is the host-side (producer) counterpart to the
+// SDK's provider.WithSettings, which the plugin server uses to expose the merged
+// effective settings to the plugin (consumer). Pooled hosts use this channel to
+// deliver per-solution values that the one-time ConfigureProvider call cannot.
+// The map and its values are treated as read-only.
+func WithExecutionSettings(ctx context.Context, settings map[string]json.RawMessage) context.Context {
+	return context.WithValue(ctx, executionSettingsKey, settings)
+}
+
+// ExecutionSettingsFromContext retrieves the per-execution host settings map.
+// Returns the settings map and true if present, nil and false otherwise.
+func ExecutionSettingsFromContext(ctx context.Context) (map[string]json.RawMessage, bool) {
+	settings, ok := ctx.Value(executionSettingsKey).(map[string]json.RawMessage)
+	return settings, ok
 }

--- a/pkg/provider/context_test.go
+++ b/pkg/provider/context_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -361,4 +362,29 @@ func TestWithSolutionDirectory_AndFromContext(t *testing.T) {
 func TestSolutionDirectoryFromContext_NotSet(t *testing.T) {
 	_, ok := SolutionDirectoryFromContext(context.Background())
 	assert.False(t, ok)
+}
+
+func TestWithExecutionSettings_AndFromContext(t *testing.T) {
+	ctx := context.Background()
+	settings := map[string]json.RawMessage{
+		"metadata": json.RawMessage(`{"solution":{"name":"demo"}}`),
+	}
+	ctx = WithExecutionSettings(ctx, settings)
+
+	got, ok := ExecutionSettingsFromContext(ctx)
+	assert.True(t, ok)
+	assert.Equal(t, settings, got)
+}
+
+func TestExecutionSettingsFromContext_NotSet(t *testing.T) {
+	got, ok := ExecutionSettingsFromContext(context.Background())
+	assert.False(t, ok)
+	assert.Nil(t, got)
+}
+
+func TestWithExecutionSettings_Nil(t *testing.T) {
+	ctx := WithExecutionSettings(context.Background(), nil)
+	got, ok := ExecutionSettingsFromContext(ctx)
+	assert.True(t, ok)
+	assert.Nil(t, got)
 }

--- a/pkg/solution/execute/execute.go
+++ b/pkg/solution/execute/execute.go
@@ -622,6 +622,7 @@ func toSolutionMeta(sol *solution.Solution) *provider.SolutionMeta {
 		Description: sol.Metadata.Description,
 		Category:    sol.Metadata.Category,
 		Tags:        sol.Metadata.Tags,
+		Source:      sol.Provenance(),
 	}
 	if sol.Metadata.Version != nil {
 		meta.Version = sol.Metadata.Version.String()

--- a/pkg/solution/execute/execute_test.go
+++ b/pkg/solution/execute/execute_test.go
@@ -17,6 +17,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestToSolutionMeta_Source(t *testing.T) {
+	t.Run("uses solution path as provenance source", func(t *testing.T) {
+		sol := &solution.Solution{}
+		sol.Metadata.Name = "demo"
+		sol.SetPath("/path/to/solution.yaml")
+		sol.Metadata.Source = "github.com/acme/solutions//demo"
+
+		meta := toSolutionMeta(sol)
+		require.NotNil(t, meta)
+		assert.Equal(t, "demo", meta.Name)
+		assert.Equal(t, "/path/to/solution.yaml", meta.Source)
+	})
+
+	t.Run("falls back to metadata source when no path", func(t *testing.T) {
+		sol := &solution.Solution{}
+		sol.Metadata.Source = "github.com/acme/solutions//demo"
+
+		meta := toSolutionMeta(sol)
+		require.NotNil(t, meta)
+		assert.Equal(t, "github.com/acme/solutions//demo", meta.Source)
+	})
+}
+
 func TestValidateSolution(t *testing.T) {
 	t.Run("valid solution with no workflow", func(t *testing.T) {
 		sol := &solution.Solution{}

--- a/pkg/solution/prepare/prepare.go
+++ b/pkg/solution/prepare/prepare.go
@@ -213,11 +213,12 @@ type Result struct {
 	// DiscoveredFrom holds metadata about how the solution file was discovered.
 	// Only populated when auto-discovery is used (path was empty).
 	DiscoveredFrom get.DiscoveryResult `json:"-" yaml:"-"`
-	// ProviderCtx enriches a context with solution provider dependencies
-	// (loader, registry, plugin deps, client tracker). Callers must apply
-	// this to the execution context before running resolvers or actions so
-	// the solution provider can resolve sub-solutions. May be nil when no
-	// solution provider is registered.
+	// ProviderCtx enriches a context with per-execution provider settings and
+	// solution provider dependencies (loader, registry, plugin deps, client
+	// tracker). Callers must apply this to the execution context before running
+	// resolvers or actions so that per-solution provider settings reach plugins
+	// on every execution and the solution provider can resolve sub-solutions.
+	// Always non-nil.
 	ProviderCtx func(ctx context.Context) context.Context `json:"-" yaml:"-"`
 }
 
@@ -490,14 +491,28 @@ func Solution(ctx context.Context, path string, opts ...Option) (*Result, error)
 		}
 	}
 
-	// Build a context enrichment function that injects solution provider
-	// dependencies via context. This avoids mutating the shared singleton
-	// in DefaultRegistry and keeps per-execution state isolated.
-	var providerCtx func(ctx context.Context) context.Context
-	if reg.Has(solutionprovider.ProviderName) {
-		tracker := solutionprovider.NewChildClientTracker()
+	// Build a context enrichment function that injects per-execution provider
+	// settings and (when present) solution provider dependencies via context.
+	// This avoids mutating the shared singleton in DefaultRegistry and keeps
+	// per-execution state isolated.
+	//
+	// The per-solution settings blob is attached unconditionally -- it must not
+	// be gated on the solution provider being registered, since it carries the
+	// per-solution metadata that pooled plugins (e.g. the metadata provider)
+	// rely on for every execution.
+	execSettings := buildPerSolutionSettings(hostEntrypoint(cfg), sol)
 
-		providerCtx = func(ctx context.Context) context.Context {
+	hasSolutionProvider := reg.Has(solutionprovider.ProviderName)
+	var tracker *solutionprovider.ChildClientTracker
+	if hasSolutionProvider {
+		tracker = solutionprovider.NewChildClientTracker()
+	}
+
+	providerCtx := func(ctx context.Context) context.Context {
+		if len(execSettings) > 0 {
+			ctx = provider.WithExecutionSettings(ctx, execSettings)
+		}
+		if hasSolutionProvider {
 			ctx = solutionprovider.WithLoaderCtx(ctx, getter)
 			ctx = solutionprovider.WithProviderRegistry(ctx, reg)
 			ctx = solutionprovider.WithChildClientTracker(ctx, tracker)
@@ -513,9 +528,11 @@ func Solution(ctx context.Context, path string, opts ...Option) (*Result, error)
 			if len(cfg.clientOpts) > 0 {
 				ctx = solutionprovider.WithClientOptionsCtx(ctx, cfg.clientOpts)
 			}
-			return ctx
 		}
+		return ctx
+	}
 
+	if hasSolutionProvider {
 		// Add tracker cleanup to kill child plugin clients for this run only.
 		origCleanup := cleanup
 		cleanup = func() {
@@ -1290,7 +1307,10 @@ func buildHostMetadataSettings(entrypoint string, sol *solution.Solution) (json.
 		if sol.Metadata.Tags != nil {
 			solMeta.Tags = sol.Metadata.Tags
 		}
-		solMeta.Source = sol.Metadata.Source
+		// Report the solution's runtime provenance (local path, else the
+		// author-declared metadata.source) so the metadata provider surfaces
+		// the same origin the proto SolutionMeta.Source carries.
+		solMeta.Source = sol.Provenance()
 		if sol.Metadata.Version != nil {
 			solMeta.Version = sol.Metadata.Version.String()
 		}
@@ -1347,15 +1367,70 @@ func injectHostMetadataSettings(cfg *plugin.ProviderConfig, sol *solution.Soluti
 		entrypoint = EntrypointUnknown
 	}
 
-	raw, err := buildHostMetadataSettings(entrypoint, sol)
-	if err != nil {
+	settings := buildPerSolutionSettings(entrypoint, sol)
+	if settings == nil {
 		return
 	}
 
 	if cfg.Settings == nil {
 		cfg.Settings = make(map[string]json.RawMessage)
 	}
-	cfg.Settings[hostMetadataSettingsKey] = raw
+	for k, v := range settings {
+		cfg.Settings[k] = v
+	}
+}
+
+// buildPerSolutionSettings builds the settings map delivered to plugins on every
+// provider execution via ExecuteProviderRequest.settings. It returns the
+// complete host metadata blob (host-static fields plus the per-solution
+// sub-object) under the "metadata" key.
+//
+// The blob must be complete rather than solution-only because the SDK merges
+// execute-time settings over configure-time settings at the key level: the
+// execute-time "metadata" entry fully replaces the configure-time one. Pool-mode
+// hosts configure pooled plugins once with an empty-solution blob, so this
+// per-execution blob is what carries correct per-solution values (name, version,
+// source, ...) to those plugins. Callers pass the entrypoint that matches the
+// configure-time blob (see hostEntrypoint) so host-static fields -- crucially
+// the entrypoint -- are preserved through the override.
+//
+// Returns nil when the blob cannot be marshaled, matching the fail-soft
+// behavior of the configure-time injection path.
+func buildPerSolutionSettings(entrypoint string, sol *solution.Solution) map[string]json.RawMessage {
+	raw, err := buildHostMetadataSettings(entrypoint, sol)
+	if err != nil {
+		return nil
+	}
+	return map[string]json.RawMessage{hostMetadataSettingsKey: raw}
+}
+
+// hostEntrypoint resolves the host entrypoint (cli/api/mcp) used to build the
+// per-execution metadata blob. In pool mode the authoritative value is the
+// entrypoint the pool baked into its host-static baseConfig at load time, so it
+// is read back from there to guarantee the per-execution blob preserves it
+// through the key-level settings override. In per-call mode (no pool) it falls
+// back to the binary-name heuristic used by injectHostMetadataSettings.
+func hostEntrypoint(cfg *prepareConfig) string {
+	if cfg.pluginPool != nil {
+		base := cfg.pluginPool.BaseProviderConfig()
+		if raw, ok := base.Settings[hostMetadataSettingsKey]; ok {
+			var meta struct {
+				Entrypoint string `json:"entrypoint"`
+			}
+			if err := json.Unmarshal(raw, &meta); err == nil && meta.Entrypoint != "" {
+				return meta.Entrypoint
+			}
+		}
+		// A pool is a long-lived server, never the one-shot CLI path, so fall
+		// back to Unknown rather than the CLI heuristic when the base config
+		// could not supply an entrypoint.
+		return EntrypointUnknown
+	}
+
+	if cfg.pluginCfg != nil && cfg.pluginCfg.BinaryName != "" {
+		return EntrypointCLI
+	}
+	return EntrypointUnknown
 }
 
 // HostStaticProviderConfig builds a ProviderConfig that carries host-static

--- a/pkg/solution/prepare/prepare_test.go
+++ b/pkg/solution/prepare/prepare_test.go
@@ -120,7 +120,7 @@ func TestSolution(t *testing.T) {
 		result.Cleanup()
 	})
 
-	t.Run("ProviderCtx nil when no solution provider in registry", func(t *testing.T) {
+	t.Run("ProviderCtx non-nil and carries execution settings without solution provider", func(t *testing.T) {
 		sol := minimalSolution()
 		getter := &mockGetter{sol: sol}
 		// Empty registry with no solution provider registered.
@@ -131,7 +131,17 @@ func TestSolution(t *testing.T) {
 			WithRegistry(emptyReg),
 		)
 		require.NoError(t, err)
-		assert.Nil(t, result.ProviderCtx, "ProviderCtx should be nil when solution provider is not in registry")
+		// ProviderCtx is always non-nil: even without the solution provider it
+		// must deliver per-execution provider settings (pool-mode metadata fix).
+		require.NotNil(t, result.ProviderCtx, "ProviderCtx should always be non-nil")
+
+		enrichedCtx := result.ProviderCtx(context.Background())
+		settings, ok := provider.ExecutionSettingsFromContext(enrichedCtx)
+		require.True(t, ok, "execution settings should be attached")
+		assert.Contains(t, settings, "metadata", "execution settings should carry the metadata blob")
+
+		// Solution provider deps must not be attached when it is not registered.
+		assert.Nil(t, solutionprovider.ProviderRegistryFromContext(enrichedCtx))
 		result.Cleanup()
 	})
 
@@ -1175,6 +1185,94 @@ func TestHostStaticProviderConfig_EmptyEntrypointDefaultsToUnknown(t *testing.T)
 	assert.Equal(t, EntrypointUnknown, meta["entrypoint"])
 }
 
+func TestBuildPerSolutionSettings(t *testing.T) {
+	t.Run("carries full metadata blob with solution values", func(t *testing.T) {
+		sol := minimalSolution()
+		sol.Metadata.Source = "github.com/acme/solutions//demo"
+
+		settings := buildPerSolutionSettings(EntrypointMCP, sol)
+		require.NotNil(t, settings)
+		raw, ok := settings[hostMetadataSettingsKey]
+		require.True(t, ok, "metadata key must be present")
+
+		var meta map[string]any
+		require.NoError(t, json.Unmarshal(raw, &meta))
+
+		// Host-static entrypoint must be preserved so the key-level settings
+		// override on the plugin side does not clobber it under pool mode.
+		assert.Equal(t, "mcp", meta["entrypoint"])
+
+		// Per-solution fields must be populated.
+		solMap, ok := meta["solution"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "test-solution", solMap["name"])
+		assert.Equal(t, "1.0.0", solMap["version"])
+		// With no local path, source falls back to the author-declared source.
+		assert.Equal(t, "github.com/acme/solutions//demo", solMap["source"])
+	})
+
+	t.Run("blob source uses local path provenance when available", func(t *testing.T) {
+		sol := minimalSolution()
+		sol.SetPath("/path/to/solution.yaml")
+		sol.Metadata.Source = "github.com/acme/solutions//demo"
+
+		settings := buildPerSolutionSettings(EntrypointMCP, sol)
+		require.NotNil(t, settings)
+
+		var meta map[string]any
+		require.NoError(t, json.Unmarshal(settings[hostMetadataSettingsKey], &meta))
+		solMap, ok := meta["solution"].(map[string]any)
+		require.True(t, ok)
+		// Path provenance takes precedence, matching the proto SolutionMeta.Source
+		// channel so the metadata provider reports a consistent origin.
+		assert.Equal(t, "/path/to/solution.yaml", solMap["source"])
+	})
+
+	t.Run("nil solution yields empty solution object", func(t *testing.T) {
+		settings := buildPerSolutionSettings(EntrypointCLI, nil)
+		require.NotNil(t, settings)
+
+		var meta map[string]any
+		require.NoError(t, json.Unmarshal(settings[hostMetadataSettingsKey], &meta))
+		solMap, ok := meta["solution"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "", solMap["name"])
+	})
+}
+
+func TestHostEntrypoint(t *testing.T) {
+	t.Run("reads authoritative entrypoint from pool base config", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(),
+			plugin.WithBaseProviderConfig(HostStaticProviderConfig("scafctl", EntrypointMCP)),
+		)
+		got := hostEntrypoint(&prepareConfig{pluginPool: pool})
+		assert.Equal(t, EntrypointMCP, got)
+	})
+
+	t.Run("falls back to CLI heuristic when binary name set (per-call)", func(t *testing.T) {
+		got := hostEntrypoint(&prepareConfig{pluginCfg: &plugin.ProviderConfig{BinaryName: "scafctl"}})
+		assert.Equal(t, EntrypointCLI, got)
+	})
+
+	t.Run("unknown when no pool and no binary name", func(t *testing.T) {
+		got := hostEntrypoint(&prepareConfig{})
+		assert.Equal(t, EntrypointUnknown, got)
+	})
+
+	t.Run("unknown for a pool whose base config lacks a metadata entrypoint", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		// Pool with no base provider config: a pool is never the CLI path, so it
+		// must not fall through to the CLI heuristic even when a binary name is set.
+		pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard())
+		got := hostEntrypoint(&prepareConfig{
+			pluginPool: pool,
+			pluginCfg:  &plugin.ProviderConfig{BinaryName: "scafctl"},
+		})
+		assert.Equal(t, EntrypointUnknown, got)
+	})
+}
+
 func TestInjectHTTPClientSettings_NilConfig(t *testing.T) {
 	// Must not panic.
 	injectHTTPClientSettings(context.Background(), nil)
@@ -1858,4 +1956,17 @@ func TestRegisterBundleAuthHandlers_NoAuthHandlers(t *testing.T) {
 	clients, err := registerBundleAuthHandlers(context.Background(), sol, &prepareConfig{})
 	require.NoError(t, err)
 	assert.Nil(t, clients, "no auth-handler plugins means no clients and no fetch")
+}
+
+func BenchmarkBuildPerSolutionSettings(b *testing.B) {
+	sol := minimalSolution()
+	sol.Metadata.Source = "github.com/acme/solutions//demo"
+	sol.Metadata.Tags = []string{"infra", "demo"}
+
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if s := buildPerSolutionSettings(EntrypointMCP, sol); s == nil {
+			b.Fatal("expected non-nil settings")
+		}
+	}
 }

--- a/pkg/solution/solution.go
+++ b/pkg/solution/solution.go
@@ -348,6 +348,19 @@ func (s *Solution) GetPath() string {
 	return s.path
 }
 
+// Provenance returns a human-meaningful origin string for the solution, used as
+// the runtime SolutionMeta.source delivered to providers. It prefers the local
+// file system path the solution was loaded from; when that is empty (e.g. a
+// solution loaded from a catalog reference, bundle, or stdin) it falls back to
+// the author-declared metadata.source (typically the source repository URL).
+// Returns an empty string when neither is known.
+func (s *Solution) Provenance() string {
+	if s.path != "" {
+		return s.path
+	}
+	return s.Metadata.Source
+}
+
 // RawContent returns a copy of the original bytes used to parse this solution.
 // It preserves the original formatting for round-trip fidelity.
 // Returns nil if the solution was not loaded from bytes.

--- a/pkg/solution/solution_test.go
+++ b/pkg/solution/solution_test.go
@@ -381,6 +381,26 @@ func TestSolution_GetSetPath(t *testing.T) {
 	assert.Equal(t, path, s.GetPath())
 }
 
+func TestSolution_Provenance(t *testing.T) {
+	t.Run("prefers file system path", func(t *testing.T) {
+		s := Solution{}
+		s.SetPath("/path/to/solution.yaml")
+		s.Metadata.Source = "github.com/acme/solutions//demo"
+		assert.Equal(t, "/path/to/solution.yaml", s.Provenance())
+	})
+
+	t.Run("falls back to metadata source when path empty", func(t *testing.T) {
+		s := Solution{}
+		s.Metadata.Source = "github.com/acme/solutions//demo"
+		assert.Equal(t, "github.com/acme/solutions//demo", s.Provenance())
+	})
+
+	t.Run("empty when neither path nor source known", func(t *testing.T) {
+		s := Solution{}
+		assert.Empty(t, s.Provenance())
+	})
+}
+
 func TestSolution_LoadFromBytes(t *testing.T) {
 	t.Run("applies defaults and validates", func(t *testing.T) {
 		data := []byte(`metadata:


### PR DESCRIPTION
Host-side half of the pool-mode metadata fix (SDK v0.17.0 provides the transport + key-level merge; scafctl fills the new fields). Closes #706.

## Problem

Pool-mode hosts (MCP / API servers) configure a pooled plugin **once** at load with a host-static `baseConfig`, then computed but **dropped** the per-solution metadata. Per-call CLI delivered full per-solution metadata via a one-time `ConfigureProvider`. Result: a pooled `metadata` provider reported stale/blank per-solution values, and `SolutionMeta.source` was never populated.

## What changed

- **SDK bump** `v0.16.0` -> `v0.17.0` (adds `ExecuteProviderRequest.settings`, `SolutionMeta.source`, protocol bump).
- **Per-execution Settings channel** (`provider.WithExecutionSettings` / `ExecutionSettingsFromContext`): the host now attaches a full per-solution `metadata` blob to the context, and `buildExecuteProviderRequest` copies it (deep-copied bytes) into `req.Settings` on every execute. Because the SDK merge is **key-level** (an execute-time `settings["metadata"]` fully replaces the configure-time one), the per-execution blob is **complete** -- it reproduces the authoritative host-static `entrypoint` (read from the pool's base config) so it never clobbers the pool baseline.
- **`SolutionMeta.source`** is now set (marshal + unmarshal) from a new `Solution.Provenance()` (local file path, else author-declared `metadata.source`), wired through both engines (`solutionMetaFromSolution`, `toSolutionMeta`).
- **`ProviderCtx` is now always non-nil**: it attaches execution settings unconditionally; solution-provider dependencies stay conditional inside the closure.
- **Metadata blob `solution.source`** uses the same `Provenance()` so the flagship `metadata` provider (which reads the blob, not the proto channel) reports a consistent origin. Documented in the provider reference.

## Tests / artifacts

- Unit tests: execution-settings context round-trip; `req.Settings` population + deep-copy alias-safety; `SolutionMeta.source` marshal/unmarshal round-trip; `Solution.Provenance()`; `buildPerSolutionSettings`; `hostEntrypoint` (pool base config / CLI heuristic / unknown, incl. pool-without-entrypoint -> Unknown); `ProviderCtx` non-nil carrying settings without a solution provider; wiring assertions for `solutionMetaFromSolution` / `toSolutionMeta`; `BenchmarkBuildPerSolutionSettings`.
- Docs: `solution.source` row added to the provider reference metadata table.

## Verification

- `task lint:changed` -> 0 issues; `task test:e2e` -> 914 passed, 0 failed.
- Non-breaking additive host behavior; per-call CLI path is unchanged (redundant dual-channel delivery is harmless).