### PR TITLE
feat(gotmpl): allow embedders to register custom Go-template functions

### DIFF
--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -17,7 +17,7 @@ Architecture and design documentation for scafctl.
 - [Actions](actions.md) — Actions system design
 - [Authentication](auth.md) — Authentication architecture
 - [CEL Integration](cel.md) — CEL expression language integration
-- [Go-Template Embedder Functions](gotmpl-embedder-funcs.md) — Registering custom Go-template functions from an embedder
+- [Go-Template Embedder Functions](gotmpl-embedder-funcs.md) -- Registering custom Go-template functions from an embedder
 - [Catalog](catalog.md) — Catalog system design
 - [CLI](cli.md) — Command-line interface design
 - [Plugins](plugins.md) — Plugin system architecture and auto-fetch

--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -17,6 +17,7 @@ Architecture and design documentation for scafctl.
 - [Actions](actions.md) — Actions system design
 - [Authentication](auth.md) — Authentication architecture
 - [CEL Integration](cel.md) — CEL expression language integration
+- [Go-Template Embedder Functions](gotmpl-embedder-funcs.md) — Registering custom Go-template functions from an embedder
 - [Catalog](catalog.md) — Catalog system design
 - [CLI](cli.md) — Command-line interface design
 - [Plugins](plugins.md) — Plugin system architecture and auto-fetch

--- a/docs/design/gotmpl-embedder-funcs.md
+++ b/docs/design/gotmpl-embedder-funcs.md
@@ -50,6 +50,15 @@ entire call is rejected with `ErrFuncNameCollision` and nothing is registered.
 This refusal to silently shadow a built-in means a typo cannot quietly change
 template behavior.
 
+Registration is **register-once**, matching the Go standard library's global
+registries (for example `sql.Register`): re-registering an already-present name
+-- even with the identical function -- is a collision. Register a given set of
+functions a single time. The root command guards its own wiring (see below), so
+executing the command more than once in a long-running host does not
+re-register or self-collide. Values are also validated up front (a nil value, a
+non-function, or a function whose return signature `text/template` rejects fails
+fast rather than panicking later at template construction).
+
 `RegisterFuncsOverride` is the escape hatch: it unconditionally replaces an
 existing function (including a built-in). Use it only when shadowing is
 intentional.
@@ -74,7 +83,9 @@ When an embedder supplies `RootOptions.GoTemplateFuncs`, a collision is treated
 as an embedder build bug: the root command reports the error and exits via the
 writer's exit path rather than dropping the function and continuing. This keeps
 the failure obvious at startup instead of surfacing as a confusing "function not
-defined" template error later.
+defined" template error later. The wiring registers exactly once per
+`RootOptions`, so a command executed more than once (a REPL or long-running
+host) does not re-register the process-global functions and self-collide.
 
 ## Discoverability
 
@@ -85,7 +96,10 @@ Registered functions are tagged with `Source: "embedder"`
 - MCP: `list_go_template_functions` with `embedder_only: true`
 
 The default (unfiltered) views also include embedder functions alongside the
-sprig (`source: sprig`) and custom (`source: custom`) built-ins.
+sprig (`source: sprig`) and custom (`source: custom`) built-ins. When an
+embedder shadows a built-in via `RegisterFuncsOverride`, the combined listing is
+de-duplicated by name (`gotmpl.CombinedFuncs`) so only the effective embedder
+function is shown, keeping discovery aligned with what actually runs.
 
 ## Related
 

--- a/docs/design/gotmpl-embedder-funcs.md
+++ b/docs/design/gotmpl-embedder-funcs.md
@@ -1,0 +1,90 @@
+---
+title: "Embedder Guide: Registering Go-Template Functions"
+---
+
+# Embedder Guide: Registering Go-Template Functions
+
+This document explains how embedders (e.g., cldctl) add custom Go-template
+functions that become available to every template scafctl renders -- resolver
+templates, the `go-template` provider, `evaluate`, and functional tests.
+
+## Scope: Go-only, not YAML
+
+Template functions are compiled Go code. An embedder registers them from its
+own `main` before handing control to scafctl. Individual **solution YAML files
+cannot declare functions** -- there is deliberately no YAML or provider-input
+surface for arbitrary code, which would be a code-injection footgun. Solutions
+consume whatever the built binary exposes.
+
+## The embedder API surface
+
+There are two entry points, in increasing order of power:
+
+- **`RootOptions.GoTemplateFuncs template.FuncMap`** -- the ergonomic path. The
+  root command registers these during `PersistentPreRun`, after the extension
+  factory is initialized, so built-in collisions are detectable.
+- **`gotmpl.RegisterFuncs` / `gotmpl.RegisterFuncsOverride`** -- the underlying
+  package API, callable directly if the embedder wires templates without
+  `Root()`.
+
+~~~go
+cmd, cleanup := scafctl.Root(&scafctl.RootOptions{
+    BinaryName: "mycli",
+    GoTemplateFuncs: template.FuncMap{
+        "shout": func(s string) string { return strings.ToUpper(s) + "!" },
+    },
+})
+defer cleanup()
+~~~
+
+## Registration model
+
+Registration is **package-global and additive**. Functions are merged at the
+single choke point (`getExtensionFuncMap`) that every `gotmpl` service uses, so
+all render paths pick them up automatically. The extension factory itself
+remains `sync.Once`-guarded; the registry is a layer on top.
+
+`RegisterFuncs` is **all-or-nothing**: if any name in the batch collides with a
+built-in (sprig or custom scafctl function) or a previously registered name, the
+entire call is rejected with `ErrFuncNameCollision` and nothing is registered.
+This refusal to silently shadow a built-in means a typo cannot quietly change
+template behavior.
+
+`RegisterFuncsOverride` is the escape hatch: it unconditionally replaces an
+existing function (including a built-in). Use it only when shadowing is
+intentional.
+
+### Precedence when a template renders
+
+Later entries win:
+
+1. Built-in factory functions (sprig + custom scafctl functions)
+2. Additive embedder functions (`RegisterFuncs`) -- applied only for names not
+   already provided by a built-in
+3. Override embedder functions (`RegisterFuncsOverride`) -- applied
+   unconditionally
+
+## Fail-loud wiring
+
+When an embedder supplies `RootOptions.GoTemplateFuncs`, a collision is treated
+as an embedder build bug: the root command reports the error and exits via the
+writer's exit path rather than dropping the function and continuing. This keeps
+the failure obvious at startup instead of surfacing as a confusing "function not
+defined" template error later.
+
+## Discoverability
+
+Registered functions are tagged with `Source: "embedder"`
+(`gotmpl.SourceEmbedder`) and surface through the normal discovery tools:
+
+- CLI: `mycli get template functions --embedder`
+- MCP: `list_go_template_functions` with `embedder_only: true`
+
+The default (unfiltered) views also include embedder functions alongside the
+sprig (`source: sprig`) and custom (`source: custom`) built-ins.
+
+## Related
+
+- Package reference: `pkg/gotmpl/README.md` ("Embedder Function Registration")
+- Other embedder hooks on `RootOptions`: `BuiltinAuthHandlers`,
+  `ClusterResolver`, `OfficialProviders`, `PluginSignaturePolicy`

--- a/docs/design/gotmpl-embedder-funcs.md
+++ b/docs/design/gotmpl-embedder-funcs.md
@@ -59,10 +59,14 @@ intentional.
 Later entries win:
 
 1. Built-in factory functions (sprig + custom scafctl functions)
-2. Additive embedder functions (`RegisterFuncs`) -- applied only for names not
-   already provided by a built-in
-3. Override embedder functions (`RegisterFuncsOverride`) -- applied
-   unconditionally
+2. Environment stripping -- unless environment access is enabled, `env` and
+   `expandenv` are removed at this layer so secrets are not exposed by default
+3. Additive embedder functions (`RegisterFuncs`) -- applied only for names not
+   already provided by a built-in, and never re-introducing a stripped
+   `env`/`expandenv` regardless of registration order
+4. Override embedder functions (`RegisterFuncsOverride`) -- applied
+   unconditionally, and the only way to deliberately re-enable a stripped
+   `env`/`expandenv`
 
 ## Fail-loud wiring
 

--- a/pkg/cmd/scafctl/defaults.go
+++ b/pkg/cmd/scafctl/defaults.go
@@ -14,8 +14,14 @@ import (
 // RegisterDefaults registers the default CEL environment, cache, and Go
 // template factories required before calling Root(). Embedders that need
 // the standard scafctl behaviour should call this once at startup.
-// Individual factories can still be overridden afterwards by calling the
-// corresponding Set*Factory functions directly.
+//
+// The Go template and CEL extension factories are set once (they establish the
+// authoritative built-in function set). Embedders extend the Go template
+// function set additively via RootOptions.GoTemplateFuncs or
+// gotmpl.RegisterFuncs / gotmpl.RegisterFuncsOverride rather than by replacing
+// the factory. The CEL cache and env factories can still be overridden by
+// calling the corresponding Set*Factory functions before RegisterDefaults
+// consumes them.
 func RegisterDefaults() {
 	celexp.SetEnvFactory(env.New)
 	celexp.SetCacheFactory(env.GlobalCache)

--- a/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
+++ b/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
@@ -181,7 +181,7 @@ func (o *Options) getFunctions() gotmpl.ExtFunctionList {
 	case o.Embedder:
 		return embedderFn()
 	default:
-		return append(allFn(), embedderFn()...)
+		return gotmpl.CombinedFuncs(allFn(), embedderFn())
 	}
 }
 

--- a/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
+++ b/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction.go
@@ -31,6 +31,7 @@ type FunctionSummary struct {
 	Name        string `json:"name" yaml:"name" required:"true"`
 	Description string `json:"description" yaml:"description"`
 	Custom      bool   `json:"custom" yaml:"custom"`
+	Source      string `json:"source,omitempty" yaml:"source,omitempty"`
 }
 
 // Options holds configuration for the get template functions command
@@ -43,14 +44,16 @@ type Options struct {
 	flags.KvxOutputFlags
 
 	// Filter options
-	Custom bool   // Show only custom (scafctl-specific) functions
-	Sprig  bool   // Show only sprig library functions
-	Search string // Search functions by name or description
+	Custom   bool   // Show only custom (scafctl-specific) functions
+	Sprig    bool   // Show only sprig library functions
+	Embedder bool   // Show only embedder-registered functions
+	Search   string // Search functions by name or description
 
 	// For dependency injection in tests
-	allFn    func() gotmpl.ExtFunctionList
-	customFn func() gotmpl.ExtFunctionList
-	sprigFn  func() gotmpl.ExtFunctionList
+	allFn      func() gotmpl.ExtFunctionList
+	customFn   func() gotmpl.ExtFunctionList
+	sprigFn    func() gotmpl.ExtFunctionList
+	embedderFn func() gotmpl.ExtFunctionList
 }
 
 // CommandFunctions creates the canonical 'get template functions' subcommand,
@@ -90,7 +93,7 @@ func newCommand(cliParams *settings.Run, ioStreams *terminal.IOStreams, path, us
 		Long: fmt.Sprintf(`List all available Go template extension functions, including sprig
 library functions and custom scafctl-specific functions.
 
-By default, lists all functions. Use --custom or --sprig to filter.
+By default, lists all functions. Use --custom, --sprig, or --embedder to filter.
 
 OUTPUT FORMATS:
   table     Table view with key information (default)
@@ -107,6 +110,9 @@ Examples:
 
   # List only sprig library functions
   %[1]s get template functions --sprig
+
+  # List only embedder-registered functions
+  %[1]s get template functions --embedder
 
   # Output as JSON
   %[1]s get template functions -o json
@@ -140,6 +146,7 @@ Examples:
 	// Filter flags
 	cCmd.Flags().BoolVar(&options.Custom, "custom", false, fmt.Sprintf("Show only custom %s functions", cliParams.BinaryName))
 	cCmd.Flags().BoolVar(&options.Sprig, "sprig", false, "Show only sprig library functions")
+	cCmd.Flags().BoolVar(&options.Embedder, "embedder", false, "Show only embedder-registered functions")
 	cCmd.Flags().StringVarP(&options.Search, "search", "s", "", "Search functions by name or description")
 
 	return cCmd
@@ -150,6 +157,7 @@ func (o *Options) getFunctions() gotmpl.ExtFunctionList {
 	allFn := gotmplext.All
 	customFn := gotmplext.Custom
 	sprigFn := gotmplext.Sprig
+	embedderFn := gotmpl.RegisteredFuncs
 
 	// Allow test injection
 	if o.allFn != nil {
@@ -161,14 +169,19 @@ func (o *Options) getFunctions() gotmpl.ExtFunctionList {
 	if o.sprigFn != nil {
 		sprigFn = o.sprigFn
 	}
+	if o.embedderFn != nil {
+		embedderFn = o.embedderFn
+	}
 
 	switch {
 	case o.Custom:
 		return customFn()
 	case o.Sprig:
 		return sprigFn()
+	case o.Embedder:
+		return embedderFn()
 	default:
-		return allFn()
+		return append(allFn(), embedderFn()...)
 	}
 }
 
@@ -216,6 +229,7 @@ func (o *Options) RunListFunctions(ctx context.Context) error {
 			Name:        fn.Name,
 			Description: fn.Description,
 			Custom:      fn.Custom,
+			Source:      fn.Source,
 		})
 	}
 	return o.writeOutput(ctx, summaries)

--- a/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction_coverage_test.go
+++ b/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction_coverage_test.go
@@ -149,6 +149,33 @@ func TestGetFunctions_DefaultAppendsEmbedder(t *testing.T) {
 	assert.Contains(t, names, "emb1")
 }
 
+func TestGetFunctions_DefaultDedupesEmbedderOverride(t *testing.T) {
+	t.Parallel()
+
+	opts := &Options{
+		allFn: func() gotmpl.ExtFunctionList {
+			return mockFunctionList() // testFunc (custom), sprigFunc (sprig)
+		},
+		embedderFn: func() gotmpl.ExtFunctionList {
+			// Shadows the built-in "sprigFunc".
+			return gotmpl.ExtFunctionList{{Name: "sprigFunc", Source: gotmpl.SourceEmbedder}}
+		},
+	}
+
+	result := opts.getFunctions()
+
+	count := 0
+	var source string
+	for _, fn := range result {
+		if fn.Name == "sprigFunc" {
+			count++
+			source = fn.Source
+		}
+	}
+	assert.Equal(t, 1, count, "shadowed built-in must not be duplicated")
+	assert.Equal(t, gotmpl.SourceEmbedder, source, "embedder override must win")
+}
+
 func TestGetFunctions_DefaultsToAll_WhenNoInjected(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction_coverage_test.go
+++ b/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction_coverage_test.go
@@ -107,6 +107,48 @@ func TestGetFunctions_Sprig(t *testing.T) {
 	assert.Equal(t, "sprig1", result[0].Name)
 }
 
+func TestGetFunctions_Embedder(t *testing.T) {
+	t.Parallel()
+
+	embedderList := gotmpl.ExtFunctionList{{Name: "emb1", Source: gotmpl.SourceEmbedder}}
+	opts := &Options{
+		Embedder: true,
+		embedderFn: func() gotmpl.ExtFunctionList {
+			return embedderList
+		},
+		allFn: func() gotmpl.ExtFunctionList {
+			return mockFunctionList()
+		},
+	}
+
+	result := opts.getFunctions()
+	assert.Len(t, result, 1)
+	assert.Equal(t, "emb1", result[0].Name)
+	assert.Equal(t, gotmpl.SourceEmbedder, result[0].Source)
+}
+
+func TestGetFunctions_DefaultAppendsEmbedder(t *testing.T) {
+	t.Parallel()
+
+	opts := &Options{
+		allFn: func() gotmpl.ExtFunctionList {
+			return mockFunctionList()
+		},
+		embedderFn: func() gotmpl.ExtFunctionList {
+			return gotmpl.ExtFunctionList{{Name: "emb1", Source: gotmpl.SourceEmbedder}}
+		},
+	}
+
+	result := opts.getFunctions()
+	// Default (no filter) appends embedder functions onto the full built-in list.
+	assert.Len(t, result, 3)
+	names := make([]string, len(result))
+	for i, fn := range result {
+		names[i] = fn.Name
+	}
+	assert.Contains(t, names, "emb1")
+}
+
 func TestGetFunctions_DefaultsToAll_WhenNoInjected(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction_schema.json
+++ b/pkg/cmd/scafctl/get/gotmplfunction/gotmplfunction_schema.json
@@ -11,7 +11,7 @@
     "titleField": "name",
     "subtitleField": "description",
     "subtitleMaxLines": 1,
-    "badgeFields": ["custom"]
+    "badgeFields": ["source"]
   },
 
   "x-kvx-detail": {
@@ -20,7 +20,7 @@
     "sections": [
       {
         "title": "",
-        "fields": ["name", "custom"],
+        "fields": ["name", "source", "custom"],
         "layout": "inline"
       },
       {
@@ -59,6 +59,11 @@
         "type": "boolean",
         "title": "Custom",
         "description": "Whether this is a custom scafctl extension"
+      },
+      "source": {
+        "type": "string",
+        "title": "Source",
+        "description": "Origin of the function: sprig, custom, or embedder"
       },
       "description": {
         "type": "string",

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -182,6 +182,13 @@ type RootOptions struct {
 	// replace a built-in, call gotmpl.RegisterFuncsOverride directly instead.
 	GoTemplateFuncs template.FuncMap
 
+	// goTemplateFuncsRegistered guards GoTemplateFuncs registration so that
+	// executing the same command more than once (a REPL, a long-running host,
+	// or repeated calls in tests) does not re-register the process-global
+	// functions and self-collide. PersistentPreRun runs sequentially, so a
+	// plain bool is sufficient.
+	goTemplateFuncsRegistered bool
+
 	// ActionDiscoveryFileNames overrides the file names used by "run action"
 	// auto-discovery. When empty, the defaults from
 	// settings.ActionFileNamesFor are used.
@@ -495,12 +502,15 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 			// Registered additively (built-ins win on collision). A collision is
 			// an embedder build bug, so fail loudly rather than silently dropping
 			// the function. Runs after RegisterDefaults has set the extension
-			// factory so built-in collisions are detectable.
-			if len(opts.GoTemplateFuncs) > 0 {
+			// factory so built-in collisions are detectable. Guarded so a command
+			// executed more than once does not re-register (and self-collide with)
+			// the process-global functions.
+			if len(opts.GoTemplateFuncs) > 0 && !opts.goTemplateFuncsRegistered {
 				if funcErr := gotmpl.RegisterFuncs(opts.GoTemplateFuncs); funcErr != nil {
 					w.ErrorWithExit(fmt.Sprintf("register Go template functions: %v", funcErr))
 					return
 				}
+				opts.goTemplateFuncsRegistered = true
 			}
 
 			// Initialize shared secrets store with config-aware settings.

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"text/template"
 	"time"
 
 	"github.com/MakeNowJust/heredoc/v2"
@@ -171,6 +172,15 @@ type RootOptions struct {
 	// startup before config-based or plugin handlers, and appear in
 	// 'auth list' immediately.
 	BuiltinAuthHandlers []auth.Handler
+
+	// GoTemplateFuncs are custom Go-template functions the embedder compiles
+	// into the binary. They are registered additively at startup (built-ins win
+	// on name collision) so they become available to the go-template provider
+	// and every other gotmpl consumer, and appear in list_go_template_functions
+	// and 'get template functions'. A name that collides with a built-in or a
+	// previously-registered function fails startup loudly. To deliberately
+	// replace a built-in, call gotmpl.RegisterFuncsOverride directly instead.
+	GoTemplateFuncs template.FuncMap
 
 	// ActionDiscoveryFileNames overrides the file names used by "run action"
 	// auto-discovery. When empty, the defaults from
@@ -480,6 +490,18 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 				EnableMetrics:     gtValues.EnableMetrics,
 				AllowEnvFunctions: gtValues.AllowEnvFunctions,
 			})
+
+			// ── Register embedder-supplied Go template functions ──
+			// Registered additively (built-ins win on collision). A collision is
+			// an embedder build bug, so fail loudly rather than silently dropping
+			// the function. Runs after RegisterDefaults has set the extension
+			// factory so built-in collisions are detectable.
+			if len(opts.GoTemplateFuncs) > 0 {
+				if funcErr := gotmpl.RegisterFuncs(opts.GoTemplateFuncs); funcErr != nil {
+					w.ErrorWithExit(fmt.Sprintf("register Go template functions: %v", funcErr))
+					return
+				}
+			}
 
 			// Initialize shared secrets store with config-aware settings.
 			// Auth handlers that receive this store will not create their own.

--- a/pkg/cmd/scafctl/root_test.go
+++ b/pkg/cmd/scafctl/root_test.go
@@ -431,6 +431,8 @@ func TestRoot_ConfigPathHonored(t *testing.T) {
 // non-default binary name. Uses a unique function name so the package-global
 // registry cannot collide with other tests in this binary.
 func TestRoot_GoTemplateFuncs_Discoverable(t *testing.T) {
+	gotmpl.ResetRegistryForTesting()
+	t.Cleanup(gotmpl.ResetRegistryForTesting)
 	ioStreams, stdout, _ := terminal.NewTestIOStreams()
 
 	cmd, cleanup := Root(&RootOptions{
@@ -455,6 +457,8 @@ func TestRoot_GoTemplateFuncs_Discoverable(t *testing.T) {
 // bug -- registering a function whose name collides with a built-in -- fails
 // loudly at startup rather than silently dropping the function.
 func TestRoot_GoTemplateFuncs_CollisionFailsLoud(t *testing.T) {
+	gotmpl.ResetRegistryForTesting()
+	t.Cleanup(gotmpl.ResetRegistryForTesting)
 	// Ensure the extension factory is set so built-in collisions are detectable.
 	RegisterDefaults()
 
@@ -480,6 +484,8 @@ func TestRoot_GoTemplateFuncs_CollisionFailsLoud(t *testing.T) {
 // functions and thus does not self-collide (register-once is enforced globally,
 // so the root wiring must guard its own registration).
 func TestRoot_GoTemplateFuncs_ReExecuteNoSelfCollision(t *testing.T) {
+	gotmpl.ResetRegistryForTesting()
+	t.Cleanup(gotmpl.ResetRegistryForTesting)
 	ioStreams, _, _ := terminal.NewTestIOStreams()
 	exitCalled := false
 	cmd, cleanup := Root(&RootOptions{

--- a/pkg/cmd/scafctl/root_test.go
+++ b/pkg/cmd/scafctl/root_test.go
@@ -12,8 +12,10 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"text/template"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/kube"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
@@ -421,4 +423,54 @@ func TestRoot_ConfigPathHonored(t *testing.T) {
 	info, err := captured.Resolve(context.Background(), "lab")
 	require.NoError(t, err)
 	assert.Equal(t, "https://api.lab.example.com:6443", info.APIServerURL)
+}
+
+// TestRoot_GoTemplateFuncs_Discoverable verifies the embedder contract: a custom
+// Go-template function supplied via RootOptions.GoTemplateFuncs is registered
+// during startup and surfaces in the discoverability output, even under a
+// non-default binary name. Uses a unique function name so the package-global
+// registry cannot collide with other tests in this binary.
+func TestRoot_GoTemplateFuncs_Discoverable(t *testing.T) {
+	ioStreams, stdout, _ := terminal.NewTestIOStreams()
+
+	cmd, cleanup := Root(&RootOptions{
+		IOStreams:  ioStreams,
+		BinaryName: "mycli",
+		GoTemplateFuncs: template.FuncMap{
+			"embedderRootDiscoverable": func(s string) string { return s },
+		},
+	})
+	defer cleanup()
+	cmd.SetArgs([]string{"get", "template", "functions", "--embedder", "-o", "json"})
+	require.NoError(t, cmd.Execute())
+
+	output := stdout.String()
+	assert.Contains(t, output, "embedderRootDiscoverable",
+		"embedder-registered function should appear in --embedder listing")
+	assert.Contains(t, output, gotmpl.SourceEmbedder,
+		"embedder function should be tagged with the embedder source")
+}
+
+// TestRoot_GoTemplateFuncs_CollisionFailsLoud verifies that an embedder build
+// bug -- registering a function whose name collides with a built-in -- fails
+// loudly at startup rather than silently dropping the function.
+func TestRoot_GoTemplateFuncs_CollisionFailsLoud(t *testing.T) {
+	// Ensure the extension factory is set so built-in collisions are detectable.
+	RegisterDefaults()
+
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	exitCalled := false
+	cmd, cleanup := Root(&RootOptions{
+		IOStreams: ioStreams,
+		ExitFunc:  func(_ int) { exitCalled = true },
+		GoTemplateFuncs: template.FuncMap{
+			"upper": func(string) string { return "" },
+		},
+	})
+	defer cleanup()
+	cmd.SetArgs([]string{"version"})
+
+	_ = cmd.Execute()
+	assert.True(t, exitCalled,
+		"ExitFunc should be called when an embedder function collides with a built-in")
 }

--- a/pkg/cmd/scafctl/root_test.go
+++ b/pkg/cmd/scafctl/root_test.go
@@ -474,3 +474,26 @@ func TestRoot_GoTemplateFuncs_CollisionFailsLoud(t *testing.T) {
 	assert.True(t, exitCalled,
 		"ExitFunc should be called when an embedder function collides with a built-in")
 }
+
+// TestRoot_GoTemplateFuncs_ReExecuteNoSelfCollision verifies that executing the
+// same command more than once does not re-register the process-global embedder
+// functions and thus does not self-collide (register-once is enforced globally,
+// so the root wiring must guard its own registration).
+func TestRoot_GoTemplateFuncs_ReExecuteNoSelfCollision(t *testing.T) {
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	exitCalled := false
+	cmd, cleanup := Root(&RootOptions{
+		IOStreams: ioStreams,
+		ExitFunc:  func(_ int) { exitCalled = true },
+		GoTemplateFuncs: template.FuncMap{
+			"embedderRootReexec": func(s string) string { return s },
+		},
+	})
+	defer cleanup()
+
+	cmd.SetArgs([]string{"version"})
+	require.NoError(t, cmd.Execute())
+	require.NoError(t, cmd.Execute(), "second execution must not self-collide")
+	assert.False(t, exitCalled,
+		"re-executing the same command must not fail the embedder registration")
+}

--- a/pkg/gotmpl/README.md
+++ b/pkg/gotmpl/README.md
@@ -239,6 +239,60 @@ result, err := svc.Execute(ctx, gotmpl.TemplateOptions{
 })
 ```
 
+### Embedder Function Registration
+
+Embedders that build their own CLI on top of scafctl can register additional
+Go-template functions that become available to **every** template rendered
+through the shared service (resolvers, the `go-template` provider, `evaluate`,
+etc.). This is Go-only: functions are compiled Go code, so individual solution
+YAML files cannot declare them.
+
+The simplest path is the `RootOptions.GoTemplateFuncs` field, which the root
+command registers during startup:
+
+```go
+cmd, cleanup := scafctl.Root(&scafctl.RootOptions{
+    BinaryName: "mycli",
+    GoTemplateFuncs: template.FuncMap{
+        "shout": func(s string) string { return strings.ToUpper(s) + "!" },
+    },
+})
+defer cleanup()
+```
+
+Under the hood this calls `gotmpl.RegisterFuncs`, which is **additive** and
+merged at the single choke point used by all services:
+
+```go
+// Additive: a name that collides with a built-in (sprig or custom) is an
+// error, and no functions are registered (all-or-nothing).
+if err := gotmpl.RegisterFuncs(template.FuncMap{
+    "shout": func(s string) string { return strings.ToUpper(s) + "!" },
+}); err != nil {
+    log.Fatal(err)
+}
+```
+
+Precedence when a template renders (later wins):
+
+1. Built-in factory functions (sprig + custom scafctl functions)
+2. Additively registered embedder functions (`RegisterFuncs`) -- only names not
+   already provided by a built-in; a collision is rejected
+3. Override embedder functions (`RegisterFuncsOverride`) -- unconditionally
+   replace an existing function; use this escape hatch only when you must shadow
+   a built-in
+
+`RegisterFuncs` deliberately refuses to shadow built-ins so that a typo cannot
+silently change template behavior. When shadowing is intentional, call
+`RegisterFuncsOverride` instead.
+
+Registered functions are discoverable:
+
+- CLI: `mycli get template functions --embedder`
+- MCP: `list_go_template_functions` with `embedder_only: true`
+
+Each is tagged with `Source: "embedder"` (see `ExtFunction.Source`).
+
 ### String Replacements
 
 Protect literal template syntax from parsing:

--- a/pkg/gotmpl/README.md
+++ b/pkg/gotmpl/README.md
@@ -294,6 +294,12 @@ Registration also fails fast if a value is not a usable template function (nil,
 a non-function, or a function whose return signature text/template rejects), so
 an embedder build bug surfaces as a clear error rather than a later panic.
 
+Registration is register-once (like `sql.Register` and other stdlib global
+registries): re-registering a name that is already present -- even with the
+identical function -- is a collision. Register your functions a single time at
+startup. The root command guards its own wiring, so executing the command more
+than once in a long-running host does not re-register or self-collide.
+
 Registered functions are discoverable:
 
 - CLI: `mycli get template functions --embedder`

--- a/pkg/gotmpl/README.md
+++ b/pkg/gotmpl/README.md
@@ -276,15 +276,23 @@ if err := gotmpl.RegisterFuncs(template.FuncMap{
 Precedence when a template renders (later wins):
 
 1. Built-in factory functions (sprig + custom scafctl functions)
-2. Additively registered embedder functions (`RegisterFuncs`) -- only names not
-   already provided by a built-in; a collision is rejected
-3. Override embedder functions (`RegisterFuncsOverride`) -- unconditionally
+2. Environment stripping: unless environment access is enabled, `env` and
+   `expandenv` are removed here so secrets cannot be exfiltrated by default
+3. Additively registered embedder functions (`RegisterFuncs`) -- only names not
+   already provided by a built-in; a collision is rejected. This layer never
+   re-introduces a stripped `env`/`expandenv`, regardless of registration order
+4. Override embedder functions (`RegisterFuncsOverride`) -- unconditionally
    replace an existing function; use this escape hatch only when you must shadow
-   a built-in
+   a built-in (this is also the only way to deliberately re-enable a stripped
+   `env`/`expandenv`)
 
 `RegisterFuncs` deliberately refuses to shadow built-ins so that a typo cannot
 silently change template behavior. When shadowing is intentional, call
 `RegisterFuncsOverride` instead.
+
+Registration also fails fast if a value is not a usable template function (nil,
+a non-function, or a function whose return signature text/template rejects), so
+an embedder build bug surfaces as a clear error rather than a later panic.
 
 Registered functions are discoverable:
 

--- a/pkg/gotmpl/ext/ext.go
+++ b/pkg/gotmpl/ext/ext.go
@@ -49,6 +49,7 @@ func Sprig() gotmpl.ExtFunctionList {
 			Name:        name,
 			Description: sprigDescription(name),
 			Custom:      false,
+			Source:      gotmpl.SourceSprig,
 			Links:       []string{"https://masterminds.github.io/sprig/"},
 			Func: template.FuncMap{
 				name: fn,
@@ -70,7 +71,7 @@ func Sprig() gotmpl.ExtFunctionList {
 //	    fmt.Printf("Custom Function: %s (%s)\n", f.Name, f.Description)
 //	}
 func Custom() gotmpl.ExtFunctionList {
-	return gotmpl.ExtFunctionList{
+	funcs := gotmpl.ExtFunctionList{
 		// HCL functions
 		hcl.ToHclFunc(),
 		hcl.ToHclValueFunc(),
@@ -96,6 +97,16 @@ func Custom() gotmpl.ExtFunctionList {
 		extyaml.MustToYamlFunc(),
 		extyaml.MustFromYamlFunc(),
 	}
+
+	// Tag every custom function with its source for discoverability. The
+	// individual constructors may predate the Source field, so backfill it here
+	// in one place.
+	for i := range funcs {
+		if funcs[i].Source == "" {
+			funcs[i].Source = gotmpl.SourceCustom
+		}
+	}
+	return funcs
 }
 
 // All returns a combined list of all Go template extension functions, including

--- a/pkg/gotmpl/ext_types.go
+++ b/pkg/gotmpl/ext_types.go
@@ -5,6 +5,17 @@ package gotmpl
 
 import "text/template"
 
+// Function source tags used by the Source field for discoverability tooling.
+const (
+	// SourceSprig marks a third-party function from the sprig library.
+	SourceSprig = "sprig"
+	// SourceCustom marks a scafctl-specific built-in function.
+	SourceCustom = "custom"
+	// SourceEmbedder marks a function supplied by an embedding application via
+	// RegisterFuncs / RegisterFuncsOverride.
+	SourceEmbedder = "embedder"
+)
+
 // ExtFunction describes a Go template function extension with metadata
 // for discoverability via MCP tools and CLI commands.
 type ExtFunction struct {
@@ -23,6 +34,12 @@ type ExtFunction struct {
 	// Custom indicates whether this is a scafctl-specific function (true)
 	// or a third-party/built-in function (false, e.g., sprig functions)
 	Custom bool `json:"custom,omitempty" yaml:"custom,omitempty" doc:"Whether this is a scafctl-specific function"`
+
+	// Source identifies where the function originates: "sprig" (third-party
+	// library), "custom" (scafctl-specific built-in), or "embedder" (registered
+	// by an embedding application via RegisterFuncs). May be empty for legacy
+	// entries that predate this field.
+	Source string `json:"source,omitempty" yaml:"source,omitempty" doc:"Origin of the function: sprig, custom, or embedder" maxLength:"32" example:"embedder"`
 
 	// Func is the template.FuncMap entry for this function.
 	// Excluded from JSON/YAML serialization.

--- a/pkg/gotmpl/gotmpl.go
+++ b/pkg/gotmpl/gotmpl.go
@@ -186,18 +186,34 @@ func getContextFuncBinder(ctx context.Context) template.FuncMap {
 	return factory(ctx)
 }
 
-// getExtensionFuncMap returns the extension function map from the factory.
-// When allowEnvFunctions is false (the default), the sprig 'env' and 'expandenv'
-// functions are removed to prevent templates from exfiltrating process secrets.
-func getExtensionFuncMap() template.FuncMap {
+// factoryFuncMap returns the raw built-in extension function map from the
+// factory (sprig + custom), or an empty map when no factory has been set. It
+// does NOT apply env-function stripping or embedder registrations, so it
+// reflects the authoritative built-in name set used for collision detection.
+func factoryFuncMap() template.FuncMap {
 	extensionFuncMapMu.RLock()
-	var fm template.FuncMap
+	defer extensionFuncMapMu.RUnlock()
 	if extensionFuncMapFactory != nil {
-		fm = extensionFuncMapFactory()
-	} else {
-		fm = make(template.FuncMap)
+		return extensionFuncMapFactory()
 	}
-	extensionFuncMapMu.RUnlock()
+	return make(template.FuncMap)
+}
+
+// getExtensionFuncMap returns the effective extension function map for a
+// service. Precedence (lowest to highest):
+//  1. built-in extension set from the factory (sprig + custom)
+//  2. env-function stripping: when allowEnvFunctions is false (the default),
+//     the sprig 'env' and 'expandenv' functions are removed to prevent
+//     templates from exfiltrating process secrets
+//  3. additive embedder functions (RegisterFuncs) — added only for names not
+//     already present, so built-ins win on collision. The env/expandenv names
+//     are never re-introduced additively while stripping is in effect, so an
+//     additive registration cannot smuggle them back regardless of whether the
+//     factory was set when the function was registered.
+//  4. override embedder functions (RegisterFuncsOverride) — overwrite
+//     unconditionally, and can re-introduce a stripped function such as env
+func getExtensionFuncMap() template.FuncMap {
+	fm := factoryFuncMap()
 
 	allowEnvFunctionsMu.RLock()
 	allow := allowEnvFunctionsFlag
@@ -206,6 +222,22 @@ func getExtensionFuncMap() template.FuncMap {
 	if !allow {
 		delete(fm, "env")
 		delete(fm, "expandenv")
+	}
+
+	additive, override := registeredExtensionFuncs()
+	for name, fn := range additive {
+		// Never re-add a stripped env function via the additive path; only the
+		// explicit override escape hatch may re-introduce it. This makes the
+		// secret-exfiltration guard independent of registration ordering.
+		if !allow && (name == "env" || name == "expandenv") {
+			continue
+		}
+		if _, exists := fm[name]; !exists {
+			fm[name] = fn
+		}
+	}
+	for name, fn := range override {
+		fm[name] = fn
 	}
 	return fm
 }

--- a/pkg/gotmpl/registry.go
+++ b/pkg/gotmpl/registry.go
@@ -56,6 +56,10 @@ var (
 // once) pass the same func map repeatedly without hitting a self-collision;
 // only a name bound to a *different* function is rejected.
 //
+// Each value is validated up front: a nil value, a non-function, or a function
+// whose return signature text/template would reject is rejected here with a
+// clear error, rather than panicking later when a template is constructed.
+//
 // This function is thread-safe.
 func RegisterFuncs(funcs template.FuncMap) error {
 	if len(funcs) == 0 {
@@ -73,6 +77,9 @@ func RegisterFuncs(funcs template.FuncMap) error {
 	for _, name := range names {
 		if name == "" {
 			return fmt.Errorf("register template func: name must not be empty")
+		}
+		if err := validateFunc(name, funcs[name]); err != nil {
+			return fmt.Errorf("register template func: %w", err)
 		}
 		if _, ok := builtins[name]; ok {
 			return fmt.Errorf("register template func %q: %w (built-in)", name, ErrFuncNameCollision)
@@ -101,7 +108,8 @@ func RegisterFuncs(funcs template.FuncMap) error {
 // embedders that need to replace a sprig/custom function (including re-enabling
 // stripped functions such as env). Unlike RegisterFuncs it does not reject
 // names that collide with built-ins; it errors only when the same name has
-// already been registered as an override (all-or-nothing).
+// already been registered as an override (all-or-nothing). Values are validated
+// the same way as RegisterFuncs so an invalid function fails fast here.
 //
 // This function is thread-safe.
 func RegisterFuncsOverride(funcs template.FuncMap) error {
@@ -117,6 +125,9 @@ func RegisterFuncsOverride(funcs template.FuncMap) error {
 	for _, name := range names {
 		if name == "" {
 			return fmt.Errorf("register template func override: name must not be empty")
+		}
+		if err := validateFunc(name, funcs[name]); err != nil {
+			return fmt.Errorf("register template func override: %w", err)
 		}
 		if _, ok := overrideFuncs[name]; ok {
 			return fmt.Errorf("register template func override %q: %w", name, ErrFuncNameCollision)
@@ -180,6 +191,37 @@ func registeredExtensionFuncs() (additive, override template.FuncMap) {
 		override[k] = v
 	}
 	return additive, override
+}
+
+// errorType is the reflect.Type of the error interface, used by validateFunc to
+// match text/template's own good-function rule for two-result functions.
+var errorType = reflect.TypeOf((*error)(nil)).Elem()
+
+// validateFunc reports whether fn is usable as a text/template function,
+// mirroring the checks text/template performs in (*Template).Funcs. Registering
+// a nil value, a non-function, or a function with an unsupported return
+// signature would otherwise panic later at template construction, far from the
+// embedder call site. Failing fast here turns that latent panic into a clear
+// error at registration time.
+func validateFunc(name string, fn any) error {
+	if fn == nil {
+		return fmt.Errorf("value for %q must not be nil", name)
+	}
+	v := reflect.ValueOf(fn)
+	if v.Kind() != reflect.Func {
+		return fmt.Errorf("value for %q is %s, want a function", name, v.Kind())
+	}
+	if v.IsNil() {
+		return fmt.Errorf("value for %q must not be a nil function", name)
+	}
+	t := v.Type()
+	switch {
+	case t.NumOut() == 1:
+	case t.NumOut() == 2 && t.Out(1) == errorType:
+	default:
+		return fmt.Errorf("function %q must return 1 value, or 2 values where the second is error", name)
+	}
+	return nil
 }
 
 // sortedFuncNames returns the keys of a FuncMap in deterministic sorted order

--- a/pkg/gotmpl/registry.go
+++ b/pkg/gotmpl/registry.go
@@ -1,0 +1,216 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gotmpl
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"sync"
+	"text/template"
+)
+
+// ErrFuncNameCollision indicates that a template function name is already
+// registered, either as a built-in extension function (sprig/custom) or by a
+// prior registration. Callers can match it with errors.Is.
+var ErrFuncNameCollision = errors.New("template function name already registered")
+
+var (
+	// registryMu guards the embedder function registries below. Registration
+	// happens at startup; the maps are read on every template render, so a
+	// RWMutex keeps the hot read path cheap.
+	registryMu sync.RWMutex
+
+	// registeredFuncs holds additively-registered embedder functions. Built-in
+	// functions win on name collision, so an entry here is only added to a
+	// service func map when the name is not already provided by the base set.
+	registeredFuncs = template.FuncMap{}
+
+	// overrideFuncs holds embedder functions that intentionally overwrite
+	// built-ins at merge time. This is the explicit escape hatch for embedders
+	// that need to replace a sprig/custom function.
+	overrideFuncs = template.FuncMap{}
+)
+
+// RegisterFuncs registers embedder-supplied Go template functions additively.
+//
+// Built-ins win on collision: if any provided name already exists in the
+// built-in extension set (sprig + custom, when the extension factory has been
+// set via SetExtensionFuncMapFactory) or was registered by a prior call, the
+// entire call is rejected with an error wrapping ErrFuncNameCollision and
+// nothing is registered (all-or-nothing). Use RegisterFuncsOverride to
+// deliberately replace a built-in.
+//
+// Registration is process-global and additive across calls; it is intended to
+// be performed once at application startup, after RegisterDefaults has set the
+// extension factory so built-in collisions can be detected. Functions
+// registered here become available to the go-template provider and every other
+// gotmpl consumer, and appear in list_go_template_functions and
+// `get template functions`.
+//
+// Re-registering an identical function under the same name is an idempotent
+// no-op rather than a collision. This lets an embedder that reconstructs the
+// root command in a long-running process (or a test that executes it more than
+// once) pass the same func map repeatedly without hitting a self-collision;
+// only a name bound to a *different* function is rejected.
+//
+// This function is thread-safe.
+func RegisterFuncs(funcs template.FuncMap) error {
+	if len(funcs) == 0 {
+		return nil
+	}
+
+	builtins := factoryFuncMap()
+	names := sortedFuncNames(funcs)
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	// Validate every name before mutating so a collision leaves the registry
+	// untouched (all-or-nothing).
+	for _, name := range names {
+		if name == "" {
+			return fmt.Errorf("register template func: name must not be empty")
+		}
+		if _, ok := builtins[name]; ok {
+			return fmt.Errorf("register template func %q: %w (built-in)", name, ErrFuncNameCollision)
+		}
+		if existing, ok := registeredFuncs[name]; ok {
+			// Idempotent re-registration of the identical function is allowed;
+			// a different function under the same name is a genuine collision.
+			if sameFunc(existing, funcs[name]) {
+				continue
+			}
+			return fmt.Errorf("register template func %q: %w", name, ErrFuncNameCollision)
+		}
+		if _, ok := overrideFuncs[name]; ok {
+			return fmt.Errorf("register template func %q: %w (override)", name, ErrFuncNameCollision)
+		}
+	}
+
+	for name, fn := range funcs {
+		registeredFuncs[name] = fn
+	}
+	return nil
+}
+
+// RegisterFuncsOverride registers embedder-supplied Go template functions that
+// overwrite built-ins at merge time. This is the explicit escape hatch for
+// embedders that need to replace a sprig/custom function (including re-enabling
+// stripped functions such as env). Unlike RegisterFuncs it does not reject
+// names that collide with built-ins; it errors only when the same name has
+// already been registered as an override (all-or-nothing).
+//
+// This function is thread-safe.
+func RegisterFuncsOverride(funcs template.FuncMap) error {
+	if len(funcs) == 0 {
+		return nil
+	}
+
+	names := sortedFuncNames(funcs)
+
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	for _, name := range names {
+		if name == "" {
+			return fmt.Errorf("register template func override: name must not be empty")
+		}
+		if _, ok := overrideFuncs[name]; ok {
+			return fmt.Errorf("register template func override %q: %w", name, ErrFuncNameCollision)
+		}
+	}
+
+	for name, fn := range funcs {
+		overrideFuncs[name] = fn
+	}
+	return nil
+}
+
+// RegisteredFuncs returns the embedder-registered functions (additive and
+// override) as an ExtFunctionList tagged with Source "embedder" for
+// discoverability tooling (MCP list_go_template_functions and the CLI
+// `get template functions` command). The returned list is sorted by name.
+func RegisteredFuncs() ExtFunctionList {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	seen := make(map[string]struct{}, len(registeredFuncs)+len(overrideFuncs))
+	list := make(ExtFunctionList, 0, len(registeredFuncs)+len(overrideFuncs))
+
+	appendFuncs := func(src template.FuncMap, description string) {
+		for _, name := range sortedFuncNames(src) {
+			if _, dup := seen[name]; dup {
+				continue
+			}
+			seen[name] = struct{}{}
+			list = append(list, ExtFunction{
+				Name:        name,
+				Description: description,
+				Source:      SourceEmbedder,
+				Func:        template.FuncMap{name: src[name]},
+			})
+		}
+	}
+
+	// Override entries take precedence in the description if a name somehow
+	// appears in both maps.
+	appendFuncs(overrideFuncs, "Embedder-registered template function (overrides a built-in)")
+	appendFuncs(registeredFuncs, "Embedder-registered template function")
+
+	sort.Slice(list, func(i, j int) bool { return list[i].Name < list[j].Name })
+	return list
+}
+
+// registeredExtensionFuncs returns copies of the additive and override
+// registries so callers cannot mutate the shared maps. Consumed by
+// getExtensionFuncMap during service construction.
+func registeredExtensionFuncs() (additive, override template.FuncMap) {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+
+	additive = make(template.FuncMap, len(registeredFuncs))
+	for k, v := range registeredFuncs {
+		additive[k] = v
+	}
+	override = make(template.FuncMap, len(overrideFuncs))
+	for k, v := range overrideFuncs {
+		override[k] = v
+	}
+	return additive, override
+}
+
+// sortedFuncNames returns the keys of a FuncMap in deterministic sorted order
+// so validation errors are reproducible.
+func sortedFuncNames(funcs template.FuncMap) []string {
+	names := make([]string, 0, len(funcs))
+	for name := range funcs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// sameFunc reports whether two registered function values refer to the same
+// underlying function. It compares code pointers via reflection, which lets an
+// idempotent re-registration (the same func passed again) be distinguished from
+// a genuine collision (a different func under an already-used name). Non-func or
+// nil values are treated as not-equal so they fall through to the collision
+// path rather than panicking.
+func sameFunc(a, b any) bool {
+	va, vb := reflect.ValueOf(a), reflect.ValueOf(b)
+	if va.Kind() != reflect.Func || vb.Kind() != reflect.Func {
+		return false
+	}
+	return va.Pointer() == vb.Pointer()
+}
+
+// resetRegistryForTesting clears both embedder registries. Tests only.
+func resetRegistryForTesting() {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registeredFuncs = template.FuncMap{}
+	overrideFuncs = template.FuncMap{}
+}

--- a/pkg/gotmpl/registry.go
+++ b/pkg/gotmpl/registry.go
@@ -258,8 +258,11 @@ func CombinedFuncs(builtins, registered ExtFunctionList) ExtFunctionList {
 	return append(out, registered...)
 }
 
-// resetRegistryForTesting clears both embedder registries. Tests only.
-func resetRegistryForTesting() {
+// ResetRegistryForTesting clears both embedder registries. It is exported so
+// tests in other packages that register process-global embedder functions can
+// restore a clean registry via t.Cleanup, keeping package test runs order-
+// independent. Tests only.
+func ResetRegistryForTesting() {
 	registryMu.Lock()
 	defer registryMu.Unlock()
 	registeredFuncs = template.FuncMap{}

--- a/pkg/gotmpl/registry.go
+++ b/pkg/gotmpl/registry.go
@@ -50,11 +50,12 @@ var (
 // gotmpl consumer, and appear in list_go_template_functions and
 // `get template functions`.
 //
-// Re-registering an identical function under the same name is an idempotent
-// no-op rather than a collision. This lets an embedder that reconstructs the
-// root command in a long-running process (or a test that executes it more than
-// once) pass the same func map repeatedly without hitting a self-collision;
-// only a name bound to a *different* function is rejected.
+// Like the Go standard library's global registries (for example sql.Register),
+// this is register-once: re-registering a name that is already present -- even
+// with an identical function -- is rejected as a collision. Callers that run in
+// a long-running process should register their functions a single time rather
+// than on every command execution (the root command guards its own wiring so a
+// command executed more than once does not self-collide).
 //
 // Each value is validated up front: a nil value, a non-function, or a function
 // whose return signature text/template would reject is rejected here with a
@@ -84,12 +85,7 @@ func RegisterFuncs(funcs template.FuncMap) error {
 		if _, ok := builtins[name]; ok {
 			return fmt.Errorf("register template func %q: %w (built-in)", name, ErrFuncNameCollision)
 		}
-		if existing, ok := registeredFuncs[name]; ok {
-			// Idempotent re-registration of the identical function is allowed;
-			// a different function under the same name is a genuine collision.
-			if sameFunc(existing, funcs[name]) {
-				continue
-			}
+		if _, ok := registeredFuncs[name]; ok {
 			return fmt.Errorf("register template func %q: %w", name, ErrFuncNameCollision)
 		}
 		if _, ok := overrideFuncs[name]; ok {
@@ -235,18 +231,31 @@ func sortedFuncNames(funcs template.FuncMap) []string {
 	return names
 }
 
-// sameFunc reports whether two registered function values refer to the same
-// underlying function. It compares code pointers via reflection, which lets an
-// idempotent re-registration (the same func passed again) be distinguished from
-// a genuine collision (a different func under an already-used name). Non-func or
-// nil values are treated as not-equal so they fall through to the collision
-// path rather than panicking.
-func sameFunc(a, b any) bool {
-	va, vb := reflect.ValueOf(a), reflect.ValueOf(b)
-	if va.Kind() != reflect.Func || vb.Kind() != reflect.Func {
-		return false
+// CombinedFuncs merges a built-in function list with embedder-registered
+// functions into a single list de-duplicated by name. Embedder entries win on a
+// name collision, so when an embedder shadows a built-in via
+// RegisterFuncsOverride the listing shows only the effective (override)
+// function rather than also showing the shadowed built-in. This keeps
+// discoverability output (MCP list_go_template_functions and the CLI
+// `get template functions` command) aligned with the function that actually
+// runs. Order is preserved: surviving built-ins first, then the registered
+// functions.
+func CombinedFuncs(builtins, registered ExtFunctionList) ExtFunctionList {
+	if len(registered) == 0 {
+		return builtins
 	}
-	return va.Pointer() == vb.Pointer()
+	shadowed := make(map[string]struct{}, len(registered))
+	for _, f := range registered {
+		shadowed[f.Name] = struct{}{}
+	}
+	out := make(ExtFunctionList, 0, len(builtins)+len(registered))
+	for _, f := range builtins {
+		if _, ok := shadowed[f.Name]; ok {
+			continue
+		}
+		out = append(out, f)
+	}
+	return append(out, registered...)
 }
 
 // resetRegistryForTesting clears both embedder registries. Tests only.

--- a/pkg/gotmpl/registry_benchmark_test.go
+++ b/pkg/gotmpl/registry_benchmark_test.go
@@ -14,8 +14,8 @@ import (
 // non-empty registry. It resets the registry on cleanup.
 func registerBenchFuncs(b *testing.B, n int) {
 	b.Helper()
-	resetRegistryForTesting()
-	b.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	b.Cleanup(ResetRegistryForTesting)
 
 	additive := make(template.FuncMap, n)
 	for i := 0; i < n; i++ {

--- a/pkg/gotmpl/registry_benchmark_test.go
+++ b/pkg/gotmpl/registry_benchmark_test.go
@@ -1,0 +1,52 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gotmpl
+
+import (
+	"fmt"
+	"testing"
+	"text/template"
+)
+
+// registerBenchFuncs populates the registry with n additive functions and a
+// handful of override functions so the merge paths exercise a realistic,
+// non-empty registry. It resets the registry on cleanup.
+func registerBenchFuncs(b *testing.B, n int) {
+	b.Helper()
+	resetRegistryForTesting()
+	b.Cleanup(resetRegistryForTesting)
+
+	additive := make(template.FuncMap, n)
+	for i := 0; i < n; i++ {
+		additive[fmt.Sprintf("embFn%d", i)] = func() string { return "v" }
+	}
+	if err := RegisterFuncs(additive); err != nil {
+		b.Fatalf("RegisterFuncs: %v", err)
+	}
+	if err := RegisterFuncsOverride(template.FuncMap{
+		"embOverride": func() string { return "o" },
+	}); err != nil {
+		b.Fatalf("RegisterFuncsOverride: %v", err)
+	}
+}
+
+// BenchmarkGetExtensionFuncMap measures the per-service merge (factory base +
+// env strip + additive + override), which runs on every service construction.
+func BenchmarkGetExtensionFuncMap(b *testing.B) {
+	registerBenchFuncs(b, 32)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = getExtensionFuncMap()
+	}
+}
+
+// BenchmarkRegisteredFuncs measures building the discoverability list consumed
+// by the CLI and MCP tooling.
+func BenchmarkRegisteredFuncs(b *testing.B) {
+	registerBenchFuncs(b, 32)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = RegisteredFuncs()
+	}
+}

--- a/pkg/gotmpl/registry_test.go
+++ b/pkg/gotmpl/registry_test.go
@@ -270,11 +270,12 @@ func TestRegisterFuncs_AdditiveEnvSkippedRegardlessOfFactory(t *testing.T) {
 	assert.False(t, ok, "additive env must not be merged while stripped")
 }
 
-// TestRegisterFuncs_IdempotentSameFunc verifies that re-registering the exact
-// same function under the same name is a no-op rather than a self-collision,
-// so an embedder that reconstructs the root command (or a test that executes it
-// repeatedly) can pass the same func map more than once.
-func TestRegisterFuncs_IdempotentSameFunc(t *testing.T) {
+// TestRegisterFuncs_DuplicateNameIsCollision verifies register-once semantics:
+// re-registering a name that is already present -- even with the identical
+// function value -- is rejected as a collision (matching stdlib global
+// registries such as sql.Register). The re-execution case is handled by the
+// root command guarding its own wiring, not by an idempotency exception here.
+func TestRegisterFuncs_DuplicateNameIsCollision(t *testing.T) {
 	resetRegistryForTesting()
 	t.Cleanup(resetRegistryForTesting)
 
@@ -282,11 +283,8 @@ func TestRegisterFuncs_IdempotentSameFunc(t *testing.T) {
 	funcs := template.FuncMap{"reg": fn}
 
 	require.NoError(t, RegisterFuncs(funcs))
-	require.NoError(t, RegisterFuncs(funcs), "identical re-registration must be a no-op")
-
-	// A different function under the same name is still a genuine collision.
-	err := RegisterFuncs(template.FuncMap{"reg": func() string { return "other" }})
-	require.ErrorIs(t, err, ErrFuncNameCollision)
+	// The very same func value re-registered is still a collision.
+	require.ErrorIs(t, RegisterFuncs(funcs), ErrFuncNameCollision)
 
 	// Exactly one registered entry remains, still the original.
 	list := RegisteredFuncs()
@@ -296,6 +294,37 @@ func TestRegisterFuncs_IdempotentSameFunc(t *testing.T) {
 	out, err := render(t, `{{ reg }}`)
 	require.NoError(t, err)
 	assert.Equal(t, "v", out)
+}
+
+func TestCombinedFuncs_DedupesOverrideByName(t *testing.T) {
+	builtins := ExtFunctionList{
+		{Name: "upper", Source: SourceSprig},
+		{Name: "custom1", Source: SourceCustom},
+	}
+	registered := ExtFunctionList{
+		{Name: "upper", Source: SourceEmbedder}, // shadows the built-in
+		{Name: "shout", Source: SourceEmbedder},
+	}
+
+	got := CombinedFuncs(builtins, registered)
+
+	bySource := make(map[string]string, len(got))
+	count := make(map[string]int, len(got))
+	for _, f := range got {
+		bySource[f.Name] = f.Source
+		count[f.Name]++
+	}
+	assert.Equal(t, 1, count["upper"], "shadowed built-in must appear once")
+	assert.Equal(t, SourceEmbedder, bySource["upper"], "embedder override must win")
+	assert.Equal(t, SourceCustom, bySource["custom1"], "non-shadowed built-in retained")
+	assert.Equal(t, SourceEmbedder, bySource["shout"], "embedder-only func retained")
+	assert.Len(t, got, 3, "no duplicate entries")
+}
+
+func TestCombinedFuncs_EmptyRegisteredReturnsBuiltins(t *testing.T) {
+	builtins := ExtFunctionList{{Name: "a", Source: SourceSprig}}
+	got := CombinedFuncs(builtins, nil)
+	assert.Equal(t, builtins, got)
 }
 
 func TestRegistry_Precedence(t *testing.T) {

--- a/pkg/gotmpl/registry_test.go
+++ b/pkg/gotmpl/registry_test.go
@@ -86,6 +86,43 @@ func TestRegisterFuncs_EmptyNameRejected(t *testing.T) {
 	assert.Empty(t, RegisteredFuncs(), "nothing should be registered on error")
 }
 
+func TestRegisterFuncs_InvalidValueRejected(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	cases := map[string]any{
+		"nil value":         nil,
+		"non-function":      "not a func",
+		"nil function":      (func())(nil),
+		"too many results":  func() (int, int, int) { return 0, 0, 0 },
+		"bad second result": func() (int, int) { return 0, 0 },
+	}
+	for name, bad := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := RegisterFuncs(template.FuncMap{"bad": bad})
+			require.Error(t, err, "invalid func value must fail fast")
+			assert.Empty(t, RegisteredFuncs(), "nothing should be registered on error")
+
+			err = RegisterFuncsOverride(template.FuncMap{"bad": bad})
+			require.Error(t, err, "override must validate too")
+			assert.Empty(t, RegisteredFuncs())
+		})
+	}
+}
+
+func TestRegisterFuncs_ValidTwoResultFuncAccepted(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	require.NoError(t, RegisterFuncs(template.FuncMap{
+		"maybe": func(s string) (string, error) { return s, nil },
+	}))
+
+	out, err := render(t, `{{ maybe "ok" }}`)
+	require.NoError(t, err)
+	assert.Equal(t, "ok", out)
+}
+
 func TestRegisterFuncs_CollisionWithBuiltin(t *testing.T) {
 	resetRegistryForTesting()
 	t.Cleanup(resetRegistryForTesting)

--- a/pkg/gotmpl/registry_test.go
+++ b/pkg/gotmpl/registry_test.go
@@ -55,8 +55,8 @@ func render(t *testing.T, content string) (string, error) {
 }
 
 func TestRegisterFuncs_RenderThroughService(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	err := RegisterFuncs(template.FuncMap{
 		"shout": func(s string) string { return s + "!" },
@@ -69,8 +69,8 @@ func TestRegisterFuncs_RenderThroughService(t *testing.T) {
 }
 
 func TestRegisterFuncs_EmptyInputIsNoop(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	assert.NoError(t, RegisterFuncs(nil))
 	assert.NoError(t, RegisterFuncs(template.FuncMap{}))
@@ -78,8 +78,8 @@ func TestRegisterFuncs_EmptyInputIsNoop(t *testing.T) {
 }
 
 func TestRegisterFuncs_EmptyNameRejected(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	err := RegisterFuncs(template.FuncMap{"": func() string { return "" }})
 	require.Error(t, err)
@@ -87,8 +87,8 @@ func TestRegisterFuncs_EmptyNameRejected(t *testing.T) {
 }
 
 func TestRegisterFuncs_InvalidValueRejected(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	cases := map[string]any{
 		"nil value":         nil,
@@ -111,8 +111,8 @@ func TestRegisterFuncs_InvalidValueRejected(t *testing.T) {
 }
 
 func TestRegisterFuncs_ValidTwoResultFuncAccepted(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	require.NoError(t, RegisterFuncs(template.FuncMap{
 		"maybe": func(s string) (string, error) { return s, nil },
@@ -124,8 +124,8 @@ func TestRegisterFuncs_ValidTwoResultFuncAccepted(t *testing.T) {
 }
 
 func TestRegisterFuncs_CollisionWithBuiltin(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	// Built-in 'upper' uppercases; the collision must be rejected and the
 	// built-in must remain unchanged.
@@ -145,8 +145,8 @@ func TestRegisterFuncs_CollisionWithBuiltin(t *testing.T) {
 }
 
 func TestRegisterFuncs_CollisionWithPriorRegistration(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	require.NoError(t, RegisterFuncs(template.FuncMap{"dup": func() string { return "a" }}))
 
@@ -160,8 +160,8 @@ func TestRegisterFuncs_CollisionWithPriorRegistration(t *testing.T) {
 }
 
 func TestRegisterFuncs_AllOrNothingOnCollision(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	require.NoError(t, RegisterFuncs(template.FuncMap{"taken": func() string { return "x" }}))
 
@@ -181,8 +181,8 @@ func TestRegisterFuncs_AllOrNothingOnCollision(t *testing.T) {
 }
 
 func TestRegisterFuncsOverride_OverwritesBuiltin(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	withFactory(t, template.FuncMap{
 		"greet": func() string { return "builtin" },
@@ -198,8 +198,8 @@ func TestRegisterFuncsOverride_OverwritesBuiltin(t *testing.T) {
 }
 
 func TestRegisterFuncsOverride_DuplicateRejected(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	require.NoError(t, RegisterFuncsOverride(template.FuncMap{"o": func() string { return "1" }}))
 	err := RegisterFuncsOverride(template.FuncMap{"o": func() string { return "2" }})
@@ -207,8 +207,8 @@ func TestRegisterFuncsOverride_DuplicateRejected(t *testing.T) {
 }
 
 func TestRegisterFuncs_AdditiveEnvIsRejectedWhenStripped(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	// Factory exposes env (as sprig does). With env functions disallowed (the
 	// default), the additive path must reject a colliding 'env' so it cannot be
@@ -227,8 +227,8 @@ func TestRegisterFuncs_AdditiveEnvIsRejectedWhenStripped(t *testing.T) {
 }
 
 func TestRegisterFuncsOverride_CanReintroduceEnv(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	withFactory(t, template.FuncMap{
 		"env": func(string) string { return "SECRET" },
@@ -253,8 +253,8 @@ func TestRegisterFuncsOverride_CanReintroduceEnv(t *testing.T) {
 // registration time because the factory had not yet been set (so built-in
 // collision detection was empty).
 func TestRegisterFuncs_AdditiveEnvSkippedRegardlessOfFactory(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	// No factory installed: factoryFuncMap() is empty, so 'env' registers
 	// additively without a built-in collision.
@@ -276,8 +276,8 @@ func TestRegisterFuncs_AdditiveEnvSkippedRegardlessOfFactory(t *testing.T) {
 // registries such as sql.Register). The re-execution case is handled by the
 // root command guarding its own wiring, not by an idempotency exception here.
 func TestRegisterFuncs_DuplicateNameIsCollision(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	fn := func() string { return "v" }
 	funcs := template.FuncMap{"reg": fn}
@@ -328,8 +328,8 @@ func TestCombinedFuncs_EmptyRegisteredReturnsBuiltins(t *testing.T) {
 }
 
 func TestRegistry_Precedence(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	// Registry provides the base value.
 	require.NoError(t, RegisterFuncs(template.FuncMap{
@@ -365,8 +365,8 @@ func TestRegistry_Precedence(t *testing.T) {
 }
 
 func TestRegisteredFuncs_SourceTagged(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	require.NoError(t, RegisterFuncs(template.FuncMap{"addFn": func() string { return "" }}))
 	require.NoError(t, RegisterFuncsOverride(template.FuncMap{"ovrFn": func() string { return "" }}))
@@ -383,26 +383,29 @@ func TestRegisteredFuncs_SourceTagged(t *testing.T) {
 }
 
 func TestResetRegistryForTesting_Isolation(t *testing.T) {
-	resetRegistryForTesting()
+	ResetRegistryForTesting()
 	require.NoError(t, RegisterFuncs(template.FuncMap{"tmp": func() string { return "" }}))
 	assert.Len(t, RegisteredFuncs(), 1)
 
-	resetRegistryForTesting()
+	ResetRegistryForTesting()
 	assert.Empty(t, RegisteredFuncs())
 }
 
 func TestRegistry_ConcurrentAccess(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	var wg sync.WaitGroup
-	// Writers registering distinct names.
+	// Writers registering distinct names. Each goroutine records its own
+	// registration error in a dedicated slot (no shared slot => no lock needed)
+	// so a failure surfaces with context instead of only as a length mismatch.
+	writeErrs := make([]error, 8)
 	for i := 0; i < 8; i++ {
 		wg.Add(1)
 		go func(n int) {
 			defer wg.Done()
 			name := "cf" + string(rune('a'+n))
-			_ = RegisterFuncs(template.FuncMap{name: func() string { return name }})
+			writeErrs[n] = RegisterFuncs(template.FuncMap{name: func() string { return name }})
 		}(i)
 	}
 	// Readers hitting the merge path concurrently.
@@ -416,13 +419,17 @@ func TestRegistry_ConcurrentAccess(t *testing.T) {
 	}
 	wg.Wait()
 
+	// Every distinct writer must have registered successfully.
+	for n, err := range writeErrs {
+		assert.NoErrorf(t, err, "writer %d failed to register", n)
+	}
 	// All 8 distinct writers should have registered without error/race.
 	assert.Len(t, RegisteredFuncs(), 8)
 }
 
 func TestErrFuncNameCollision_Is(t *testing.T) {
-	resetRegistryForTesting()
-	t.Cleanup(resetRegistryForTesting)
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 
 	require.NoError(t, RegisterFuncs(template.FuncMap{"x": func() string { return "" }}))
 	err := RegisterFuncs(template.FuncMap{"x": func() string { return "" }})

--- a/pkg/gotmpl/registry_test.go
+++ b/pkg/gotmpl/registry_test.go
@@ -1,0 +1,364 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gotmpl
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withFactory temporarily installs a custom extension func map factory,
+// bypassing the sync.Once guard, and restores the previous factory on cleanup.
+// This lets registry tests exercise built-in collision detection.
+func withFactory(t *testing.T, fm template.FuncMap) {
+	t.Helper()
+	extensionFuncMapMu.Lock()
+	old := extensionFuncMapFactory
+	extensionFuncMapFactory = func() template.FuncMap {
+		// Return a fresh copy each call so callers that mutate (env stripping)
+		// do not corrupt the shared map.
+		cp := make(template.FuncMap, len(fm))
+		for k, v := range fm {
+			cp[k] = v
+		}
+		return cp
+	}
+	extensionFuncMapMu.Unlock()
+	t.Cleanup(func() {
+		extensionFuncMapMu.Lock()
+		extensionFuncMapFactory = old
+		extensionFuncMapMu.Unlock()
+	})
+}
+
+// render is a small helper that renders content through a fresh nil-func
+// service (which picks up the registry via getExtensionFuncMap).
+func render(t *testing.T, content string) (string, error) {
+	t.Helper()
+	svc := NewService(nil)
+	res, err := svc.Execute(context.Background(), TemplateOptions{
+		Content:    content,
+		Name:       "registry-test",
+		MissingKey: MissingKeyDefault,
+	})
+	if err != nil {
+		return "", err
+	}
+	return res.Output, nil
+}
+
+func TestRegisterFuncs_RenderThroughService(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	err := RegisterFuncs(template.FuncMap{
+		"shout": func(s string) string { return s + "!" },
+	})
+	require.NoError(t, err)
+
+	out, err := render(t, `{{ shout "hi" }}`)
+	require.NoError(t, err)
+	assert.Equal(t, "hi!", out)
+}
+
+func TestRegisterFuncs_EmptyInputIsNoop(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	assert.NoError(t, RegisterFuncs(nil))
+	assert.NoError(t, RegisterFuncs(template.FuncMap{}))
+	assert.Empty(t, RegisteredFuncs())
+}
+
+func TestRegisterFuncs_EmptyNameRejected(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	err := RegisterFuncs(template.FuncMap{"": func() string { return "" }})
+	require.Error(t, err)
+	assert.Empty(t, RegisteredFuncs(), "nothing should be registered on error")
+}
+
+func TestRegisterFuncs_CollisionWithBuiltin(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	// Built-in 'upper' uppercases; the collision must be rejected and the
+	// built-in must remain unchanged.
+	withFactory(t, template.FuncMap{
+		"upper": func(s string) string { return "BUILTIN:" + s },
+	})
+
+	err := RegisterFuncs(template.FuncMap{
+		"upper": func(s string) string { return "embedder" },
+	})
+	require.ErrorIs(t, err, ErrFuncNameCollision)
+	assert.Empty(t, RegisteredFuncs(), "collision leaves registry untouched")
+
+	out, err := render(t, `{{ upper "x" }}`)
+	require.NoError(t, err)
+	assert.Equal(t, "BUILTIN:x", out, "built-in must be unchanged")
+}
+
+func TestRegisterFuncs_CollisionWithPriorRegistration(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	require.NoError(t, RegisterFuncs(template.FuncMap{"dup": func() string { return "a" }}))
+
+	err := RegisterFuncs(template.FuncMap{"dup": func() string { return "b" }})
+	require.ErrorIs(t, err, ErrFuncNameCollision)
+
+	// First registration remains intact.
+	out, err := render(t, `{{ dup }}`)
+	require.NoError(t, err)
+	assert.Equal(t, "a", out)
+}
+
+func TestRegisterFuncs_AllOrNothingOnCollision(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	require.NoError(t, RegisterFuncs(template.FuncMap{"taken": func() string { return "x" }}))
+
+	// One good name + one colliding name: nothing from this call registers.
+	err := RegisterFuncs(template.FuncMap{
+		"fresh": func() string { return "y" },
+		"taken": func() string { return "z" },
+	})
+	require.ErrorIs(t, err, ErrFuncNameCollision)
+
+	names := make(map[string]struct{})
+	for _, f := range RegisteredFuncs() {
+		names[f.Name] = struct{}{}
+	}
+	assert.Contains(t, names, "taken")
+	assert.NotContains(t, names, "fresh", "partial registration must not occur")
+}
+
+func TestRegisterFuncsOverride_OverwritesBuiltin(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	withFactory(t, template.FuncMap{
+		"greet": func() string { return "builtin" },
+	})
+
+	require.NoError(t, RegisterFuncsOverride(template.FuncMap{
+		"greet": func() string { return "override" },
+	}))
+
+	out, err := render(t, `{{ greet }}-marker-override`)
+	require.NoError(t, err)
+	assert.Equal(t, "override-marker-override", out)
+}
+
+func TestRegisterFuncsOverride_DuplicateRejected(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	require.NoError(t, RegisterFuncsOverride(template.FuncMap{"o": func() string { return "1" }}))
+	err := RegisterFuncsOverride(template.FuncMap{"o": func() string { return "2" }})
+	require.ErrorIs(t, err, ErrFuncNameCollision)
+}
+
+func TestRegisterFuncs_AdditiveEnvIsRejectedWhenStripped(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	// Factory exposes env (as sprig does). With env functions disallowed (the
+	// default), the additive path must reject a colliding 'env' so it cannot be
+	// smuggled back in via the always-stripped name.
+	withFactory(t, template.FuncMap{
+		"env": func(string) string { return "SECRET" },
+	})
+	SetAllowEnvFunctions(false)
+
+	err := RegisterFuncs(template.FuncMap{"env": func(string) string { return "leak" }})
+	require.ErrorIs(t, err, ErrFuncNameCollision)
+
+	// And the effective map must not contain env.
+	_, ok := getExtensionFuncMap()["env"]
+	assert.False(t, ok, "env must remain stripped")
+}
+
+func TestRegisterFuncsOverride_CanReintroduceEnv(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	withFactory(t, template.FuncMap{
+		"env": func(string) string { return "SECRET" },
+	})
+	SetAllowEnvFunctions(false)
+
+	require.NoError(t, RegisterFuncsOverride(template.FuncMap{
+		"env": func(string) string { return "embedder-env" },
+	}))
+
+	fm := getExtensionFuncMap()
+	fn, ok := fm["env"]
+	require.True(t, ok, "override must re-introduce env")
+	casted, ok := fn.(func(string) string)
+	require.True(t, ok)
+	assert.Equal(t, "embedder-env", casted(""))
+}
+
+// TestRegisterFuncs_AdditiveEnvSkippedRegardlessOfFactory guards the
+// defense-in-depth property that the additive merge never re-introduces a
+// stripped env function, even when the additive 'env' was accepted at
+// registration time because the factory had not yet been set (so built-in
+// collision detection was empty).
+func TestRegisterFuncs_AdditiveEnvSkippedRegardlessOfFactory(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	// No factory installed: factoryFuncMap() is empty, so 'env' registers
+	// additively without a built-in collision.
+	withFactory(t, template.FuncMap{})
+	SetAllowEnvFunctions(false)
+
+	require.NoError(t, RegisterFuncs(template.FuncMap{
+		"env": func(string) string { return "leak" },
+	}))
+
+	// The merge must still refuse to expose env while stripping is in effect.
+	_, ok := getExtensionFuncMap()["env"]
+	assert.False(t, ok, "additive env must not be merged while stripped")
+}
+
+// TestRegisterFuncs_IdempotentSameFunc verifies that re-registering the exact
+// same function under the same name is a no-op rather than a self-collision,
+// so an embedder that reconstructs the root command (or a test that executes it
+// repeatedly) can pass the same func map more than once.
+func TestRegisterFuncs_IdempotentSameFunc(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	fn := func() string { return "v" }
+	funcs := template.FuncMap{"reg": fn}
+
+	require.NoError(t, RegisterFuncs(funcs))
+	require.NoError(t, RegisterFuncs(funcs), "identical re-registration must be a no-op")
+
+	// A different function under the same name is still a genuine collision.
+	err := RegisterFuncs(template.FuncMap{"reg": func() string { return "other" }})
+	require.ErrorIs(t, err, ErrFuncNameCollision)
+
+	// Exactly one registered entry remains, still the original.
+	list := RegisteredFuncs()
+	require.Len(t, list, 1)
+	assert.Equal(t, "reg", list[0].Name)
+
+	out, err := render(t, `{{ reg }}`)
+	require.NoError(t, err)
+	assert.Equal(t, "v", out)
+}
+
+func TestRegistry_Precedence(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	// Registry provides the base value.
+	require.NoError(t, RegisterFuncs(template.FuncMap{
+		"who": func() string { return "registry" },
+	}))
+
+	// A service-level func overrides the registry.
+	svc := NewService(template.FuncMap{
+		"who": func() string { return "service" },
+	})
+
+	// 1. registry only, via a fresh nil service.
+	base, err := render(t, `{{ who }}-base`)
+	require.NoError(t, err)
+	assert.Equal(t, "registry-base", base)
+
+	// 2. service-level override.
+	res, err := svc.Execute(context.Background(), TemplateOptions{
+		Content: `{{ who }}-svc`,
+		Name:    "prec-svc",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "service-svc", res.Output)
+
+	// 3. per-call override wins over service and registry.
+	res, err = svc.Execute(context.Background(), TemplateOptions{
+		Content: `{{ who }}-call`,
+		Name:    "prec-call",
+		Funcs:   template.FuncMap{"who": func() string { return "call" }},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "call-call", res.Output)
+}
+
+func TestRegisteredFuncs_SourceTagged(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	require.NoError(t, RegisterFuncs(template.FuncMap{"addFn": func() string { return "" }}))
+	require.NoError(t, RegisterFuncsOverride(template.FuncMap{"ovrFn": func() string { return "" }}))
+
+	list := RegisteredFuncs()
+	require.Len(t, list, 2)
+	// Sorted by name: addFn, ovrFn.
+	assert.Equal(t, "addFn", list[0].Name)
+	assert.Equal(t, "ovrFn", list[1].Name)
+	for _, f := range list {
+		assert.Equal(t, SourceEmbedder, f.Source)
+		assert.NotEmpty(t, f.Func, "Func entry must be populated for discoverability")
+	}
+}
+
+func TestResetRegistryForTesting_Isolation(t *testing.T) {
+	resetRegistryForTesting()
+	require.NoError(t, RegisterFuncs(template.FuncMap{"tmp": func() string { return "" }}))
+	assert.Len(t, RegisteredFuncs(), 1)
+
+	resetRegistryForTesting()
+	assert.Empty(t, RegisteredFuncs())
+}
+
+func TestRegistry_ConcurrentAccess(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	var wg sync.WaitGroup
+	// Writers registering distinct names.
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(n int) {
+			defer wg.Done()
+			name := "cf" + string(rune('a'+n))
+			_ = RegisterFuncs(template.FuncMap{name: func() string { return name }})
+		}(i)
+	}
+	// Readers hitting the merge path concurrently.
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = getExtensionFuncMap()
+			_ = RegisteredFuncs()
+		}()
+	}
+	wg.Wait()
+
+	// All 8 distinct writers should have registered without error/race.
+	assert.Len(t, RegisteredFuncs(), 8)
+}
+
+func TestErrFuncNameCollision_Is(t *testing.T) {
+	resetRegistryForTesting()
+	t.Cleanup(resetRegistryForTesting)
+
+	require.NoError(t, RegisterFuncs(template.FuncMap{"x": func() string { return "" }}))
+	err := RegisterFuncs(template.FuncMap{"x": func() string { return "" }})
+	assert.True(t, errors.Is(err, ErrFuncNameCollision))
+}

--- a/pkg/mcp/tools_template.go
+++ b/pkg/mcp/tools_template.go
@@ -103,7 +103,7 @@ func (s *Server) registerTemplateTools() {
 
 	// list_go_template_functions
 	listGoTemplateFunctionsTool := mcp.NewTool("list_go_template_functions",
-		mcp.WithDescription("List all available Go template extension functions. Includes both sprig functions (upper, lower, toJson, dict, etc.) and custom scafctl-specific functions (toHcl, toYaml, fromYaml, mustToYaml, mustFromYaml)."),
+		mcp.WithDescription("List all available Go template extension functions. Includes sprig functions (upper, lower, toJson, dict, etc.), custom scafctl-specific functions (toHcl, toYaml, fromYaml, mustToYaml, mustFromYaml), and any functions registered by an embedding application. Each result carries a 'source' tag: sprig, custom, or embedder."),
 		mcp.WithTitleAnnotation("List Go Template Functions"),
 		mcp.WithToolIcons(toolIcons["template"]),
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -115,6 +115,9 @@ func (s *Server) registerTemplateTools() {
 		),
 		mcp.WithBoolean("sprig_only",
 			mcp.Description("If true, only return sprig library functions"),
+		),
+		mcp.WithBoolean("embedder_only",
+			mcp.Description("If true, only return functions registered by the embedding application"),
 		),
 		mcp.WithString("name",
 			mcp.Description("Get details for a specific function by name (substring match)"),
@@ -213,13 +216,19 @@ func (s *Server) handleEvaluateGoTemplate(_ context.Context, request mcp.CallToo
 func (s *Server) handleListGoTemplateFunctions(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	customOnly := request.GetBool("custom_only", false)
 	sprigOnly := request.GetBool("sprig_only", false)
+	embedderOnly := request.GetBool("embedder_only", false)
 	name := request.GetString("name", "")
 
-	functions := gotmplext.All()
-	if customOnly {
+	var functions gotmpl.ExtFunctionList
+	switch {
+	case customOnly:
 		functions = gotmplext.Custom()
-	} else if sprigOnly {
+	case sprigOnly:
 		functions = gotmplext.Sprig()
+	case embedderOnly:
+		functions = gotmpl.RegisteredFuncs()
+	default:
+		functions = append(gotmplext.All(), gotmpl.RegisteredFuncs()...)
 	}
 
 	return filterAndReturnNamedFunctions(

--- a/pkg/mcp/tools_template.go
+++ b/pkg/mcp/tools_template.go
@@ -228,7 +228,7 @@ func (s *Server) handleListGoTemplateFunctions(_ context.Context, request mcp.Ca
 	case embedderOnly:
 		functions = gotmpl.RegisteredFuncs()
 	default:
-		functions = append(gotmplext.All(), gotmpl.RegisteredFuncs()...)
+		functions = gotmpl.CombinedFuncs(gotmplext.All(), gotmpl.RegisteredFuncs())
 	}
 
 	return filterAndReturnNamedFunctions(

--- a/pkg/mcp/tools_template_test.go
+++ b/pkg/mcp/tools_template_test.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"text/template"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,6 +74,58 @@ func TestHandleEvaluateGoTemplate(t *testing.T) {
 		result, err := srv.handleEvaluateGoTemplate(context.Background(), request)
 		require.NoError(t, err)
 		assert.True(t, result.IsError)
+	})
+}
+
+// TestHandleListGoTemplateFunctions_EmbedderOnly verifies the MCP
+// list_go_template_functions tool surfaces embedder-registered functions,
+// tagged with the embedder source, both in the embedder_only view and the
+// default (combined) view.
+func TestHandleListGoTemplateFunctions_EmbedderOnly(t *testing.T) {
+	require.NoError(t, gotmpl.RegisterFuncs(template.FuncMap{
+		"mcpEmbedderListTestFunc": func(s string) string { return s },
+	}))
+
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	list := func(t *testing.T, args map[string]any) []map[string]any {
+		t.Helper()
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "list_go_template_functions"
+		request.Params.Arguments = args
+
+		result, err := srv.handleListGoTemplateFunctions(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output struct {
+			Functions []map[string]any `json:"functions"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		return output.Functions
+	}
+
+	find := func(fns []map[string]any, name string) map[string]any {
+		for _, fn := range fns {
+			if fn["name"] == name {
+				return fn
+			}
+		}
+		return nil
+	}
+
+	t.Run("embedder_only view", func(t *testing.T) {
+		fn := find(list(t, map[string]any{"embedder_only": true}), "mcpEmbedderListTestFunc")
+		require.NotNil(t, fn, "embedder function should appear in embedder_only listing")
+		assert.Equal(t, gotmpl.SourceEmbedder, fn["source"])
+	})
+
+	t.Run("default combined view", func(t *testing.T) {
+		fn := find(list(t, map[string]any{}), "mcpEmbedderListTestFunc")
+		require.NotNil(t, fn, "embedder function should appear in the default listing")
+		assert.Equal(t, gotmpl.SourceEmbedder, fn["source"])
 	})
 }
 

--- a/pkg/mcp/tools_template_test.go
+++ b/pkg/mcp/tools_template_test.go
@@ -82,6 +82,11 @@ func TestHandleEvaluateGoTemplate(t *testing.T) {
 // tagged with the embedder source, both in the embedder_only view and the
 // default (combined) view.
 func TestHandleListGoTemplateFunctions_EmbedderOnly(t *testing.T) {
+	// The gotmpl registry is process-global; reset it so this test does not leak
+	// the embedder function into other tests in this binary (which could hit
+	// register-once collisions or see extra entries in default listings).
+	gotmpl.ResetRegistryForTesting()
+	t.Cleanup(gotmpl.ResetRegistryForTesting)
 	require.NoError(t, gotmpl.RegisterFuncs(template.FuncMap{
 		"mcpEmbedderListTestFunc": func(s string) string { return s },
 	}))

--- a/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"text/template"
 
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -48,6 +49,32 @@ func TestGoTemplateProvider_Execute_SimpleTemplate(t *testing.T) {
 	require.NotNil(t, output)
 
 	assert.Equal(t, "Hello, World!", output.Data)
+}
+
+// TestGoTemplateProvider_Execute_EmbedderRegisteredFunc proves that a function
+// registered by an embedder via gotmpl.RegisterFuncs is available through the
+// go-template provider (i.e. the single-choke-point merge reaches the provider
+// service). The function name is unique to avoid collisions in the shared,
+// process-global registry.
+func TestGoTemplateProvider_Execute_EmbedderRegisteredFunc(t *testing.T) {
+	require.NoError(t, gotmpl.RegisterFuncs(template.FuncMap{
+		"providerTestEmbedderShout": func(s string) string { return s + "!!!" },
+	}))
+
+	// Provider must be constructed AFTER registration so its service captures
+	// the merged func map.
+	p := NewGoTemplateProvider()
+	ctx := context.Background()
+
+	inputs := map[string]any{
+		"name":     "embedder-func-test",
+		"template": `{{ providerTestEmbedderShout "hi" }}`,
+	}
+
+	output, err := p.Execute(ctx, inputs)
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, "hi!!!", output.Data)
 }
 
 func TestGoTemplateProvider_Execute_WithName(t *testing.T) {

--- a/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl_test.go
@@ -57,6 +57,11 @@ func TestGoTemplateProvider_Execute_SimpleTemplate(t *testing.T) {
 // service). The function name is unique to avoid collisions in the shared,
 // process-global registry.
 func TestGoTemplateProvider_Execute_EmbedderRegisteredFunc(t *testing.T) {
+	// The gotmpl registry is process-global; reset it so this test does not leak
+	// the embedder function into other tests in this binary (register-once means
+	// a later duplicate registration would otherwise collide).
+	gotmpl.ResetRegistryForTesting()
+	t.Cleanup(gotmpl.ResetRegistryForTesting)
 	require.NoError(t, gotmpl.RegisterFuncs(template.FuncMap{
 		"providerTestEmbedderShout": func(s string) string { return s + "!!!" },
 	}))


### PR DESCRIPTION
Embedders that build their own CLI on top of scafctl can now register custom Go-template functions that become available to every template scafctl renders (resolver templates, the `go-template` provider, `evaluate`, and functional tests). This is Go-only by design: functions are compiled Go code, so individual solution YAML files cannot declare them (avoiding a code-injection surface).

## New embedder API

- `RootOptions.GoTemplateFuncs` is registered during startup and fails loud if a name collides with a built-in (an embedder build bug). The root wiring registers exactly once per `RootOptions`, so a command executed more than once (a REPL or long-running host) does not re-register the process-global functions and self-collide.
- `gotmpl.RegisterFuncs` is additive and all-or-nothing; built-ins win on collision. It is register-once, matching Go's stdlib global registries (`sql.Register`): re-registering an already-present name -- even with the identical function -- is a collision. Register a given set of functions a single time.
- `gotmpl.RegisterFuncsOverride` is the explicit escape hatch to shadow a built-in (and may re-introduce a stripped `env` function).
- Both registration paths validate each value up front: a nil value, a non-function, or a function whose return signature text/template would reject fails fast with a clear error at registration time instead of panicking later at template construction.

Registration is merged at the single choke point (`getExtensionFuncMap`) that every gotmpl service uses, with precedence: factory built-ins -> env stripping -> additive registry -> override registry. The additive path never re-adds a stripped `env`/`expandenv` regardless of registration order, keeping the secret-exfiltration guard intact.

## Discoverability

- `ExtFunction` gains a `Source` field (`sprig`/`custom`/`embedder`).
- CLI: `get template functions --embedder` (kvx schema surfaces `source`).
- MCP: `list_go_template_functions` `embedder_only`.
- The combined (default) listings are de-duplicated by name via `gotmpl.CombinedFuncs` (embedder wins), so an override is shown once as the effective function rather than alongside the shadowed built-in.

## Tests & docs

- New `registry_test.go` (collision incl. register-once duplicate rejection, all-or-nothing, override, env strip/reintroduce, invalid-value rejection, `CombinedFuncs` de-dup, precedence, source-tagging, concurrency with `-race`), `registry_benchmark_test.go`, embedder-contract tests in `root_test.go` (non-default binary name, discoverability, collision fail-loud, re-execute-no-self-collision), MCP and CLI unit tests, and a provider-level test.
- `pkg/gotmpl/README.md` section and `docs/design/gotmpl-embedder-funcs.md` (register-once, the full precedence chain including env stripping, and override de-duplication).

## Out of scope

The symmetric CEL embedder-function registration is intentionally left to a separate follow-up PR.