### PR TITLE
feat(cli): dedupe plugins list to latest version by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🚀 Features
 
+- *(cli)* `plugins list` now dedupes to the latest cached version per plugin (name+platform) by default, matching `catalog list`'s existing behavior; pass `--all-versions` (or its alias `--all`) to show every cached version (#532)
 - *(provider)* [**breaking**] Give the `parameter` provider an explicit `type` enum (`auto`, `string`, `raw`, `int`, `float`, `bool`, `json`, `csv`) for per-type coercion, replacing the previous all-or-nothing `type: string` escape hatch. Automatic inference (`auto`, the default) no longer splits comma-separated values into lists -- set `type: csv` to opt in. Numeric-looking values continue to infer to numbers under `auto`; use `type: string` to keep them strings (e.g. for CEL `matches()`) or `type: raw` to disable inference entirely. Typed values that fail to parse now error clearly instead of silently returning the wrong type (#624)
 - *(lint)* Add `parameter-numeric-matches` rule (warning) to flag resolvers that read a numeric `parameter` default without an explicit `type` yet call `matches()` on the value, where automatic inference would coerce the value to an integer and fail at runtime
 

--- a/docs/design/plugins.md
+++ b/docs/design/plugins.md
@@ -70,7 +70,7 @@ A plugin may expose one or more providers OR one or more auth handlers (not both
 When distributed via the catalog, plugins are categorized by their purpose:
 
 | Artifact Kind | Description | Repository Path |
-|--------------|-------------|-----------------|
+| -------------- | ------------- | ----------------- |
 | `provider` | go-plugin binary exposing providers | `/providers/` |
 | `auth-handler` | go-plugin binary exposing auth handlers | `/auth-handlers/` |
 
@@ -130,7 +130,7 @@ performance-critical remain in-process.
 ### Current Built-in Providers
 
 | Provider | Reason |
-|----------|--------|
+| ---------- | -------- |
 | `cel` | Imports `pkg/celexp` (rule 1) |
 | `go-template` | Imports `pkg/gotmpl` (rule 1) |
 | `validation` | Imports `pkg/celexp` for CEL-based validation rules (rule 1) |
@@ -215,7 +215,7 @@ service HostService {
 ### RPC Lifecycle
 
 | Phase | RPC | Direction | When |
-|-------|-----|-----------|------|
+| ------- | ----- | ----------- | ------ |
 | Discovery | `GetProviders` | host -> plugin | On plugin load |
 | Schema | `GetProviderDescriptor` | host -> plugin | After discovery |
 | Configuration | `ConfigureProvider` | host -> plugin | Once after load, before any execution |
@@ -229,7 +229,7 @@ service HostService {
 ### Auth Handler RPC Lifecycle
 
 | Phase | RPC | Direction | When |
-|-------|-----|-----------|------|
+| ------- | ----- | ----------- | ------ |
 | Discovery | `GetAuthHandlers` | host -> plugin | On plugin load |
 | Configuration | `ConfigureAuthHandler` | host -> plugin | Once after load, before any auth calls |
 | Authentication | `Login` | host -> plugin | On `auth login` |
@@ -273,7 +273,7 @@ Called during CLI shutdown or context cancellation to allow auth handler plugins
 Plugins that need host-side resources (secrets, auth tokens) use the `HostService` callback service. The host registers this service via the go-plugin GRPCBroker during plugin startup.
 
 | Callback | Purpose |
-|----------|---------|
+| ---------- | --------- |
 | `GetSecret` / `SetSecret` / `DeleteSecret` / `ListSecrets` | Access the host's secret store |
 | `GetAuthIdentity` | Retrieve identity claims from the host's auth registry |
 | `ListAuthHandlers` | List available auth handlers (filtered by AllowedAuthHandlers) |
@@ -496,6 +496,7 @@ bundle:
 ```
 
 scafctl will:
+
 1. Check if the plugin exists in the local catalog
 2. Pull missing plugins from configured remote catalogs
 3. Validate version constraints are met
@@ -587,7 +588,7 @@ When a solution declares plugin dependencies under `bundle.plugins`, scafctl aut
 ### Architecture
 
 | Component | Package | Responsibility |
-|-----------|---------|----------------|
+| ----------- | --------- | ---------------- |
 | **Fetcher** | `pkg/plugin/fetcher.go` | Orchestrates fetch + cache + registration |
 | **Cache** | `pkg/plugin/cache.go` | Content-addressed binary cache under `$XDG_CACHE_HOME/scafctl/plugins/` |
 | **ChainCatalog** | `pkg/catalog/chain.go` | Tries catalogs in order (local → remote OCI) |
@@ -607,7 +608,10 @@ When a solution declares plugin dependencies under `bundle.plugins`, scafctl aut
 ### CLI Commands
 
 - **`scafctl plugins install`** — Pre-fetch plugin binaries from catalogs before a build or run
-- **`scafctl plugins list`** — List cached plugin binaries with digest, size, and platform info
+- **`scafctl plugins list`** — List cached plugin binaries with digest, size, and platform info.
+  By default shows only the latest cached version per name+platform (matching
+  `catalog list`'s dedupe behavior); pass `--all-versions` (or `--all`) to show
+  every cached version.
 
 Both commands live in `pkg/cmd/scafctl/plugins/`.
 
@@ -631,7 +635,7 @@ combinations, scafctl supports **OCI image indexes** (fat manifests).
 ### Architecture
 
 | Component | Package | Responsibility |
-|-----------|---------|----------------|
+| ----------- | --------- | ---------------- |
 | **MultiPlatform helpers** | `pkg/catalog/multiplatform.go` | Platform↔OCI conversion, index matching |
 | **StoreMultiPlatform** | `pkg/catalog/local_multiplatform.go` | Store multi-platform artifact as image index |
 | **FetchByPlatform** | `pkg/catalog/local_multiplatform.go` | Fetch correct platform binary from image index |
@@ -704,7 +708,7 @@ identities are loaded.
 ### Verification Modes
 
 | Mode | Behavior |
-|------|----------|
+| ------ | ---------- |
 | `off` (default) | Digest-only verification; no signature check |
 | `warn` | Verify signature; log a warning on failure but continue |
 | `enforce` | Verify signature; fail on missing or invalid signature |
@@ -724,7 +728,7 @@ plugins:
 ```
 
 | Field | Description |
-|-------|-------------|
+| ------- | ------------- |
 | `mode` | `off`, `warn`, or `enforce` |
 | `trustedIssuers` | OIDC token issuers whose signing certificates are trusted |
 | `trustedIdentities` | Glob patterns matching the certificate subject/identity |
@@ -807,7 +811,7 @@ and testing workflows where different versions must be compared.
 ### Pinning Mechanisms
 
 | Mechanism | Scope | Example |
-|-----------|-------|---------|
+| ----------- | ------- | --------- |
 | `name@version` positional syntax | Single `run provider` invocation | `scafctl run provider exec@0.5.0 command="echo hi"` |
 | `--plugin-version` flag | Single `run provider` invocation | `scafctl run provider exec --plugin-version 0.5.0 command="echo hi"` |
 | `bundle.plugins[].version` | Solution-level constraint | `version: "0.5.0"` or `version: "^1.0.0"` |
@@ -826,7 +830,7 @@ A bare `@` at position 0 (e.g., `@latest`) is treated as a name with no version.
 ### Implementation
 
 | Component | Package | Role |
-|-----------|---------|------|
+| ----------- | --------- | ------ |
 | `parseProviderNameVersion` | `pkg/cmd/scafctl/run/provider.go` | Splits `name@version` |
 | `RegisterCachedPluginVersion` | `pkg/plugin/fetcher.go` | Loads exact version from cache |
 | `PluginVersion` field on `ProviderOptions` | `pkg/cmd/scafctl/run/provider.go` | Carries version through CLI |
@@ -836,7 +840,8 @@ A bare `@` at position 0 (e.g., `@latest`) is treated as a name with no version.
 
 Plugin versions are visible through:
 
-- `scafctl plugins list` -- shows version column for cached plugins
+- `scafctl plugins list` -- shows version column for cached plugins (latest per
+  name+platform by default; `--all-versions`/`--all` shows every cached version)
 - `scafctl get provider -o json` -- includes version for all providers
 - `scafctl catalog list --kind provider --all-versions` -- shows all available versions
 - MCP `list_providers` tool -- returns version field per provider
@@ -860,6 +865,7 @@ order is:
 Plugins are the extensibility layer of scafctl. They exist to supply providers in an isolated, versioned, and scalable way using go-plugin. Plugins are not a new execution model or abstraction. They are the mechanism by which providers are distributed and invoked, keeping the core system small, stable, and extensible.
 
 Plugins are distributed through the catalog system as OCI artifacts, enabling:
+
 - Versioned plugin releases with semantic versioning
 - Multi-platform support (linux/amd64, darwin/arm64, etc.)
 - Offline distribution via `scafctl save/load`

--- a/docs/tutorials/plugin-auto-fetch-tutorial.md
+++ b/docs/tutorials/plugin-auto-fetch-tutorial.md
@@ -50,12 +50,13 @@ spec:
 ### Fields
 
 | Field | Description | Example |
-|-------|-------------|---------|
+| ------- | ------------- | --------- |
 | `name` | Plugin catalog reference | `aws-provider` |
 | `kind` | Plugin type: `provider` or `auth-handler` | `provider` |
 | `version` | Semver constraint | `^1.5.0`, `>=2.0.0`, `1.2.3` |
 
 Version constraints follow [semver](https://semver.org/) conventions:
+
 - `^1.5.0` — any 1.x.y where x ≥ 5
 - `~1.5.0` — any 1.5.x
 - `>=2.0.0` — 2.0.0 or higher
@@ -67,6 +68,7 @@ Use `scafctl plugins install` to download plugin binaries before running a solut
 
 {{< tabs "plugin-auto-fetch-tutorial-cmd-1" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # Install plugins for a solution
 scafctl plugins install -f solution.yaml
@@ -77,8 +79,10 @@ scafctl plugins install -f solution.yaml --platform linux/amd64
 # Use a custom cache directory
 scafctl plugins install -f solution.yaml --cache-dir /tmp/plugins
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 # Install plugins for a solution
 scafctl plugins install -f solution.yaml
@@ -89,10 +93,12 @@ scafctl plugins install -f solution.yaml --platform linux/amd64
 # Use a custom cache directory
 scafctl plugins install -f solution.yaml --cache-dir /tmp/plugins
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
 This is useful for:
+
 - **CI/CD**: Pre-fetch plugins in a setup step, then run solutions offline
 - **Air-gapped environments**: Fetch once on a connected machine, copy the cache
 - **Reproducibility**: Pin versions with a lock file, then install from locks
@@ -103,6 +109,7 @@ View what's in your local plugin cache:
 
 {{< tabs "plugin-auto-fetch-tutorial-cmd-2" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # Table view (default)
 scafctl plugins list
@@ -113,8 +120,10 @@ scafctl plugins list -o json
 # YAML output
 scafctl plugins list -o yaml
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 # Table view (default)
 scafctl plugins list
@@ -125,8 +134,17 @@ scafctl plugins list -o json
 # YAML output
 scafctl plugins list -o yaml
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
+
+> **Note:** By default, `plugins list` shows only the latest cached version of
+> each plugin (per platform). Pass `--all-versions` (or its alias `--all`) to
+> see every cached version:
+>
+> ```bash
+> scafctl plugins list --all-versions
+> ```
 
 ## Lock Files for Reproducibility
 
@@ -167,7 +185,7 @@ plugins:
 ### Verification Modes
 
 | Mode | Behavior |
-|------|----------|
+| ------ | ---------- |
 | `off` (default) | No signature check; digest verification only |
 | `warn` | Verify signature; log a warning on failure but continue execution |
 | `enforce` | Verify signature; fail with an error on missing or invalid signature |
@@ -189,10 +207,12 @@ Signature verification requires the `cosign` build tag:
 
 {{< tabs "plugin-signature-build" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # Build scafctl with cosign signature verification support
 go build -tags cosign -o scafctl ./cmd/scafctl/scafctl.go
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -219,10 +239,12 @@ For production CI/CD pipelines, combine signature enforcement with strict mode:
 
 {{< tabs "plugin-signature-ci" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # Enforce both explicit plugin declarations and valid signatures
 scafctl run solution -f solution.yaml --strict
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -276,6 +298,7 @@ $XDG_CACHE_HOME/scafctl/plugins/
 
 {{< tabs "plugin-auto-fetch-tutorial-cmd-3" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # List cached plugins
 scafctl plugins list
@@ -284,8 +307,10 @@ scafctl plugins list
 # To clear the entire cache:
 rm -rf ~/.cache/scafctl/plugins/
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 # List cached plugins
 scafctl plugins list
@@ -294,6 +319,7 @@ scafctl plugins list
 # To clear the entire cache:
 Remove-Item -Recurse -Force "$env:LOCALAPPDATA\scafctl\plugins\"
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -329,6 +355,7 @@ $XDG_CACHE_HOME/scafctl/provider-schemas/
 
 {{< tabs "plugin-auto-fetch-tutorial-cmd-4" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # Schema cache is at $XDG_CACHE_HOME/scafctl/provider-schemas/
 # To clear all cached schemas (forces re-fetch on next access):
@@ -337,8 +364,10 @@ rm -rf ~/.cache/scafctl/provider-schemas/
 # To invalidate a single provider:
 rm ~/.cache/scafctl/provider-schemas/exec.json
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 # Schema cache is at $env:LOCALAPPDATA\cache\scafctl\provider-schemas\
 # To clear all cached schemas:
@@ -347,6 +376,7 @@ Remove-Item -Recurse -Force "$env:LOCALAPPDATA\cache\scafctl\provider-schemas\"
 # To invalidate a single provider:
 Remove-Item "$env:LOCALAPPDATA\cache\scafctl\provider-schemas\exec.json"
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -365,6 +395,7 @@ dev.scafctl.plugin.platform: linux/amd64
 ```
 
 When fetching, scafctl:
+
 1. Lists all artifacts for the plugin version
 2. Matches the `dev.scafctl.plugin.platform` annotation against the current (or requested) platform
 3. Falls back to a direct fetch if no platform annotation exists (single-platform plugin)
@@ -373,16 +404,20 @@ When fetching, scafctl:
 
 {{< tabs "plugin-auto-fetch-tutorial-cmd-4" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # Fetch for a different platform
 scafctl plugins install -f solution.yaml --platform linux/amd64
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 # Fetch for a different platform
 scafctl plugins install -f solution.yaml --platform linux/amd64
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -394,18 +429,23 @@ When you run a solution that declares plugin dependencies:
 
 {{< tabs "plugin-auto-fetch-tutorial-cmd-5" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl run solution -f solution.yaml
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl run solution -f solution.yaml
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
 The prepare phase automatically:
+
 1. Reads `bundle.plugins` from the solution
 2. Checks the lock file for pinned versions
 3. Fetches any missing plugins from the catalog chain
@@ -422,7 +462,7 @@ scafctl includes a built-in registry of 10 **official providers** distributed as
 ### Official Providers
 
 | Provider | Description |
-|----------|-------------|
+| ---------- | ------------- |
 | `directory` | File system directory operations |
 | `env` | Environment variable lookup |
 | `exec` | Shell command execution |
@@ -456,6 +496,7 @@ The `run provider` command also auto-resolves official providers. You can invoke
 
 {{< tabs "plugin-auto-fetch-tutorial-cmd-run-provider" >}}
 {{% tab "Bash" %}}
+
 ~~~bash
 # Auto-resolves the exec provider plugin and runs it
 scafctl run provider exec command='echo hello' -o json
@@ -463,8 +504,10 @@ scafctl run provider exec command='echo hello' -o json
 # Auto-resolves the env provider plugin
 scafctl run provider env name=HOME -o json
 ~~~
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ~~~powershell
 # Auto-resolves the exec provider plugin and runs it
 scafctl run provider exec command='echo hello' -o json
@@ -472,6 +515,7 @@ scafctl run provider exec command='echo hello' -o json
 # Auto-resolves the env provider plugin
 scafctl run provider env name=HOME -o json
 ~~~
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -503,6 +547,7 @@ The `--strict` flag disables auto-resolution and requires all providers to be ei
 
 {{< tabs "plugin-auto-fetch-tutorial-cmd-strict" >}}
 {{% tab "Bash" %}}
+
 ~~~bash
 # Fails if any provider would be auto-resolved
 scafctl run solution -f solution.yaml --strict
@@ -510,8 +555,10 @@ scafctl run solution -f solution.yaml --strict
 # Also works with run resolver
 scafctl run resolver -f solution.yaml --strict
 ~~~
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ~~~powershell
 # Fails if any provider would be auto-resolved
 scafctl run solution -f solution.yaml --strict
@@ -519,6 +566,7 @@ scafctl run solution -f solution.yaml --strict
 # Also works with run resolver
 scafctl run resolver -f solution.yaml --strict
 ~~~
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -540,6 +588,7 @@ With this setting, solutions must declare all non-built-in providers in `bundle.
 
 {{< tabs "plugin-auto-fetch-tutorial-cmd-6" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # 1. Develop your solution with plugin dependencies
 cat > solution.yaml << 'EOF'
@@ -575,8 +624,10 @@ scafctl run solution -f solution.yaml
 # 5. Check what's cached
 scafctl plugins list
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 # 1. Develop your solution with plugin dependencies
 @'
@@ -612,6 +663,7 @@ scafctl run solution -f solution.yaml
 # 5. Check what's cached
 scafctl plugins list
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -642,6 +694,7 @@ If a cached binary seems corrupt:
 
 {{< tabs "plugin-auto-fetch-tutorial-cmd-7" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # Remove the specific plugin from cache
 rm -rf ~/.cache/scafctl/plugins/<plugin-name>/<version>/
@@ -649,8 +702,10 @@ rm -rf ~/.cache/scafctl/plugins/<plugin-name>/<version>/
 # Re-fetch
 scafctl plugins install -f solution.yaml
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 # Remove the specific plugin from cache
 Remove-Item -Recurse -Force "$env:LOCALAPPDATA\scafctl\plugins\<plugin-name>\<version>\"
@@ -658,5 +713,6 @@ Remove-Item -Recurse -Force "$env:LOCALAPPDATA\scafctl\plugins\<plugin-name>\<ve
 # Re-fetch
 scafctl plugins install -f solution.yaml
 ```
+
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/tutorials/plugin-development.md
+++ b/docs/tutorials/plugin-development.md
@@ -56,17 +56,21 @@ scafctl resolves plugins through two mechanisms:
 
 {{< tabs "plugin-development-cmd-1" >}}
 {{% tab "Bash" %}}
+
 ```bash
    mkdir -p "$(scafctl paths cache)/plugins"
    cp my-plugin "$(scafctl paths cache)/plugins/"
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
    $pluginDir = "$(scafctl paths cache)/plugins"
    New-Item -ItemType Directory -Force -Path $pluginDir
    Copy-Item my-plugin $pluginDir
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -74,6 +78,7 @@ scafctl resolves plugins through two mechanisms:
 
 {{< tabs "plugin-development-cmd-2" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # Pre-fetch plugins declared in a solution
 scafctl plugins install -f my-solution.yaml
@@ -84,8 +89,10 @@ scafctl plugins list
 # Push to a remote registry
 scafctl catalog push my-plugin@1.0.0 --catalog ghcr.io/myorg
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 # Pre-fetch plugins declared in a solution
 scafctl plugins install -f my-solution.yaml
@@ -96,12 +103,15 @@ scafctl plugins list
 # Push to a remote registry
 scafctl catalog push my-plugin@1.0.0 --catalog ghcr.io/myorg
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
 > **Note:** `plugins list` shows only plugins fetched from the remote catalog
-> cache. Local builds loaded via `--plugin-dir` are not listed. To see all
-> available versions (including pre-release), use:
+> cache. Local builds loaded via `--plugin-dir` are not listed. By default it
+> shows only the latest cached version of each plugin; pass `--all-versions`
+> (or `--all`) to see every cached version. To see all available versions
+> from the catalog (including pre-release), use:
 > `scafctl catalog list --kind provider --pre-release --all-versions`
 
 ## Next Steps

--- a/pkg/cmd/scafctl/plugins/list.go
+++ b/pkg/cmd/scafctl/plugins/list.go
@@ -21,10 +21,11 @@ import (
 
 // ListOptions holds options for the list command.
 type ListOptions struct {
-	BinaryName string
-	CliParams  *settings.Run
-	IOStreams  *terminal.IOStreams
-	CacheDir   string
+	BinaryName  string
+	CliParams   *settings.Run
+	IOStreams   *terminal.IOStreams
+	CacheDir    string
+	AllVersions bool
 	flags.KvxOutputFlags
 }
 
@@ -65,7 +66,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 		Short:        "List cached plugin binaries",
 		SilenceUsage: true,
 		Long: strings.ReplaceAll(heredoc.Doc(`
-			List all plugin binaries stored in the local plugin cache.
+			List plugin binaries stored in the local plugin cache.
 
 			Shows the name, version, platform, and size for each cached binary.
 			This command shows the remote download cache only (plugins fetched
@@ -73,9 +74,16 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 			'scafctl build plugin', use:
 			  scafctl catalog list --kind provider --pre-release --all-versions
 
+			By default, only the latest cached version of each plugin (per name
+			+ platform) is shown. Use --all-versions (or its alias --all) to
+			show every cached version.
+
 			Examples:
-			  # List all cached plugins
+			  # List the latest cached version of each plugin
 			  scafctl plugins list
+
+			  # List every cached version of every plugin
+			  scafctl plugins list --all-versions
 
 			  # List in JSON format
 			  scafctl plugins list -o json
@@ -100,6 +108,8 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 	}
 
 	cmd.Flags().StringVar(&opts.CacheDir, "cache-dir", "", fmt.Sprintf("Plugin cache directory (default: $XDG_CACHE_HOME/%s/plugins/)", path))
+	cmd.Flags().BoolVar(&opts.AllVersions, "all-versions", false, "Show all cached versions instead of just the latest per plugin")
+	cmd.Flags().BoolVar(&opts.AllVersions, "all", false, "Alias for --all-versions")
 	flags.AddKvxOutputFlagsToStruct(cmd, &opts.KvxOutputFlags)
 
 	return cmd
@@ -131,6 +141,12 @@ func runList(ctx context.Context, opts *ListOptions, kvxOpts *kvx.OutputOptions)
 		w.PlainStderrf("To see locally-built artifacts: %s catalog list --kind provider --pre-release --all-versions", opts.BinaryName)
 		return kvxOpts.Write([]pluginListItem{})
 	}
+
+	// By default, keep only the latest cached version per name+platform
+	// (real semver comparison). --all-versions (or --all) restores the full
+	// listing. See plugin.SortAndDedupeLatest for the shared dedup logic
+	// (also used by the MCP list_plugins tool).
+	cached = plugin.SortAndDedupeLatest(cached, opts.AllVersions)
 
 	items := make([]pluginListItem, len(cached))
 	for i, p := range cached {

--- a/pkg/cmd/scafctl/plugins/list_test.go
+++ b/pkg/cmd/scafctl/plugins/list_test.go
@@ -4,9 +4,11 @@
 package plugins
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -138,6 +140,187 @@ func TestRunList_PopulatedCache_ReturnsItems(t *testing.T) {
 	assert.Contains(t, out, "test-plugin")
 	assert.Contains(t, out, "1.2.3")
 	assert.Contains(t, out, "sizeHuman")
+}
+
+func TestRunList_MultipleVersions_DedupesToLatestByDefault(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	outputOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	platform := runtime.GOOS + "-" + runtime.GOARCH
+	binName := "test-plugin"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	for _, version := range []string{"0.1.1", "0.2.0", "0.9.0", "0.10.0"} {
+		pluginDir := filepath.Join(cacheDir, "test-plugin", version, platform)
+		require.NoError(t, os.MkdirAll(pluginDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(pluginDir, binName), []byte("binary"), 0o755))
+	}
+
+	opts := &ListOptions{
+		BinaryName: "scafctl",
+		CacheDir:   cacheDir,
+	}
+
+	err := runList(ctx, opts, outputOpts)
+	require.NoError(t, err)
+
+	var items []pluginListItem
+	require.NoError(t, json.Unmarshal(outBuf.Bytes(), &items))
+	require.Len(t, items, 1, "expected only the latest version to be returned by default")
+	assert.Equal(t, "0.10.0", items[0].Version, "0.10.0 should sort above 0.9.0 via semver comparison")
+}
+
+func TestRunList_AllVersionsFlag_ShowsEveryCachedVersion(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	outputOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	platform := runtime.GOOS + "-" + runtime.GOARCH
+	binName := "test-plugin"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	for _, version := range []string{"0.1.1", "0.2.0"} {
+		pluginDir := filepath.Join(cacheDir, "test-plugin", version, platform)
+		require.NoError(t, os.MkdirAll(pluginDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(pluginDir, binName), []byte("binary"), 0o755))
+	}
+
+	opts := &ListOptions{
+		BinaryName:  "scafctl",
+		CacheDir:    cacheDir,
+		AllVersions: true,
+	}
+
+	err := runList(ctx, opts, outputOpts)
+	require.NoError(t, err)
+
+	var items []pluginListItem
+	require.NoError(t, json.Unmarshal(outBuf.Bytes(), &items))
+	require.Len(t, items, 2, "--all-versions should show every cached version")
+}
+
+func TestRunList_MixedSemverAndNonSemverVersions_PicksLatestSemver(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	outputOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	platform := runtime.GOOS + "-" + runtime.GOARCH
+	binName := "test-plugin"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	// "zzz-not-a-version" sorts lexically above any of the valid semver
+	// strings but must never be picked as "latest" since it's not a valid
+	// semver version -- a valid semver version always wins.
+	for _, version := range []string{"1.0.0", "9.0.0", "zzz-not-a-version"} {
+		pluginDir := filepath.Join(cacheDir, "test-plugin", version, platform)
+		require.NoError(t, os.MkdirAll(pluginDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(pluginDir, binName), []byte("binary"), 0o755))
+	}
+
+	opts := &ListOptions{
+		BinaryName: "scafctl",
+		CacheDir:   cacheDir,
+	}
+
+	err := runList(ctx, opts, outputOpts)
+	require.NoError(t, err)
+
+	var items []pluginListItem
+	require.NoError(t, json.Unmarshal(outBuf.Bytes(), &items))
+	require.Len(t, items, 1, "expected only the latest version to be returned by default")
+	assert.Equal(t, "9.0.0", items[0].Version, "valid semver must win over a lexically-larger non-semver string")
+}
+
+func TestRunList_SameVersionDifferentPlatforms_BothRetained(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	outputOpts := kvx.NewOutputOptions(ioStreams)
+	outputOpts.Format = "json"
+
+	cacheDir := t.TempDir()
+	binName := "test-plugin"
+
+	for _, platform := range []string{"linux-amd64", "darwin-arm64"} {
+		pluginDir := filepath.Join(cacheDir, "test-plugin", "1.0.0", platform)
+		require.NoError(t, os.MkdirAll(pluginDir, 0o755))
+		bin := binName
+		if strings.HasPrefix(platform, "windows") {
+			bin += ".exe"
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(pluginDir, bin), []byte("binary"), 0o755))
+	}
+
+	opts := &ListOptions{
+		BinaryName: "scafctl",
+		CacheDir:   cacheDir,
+	}
+
+	err := runList(ctx, opts, outputOpts)
+	require.NoError(t, err)
+
+	var items []pluginListItem
+	require.NoError(t, json.Unmarshal(outBuf.Bytes(), &items))
+	require.Len(t, items, 2, "the name+platform dedupe key must retain both platforms of the same version")
+}
+
+func TestCommandList_AllVersionsAndAllFlags(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	cmd := CommandList(cliParams, ioStreams, "scafctl")
+
+	f := cmd.Flags().Lookup("all-versions")
+	require.NotNil(t, f, "all-versions flag should exist")
+	assert.Equal(t, "false", f.DefValue)
+
+	all := cmd.Flags().Lookup("all")
+	require.NotNil(t, all, "all flag should exist as an alias for all-versions")
+	assert.Equal(t, "false", all.DefValue)
+}
+
+func TestCommandList_AllFlag_IsAliasForAllVersions(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	cmd := CommandList(cliParams, ioStreams, "scafctl")
+
+	require.NoError(t, cmd.Flags().Set("all", "true"))
+
+	f := cmd.Flags().Lookup("all-versions")
+	require.NotNil(t, f)
+	assert.Equal(t, "true", f.Value.String(), "--all should also flip --all-versions since they share the same backing variable")
 }
 
 func TestRunList_NoWriterInContext_ReturnsError(t *testing.T) {

--- a/pkg/mcp/tools_plugin.go
+++ b/pkg/mcp/tools_plugin.go
@@ -22,7 +22,8 @@ import (
 func (s *Server) registerPluginTools() {
 	listPluginsTool := mcp.NewTool("list_plugins",
 		mcp.WithDescription(fmt.Sprintf(
-			"List cached plugin binaries in the %s plugin cache. Returns name, version, platform, path, and size for each cached plugin. Plugins are cached after being fetched from catalogs or installed locally.",
+			"List cached plugin binaries in the %s plugin cache. Returns name, version, platform, path, and size for each cached plugin. Plugins are cached after being fetched from catalogs or installed locally. "+
+				"By default, only the latest cached version of each plugin (per name+platform) is returned, matching the 'plugins list' CLI command; set 'all_versions' to true to return every cached version.",
 			s.name,
 		)),
 		mcp.WithTitleAnnotation("List Cached Plugins"),
@@ -31,6 +32,9 @@ func (s *Server) registerPluginTools() {
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithBoolean("all_versions",
+			mcp.Description("Return every cached version of each plugin instead of just the latest (per name+platform). Defaults to false."),
+		),
 	)
 	s.addTool(listPluginsTool, s.handleListPlugins)
 
@@ -115,8 +119,13 @@ func (s *Server) registerPluginTools() {
 	s.addTool(getSignaturePolicyTool, s.handleGetSignaturePolicy)
 }
 
-// handleListPlugins lists cached plugin binaries.
-func (s *Server) handleListPlugins(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// handleListPlugins lists cached plugin binaries. By default it returns only
+// the latest cached version of each plugin (per name+platform), matching the
+// 'plugins list' CLI command; set 'all_versions' to true to return every
+// cached version.
+func (s *Server) handleListPlugins(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	allVersions := request.GetBool("all_versions", false)
+
 	cache := plugin.NewCache(paths.PluginCacheDir())
 	plugins, err := cache.List()
 	if err != nil {
@@ -124,6 +133,8 @@ func (s *Server) handleListPlugins(_ context.Context, _ mcp.CallToolRequest) (*m
 			WithSuggestion("Check that the plugin cache directory exists and is readable"),
 		), nil
 	}
+
+	plugins = plugin.SortAndDedupeLatest(plugins, allVersions)
 
 	if len(plugins) == 0 {
 		// Return an empty envelope (not plain text) so strict MCP clients still

--- a/pkg/mcp/tools_plugin_test.go
+++ b/pkg/mcp/tools_plugin_test.go
@@ -88,6 +88,69 @@ func TestHandleListPlugins(t *testing.T) {
 		}
 		assert.True(t, found, "expected mcp-test-provider in plugin list")
 	})
+
+	t.Run("dedupes to latest version by default and all_versions restores full list", func(t *testing.T) {
+		t.Setenv("XDG_CACHE_HOME", t.TempDir())
+		xdg.Reload()
+
+		cacheDir := paths.PluginCacheDir()
+		for _, version := range []string{"0.1.1", "0.2.0"} {
+			pluginDir := filepath.Join(cacheDir, "mcp-dedup-provider", version, "linux-amd64")
+			require.NoError(t, os.MkdirAll(pluginDir, 0o755))
+			binPath := filepath.Join(pluginDir, "mcp-dedup-provider")
+			require.NoError(t, os.WriteFile(binPath, []byte("binary"), 0o755))
+		}
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		countVersions := func(plugins []plugin.CachedPlugin) int {
+			count := 0
+			for _, p := range plugins {
+				if p.Name == "mcp-dedup-provider" {
+					count++
+				}
+			}
+			return count
+		}
+
+		// Default: latest only.
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "list_plugins"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleListPlugins(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var envelope struct {
+			Plugins []plugin.CachedPlugin `json:"plugins"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &envelope))
+		assert.Equal(t, 1, countVersions(envelope.Plugins), "default should dedupe to latest version only")
+		for _, p := range envelope.Plugins {
+			if p.Name == "mcp-dedup-provider" {
+				assert.Equal(t, "0.2.0", p.Version)
+			}
+		}
+
+		// all_versions=true: full listing restored.
+		requestAll := mcp.CallToolRequest{}
+		requestAll.Params.Name = "list_plugins"
+		requestAll.Params.Arguments = map[string]any{"all_versions": true}
+
+		resultAll, err := srv.handleListPlugins(context.Background(), requestAll)
+		require.NoError(t, err)
+		assert.False(t, resultAll.IsError)
+
+		textAll := resultAll.Content[0].(mcp.TextContent).Text
+		var envelopeAll struct {
+			Plugins []plugin.CachedPlugin `json:"plugins"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(textAll), &envelopeAll))
+		assert.Equal(t, 2, countVersions(envelopeAll.Plugins), "all_versions=true should return every cached version")
+	})
 }
 
 func TestHandleGetPluginCachePath(t *testing.T) {

--- a/pkg/plugin/cache.go
+++ b/pkg/plugin/cache.go
@@ -585,6 +585,56 @@ func (c *Cache) GetLatestBinary(name string) (string, string, bool) {
 	return c.GetLatestCached(name, CurrentPlatform())
 }
 
+// SortAndDedupeLatest sorts a slice of CachedPlugin by name, then version
+// descending (real semver comparison so e.g. 0.10.0 sorts above 0.9.0), and --
+// unless allVersions is true -- collapses it to only the latest cached
+// version per name+platform. This is the shared dedup-to-latest logic used
+// by both `plugins list` and the MCP list_plugins tool, mirroring the
+// `catalog list` behavior for consistency across cached-plugin listings.
+//
+// A version that fails to parse as semver always sorts below one that does
+// (matching GetLatestCached's "valid semver always wins" precedent); only
+// when BOTH sides fail to parse is a lexical fallback used. This avoids an
+// invalid strict-weak-ordering that could otherwise pick an arbitrary
+// "latest" when comparing valid and invalid versions pairwise.
+//
+// The input slice is sorted and filtered in place; the returned slice shares
+// the input's backing array.
+func SortAndDedupeLatest(cached []CachedPlugin, allVersions bool) []CachedPlugin {
+	sort.Slice(cached, func(i, j int) bool {
+		if cached[i].Name != cached[j].Name {
+			return cached[i].Name < cached[j].Name
+		}
+		vi, iErr := semver.NewVersion(cached[i].Version)
+		vj, jErr := semver.NewVersion(cached[j].Version)
+		switch {
+		case iErr == nil && jErr == nil:
+			return vi.GreaterThan(vj)
+		case iErr == nil:
+			return true // valid semver always sorts above invalid
+		case jErr == nil:
+			return false
+		default:
+			return cached[i].Version > cached[j].Version
+		}
+	})
+
+	if allVersions {
+		return cached
+	}
+
+	seen := make(map[string]bool)
+	filtered := cached[:0]
+	for _, p := range cached {
+		key := p.Name + "/" + p.Platform
+		if !seen[key] {
+			seen[key] = true
+			filtered = append(filtered, p)
+		}
+	}
+	return filtered
+}
+
 // ListCurrentPlatform returns cached plugins that match the current platform.
 // When multiple versions of the same plugin are cached, only the latest
 // (by semver) is included.

--- a/pkg/plugin/cache.go
+++ b/pkg/plugin/cache.go
@@ -609,14 +609,30 @@ func SortAndDedupeLatest(cached []CachedPlugin, allVersions bool) []CachedPlugin
 		vj, jErr := semver.NewVersion(cached[j].Version)
 		switch {
 		case iErr == nil && jErr == nil:
-			return vi.GreaterThan(vj)
+			if !vi.Equal(vj) {
+				return vi.GreaterThan(vj)
+			}
 		case iErr == nil:
 			return true // valid semver always sorts above invalid
 		case jErr == nil:
 			return false
 		default:
-			return cached[i].Version > cached[j].Version
+			if cached[i].Version != cached[j].Version {
+				return cached[i].Version > cached[j].Version
+			}
 		}
+		// Deterministic tie-breakers for equal Name+Version (e.g. the same
+		// version cached for different platforms or registry hashes): fall
+		// back to Platform, then RegistryHash, then Path so sort.Slice's
+		// output ordering never depends on input order, and the subsequent
+		// name+platform dedupe always retains a consistent entry.
+		if cached[i].Platform != cached[j].Platform {
+			return cached[i].Platform < cached[j].Platform
+		}
+		if cached[i].RegistryHash != cached[j].RegistryHash {
+			return cached[i].RegistryHash < cached[j].RegistryHash
+		}
+		return cached[i].Path < cached[j].Path
 	})
 
 	if allVersions {

--- a/pkg/plugin/cache_test.go
+++ b/pkg/plugin/cache_test.go
@@ -316,6 +316,74 @@ func TestCache_GetLatestCached_SemverBeatsLexicographic(t *testing.T) {
 	assert.Equal(t, "0.10.0", version, "should pick 0.10.0 (semver) not 0.9.0 (lexicographic)")
 }
 
+func TestSortAndDedupeLatest_DefaultKeepsOnlyLatestPerNamePlatform(t *testing.T) {
+	cached := []CachedPlugin{
+		{Name: "myplugin", Version: "0.9.0", Platform: "linux/amd64"},
+		{Name: "myplugin", Version: "0.10.0", Platform: "linux/amd64"},
+		{Name: "myplugin", Version: "1.0.0", Platform: "linux/amd64"},
+	}
+
+	result := SortAndDedupeLatest(cached, false)
+	require.Len(t, result, 1)
+	assert.Equal(t, "1.0.0", result[0].Version)
+}
+
+func TestSortAndDedupeLatest_AllVersionsReturnsEveryEntrySorted(t *testing.T) {
+	cached := []CachedPlugin{
+		{Name: "myplugin", Version: "0.9.0", Platform: "linux/amd64"},
+		{Name: "myplugin", Version: "1.0.0", Platform: "linux/amd64"},
+	}
+
+	result := SortAndDedupeLatest(cached, true)
+	require.Len(t, result, 2)
+	// Sorted descending by semver within the same name.
+	assert.Equal(t, "1.0.0", result[0].Version)
+	assert.Equal(t, "0.9.0", result[1].Version)
+}
+
+func TestSortAndDedupeLatest_SemverBeatsLexicographic(t *testing.T) {
+	cached := []CachedPlugin{
+		{Name: "myplugin", Version: "0.9.0", Platform: "linux/amd64"},
+		{Name: "myplugin", Version: "0.10.0", Platform: "linux/amd64"},
+	}
+
+	result := SortAndDedupeLatest(cached, false)
+	require.Len(t, result, 1)
+	assert.Equal(t, "0.10.0", result[0].Version, "should pick 0.10.0 (semver) not 0.9.0 (lexicographic)")
+}
+
+func TestSortAndDedupeLatest_ValidSemverAlwaysBeatsNonSemver(t *testing.T) {
+	// "zzz-not-a-version" sorts lexically above all valid semver strings,
+	// but a valid semver version must always be preferred as "latest".
+	cached := []CachedPlugin{
+		{Name: "myplugin", Version: "1.0.0", Platform: "linux/amd64"},
+		{Name: "myplugin", Version: "9.0.0", Platform: "linux/amd64"},
+		{Name: "myplugin", Version: "zzz-not-a-version", Platform: "linux/amd64"},
+	}
+
+	result := SortAndDedupeLatest(cached, false)
+	require.Len(t, result, 1)
+	assert.Equal(t, "9.0.0", result[0].Version)
+}
+
+func TestSortAndDedupeLatest_DedupeKeyIncludesPlatform(t *testing.T) {
+	cached := []CachedPlugin{
+		{Name: "myplugin", Version: "1.0.0", Platform: "linux/amd64"},
+		{Name: "myplugin", Version: "1.0.0", Platform: "darwin/arm64"},
+	}
+
+	result := SortAndDedupeLatest(cached, false)
+	assert.Len(t, result, 2, "same version across different platforms must both be retained")
+}
+
+func TestSortAndDedupeLatest_EmptyInput(t *testing.T) {
+	result := SortAndDedupeLatest(nil, false)
+	assert.Empty(t, result)
+
+	result = SortAndDedupeLatest([]CachedPlugin{}, true)
+	assert.Empty(t, result)
+}
+
 func TestCache_Get_MigrationFallback(t *testing.T) {
 	tmpDir := t.TempDir()
 	cache := NewCache(tmpDir)

--- a/pkg/plugin/cache_test.go
+++ b/pkg/plugin/cache_test.go
@@ -376,6 +376,27 @@ func TestSortAndDedupeLatest_DedupeKeyIncludesPlatform(t *testing.T) {
 	assert.Len(t, result, 2, "same version across different platforms must both be retained")
 }
 
+func TestSortAndDedupeLatest_DeterministicTieBreakOnEqualVersion(t *testing.T) {
+	// Same Name+Version but different Platform/RegistryHash/Path: the sort
+	// must produce a stable, deterministic order regardless of input order
+	// (not left to sort.Slice's unstable behavior), and allVersions=true
+	// must preserve every entry.
+	cached := []CachedPlugin{
+		{Name: "myplugin", Version: "1.0.0", Platform: "linux/amd64", RegistryHash: "hashB", Path: "/z"},
+		{Name: "myplugin", Version: "1.0.0", Platform: "darwin/arm64", RegistryHash: "hashA", Path: "/a"},
+		{Name: "myplugin", Version: "1.0.0", Platform: "linux/amd64", RegistryHash: "hashA", Path: "/y"},
+	}
+	want := []CachedPlugin{
+		{Name: "myplugin", Version: "1.0.0", Platform: "darwin/arm64", RegistryHash: "hashA", Path: "/a"},
+		{Name: "myplugin", Version: "1.0.0", Platform: "linux/amd64", RegistryHash: "hashA", Path: "/y"},
+		{Name: "myplugin", Version: "1.0.0", Platform: "linux/amd64", RegistryHash: "hashB", Path: "/z"},
+	}
+
+	result := SortAndDedupeLatest(cached, true)
+	require.Len(t, result, 3)
+	assert.Equal(t, want, result)
+}
+
 func TestSortAndDedupeLatest_EmptyInput(t *testing.T) {
 	result := SortAndDedupeLatest(nil, false)
 	assert.Empty(t, result)

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -11916,6 +11916,55 @@ func TestIntegration_PluginsList_PathNotInTable(t *testing.T) {
 	assert.NotContains(t, stdout, "path")
 }
 
+// TestIntegration_PluginsList_DedupesToLatestByDefault verifies that plugins
+// list shows only the latest cached version of each plugin by default, and
+// that --all-versions restores the full listing (issue #532).
+func TestIntegration_PluginsList_DedupesToLatestByDefault(t *testing.T) {
+	t.Parallel()
+	cacheDir := t.TempDir()
+
+	platform := runtime.GOOS + "-" + runtime.GOARCH
+	binName := "fake-plugin"
+	if runtime.GOOS == "windows" {
+		binName += ".exe"
+	}
+	for _, version := range []string{"0.1.1", "0.2.0"} {
+		pluginDir := filepath.Join(cacheDir, "scafctl", "plugins", "fake-plugin", version, platform)
+		require.NoError(t, os.MkdirAll(pluginDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(pluginDir, binName), []byte("#!/bin/sh\nexit 0"), 0o755))
+	}
+
+	env := map[string]string{"XDG_CACHE_HOME": cacheDir}
+
+	stdout, _, exitCode := runScafctlWithEnv(t, env, "plugins", "list", "-o", "json")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "0.2.0")
+	assert.NotContains(t, stdout, "0.1.1")
+
+	stdoutAll, _, exitCodeAll := runScafctlWithEnv(t, env, "plugins", "list", "--all-versions", "-o", "json")
+	assert.Equal(t, 0, exitCodeAll)
+	assert.Contains(t, stdoutAll, "0.2.0")
+	assert.Contains(t, stdoutAll, "0.1.1")
+
+	// The --all alias must behave identically to --all-versions end-to-end.
+	stdoutAlias, _, exitCodeAlias := runScafctlWithEnv(t, env, "plugins", "list", "--all", "-o", "json")
+	assert.Equal(t, 0, exitCodeAlias)
+	assert.Contains(t, stdoutAlias, "0.2.0")
+	assert.Contains(t, stdoutAlias, "0.1.1")
+}
+
+// TestIntegration_PluginsListHelp verifies plugins list --help documents the
+// new --all-versions/--all flags (issue #532), mirroring
+// TestIntegration_CatalogListHelp for catalog list.
+func TestIntegration_PluginsListHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "plugins", "list", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "--all-versions")
+	assert.Contains(t, stdout, "--all")
+}
+
 func TestIntegration_RunProvider_VersionPinFlag(t *testing.T) {
 	t.Parallel()
 	cacheDir := t.TempDir()

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"sync"
@@ -11962,7 +11963,11 @@ func TestIntegration_PluginsListHelp(t *testing.T) {
 
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "--all-versions")
-	assert.Contains(t, stdout, "--all")
+	// Line-anchored so this only matches "--all" as its own flag (e.g.
+	// "    --all    Alias for --all-versions"), not merely as a substring
+	// of "--all-versions" which assert.Contains alone would also satisfy.
+	allFlagPattern := regexp.MustCompile(`(?m)^\s+--all\s`)
+	assert.True(t, allFlagPattern.MatchString(stdout), "expected --help to document --all as its own flag, got:\n%s", stdout)
 }
 
 func TestIntegration_RunProvider_VersionPinFlag(t *testing.T) {


### PR DESCRIPTION
## Summary

`plugins list` now shows only the latest cached version of each plugin (per name+platform) by default, matching `catalog list`'s existing dedupe behavior. Pass `--all-versions` (or its alias `--all`) to restore the full listing of every cached version.

## Changes

- Add `plugin.SortAndDedupeLatest`, a shared helper that sorts by name then semver descending (valid semver always outranks invalid/non-semver strings, with lexical fallback only when both sides fail to parse) and dedupes on the first occurrence of each name+platform key. Ties on equal Name+Version (e.g. the same version cached for different platforms/registry hashes) are broken deterministically by Platform, then RegistryHash, then Path, so output ordering never depends on input order.
- Wire `AllVersions` into `plugins list`'s `ListOptions`, CLI flags (`--all-versions`, `--all`), and Long/examples docs.
- Reconcile the `list_plugins` MCP tool with the new CLI default by adding an `all_versions` parameter and reusing the same shared helper, so MCP clients get the same latest-only default.
- Add unit, MCP, and CLI integration test coverage for: the default dedupe, `--all-versions`, the `--all` alias (including end-to-end through the compiled binary), mixed semver/non-semver version groups, same-version-different-platform retention, and deterministic tie-breaking on equal Name+Version.
- Line-anchor the `--help` assertion for the `--all` flag alias so it can't pass merely by matching the `--all-versions` substring.
- Update `docs/tutorials/plugin-development.md`, `docs/tutorials/plugin-auto-fetch-tutorial.md`, `docs/design/plugins.md`, and `CHANGELOG.md`.

## Testing

- `go build ./...`, `go vet ./...` -- clean
- `task lint:changed` -- 0 new issues
- `go test ./pkg/plugin/... ./pkg/mcp/... ./pkg/cmd/scafctl/plugins/...` -- all pass
- `go test ./tests/integration/... -run TestIntegration_PluginsList` -- all pass, including the help-text test and an end-to-end `--all` alias check

Closes #532
