### PR TITLE
feat: add machine-readable output to build solution (-o json|yaml, --composed-out)

### DIFF
--- a/docs/design/catalog-build-bundling.md
+++ b/docs/design/catalog-build-bundling.md
@@ -370,6 +370,33 @@ scafctl package solution -f ./my-solution.yaml
 | `--no-vendor` | `false` | Skip vendoring catalog dependencies |
 | `--bundle-max-size` | `50MB` | Maximum total size of bundled files |
 | `--dry-run` | `false` | Show what would be bundled without building |
+| `-o`, `--output` | (none) | Emit a machine-readable build report on stdout (`json` or `yaml`) |
+| `--composed-out` | (none) | Write the composed (flattened) solution document to a path (`.json` for JSON, otherwise YAML) |
+
+#### Machine-Readable Build Report
+
+Passing `-o json` (or `-o yaml`) emits a structured `PackageReport` on **stdout**
+and routes all human progress to **stderr**, so the report can be piped into
+tooling without contamination:
+
+```bash
+$ scafctl package solution -f ./solution.yaml -o json | jq .reference
+"dynamic-paths-example@1.0.0"
+```
+
+The report captures the resolved identity, storage digest, catalog path, build
+fingerprint/cache status, the bundle manifest (files, vendored refs, plugins),
+the completeness-verification summary, and the fully composed solution document
+(under `solution`). Reports are emitted for the normal store path, build-cache
+hits, and `--dry-run` (where `dryRun: true` and no `digest`/`catalog` are set,
+since nothing is stored). Under `--no-verify` the `verification` section is
+omitted.
+
+`--composed-out <path>` additionally writes just the composed (flattened)
+solution document to a file, mirroring what is stored: composed when bundling
+ran, or the original document under `--no-bundle` (composition only runs inside
+the bundle pipeline). The format follows the extension (`.json` for pretty JSON,
+otherwise YAML).
 
 #### Dry-Run Output
 

--- a/docs/tutorials/catalog-tutorial.md
+++ b/docs/tutorials/catalog-tutorial.md
@@ -1871,6 +1871,58 @@ rm -rf extracted/ config-only/
 
 ---
 
+## Machine-Readable Build Output (CI)
+
+For pipelines, `scafctl package solution` can emit a structured build report on
+**stdout** while all human progress goes to **stderr**, so the report pipes
+cleanly into tools like `jq`.
+
+### Step 1: Emit a JSON Build Report
+
+{{< tabs "catalog-tutorial-cmd-mrbo-1" >}}
+{{% tab "Bash" %}}
+```bash
+scafctl package solution -f ./solution.yaml -o json | jq '{reference, digest, cacheHit}'
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+scafctl package solution -f ./solution.yaml -o json | ConvertFrom-Json | Select-Object reference, digest, cacheHit
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+The report captures the resolved `reference`, storage `digest`, `catalog` path,
+build `fingerprint`/`cacheHit`, the `bundle` manifest (files, vendored refs,
+plugins), the `verification` summary, and the fully composed `solution`
+document. Use `-o yaml` for YAML instead.
+
+### Step 2: Preview Without Storing
+
+Combine with `--dry-run` to inspect what *would* be built (the report has
+`dryRun: true` and no `digest`, since nothing is stored):
+
+```bash
+scafctl package solution -f ./solution.yaml --dry-run -o json | jq '.dryRun, .bundle.fileCount'
+```
+
+### Step 3: Write the Composed Solution to a File
+
+`--composed-out` writes just the composed (flattened) solution document. The
+format follows the extension (`.json` for pretty JSON, otherwise YAML):
+
+```bash
+scafctl package solution -f ./solution.yaml --composed-out composed.yaml
+```
+
+### What You Learned
+
+- `-o json`/`-o yaml` emits a machine-readable build report on stdout (progress moves to stderr)
+- The report works on the normal store path, build-cache hits, and `--dry-run`
+- `--composed-out PATH` writes the flattened solution document for inspection or downstream tooling
+
+---
+
 ## Comparing Bundle Versions
 
 When you release a new version of a bundled solution, `diff bundle` shows exactly what changed.

--- a/pkg/cmd/scafctl/packagecmd/solution.go
+++ b/pkg/cmd/scafctl/packagecmd/solution.go
@@ -289,8 +289,10 @@ func runPackageSolution(ctx context.Context, opts *SolutionOptions) error {
 
 	// When emitting a machine-readable report on stdout, route all human
 	// progress output to stderr so stdout carries only the report document.
+	// Clone the existing writer so root-level options (e.g. RootOptions.ExitFunc
+	// via writer.WithExitFunc) are preserved rather than discarded.
 	if opts.Output != "" {
-		w = writer.New(opts.IOStreams, opts.CliParams, writer.WithHumanToStderr())
+		w = w.Clone(writer.WithHumanToStderr())
 		ctx = writer.WithWriter(ctx, w)
 	}
 

--- a/pkg/cmd/scafctl/packagecmd/solution.go
+++ b/pkg/cmd/scafctl/packagecmd/solution.go
@@ -30,9 +30,14 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
 	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/output"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
 )
+
+// ValidPackageOutputTypes lists the machine-readable formats accepted by the
+// package/build solution -o/--output flag.
+var ValidPackageOutputTypes = []string{"json", "yaml"}
 
 // SolutionOptions holds options for the package solution command.
 type SolutionOptions struct {
@@ -58,6 +63,8 @@ type SolutionOptions struct {
 	Bump            string
 	Strict          bool
 	NoVerify        bool
+	Output          string
+	ComposedOut     string
 	CliParams       *settings.Run
 	IOStreams       *terminal.IOStreams
 
@@ -126,9 +133,26 @@ func CommandPackageSolution(cliParams *settings.Run, ioStreams *terminal.IOStrea
 
 			  # Package without bundling
 			  scafctl package solution -f ./solution.yaml --no-bundle
+
+			  # Emit a machine-readable build report on stdout (progress goes to stderr)
+			  scafctl package solution -f ./solution.yaml -o json
+
+			  # Preview the build result as JSON without storing anything
+			  scafctl package solution -f ./solution.yaml --dry-run -o json
+
+			  # Write the composed (flattened) solution to a file
+			  scafctl package solution -f ./solution.yaml --composed-out composed.yaml
 		`), settings.CliBinaryName, cliParams.BinaryName),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			// Validate -o/--output early.
+			if err := output.ValidateOutputType(options.Output, ValidPackageOutputTypes); err != nil {
+				if w := writer.FromContext(cmd.Context()); w != nil {
+					w.Errorf("%v", err)
+				}
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+
 			// Validate --bump value early
 			if options.Bump != "" {
 				if _, err := solution.ParseBumpLevel(options.Bump); err != nil {
@@ -253,6 +277,8 @@ func CommandPackageSolution(cliParams *settings.Run, ioStreams *terminal.IOStrea
 	cmd.Flags().StringVar(&options.Bump, "bump", "", "Auto-increment version based on last published version (patch, minor, major)")
 	cmd.Flags().BoolVar(&options.Strict, "strict", false, "Fail if the built bundle has completeness warnings")
 	cmd.Flags().BoolVar(&options.NoVerify, "no-verify", false, "Skip built-bundle completeness verification")
+	cmd.Flags().StringVarP(&options.Output, "output", "o", "", fmt.Sprintf("Emit a machine-readable build report on stdout. One of: (%s)", strings.Join(ValidPackageOutputTypes, ", ")))
+	cmd.Flags().StringVar(&options.ComposedOut, "composed-out", "", "Write the composed (flattened) solution document to this path (.json for JSON, otherwise YAML)")
 
 	return cmd
 }
@@ -260,6 +286,13 @@ func CommandPackageSolution(cliParams *settings.Run, ioStreams *terminal.IOStrea
 func runPackageSolution(ctx context.Context, opts *SolutionOptions) error {
 	lgr := logger.FromContext(ctx)
 	w := writer.FromContext(ctx)
+
+	// When emitting a machine-readable report on stdout, route all human
+	// progress output to stderr so stdout carries only the report document.
+	if opts.Output != "" {
+		w = writer.New(opts.IOStreams, opts.CliParams, writer.WithHumanToStderr())
+		ctx = writer.WithWriter(ctx, w)
+	}
 
 	w.Verbosef("Reading solution from %s", opts.File)
 
@@ -498,6 +531,17 @@ func runPackageSolution(ctx context.Context, opts *SolutionOptions) error {
 		}
 	}
 
+	// Write the composed (flattened) solution document if requested. This
+	// reflects the solution as it will be stored: composed when bundling ran,
+	// or the original document under --no-bundle (composition only runs inside
+	// the bundle pipeline). Emitted for all downstream paths (cache hit,
+	// dry-run, and normal store).
+	if opts.ComposedOut != "" {
+		if err := writeComposedSolution(opts.ComposedOut, &sol, w); err != nil {
+			return err
+		}
+	}
+
 	// Handle build cache hit — artifact unchanged since last build
 	if br != nil && br.CacheHit {
 		// Verify the artifact still exists in the local catalog. It may have
@@ -505,7 +549,9 @@ func runPackageSolution(ctx context.Context, opts *SolutionOptions) error {
 		// entry remained on disk.
 		localCat, catErr := catalog.NewLocalCatalog(*lgr)
 		catalogMissing := false
+		catalogPath := ""
 		if catErr == nil {
+			catalogPath = localCat.Path()
 			ref := catalog.Reference{
 				Kind:    catalog.ArtifactKindSolution,
 				Name:    br.CacheEntry.ArtifactName,
@@ -520,7 +566,14 @@ func runPackageSolution(ctx context.Context, opts *SolutionOptions) error {
 			w.Infof("  Digest: %s", br.CacheEntry.ArtifactDigest)
 			w.Infof("  Use --no-cache to force a full rebuild")
 			w.Verbosef("Fingerprint: %s (%d input files)", br.CacheEntry.Fingerprint, br.CacheEntry.InputFiles)
-			return nil
+			return emitPackageReport(ctx, opts, builder.PackageReportInput{
+				Name:            br.CacheEntry.ArtifactName,
+				Version:         br.CacheEntry.ArtifactVersion,
+				Solution:        &sol,
+				Build:           br,
+				CatalogPath:     catalogPath,
+				IncludeSolution: true,
+			})
 		}
 
 		// Artifact missing from catalog — fall through to re-store it.
@@ -532,11 +585,18 @@ func runPackageSolution(ctx context.Context, opts *SolutionOptions) error {
 
 	// Dry-run: show what would be built but don't store
 	if opts.DryRun {
-		if br != nil && br.Discovery != nil {
+		if opts.Output == "" && br != nil && br.Discovery != nil {
 			printDryRunOutput(w, br.Discovery, &sol, opts)
 		}
 		w.Infof("Dry run: would build %s@%s", name, version.String())
-		return nil
+		return emitPackageReport(ctx, opts, builder.PackageReportInput{
+			Name:            name,
+			Version:         version.String(),
+			Solution:        &sol,
+			Build:           br,
+			DryRun:          true,
+			IncludeSolution: true,
+		})
 	}
 
 	// Create local catalog
@@ -615,7 +675,25 @@ func runPackageSolution(ctx context.Context, opts *SolutionOptions) error {
 	// rerun re-builds and re-verifies instead of hitting a cached broken
 	// artifact and exiting 0. The stored catalog artifact is left in place.
 	if !opts.NoVerify {
-		if verr := verifyBuiltBundle(ctx, localCatalog, info.Reference, opts, w, lgr); verr != nil {
+		vr, verr := verifyBuiltBundle(ctx, localCatalog, info.Reference, opts, w, lgr)
+		if verr != nil {
+			// Emit a best-effort report so machine consumers get the structured
+			// failure (verification.passed=false + errors/warnings) alongside the
+			// non-zero exit. The stored artifact is intentionally left in place
+			// (no rollback), so the report still describes what was written.
+			// A report write error must not mask the original verification error.
+			if rerr := emitPackageReport(ctx, opts, builder.PackageReportInput{
+				Name:            info.Reference.Name,
+				Version:         info.Reference.Version.String(),
+				Solution:        &sol,
+				Build:           br,
+				Info:            &info,
+				Verify:          vr,
+				CatalogPath:     localCatalog.Path(),
+				IncludeSolution: true,
+			}); rerr != nil {
+				lgr.V(1).Info("failed to emit failure report", "error", rerr)
+			}
 			return verr
 		}
 
@@ -631,30 +709,93 @@ func runPackageSolution(ctx context.Context, opts *SolutionOptions) error {
 		if builder.WriteBuildCacheEntry(ctx, storeResult) {
 			w.Verbose("Build cache entry written")
 		}
-	} else {
-		w.Verbose("Skipping build-cache entry (--no-verify): unverified artifacts are not cached")
+
+		return emitPackageReport(ctx, opts, builder.PackageReportInput{
+			Name:            info.Reference.Name,
+			Version:         info.Reference.Version.String(),
+			Solution:        &sol,
+			Build:           br,
+			Info:            &info,
+			Verify:          vr,
+			CatalogPath:     localCatalog.Path(),
+			IncludeSolution: true,
+		})
 	}
 
+	w.Verbose("Skipping build-cache entry (--no-verify): unverified artifacts are not cached")
+
+	return emitPackageReport(ctx, opts, builder.PackageReportInput{
+		Name:            info.Reference.Name,
+		Version:         info.Reference.Version.String(),
+		Solution:        &sol,
+		Build:           br,
+		Info:            &info,
+		CatalogPath:     localCatalog.Path(),
+		IncludeSolution: true,
+	})
+}
+
+// emitPackageReport writes a machine-readable package report to stdout when a
+// structured output format is requested. It is a no-op when -o/--output is unset.
+func emitPackageReport(ctx context.Context, opts *SolutionOptions, in builder.PackageReportInput) error {
+	if opts.Output == "" {
+		return nil
+	}
+	report := builder.NewPackageReport(in)
+	if err := output.WriteOutput(opts.IOStreams, opts.Output, report, nil); err != nil {
+		if w := writer.FromContext(ctx); w != nil {
+			w.Errorf("failed to write %s output: %v", opts.Output, err)
+		}
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+	return nil
+}
+
+// writeComposedSolution serializes the composed solution to the given path.
+// The format is JSON when the path ends in ".json", otherwise YAML.
+func writeComposedSolution(path string, sol *solution.Solution, w *writer.Writer) error {
+	var (
+		data []byte
+		err  error
+	)
+	if strings.EqualFold(filepath.Ext(path), ".json") {
+		data, err = sol.ToJSONPretty()
+	} else {
+		data, err = sol.ToYAML()
+	}
+	if err != nil {
+		w.Errorf("failed to serialize composed solution: %v", err)
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil { //nolint:gosec // user-specified output path, world-readable solution document
+		w.Errorf("failed to write composed solution to %s: %v", path, err)
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+	w.SuccessStderrf("Composed solution written: %s", path)
 	return nil
 }
 
 // verifyBuiltBundle fetches the stored bundle for ref, verifies its
 // completeness, renders the result, and enforces producer policy: fail on
-// errors, and (under --strict) fail on warnings.
-func verifyBuiltBundle(ctx context.Context, localCatalog catalog.Catalog, ref catalog.Reference, opts *SolutionOptions, w *writer.Writer, lgr *logr.Logger) error {
+// errors, and (under --strict) fail on warnings. It returns the verify result
+// so callers can surface it in a machine-readable report -- including on a
+// policy-decision failure, where the (non-nil) result carries the errors and
+// warnings that triggered the failure. The result is nil only when
+// verification could not run (fetch/parse/verify infrastructure errors).
+func verifyBuiltBundle(ctx context.Context, localCatalog catalog.Catalog, ref catalog.Reference, opts *SolutionOptions, w *writer.Writer, lgr *logr.Logger) (*bundler.VerifyResult, error) {
 	content, bundleData, _, ferr := localCatalog.FetchWithBundle(ctx, ref)
 	if ferr != nil {
 		// Producer errors are always fatal: we cannot confirm a good build.
 		err := fmt.Errorf("fetching built bundle for verification: %w", ferr)
 		w.Errorf("%v", err)
-		return exitcode.WithCode(err, exitcode.GeneralError)
+		return nil, exitcode.WithCode(err, exitcode.GeneralError)
 	}
 
 	var vsol solution.Solution
 	if err := vsol.LoadFromBytes(content); err != nil {
 		err = fmt.Errorf("parsing built solution for verification: %w", err)
 		w.Errorf("%v", err)
-		return exitcode.WithCode(err, exitcode.GeneralError)
+		return nil, exitcode.WithCode(err, exitcode.GeneralError)
 	}
 
 	// Pass the (possibly empty) bundleData through to VerifyBundle: the empty
@@ -666,7 +807,7 @@ func verifyBuiltBundle(ctx context.Context, localCatalog catalog.Catalog, ref ca
 	if err != nil {
 		err = fmt.Errorf("verifying built bundle: %w", err)
 		w.Errorf("%v", err)
-		return exitcode.WithCode(err, exitcode.GeneralError)
+		return nil, exitcode.WithCode(err, exitcode.GeneralError)
 	}
 
 	// Producer: incompleteness fails the build, so render failures as errors.
@@ -674,10 +815,12 @@ func verifyBuiltBundle(ctx context.Context, localCatalog catalog.Catalog, ref ca
 
 	if failErr := packageVerifyDecision(vr, opts.Strict); failErr != nil {
 		w.Errorf("%v", failErr)
-		return failErr
+		// Return vr alongside the error so the caller can emit a report whose
+		// verification section explains why the build failed.
+		return vr, failErr
 	}
 
-	return nil
+	return vr, nil
 }
 
 // packageVerifyDecision applies the producer verification policy to a verify

--- a/pkg/cmd/scafctl/packagecmd/solution.go
+++ b/pkg/cmd/scafctl/packagecmd/solution.go
@@ -767,7 +767,7 @@ func writeComposedSolution(path string, sol *solution.Solution, w *writer.Writer
 		w.Errorf("failed to serialize composed solution: %v", err)
 		return exitcode.WithCode(err, exitcode.GeneralError)
 	}
-	if err := os.WriteFile(path, data, 0o644); err != nil { //nolint:gosec // user-specified output path, world-readable solution document
+	if err := os.WriteFile(path, data, 0o600); err != nil {
 		w.Errorf("failed to write composed solution to %s: %v", path, err)
 		return exitcode.WithCode(err, exitcode.GeneralError)
 	}

--- a/pkg/cmd/scafctl/packagecmd/solution_output_test.go
+++ b/pkg/cmd/scafctl/packagecmd/solution_output_test.go
@@ -1,0 +1,255 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package packagecmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/builder"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const minimalSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: report-test
+  version: 1.0.0
+spec: {}
+`
+
+// failWriter always fails, used to exercise write-error propagation.
+type failWriter struct{}
+
+func (failWriter) Write([]byte) (int, error) { return 0, assert.AnError }
+
+// solutionFromMinimal parses the minimal solution fixture into a Solution.
+func solutionFromMinimal(t *testing.T) *solution.Solution {
+	t.Helper()
+	var sol solution.Solution
+	require.NoError(t, sol.LoadFromBytes([]byte(minimalSolution)))
+	return &sol
+}
+
+// writeSolutionFile writes the minimal solution to a temp dir and returns its path.
+func writeSolutionFile(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	solFile := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solFile, []byte(minimalSolution), 0o600))
+	return solFile
+}
+
+// dryRunOpts builds SolutionOptions for a dry-run report test with separate
+// stdout/stderr buffers so we can assert the report lands on stdout and human
+// progress lands on stderr.
+func dryRunOpts(t *testing.T, solFile, output string) (*SolutionOptions, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, outBuf, errBuf, false)
+	cliParams := settings.NewCliParams()
+	opts := &SolutionOptions{
+		File:          solFile,
+		Output:        output,
+		IOStreams:     ioStreams,
+		CliParams:     cliParams,
+		DryRun:        true,
+		BundleMaxSize: "50MB",
+	}
+	return opts, outBuf, errBuf
+}
+
+func TestRunPackageSolution_DryRunJSONReport(t *testing.T) {
+	solFile := writeSolutionFile(t)
+	opts, outBuf, errBuf := dryRunOpts(t, solFile, "json")
+
+	w := writer.New(opts.IOStreams, opts.CliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	require.NoError(t, runPackageSolution(ctx, opts))
+
+	// stdout must be valid JSON: the machine-readable report only.
+	var report builder.PackageReport
+	require.NoError(t, json.Unmarshal(outBuf.Bytes(), &report),
+		"stdout must be clean JSON, got: %s", outBuf.String())
+
+	assert.Equal(t, "report-test", report.Name)
+	assert.Equal(t, "1.0.0", report.Version)
+	assert.Equal(t, "report-test@1.0.0", report.Reference)
+	assert.True(t, report.DryRun)
+	assert.Empty(t, report.Digest, "dry-run stores nothing, so no digest")
+	require.NotNil(t, report.Solution, "composed solution is embedded")
+
+	// Human progress goes to stderr, never stdout.
+	assert.Contains(t, errBuf.String(), "Dry run:")
+	assert.NotContains(t, outBuf.String(), "Dry run:")
+}
+
+func TestRunPackageSolution_DryRunYAMLReport(t *testing.T) {
+	solFile := writeSolutionFile(t)
+	opts, outBuf, _ := dryRunOpts(t, solFile, "yaml")
+
+	w := writer.New(opts.IOStreams, opts.CliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	require.NoError(t, runPackageSolution(ctx, opts))
+
+	out := outBuf.String()
+	assert.Contains(t, out, "name: report-test")
+	assert.Contains(t, out, "dryRun: true")
+}
+
+func TestRunPackageSolution_DryRunNoOutputStaysHuman(t *testing.T) {
+	solFile := writeSolutionFile(t)
+	outBuf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, outBuf, outBuf, false)
+	cliParams := settings.NewCliParams()
+	opts := &SolutionOptions{
+		File:          solFile,
+		IOStreams:     ioStreams,
+		CliParams:     cliParams,
+		DryRun:        true,
+		BundleMaxSize: "50MB",
+	}
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	require.NoError(t, runPackageSolution(ctx, opts))
+
+	// Without -o, the human dry-run summary is printed and no JSON is emitted.
+	assert.Contains(t, outBuf.String(), "Dry run:")
+	assert.NotContains(t, outBuf.String(), `"dryRun"`)
+}
+
+func TestRunPackageSolution_ComposedOutYAML(t *testing.T) {
+	solFile := writeSolutionFile(t)
+	composedOut := filepath.Join(t.TempDir(), "composed.yaml")
+
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, outBuf, errBuf, false)
+	cliParams := settings.NewCliParams()
+	opts := &SolutionOptions{
+		File:          solFile,
+		ComposedOut:   composedOut,
+		IOStreams:     ioStreams,
+		CliParams:     cliParams,
+		DryRun:        true,
+		BundleMaxSize: "50MB",
+	}
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	require.NoError(t, runPackageSolution(ctx, opts))
+
+	data, err := os.ReadFile(composedOut)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "name: report-test")
+}
+
+func TestRunPackageSolution_ComposedOutJSON(t *testing.T) {
+	solFile := writeSolutionFile(t)
+	composedOut := filepath.Join(t.TempDir(), "composed.json")
+
+	outBuf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, outBuf, errBuf, false)
+	cliParams := settings.NewCliParams()
+	opts := &SolutionOptions{
+		File:          solFile,
+		ComposedOut:   composedOut,
+		IOStreams:     ioStreams,
+		CliParams:     cliParams,
+		DryRun:        true,
+		BundleMaxSize: "50MB",
+	}
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	require.NoError(t, runPackageSolution(ctx, opts))
+
+	data, err := os.ReadFile(composedOut)
+	require.NoError(t, err)
+
+	// .json extension yields a valid JSON document.
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(data, &doc), "composed .json must be valid JSON")
+	assert.Equal(t, "report-test", doc["metadata"].(map[string]any)["name"])
+}
+
+func TestCommandPackageSolution_RejectsInvalidOutput(t *testing.T) {
+	solFile := writeSolutionFile(t)
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	cmd := CommandPackageSolution(cliParams, ioStreams, "build")
+	w := writer.New(ioStreams, cliParams)
+	cmd.SetContext(writer.WithWriter(t.Context(), w))
+	cmd.SetArgs([]string{"-f", solFile, "-o", "xml"})
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "xml")
+}
+
+func TestCommandPackageSolution_OutputFlags(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	cmd := CommandPackageSolution(cliParams, ioStreams, "build")
+
+	outFlag := cmd.Flags().Lookup("output")
+	require.NotNil(t, outFlag)
+	require.NotNil(t, cmd.Flags().ShorthandLookup("o"))
+	assert.Equal(t, "output", cmd.Flags().ShorthandLookup("o").Name)
+
+	composedFlag := cmd.Flags().Lookup("composed-out")
+	require.NotNil(t, composedFlag)
+}
+
+func TestEmitPackageReport_NoOutputIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	opts := &SolutionOptions{Output: "", IOStreams: ioStreams}
+	err := emitPackageReport(t.Context(), opts, builder.PackageReportInput{Name: "n", Version: "1.0.0"})
+	require.NoError(t, err)
+}
+
+func TestEmitPackageReport_WriteError(t *testing.T) {
+	t.Parallel()
+
+	// A failing Out writer makes output.WriteOutput return a write error, which
+	// emitPackageReport must surface (not swallow) as a non-nil error.
+	ioStreams := terminal.NewIOStreams(nil, failWriter{}, &bytes.Buffer{}, false)
+	opts := &SolutionOptions{Output: "json", IOStreams: ioStreams}
+	err := emitPackageReport(t.Context(), opts, builder.PackageReportInput{Name: "n", Version: "1.0.0"})
+	require.Error(t, err)
+}
+
+func TestWriteComposedSolution_WriteError(t *testing.T) {
+	t.Parallel()
+
+	// A path inside a nonexistent directory makes os.WriteFile fail.
+	badPath := filepath.Join(t.TempDir(), "nope", "composed.yaml")
+
+	errBuf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, errBuf, errBuf, false)
+	w := writer.New(ioStreams, settings.NewCliParams())
+
+	sol := solutionFromMinimal(t)
+	err := writeComposedSolution(badPath, sol, w)
+	require.Error(t, err)
+	assert.Contains(t, errBuf.String(), "failed to write composed solution")
+}

--- a/pkg/cmd/scafctl/packagecmd/solution_verify_hook_test.go
+++ b/pkg/cmd/scafctl/packagecmd/solution_verify_hook_test.go
@@ -72,7 +72,7 @@ func TestVerifyBuiltBundle_FetchErrorAlwaysFatal(t *testing.T) {
 	cat := &fetchBundleCatalog{fetchErr: errors.New("boom")}
 	// Producer fetch errors are fatal even without --strict.
 	opts := &SolutionOptions{Strict: false}
-	err := verifyBuiltBundle(ctx, cat, catalog.Reference{Name: "s", Kind: catalog.ArtifactKindSolution}, opts, w, lgr)
+	_, err := verifyBuiltBundle(ctx, cat, catalog.Reference{Name: "s", Kind: catalog.ArtifactKindSolution}, opts, w, lgr)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "fetching built bundle")
 }
@@ -84,7 +84,7 @@ func TestVerifyBuiltBundle_ParseErrorFatal(t *testing.T) {
 
 	cat := &fetchBundleCatalog{content: []byte("::not yaml::")}
 	opts := &SolutionOptions{}
-	err := verifyBuiltBundle(ctx, cat, catalog.Reference{Name: "s", Kind: catalog.ArtifactKindSolution}, opts, w, lgr)
+	_, err := verifyBuiltBundle(ctx, cat, catalog.Reference{Name: "s", Kind: catalog.ArtifactKindSolution}, opts, w, lgr)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "parsing built solution")
 }
@@ -99,9 +99,13 @@ func TestVerifyBuiltBundle_BundleLessIncompleteStrictFails(t *testing.T) {
 	// warning, which is fatal under producer --strict.
 	cat := &fetchBundleCatalog{content: []byte(solutionReferencingLocalFile), bundleData: nil}
 	opts := &SolutionOptions{Strict: true}
-	err := verifyBuiltBundle(ctx, cat, catalog.Reference{Name: "s", Kind: catalog.ArtifactKindSolution}, opts, w, lgr)
+	vr, err := verifyBuiltBundle(ctx, cat, catalog.Reference{Name: "s", Kind: catalog.ArtifactKindSolution}, opts, w, lgr)
 	require.Error(t, err, "bundle-less incomplete artifact must fail under --strict")
 	assert.Contains(t, err.Error(), "warning(s) (strict)")
+	// The verify result is returned even on a policy-decision failure so callers
+	// can surface it in a machine-readable report.
+	require.NotNil(t, vr, "verify result must accompany a policy-decision failure")
+	assert.NotEmpty(t, vr.Warnings, "failure result should carry the triggering warnings")
 }
 
 func TestVerifyBuiltBundle_BundleLessNonStrictPasses(t *testing.T) {
@@ -112,6 +116,6 @@ func TestVerifyBuiltBundle_BundleLessNonStrictPasses(t *testing.T) {
 
 	cat := &fetchBundleCatalog{content: []byte(solutionReferencingLocalFile), bundleData: nil}
 	opts := &SolutionOptions{Strict: false}
-	err := verifyBuiltBundle(ctx, cat, catalog.Reference{Name: "s", Kind: catalog.ArtifactKindSolution}, opts, w, lgr)
+	_, err := verifyBuiltBundle(ctx, cat, catalog.Reference{Name: "s", Kind: catalog.ArtifactKindSolution}, opts, w, lgr)
 	assert.NoError(t, err, "producer warnings are non-fatal without --strict")
 }

--- a/pkg/solution/builder/report.go
+++ b/pkg/solution/builder/report.go
@@ -1,0 +1,267 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
+)
+
+// PackageReport is the machine-readable result of a `package/build solution`
+// invocation. It is emitted on stdout via -o json|yaml and captures the
+// build outcome without requiring the caller to inspect the catalog.
+//
+// The report is a stable contract for CI pipelines and tooling: it records the
+// resolved artifact identity, storage digest, bundle manifest, completeness
+// verification summary, and (optionally) the fully composed solution document.
+type PackageReport struct {
+	// Name is the resolved artifact name.
+	Name string `json:"name" yaml:"name"`
+
+	// Version is the resolved semantic version.
+	Version string `json:"version" yaml:"version"`
+
+	// Reference is the canonical artifact reference (e.g., "my-solution@1.2.3").
+	Reference string `json:"reference" yaml:"reference"`
+
+	// Digest is the content digest of the stored artifact (sha256:...).
+	// Empty for dry-run reports, where nothing is stored.
+	Digest string `json:"digest,omitempty" yaml:"digest,omitempty"`
+
+	// Catalog is the path or name of the catalog the artifact was stored in.
+	// Empty for dry-run reports.
+	Catalog string `json:"catalog,omitempty" yaml:"catalog,omitempty"`
+
+	// Size is the stored artifact size in bytes. Zero for dry-run reports.
+	Size int64 `json:"size,omitempty" yaml:"size,omitempty"`
+
+	// DryRun is true when the report describes what would be built without
+	// storing anything.
+	DryRun bool `json:"dryRun" yaml:"dryRun"`
+
+	// CacheHit is true when the artifact was unchanged since the last build
+	// and served from the build cache.
+	CacheHit bool `json:"cacheHit" yaml:"cacheHit"`
+
+	// Fingerprint is the build fingerprint used for cache lookups.
+	Fingerprint string `json:"fingerprint,omitempty" yaml:"fingerprint,omitempty"`
+
+	// InputFileCount is the number of input files that contributed to the
+	// build fingerprint.
+	InputFileCount int `json:"inputFileCount,omitempty" yaml:"inputFileCount,omitempty"`
+
+	// Bundle summarizes the files and dependencies packaged with the solution.
+	// Nil when packaging with --no-bundle (only the solution YAML is stored).
+	Bundle *BundleReport `json:"bundle,omitempty" yaml:"bundle,omitempty"`
+
+	// Verification summarizes the built-bundle completeness check.
+	// Nil when verification was skipped (--no-verify) or not applicable (dry-run).
+	Verification *VerificationReport `json:"verification,omitempty" yaml:"verification,omitempty"`
+
+	// Solution is the fully composed (flattened) solution document. It is
+	// populated only when the caller requests it, so the report stays compact
+	// by default.
+	Solution *solution.Solution `json:"solution,omitempty" yaml:"solution,omitempty"`
+}
+
+// BundleReport summarizes the contents of a solution bundle.
+type BundleReport struct {
+	// FileCount is the total number of local files in the bundle.
+	FileCount int `json:"fileCount" yaml:"fileCount"`
+
+	// Files lists the local files packaged in the bundle.
+	Files []BundleFile `json:"files,omitempty" yaml:"files,omitempty"`
+
+	// VendoredRefs lists the catalog dependencies vendored into the bundle.
+	VendoredRefs []VendoredRef `json:"vendoredRefs,omitempty" yaml:"vendoredRefs,omitempty"`
+
+	// Plugins lists the external plugin dependencies recorded for the bundle.
+	Plugins []BundlePluginRef `json:"plugins,omitempty" yaml:"plugins,omitempty"`
+}
+
+// BundleFile describes a single local file packaged in a bundle.
+type BundleFile struct {
+	// Path is the file path relative to the bundle root.
+	Path string `json:"path" yaml:"path"`
+
+	// Source indicates how the file was discovered (static-analysis,
+	// explicit-include, or test-include).
+	Source string `json:"source" yaml:"source"`
+}
+
+// VendoredRef describes a catalog dependency vendored into a bundle.
+type VendoredRef struct {
+	// Ref is the original catalog reference (e.g., "deploy-to-k8s@2.0.0").
+	Ref string `json:"ref" yaml:"ref"`
+
+	// VendorPath is the path within the bundle where the artifact is stored.
+	VendorPath string `json:"vendorPath" yaml:"vendorPath"`
+}
+
+// BundlePluginRef describes an external plugin dependency of a bundle.
+type BundlePluginRef struct {
+	// Name is the plugin's catalog reference.
+	Name string `json:"name" yaml:"name"`
+
+	// Kind is the plugin type (provider or auth-handler).
+	Kind string `json:"kind" yaml:"kind"`
+
+	// Version is the semver constraint or "latest".
+	Version string `json:"version" yaml:"version"`
+}
+
+// VerificationReport summarizes a built-bundle completeness verification.
+type VerificationReport struct {
+	// Passed is true when the bundle has no completeness errors.
+	Passed bool `json:"passed" yaml:"passed"`
+
+	// Errors are hard completeness failures (missing files or dependencies).
+	Errors []VerificationError `json:"errors,omitempty" yaml:"errors,omitempty"`
+
+	// Warnings are non-fatal completeness issues.
+	Warnings []string `json:"warnings,omitempty" yaml:"warnings,omitempty"`
+}
+
+// VerificationError describes a single completeness failure.
+type VerificationError struct {
+	// Path is the file or dependency path that failed verification.
+	Path string `json:"path" yaml:"path"`
+
+	// Reason describes why the verification failed.
+	Reason string `json:"reason" yaml:"reason"`
+}
+
+// PackageReportInput carries the data needed to assemble a PackageReport.
+type PackageReportInput struct {
+	// Name is the resolved artifact name.
+	Name string
+
+	// Version is the resolved semantic version.
+	Version string
+
+	// Solution is the composed (flattened) solution. Required.
+	Solution *solution.Solution
+
+	// Build is the bundle build result. Nil when packaging with --no-bundle.
+	Build *BuildResult
+
+	// Info is the stored artifact info. Nil for dry-run reports.
+	Info *catalog.ArtifactInfo
+
+	// Verify is the built-bundle verification result. Nil when verification
+	// was skipped or is not applicable.
+	Verify *bundler.VerifyResult
+
+	// CatalogPath is the path or name of the catalog the artifact was stored in.
+	CatalogPath string
+
+	// DryRun marks the report as a preview (nothing stored).
+	DryRun bool
+
+	// IncludeSolution embeds the composed solution document in the report.
+	IncludeSolution bool
+}
+
+// NewPackageReport assembles a PackageReport from the outcome of a package
+// build. It is pure: it reads the provided inputs and never touches the
+// filesystem or catalog.
+func NewPackageReport(in PackageReportInput) *PackageReport {
+	report := &PackageReport{
+		Name:     in.Name,
+		Version:  in.Version,
+		DryRun:   in.DryRun,
+		CacheHit: in.Build != nil && in.Build.CacheHit,
+	}
+
+	report.Reference = catalog.Reference{
+		Kind: catalog.ArtifactKindSolution,
+		Name: in.Name,
+	}.String()
+	if in.Version != "" {
+		report.Reference = in.Name + "@" + in.Version
+	}
+
+	if in.Info != nil {
+		report.Digest = in.Info.Digest
+		report.Size = in.Info.Size
+	}
+	report.Catalog = in.CatalogPath
+
+	if in.Build != nil {
+		report.Fingerprint = in.Build.BuildFingerprint
+		report.InputFileCount = in.Build.InputFileCount
+		if in.Build.CacheHit && in.Build.CacheEntry != nil {
+			if report.Fingerprint == "" {
+				report.Fingerprint = in.Build.CacheEntry.Fingerprint
+			}
+			if report.InputFileCount == 0 {
+				report.InputFileCount = in.Build.CacheEntry.InputFiles
+			}
+			if report.Digest == "" {
+				report.Digest = in.Build.CacheEntry.ArtifactDigest
+			}
+		}
+		report.Bundle = newBundleReport(in.Build.Discovery, in.Solution)
+	}
+
+	if in.Verify != nil {
+		report.Verification = newVerificationReport(in.Verify)
+	}
+
+	if in.IncludeSolution {
+		report.Solution = in.Solution
+	}
+
+	return report
+}
+
+// newBundleReport builds the bundle manifest section from discovery results and
+// the composed solution's plugin dependencies.
+func newBundleReport(discovery *bundler.DiscoveryResult, sol *solution.Solution) *BundleReport {
+	br := &BundleReport{}
+
+	if discovery != nil {
+		br.FileCount = len(discovery.LocalFiles)
+		for _, f := range discovery.LocalFiles {
+			br.Files = append(br.Files, BundleFile{
+				Path:   f.RelPath,
+				Source: f.Source.String(),
+			})
+		}
+		for _, ref := range discovery.CatalogRefs {
+			br.VendoredRefs = append(br.VendoredRefs, VendoredRef{
+				Ref:        ref.Ref,
+				VendorPath: ref.VendorPath,
+			})
+		}
+	}
+
+	if sol != nil {
+		for _, p := range sol.Bundle.Plugins {
+			br.Plugins = append(br.Plugins, BundlePluginRef{
+				Name:    p.Name,
+				Kind:    string(p.Kind),
+				Version: p.Version,
+			})
+		}
+	}
+
+	return br
+}
+
+// newVerificationReport translates a bundler.VerifyResult into the report shape.
+func newVerificationReport(vr *bundler.VerifyResult) *VerificationReport {
+	report := &VerificationReport{
+		Passed:   vr.Passed(),
+		Warnings: vr.Warnings,
+	}
+	for _, e := range vr.Errors {
+		report.Errors = append(report.Errors, VerificationError{
+			Path:   e.Path,
+			Reason: e.Reason,
+		})
+	}
+	return report
+}

--- a/pkg/solution/builder/report.go
+++ b/pkg/solution/builder/report.go
@@ -27,14 +27,15 @@ type PackageReport struct {
 	Reference string `json:"reference" yaml:"reference"`
 
 	// Digest is the content digest of the stored artifact (sha256:...).
-	// Empty for dry-run reports, where nothing is stored.
+	// Omitted from the report for dry-run builds, where nothing is stored.
 	Digest string `json:"digest,omitempty" yaml:"digest,omitempty"`
 
 	// Catalog is the path or name of the catalog the artifact was stored in.
-	// Empty for dry-run reports.
+	// Omitted from the report for dry-run builds.
 	Catalog string `json:"catalog,omitempty" yaml:"catalog,omitempty"`
 
-	// Size is the stored artifact size in bytes. Zero for dry-run reports.
+	// Size is the stored artifact size in bytes.
+	// Omitted from the report for dry-run builds.
 	Size int64 `json:"size,omitempty" yaml:"size,omitempty"`
 
 	// DryRun is true when the report describes what would be built without

--- a/pkg/solution/builder/report.go
+++ b/pkg/solution/builder/report.go
@@ -207,7 +207,7 @@ func NewPackageReport(in PackageReportInput) *PackageReport {
 		report.Bundle = newBundleReport(in.Build.Discovery, in.Solution)
 	}
 
-	if in.Verify != nil {
+	if in.Verify != nil && !in.DryRun {
 		report.Verification = newVerificationReport(in.Verify)
 	}
 

--- a/pkg/solution/builder/report_test.go
+++ b/pkg/solution/builder/report_test.go
@@ -1,0 +1,186 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package builder
+
+import (
+	"testing"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/oakwood-commons/scafctl/pkg/catalog"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/bundler"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestSolution() *solution.Solution {
+	sol := &solution.Solution{}
+	sol.Metadata.Name = "my-solution"
+	sol.Metadata.Version = semver.MustParse("1.2.3")
+	sol.Bundle.Plugins = []solution.PluginDependency{
+		{Name: "aws-provider", Kind: solution.PluginKindProvider, Version: "^1.5.0"},
+	}
+	return sol
+}
+
+func TestNewPackageReport_StoredArtifact(t *testing.T) {
+	sol := newTestSolution()
+	build := &BuildResult{
+		BuildFingerprint: "fp-123",
+		InputFileCount:   4,
+		Discovery: &bundler.DiscoveryResult{
+			LocalFiles: []bundler.FileEntry{
+				{RelPath: "templates/main.tf", Source: bundler.StaticAnalysis},
+				{RelPath: "extra/notes.md", Source: bundler.ExplicitInclude},
+			},
+			CatalogRefs: []bundler.CatalogRefEntry{
+				{Ref: "deploy-to-k8s@2.0.0", VendorPath: "vendor/deploy-to-k8s"},
+			},
+		},
+	}
+	info := &catalog.ArtifactInfo{
+		Reference: catalog.Reference{Kind: catalog.ArtifactKindSolution, Name: "my-solution", Version: semver.MustParse("1.2.3")},
+		Digest:    "sha256:abc123",
+		Size:      2048,
+	}
+	vr := &bundler.VerifyResult{
+		Warnings: []string{"dynamic path detected"},
+	}
+
+	report := NewPackageReport(PackageReportInput{
+		Name:            "my-solution",
+		Version:         "1.2.3",
+		Solution:        sol,
+		Build:           build,
+		Info:            info,
+		Verify:          vr,
+		CatalogPath:     "/home/user/.local/catalog",
+		IncludeSolution: true,
+	})
+
+	assert.Equal(t, "my-solution", report.Name)
+	assert.Equal(t, "1.2.3", report.Version)
+	assert.Equal(t, "my-solution@1.2.3", report.Reference)
+	assert.Equal(t, "sha256:abc123", report.Digest)
+	assert.Equal(t, int64(2048), report.Size)
+	assert.Equal(t, "/home/user/.local/catalog", report.Catalog)
+	assert.False(t, report.DryRun)
+	assert.False(t, report.CacheHit)
+	assert.Equal(t, "fp-123", report.Fingerprint)
+	assert.Equal(t, 4, report.InputFileCount)
+
+	require.NotNil(t, report.Bundle)
+	assert.Equal(t, 2, report.Bundle.FileCount)
+	require.Len(t, report.Bundle.Files, 2)
+	assert.Equal(t, "templates/main.tf", report.Bundle.Files[0].Path)
+	assert.Equal(t, "static-analysis", report.Bundle.Files[0].Source)
+	assert.Equal(t, "explicit-include", report.Bundle.Files[1].Source)
+	require.Len(t, report.Bundle.VendoredRefs, 1)
+	assert.Equal(t, "deploy-to-k8s@2.0.0", report.Bundle.VendoredRefs[0].Ref)
+	assert.Equal(t, "vendor/deploy-to-k8s", report.Bundle.VendoredRefs[0].VendorPath)
+	require.Len(t, report.Bundle.Plugins, 1)
+	assert.Equal(t, "aws-provider", report.Bundle.Plugins[0].Name)
+	assert.Equal(t, "provider", report.Bundle.Plugins[0].Kind)
+	assert.Equal(t, "^1.5.0", report.Bundle.Plugins[0].Version)
+
+	require.NotNil(t, report.Verification)
+	assert.True(t, report.Verification.Passed)
+	assert.Empty(t, report.Verification.Errors)
+	assert.Equal(t, []string{"dynamic path detected"}, report.Verification.Warnings)
+
+	require.NotNil(t, report.Solution)
+	assert.Equal(t, "my-solution", report.Solution.Metadata.Name)
+}
+
+func TestNewPackageReport_DryRunOmitsStoreFields(t *testing.T) {
+	sol := newTestSolution()
+	build := &BuildResult{
+		Discovery: &bundler.DiscoveryResult{},
+	}
+
+	report := NewPackageReport(PackageReportInput{
+		Name:     "my-solution",
+		Version:  "1.2.3",
+		Solution: sol,
+		Build:    build,
+		DryRun:   true,
+	})
+
+	assert.True(t, report.DryRun)
+	assert.Empty(t, report.Digest)
+	assert.Empty(t, report.Catalog)
+	assert.Zero(t, report.Size)
+	assert.Nil(t, report.Verification)
+	assert.Nil(t, report.Solution, "solution not embedded unless requested")
+}
+
+func TestNewPackageReport_CacheHitUsesCacheEntry(t *testing.T) {
+	sol := newTestSolution()
+	build := &BuildResult{
+		CacheHit: true,
+		CacheEntry: &bundler.BuildCacheEntry{
+			Fingerprint:     "fp-cache",
+			ArtifactDigest:  "sha256:cached",
+			InputFiles:      7,
+			ArtifactName:    "my-solution",
+			ArtifactVersion: "1.2.3",
+		},
+	}
+
+	report := NewPackageReport(PackageReportInput{
+		Name:            "my-solution",
+		Version:         "1.2.3",
+		Solution:        sol,
+		Build:           build,
+		CatalogPath:     "/cat",
+		IncludeSolution: true,
+	})
+
+	assert.True(t, report.CacheHit)
+	assert.Equal(t, "fp-cache", report.Fingerprint)
+	assert.Equal(t, "sha256:cached", report.Digest)
+	assert.Equal(t, 7, report.InputFileCount)
+	assert.Equal(t, "/cat", report.Catalog)
+}
+
+func TestNewPackageReport_NoBundle(t *testing.T) {
+	sol := newTestSolution()
+	info := &catalog.ArtifactInfo{
+		Reference: catalog.Reference{Kind: catalog.ArtifactKindSolution, Name: "my-solution", Version: semver.MustParse("1.2.3")},
+		Digest:    "sha256:nobundle",
+	}
+
+	report := NewPackageReport(PackageReportInput{
+		Name:     "my-solution",
+		Version:  "1.2.3",
+		Solution: sol,
+		Info:     info,
+	})
+
+	assert.Nil(t, report.Bundle, "no bundle section when build result is nil")
+	assert.Equal(t, "sha256:nobundle", report.Digest)
+}
+
+func TestNewPackageReport_VerificationErrors(t *testing.T) {
+	sol := newTestSolution()
+	vr := &bundler.VerifyResult{
+		Errors: []bundler.VerifyError{
+			{Path: "templates/missing.tf", Reason: "file not found in bundle"},
+		},
+	}
+
+	report := NewPackageReport(PackageReportInput{
+		Name:     "my-solution",
+		Version:  "1.2.3",
+		Solution: sol,
+		Build:    &BuildResult{},
+		Verify:   vr,
+	})
+
+	require.NotNil(t, report.Verification)
+	assert.False(t, report.Verification.Passed)
+	require.Len(t, report.Verification.Errors, 1)
+	assert.Equal(t, "templates/missing.tf", report.Verification.Errors[0].Path)
+	assert.Equal(t, "file not found in bundle", report.Verification.Errors[0].Reason)
+}

--- a/pkg/solution/builder/report_test.go
+++ b/pkg/solution/builder/report_test.go
@@ -115,6 +115,26 @@ func TestNewPackageReport_DryRunOmitsStoreFields(t *testing.T) {
 	assert.Nil(t, report.Solution, "solution not embedded unless requested")
 }
 
+func TestNewPackageReport_DryRunOmitsVerification(t *testing.T) {
+	sol := newTestSolution()
+	build := &BuildResult{
+		Discovery: &bundler.DiscoveryResult{},
+	}
+	vr := &bundler.VerifyResult{Warnings: []string{"dynamic path detected"}}
+
+	report := NewPackageReport(PackageReportInput{
+		Name:     "my-solution",
+		Version:  "1.2.3",
+		Solution: sol,
+		Build:    build,
+		Verify:   vr,
+		DryRun:   true,
+	})
+
+	assert.True(t, report.DryRun)
+	assert.Nil(t, report.Verification, "verification is not applicable for dry-run builds")
+}
+
 func TestNewPackageReport_CacheHitUsesCacheEntry(t *testing.T) {
 	sol := newTestSolution()
 	build := &BuildResult{

--- a/pkg/terminal/output/output.go
+++ b/pkg/terminal/output/output.go
@@ -273,7 +273,9 @@ func WriteJSONOutput(ioStreams *terminal.IOStreams, data any) error {
 	if err != nil {
 		return fmt.Errorf("unable to generate JSON output: %w", err)
 	}
-	fmt.Fprintf(ioStreams.Out, "%s\n", string(jsonBytes))
+	if _, err := fmt.Fprintf(ioStreams.Out, "%s\n", string(jsonBytes)); err != nil {
+		return fmt.Errorf("unable to write JSON output: %w", err)
+	}
 	return nil
 }
 
@@ -293,6 +295,8 @@ func WriteYAMLOutput(ioStreams *terminal.IOStreams, data any) error {
 	if err != nil {
 		return fmt.Errorf("unable to generate YAML output: %w", err)
 	}
-	fmt.Fprintf(ioStreams.Out, "%s\n", string(yamlBytes))
+	if _, err := fmt.Fprintf(ioStreams.Out, "%s\n", string(yamlBytes)); err != nil {
+		return fmt.Errorf("unable to write YAML output: %w", err)
+	}
 	return nil
 }

--- a/pkg/terminal/output/output_test.go
+++ b/pkg/terminal/output/output_test.go
@@ -5,10 +5,16 @@ package output
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 )
+
+// errWriter always fails, used to exercise write-error propagation.
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) { return 0, fmt.Errorf("boom") }
 
 func TestParseOutputFormat(t *testing.T) {
 	tests := []struct {
@@ -746,6 +752,30 @@ func TestWriteOutput(t *testing.T) {
 				if got := errOutBuf.String(); got != tt.wantErrOut {
 					t.Errorf("WriteOutput() errOut = %q, want %q", got, tt.wantErrOut)
 				}
+			}
+		})
+	}
+}
+
+func TestWriteOutput_WriteError(t *testing.T) {
+	tests := []struct {
+		name       string
+		outputType string
+		wantErr    string
+	}{
+		{name: "json write error", outputType: "json", wantErr: "unable to write JSON output"},
+		{name: "yaml write error", outputType: "yaml", wantErr: "unable to write YAML output"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ioStreams := terminal.NewIOStreams(nil, errWriter{}, errWriter{}, false)
+			err := WriteOutput(ioStreams, tt.outputType, map[string]string{"foo": "bar"}, nil)
+			if err == nil {
+				t.Fatalf("WriteOutput() error = nil, want write error")
+			}
+			if got := err.Error(); !strings.Contains(got, tt.wantErr) {
+				t.Errorf("WriteOutput() error = %q, want substring %q", got, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/terminal/writer/options.go
+++ b/pkg/terminal/writer/options.go
@@ -13,3 +13,15 @@ func WithExitFunc(fn func(code int)) Option {
 		w.exitFunc = fn
 	}
 }
+
+// WithHumanToStderr routes human-facing messages (success, info, warning,
+// section header, debug, and plain output) to stderr instead of stdout.
+//
+// Use this for commands that emit structured data on stdout (e.g., -o json/yaml)
+// so progress and status noise never corrupts the machine-readable stream.
+// Error output always goes to stderr regardless of this option.
+func WithHumanToStderr() Option {
+	return func(w *Writer) {
+		w.humanToStderr = true
+	}
+}

--- a/pkg/terminal/writer/writer.go
+++ b/pkg/terminal/writer/writer.go
@@ -8,6 +8,7 @@ package writer
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/oakwood-commons/scafctl/pkg/logger"
@@ -22,6 +23,21 @@ type Writer struct {
 	ioStreams *terminal.IOStreams
 	cliParams *settings.Run
 	exitFunc  func(code int)
+
+	// humanToStderr routes human-facing messages (success/info/warning/
+	// section-header/debug/plain) to stderr instead of stdout. It is set via
+	// WithHumanToStderr for commands that emit structured data on stdout
+	// (e.g., -o json) and must keep progress noise off that stream.
+	humanToStderr bool
+}
+
+// humanOut returns the stream for human-facing (non-error) messages. It is
+// stderr when humanToStderr is set, otherwise stdout.
+func (w *Writer) humanOut() io.Writer {
+	if w.humanToStderr {
+		return w.ioStreams.ErrOut
+	}
+	return w.ioStreams.Out
 }
 
 // New creates a new Writer with the given IOStreams and CLI params.
@@ -37,13 +53,13 @@ func New(ioStreams *terminal.IOStreams, cliParams *settings.Run, opts ...Option)
 	return w
 }
 
-// Success writes a success message to stdout.
+// Success writes a success message to stdout (or stderr when WithHumanToStderr is set).
 // Respects --quiet and --no-color flags.
 func (w *Writer) Success(msg string) {
 	if w.cliParams.IsQuiet {
 		return
 	}
-	fmt.Fprintln(w.ioStreams.Out, output.SuccessMessage(msg, w.cliParams.NoColor))
+	fmt.Fprintln(w.humanOut(), output.SuccessMessage(msg, w.cliParams.NoColor))
 }
 
 // Successf writes a formatted success message to stdout.
@@ -69,13 +85,13 @@ func (w *Writer) SuccessStderrf(format string, args ...any) {
 	w.SuccessStderr(fmt.Sprintf(format, args...))
 }
 
-// Warning writes a warning message to stdout.
+// Warning writes a warning message to stdout (or stderr when WithHumanToStderr is set).
 // Respects --quiet and --no-color flags.
 func (w *Writer) Warning(msg string) {
 	if w.cliParams.IsQuiet {
 		return
 	}
-	fmt.Fprintln(w.ioStreams.Out, output.WarningMessage(msg, w.cliParams.NoColor))
+	fmt.Fprintln(w.humanOut(), output.WarningMessage(msg, w.cliParams.NoColor))
 }
 
 // Warningf writes a formatted warning message to stdout.
@@ -146,13 +162,13 @@ func (w *Writer) ErrorWithCodef(code int, format string, args ...any) {
 	w.ErrorWithCode(code, fmt.Sprintf(format, args...))
 }
 
-// Info writes an informational message to stdout.
+// Info writes an informational message to stdout (or stderr when WithHumanToStderr is set).
 // Respects --quiet and --no-color flags.
 func (w *Writer) Info(msg string) {
 	if w.cliParams.IsQuiet {
 		return
 	}
-	fmt.Fprintln(w.ioStreams.Out, output.InfoMessage(msg, w.cliParams.NoColor))
+	fmt.Fprintln(w.humanOut(), output.InfoMessage(msg, w.cliParams.NoColor))
 }
 
 // Infof writes a formatted informational message to stdout.
@@ -161,23 +177,23 @@ func (w *Writer) Infof(format string, args ...any) {
 	w.Info(fmt.Sprintf(format, args...))
 }
 
-// SectionHeader writes a bold section header to stdout.
+// SectionHeader writes a bold section header to stdout (or stderr when WithHumanToStderr is set).
 // Respects --quiet and --no-color flags.
 func (w *Writer) SectionHeader(msg string) {
 	if w.cliParams.IsQuiet {
 		return
 	}
-	fmt.Fprintln(w.ioStreams.Out, output.SectionHeaderMessage(msg, w.cliParams.NoColor))
+	fmt.Fprintln(w.humanOut(), output.SectionHeaderMessage(msg, w.cliParams.NoColor))
 }
 
-// Debug writes a debug message to stdout.
+// Debug writes a debug message to stdout (or stderr when WithHumanToStderr is set).
 // Respects --quiet and --no-color flags.
 // Only writes if log level indicates debug output is enabled (debug, trace, or numeric V-level).
 func (w *Writer) Debug(msg string) {
 	if w.cliParams.IsQuiet || !logger.IsDebugLevel(w.cliParams.MinLogLevel) {
 		return
 	}
-	fmt.Fprintln(w.ioStreams.Out, output.DebugMessage(msg, w.cliParams.NoColor))
+	fmt.Fprintln(w.humanOut(), output.DebugMessage(msg, w.cliParams.NoColor))
 }
 
 // Debugf writes a formatted debug message to stdout.
@@ -228,13 +244,13 @@ func (w *Writer) Verbosef(format string, args ...any) {
 	w.Verbose(fmt.Sprintf(format, args...))
 }
 
-// Plain writes a plain message to stdout without any styling or newline.
+// Plain writes a plain message to stdout (or stderr when WithHumanToStderr is set) without any styling or newline.
 // Respects --quiet flag only.
 func (w *Writer) Plain(msg string) {
 	if w.cliParams.IsQuiet {
 		return
 	}
-	fmt.Fprint(w.ioStreams.Out, msg)
+	fmt.Fprint(w.humanOut(), msg)
 }
 
 // Plainf writes a formatted plain message to stdout without any styling or newline.
@@ -243,13 +259,13 @@ func (w *Writer) Plainf(format string, args ...any) {
 	w.Plain(fmt.Sprintf(format, args...))
 }
 
-// Plainln writes a plain message to stdout with a newline, without any styling.
+// Plainln writes a plain message to stdout (or stderr when WithHumanToStderr is set) with a newline, without any styling.
 // Respects --quiet flag only.
 func (w *Writer) Plainln(msg string) {
 	if w.cliParams.IsQuiet {
 		return
 	}
-	fmt.Fprintln(w.ioStreams.Out, msg)
+	fmt.Fprintln(w.humanOut(), msg)
 }
 
 // Plainlnf writes a formatted plain message to stdout with a newline, without any styling.

--- a/pkg/terminal/writer/writer.go
+++ b/pkg/terminal/writer/writer.go
@@ -53,6 +53,18 @@ func New(ioStreams *terminal.IOStreams, cliParams *settings.Run, opts ...Option)
 	return w
 }
 
+// Clone returns a copy of the writer with the given options applied on top of
+// its existing configuration. Unlike New, it preserves the current fields
+// (streams, CLI params, exit function, human routing) so a derived writer does
+// not silently drop root-level options such as WithExitFunc.
+func (w *Writer) Clone(opts ...Option) *Writer {
+	clone := *w
+	for _, opt := range opts {
+		opt(&clone)
+	}
+	return &clone
+}
+
 // Success writes a success message to stdout (or stderr when WithHumanToStderr is set).
 // Respects --quiet and --no-color flags.
 func (w *Writer) Success(msg string) {

--- a/pkg/terminal/writer/writer_test.go
+++ b/pkg/terminal/writer/writer_test.go
@@ -492,3 +492,38 @@ func TestVerboseEnabled(t *testing.T) {
 		assert.False(t, w.VerboseEnabled())
 	})
 }
+
+func TestWithHumanToStderr(t *testing.T) {
+	t.Run("routes human output to stderr", func(t *testing.T) {
+		w, outBuf, errBuf := newTestWriter(WithHumanToStderr())
+		w.cliParams.NoColor = true
+
+		w.Success("done")
+		w.Info("informational")
+		w.Warning("careful")
+		w.SectionHeader("section")
+		w.Plain("plain")
+		w.Plainln("plainln")
+
+		assert.Empty(t, outBuf.String(), "stdout must stay clean for machine-readable output")
+		combined := errBuf.String()
+		assert.Contains(t, combined, "done")
+		assert.Contains(t, combined, "informational")
+		assert.Contains(t, combined, "careful")
+		assert.Contains(t, combined, "section")
+		assert.Contains(t, combined, "plain")
+		assert.Contains(t, combined, "plainln")
+	})
+
+	t.Run("default routes human output to stdout", func(t *testing.T) {
+		w, outBuf, errBuf := newTestWriter()
+		w.cliParams.NoColor = true
+
+		w.Success("done")
+		w.Info("informational")
+
+		assert.Contains(t, outBuf.String(), "done")
+		assert.Contains(t, outBuf.String(), "informational")
+		assert.Empty(t, errBuf.String())
+	})
+}

--- a/pkg/terminal/writer/writer_test.go
+++ b/pkg/terminal/writer/writer_test.go
@@ -527,3 +527,36 @@ func TestWithHumanToStderr(t *testing.T) {
 		assert.Empty(t, errBuf.String())
 	})
 }
+
+func TestClone(t *testing.T) {
+	t.Run("preserves exit func while applying new options", func(t *testing.T) {
+		var exitCode int
+		base, outBuf, errBuf := newTestWriter(WithExitFunc(func(code int) {
+			exitCode = code
+		}))
+		base.cliParams.NoColor = true
+
+		clone := base.Clone(WithHumanToStderr())
+
+		// The clone keeps the exit function from the base writer.
+		clone.ErrorWithCode(7, "boom")
+		assert.Equal(t, 7, exitCode)
+		assert.Contains(t, errBuf.String(), "boom")
+
+		// The clone applies the new option: human output goes to stderr.
+		clone.Success("done")
+		assert.Empty(t, outBuf.String(), "cloned writer must keep stdout clean")
+		assert.Contains(t, errBuf.String(), "done")
+	})
+
+	t.Run("does not mutate the original writer", func(t *testing.T) {
+		base, outBuf, _ := newTestWriter()
+		base.cliParams.NoColor = true
+
+		_ = base.Clone(WithHumanToStderr())
+
+		// The original still routes human output to stdout.
+		base.Success("original")
+		assert.Contains(t, outBuf.String(), "original")
+	})
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -4396,6 +4396,113 @@ func TestIntegration_BuildSolution_DryRun(t *testing.T) {
 	assert.Contains(t, stdout, "Dry run")
 }
 
+func TestIntegration_BuildSolution_JSONReport(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	env := map[string]string{
+		"XDG_DATA_HOME":  tmpDir,
+		"XDG_CACHE_HOME": tmpDir,
+	}
+
+	stdout, stderr, exitCode := runScafctlWithEnv(t, env, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "-o", "json")
+
+	if exitCode != 0 {
+		t.Logf("stdout: %s", stdout)
+		t.Logf("stderr: %s", stderr)
+	}
+	assert.Equal(t, 0, exitCode)
+
+	// stdout must be clean JSON: the report only, no human progress.
+	var report map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &report),
+		"stdout must be valid JSON, got: %s", stdout)
+	assert.Equal(t, "1.0.0", report["version"])
+	assert.NotEmpty(t, report["digest"], "a stored artifact has a digest")
+	assert.NotNil(t, report["solution"], "composed solution is embedded")
+
+	// Human progress is routed to stderr.
+	assert.Contains(t, stderr, "Built")
+}
+
+func TestIntegration_BuildSolution_YAMLReport(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	env := map[string]string{
+		"XDG_DATA_HOME":  tmpDir,
+		"XDG_CACHE_HOME": tmpDir,
+	}
+
+	stdout, stderr, exitCode := runScafctlWithEnv(t, env, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "-o", "yaml")
+
+	if exitCode != 0 {
+		t.Logf("stdout: %s", stdout)
+		t.Logf("stderr: %s", stderr)
+	}
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "version: 1.0.0")
+	assert.Contains(t, stdout, "reference:")
+	assert.Contains(t, stderr, "Built")
+}
+
+func TestIntegration_BuildSolution_DryRunJSONReport(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	env := map[string]string{
+		"XDG_DATA_HOME":  tmpDir,
+		"XDG_CACHE_HOME": tmpDir,
+	}
+
+	stdout, stderr, exitCode := runScafctlWithEnv(t, env, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "--dry-run", "-o", "json")
+
+	if exitCode != 0 {
+		t.Logf("stdout: %s", stdout)
+		t.Logf("stderr: %s", stderr)
+	}
+	assert.Equal(t, 0, exitCode)
+
+	var report map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &report),
+		"stdout must be valid JSON, got: %s", stdout)
+	assert.Equal(t, true, report["dryRun"])
+	assert.Empty(t, report["digest"], "dry-run stores nothing")
+	assert.Contains(t, stderr, "Dry run")
+}
+
+func TestIntegration_BuildSolution_ComposedOut(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	env := map[string]string{
+		"XDG_DATA_HOME":  tmpDir,
+		"XDG_CACHE_HOME": tmpDir,
+	}
+	composedOut := filepath.Join(tmpDir, "composed.yaml")
+
+	_, stderr, exitCode := runScafctlWithEnv(t, env, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "--dry-run", "--composed-out", composedOut)
+
+	if exitCode != 0 {
+		t.Logf("stderr: %s", stderr)
+	}
+	assert.Equal(t, 0, exitCode)
+
+	data, err := os.ReadFile(composedOut)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "apiVersion:")
+}
+
+func TestIntegration_BuildSolution_InvalidOutput(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	env := map[string]string{
+		"XDG_DATA_HOME":  tmpDir,
+		"XDG_CACHE_HOME": tmpDir,
+	}
+
+	_, stderr, exitCode := runScafctlWithEnv(t, env, "build", "solution", "-f", "examples/resolver-demo.yaml", "--version", "1.0.0", "-o", "xml")
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "xml")
+}
+
 func TestIntegration_BuildSolution_NoBundle(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()


### PR DESCRIPTION
Adds structured, pipeable output to `build`/`package solution` for CI and tooling.

## What changed

- **`-o json|yaml`** emits a machine-readable `PackageReport` on **stdout**; all human progress is routed to **stderr** via a new `writer.WithHumanToStderr` option, so stdout carries only the report document (clean to pipe into `jq`/`yq`).
- **`--composed-out <path>`** writes the composed (flattened) solution document (`.json` -> JSON, otherwise YAML). Emitted for all downstream paths: cache hit, dry-run, and normal store.

The report (`pkg/solution/builder.PackageReport`) covers `name`/`version`/`reference`, `digest`, `catalog`, `size`, `dryRun`, `cacheHit`, `fingerprint`, the `bundle` manifest, the `verification` result, and the embedded composed `solution`. On a cache hit the digest/fingerprint come from the cache entry; on dry-run no store fields are populated.

## Verify-failure reporting

`verifyBuiltBundle` now returns the `*VerifyResult` even on a **policy-decision failure** (`--strict`/incomplete bundle), so with `-o json` the caller emits a best-effort report with `verification.passed: false` and the triggering errors/warnings **before** returning the non-zero exit. The stored artifact is intentionally left in place (no rollback), so CI consumers can parse *why* the build failed. A report-write error never masks the original verification error.

## Swallowed write-error fix

`WriteJSONOutput`/`WriteYAMLOutput` in `pkg/terminal/output` now **propagate** the underlying `fmt.Fprintf` error instead of discarding it, so a failed stdout write no longer exits 0. This also makes `emitPackageReport`'s error path reachable and tested.

## Tests / artifacts

- Unit: `NewPackageReport` (stored/dry-run/cache-hit/no-bundle/verification-errors, 100%), writer routing (`TestWithHumanToStderr`), output write-error propagation (`TestWriteOutput_WriteError`), `emitPackageReport`/`writeComposedSolution` error paths, verify-failure result passthrough (`TestVerifyBuiltBundle_BundleLessIncompleteStrictFails` now asserts the result + warnings are returned), and command flags/validation.
- Integration: `TestIntegration_BuildSolution_{JSONReport,YAMLReport,DryRunJSONReport,ComposedOut,InvalidOutput}` -- assert clean JSON/YAML on stdout, progress on stderr, `dryRun`/`digest` semantics, composed-out file contents, and invalid `-o` rejection.
- Docs: `docs/design/catalog-build-bundling.md` (flags table + "Machine-Readable Build Report") and `docs/tutorials/catalog-tutorial.md` ("Machine-Readable Build Output (CI)").

## Verification

- `task test:e2e` -> 914 passed, 0 failed (2 relaxed snapshot-fidelity, expected).
- `task lint:changed` -> 0 issues.
- Non-breaking additive change: default human output is unchanged when `-o` is unset.