### PR TITLE
refactor!: replace internal references with neutral placeholders and drive catalog enumerator selection by hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🚀 Features
 
-- *(solution)* Add cldctl get solution command (#1)
+- *(solution)* Add mycli get solution command (#1)
 - *(cel)* Start cel implementation (#2)
 - *(cel)* Implement custom CEL extension functions (#3)
 - *(gotmpl)* Implement Go templating service with customizable options (#5)

--- a/docs/design/auth.md
+++ b/docs/design/auth.md
@@ -29,7 +29,7 @@ Authentication is a system concern, not a provider implementation detail.
 scafctl provides built-in auth handlers for common identity providers:
 
 | Handler | Status | Description |
-|---------|--------|-------------|
+| --------- | -------- | ------------- |
 | `entra` | ✅ Implemented | Microsoft Entra ID (Azure AD) |
 | `github` | ✅ Implemented | GitHub OAuth (Device Code + PAT) |
 | `gcp` | ✅ Implemented | Google Cloud Platform (ADC, Service Account, Metadata, Workload Identity, gcloud ADC, Impersonation) |
@@ -97,7 +97,6 @@ auth:
         - sso.openshift.example.com
 ```
 
-
 ---
 
 ## Core Principles
@@ -136,7 +135,7 @@ Auth handlers are not action providers and do not perform side effects outside a
 Each handler declares a set of capabilities that describe which features it supports. CLI commands use these capabilities to dynamically validate flags and provide meaningful errors.
 
 | Capability | Description | Entra | GitHub | GCP |
-|------------|-------------|-------|--------|-----|
+| ------------ | ------------- | ------- | -------- | ----- |
 | `scopes_on_login` | Supports specifying scopes at login time | ✅ | ✅ | ✅ |
 | `scopes_on_token_request` | Supports per-request scopes when acquiring tokens | ✅ | ❌ | ✅ |
 | `tenant_id` | Supports tenant ID parameter | ✅ | ❌ | ❌ |
@@ -233,7 +232,7 @@ Behavior:
 **Supported Flows:**
 
 | Flow | Flag | Use Case |
-|------|------|----------|
+| ------ | ------ | ---------- |
 | Device Code | `--flow device-code` | Interactive user authentication |
 | Service Principal | `--flow service-principal` | CI/CD pipelines, automation |
 | Workload Identity | `--flow workload-identity` | Kubernetes (AKS) workload identity |
@@ -247,7 +246,7 @@ scafctl auth login github
 Behavior:
 
 - Initiates GitHub OAuth device code flow
-- User authenticates in a browser at https://github.com/login/device
+- User authenticates in a browser at <https://github.com/login/device>
 - An access token (and optionally refresh token) is obtained
 - Credentials are stored securely
 - Supports GitHub Enterprise Server via `--hostname`
@@ -308,7 +307,7 @@ Behavior:
 When `GetToken` is called, the Entra handler selects the flow in this order:
 
 | Priority | Flow | Condition |
-|----------|------|-----------|
+| ---------- | ------ | ----------- |
 | 1 | Workload Identity | `AZURE_FEDERATED_TOKEN_FILE` or `AZURE_FEDERATED_TOKEN` is set and valid |
 | 2 | Service Principal | `AZURE_CLIENT_SECRET` is set |
 | 3 | Device Code (refresh token) | A refresh token is present in the system secret store |
@@ -378,7 +377,7 @@ Uses the system secret store for long-lived credentials.
 Uses the system secret store for access tokens and optional refresh tokens.
 
 | Variable | Description |
-|----------|-------------|
+| ---------- | ------------- |
 | `GITHUB_TOKEN` | GitHub personal access token or Actions token |
 | `GH_TOKEN` | GitHub personal access token (gh CLI convention) |
 | `GH_HOST` | GitHub hostname for Enterprise Server |
@@ -388,7 +387,7 @@ Uses the system secret store for access tokens and optional refresh tokens.
 Credentials are read from environment variables (never stored):
 
 | Variable | Description |
-|----------|-------------|
+| ---------- | ------------- |
 | `AZURE_CLIENT_ID` | Application (client) ID |
 | `AZURE_TENANT_ID` | Directory (tenant) ID |
 | `AZURE_CLIENT_SECRET` | Client secret value |
@@ -400,7 +399,7 @@ Access tokens are still cached to disk like device code flow.
 Credentials are read from environment variables and projected token files (never stored):
 
 | Variable | Description |
-|----------|-------------|
+| ---------- | ------------- |
 | `AZURE_CLIENT_ID` | Application (client) ID |
 | `AZURE_TENANT_ID` | Directory (tenant) ID |
 | `AZURE_FEDERATED_TOKEN_FILE` | Path to projected service account token file |
@@ -421,7 +420,7 @@ scafctl.auth.<handler>.<type>
 For the Entra handler:
 
 | Secret Name | Description |
-|-------------|-------------|
+| ------------- | ------------- |
 | `scafctl.auth.entra.refresh_token` | Long-lived refresh token |
 | `scafctl.auth.entra.metadata` | Token metadata (claims, tenant, client ID, expiry) |
 | `scafctl.auth.entra.token.<flow>.<fingerprint>.<scope-hash>` | Cached access tokens partitioned by flow, config identity, and scope |
@@ -429,7 +428,7 @@ For the Entra handler:
 For the GitHub handler:
 
 | Secret Name | Description |
-|-------------|-------------|
+| ------------- | ------------- |
 | `scafctl.auth.github.refresh_token` | OAuth refresh token (if token expiration is enabled) |
 | `scafctl.auth.github.access_token` | OAuth access token (non-expiring apps) |
 | `scafctl.auth.github.metadata` | Token metadata (claims, hostname, client ID, expiry) |
@@ -510,13 +509,13 @@ Providers never see refresh tokens.
 ### Example Provider Declaration
 
 ~~~yaml
-caasByID:
+clustersByID:
   authProvider: entra
   authScope: "{{ .platform.scope }}"
   headers:
     Accept: application/json, application/problem+json
   method: GET
-  uri: https://{{ .platform.host }}/platform-assets/api/v1/kubenamespace/find?clientID={{ .platformClientID }}
+  uri: https://{{ .platform.host }}/api/v1/resources/find?clientID={{ .platformClientID }}
 ~~~
 
 Meaning:

--- a/docs/design/embedder-catalog-defaults.md
+++ b/docs/design/embedder-catalog-defaults.md
@@ -4,7 +4,7 @@ title: "Embedder Guide: Catalog Default Configuration"
 
 # Embedder Guide: Catalog Default Configuration
 
-This document explains how embedders (e.g., cldctl) should consume scafctl's
+This document explains how embedders (e.g., mycli) should consume scafctl's
 catalog configuration system. It covers the reserved name enforcement model,
 how to add organization-specific catalogs, and how to migrate away from custom
 merge logic.
@@ -44,7 +44,7 @@ if config.IsReservedCatalogName("official") {
     // true -- this name is owned by scafctl defaults
 }
 
-if config.IsReservedCatalogName("ford-internal") {
+if config.IsReservedCatalogName("internal-catalog") {
     // false -- safe to use as an embedder catalog name
 }
 ~~~
@@ -75,13 +75,13 @@ config file, so users can still override non-reserved values.
 ~~~go
 baseConfig := []byte(`
 catalogs:
-  - name: ford-internal
+  - name: internal-catalog
     type: oci
-    url: oci://ghcr.io/ford-cloud/catalog
+    url: oci://ghcr.io/example-org/catalog
     authProvider: github
     discoveryStrategy: auto
 settings:
-  defaultCatalog: ford-internal
+  defaultCatalog: internal-catalog
 `)
 
 mgr := config.NewManager(configPath, config.WithBaseConfig(baseConfig))
@@ -97,7 +97,7 @@ Those entries will be overwritten by scafctl's defaults at load time.
 ### Step 3: Remove custom merge logic
 
 Embedders should **not** implement their own catalog merge functions. The
-`mergeCatalogs` function in cldctl's `pkg/config/defaults.go` should be
+`mergeCatalogs` function in mycli's `pkg/config/defaults.go` should be
 deleted. It is redundant and contains a bug that panics when catalog entries
 have nested map values:
 
@@ -117,7 +117,7 @@ The final configuration is built from these layers, last wins:
 | 1. Built-in defaults | `setDefaults()` | N/A (source of truth) |
 | 2. Embedder base config | `WithBaseConfig(data)` | Yes, after merge |
 | 3. User config file | `~/.config/scafctl/config.yaml` | Yes, after merge |
-| 4. Environment variables | `SCAFCTL_*` / `CLDCTL_*` | N/A (scalar only) |
+| 4. Environment variables | `SCAFCTL_*` / `MYCLI_*` | N/A (scalar only) |
 | 5. Reserved enforcement | `mergeDefaultCatalogEntries` | **Enforced** |
 
 Viper replaces arrays entirely when merging layers, so catalogs defined in
@@ -132,15 +132,15 @@ default entries after Viper's merge is complete.
 | `config.EnsureDefaults(path)` | Write/merge config file with defaults |
 | `config.NewManager(path, opts...)` | Create a config manager |
 | `config.WithBaseConfig(data)` | Inject embedder config layer |
-| `config.WithEnvPrefix(prefix)` | Override env var prefix (e.g., `CLDCTL`) |
+| `config.WithEnvPrefix(prefix)` | Override env var prefix (e.g., `MYCLI`) |
 | `config.IsReservedCatalogName(name)` | Check if a catalog name is reserved |
 | `config.DefaultsYAML()` | Get a copy of the embedded defaults |
 | `config.EmbeddedCatalogDefaults()` | Get parsed default catalog entries |
 
 ## Migration Checklist
 
-- [ ] Delete cldctl's `mergeCatalogs` function
+- [ ] Delete mycli's `mergeCatalogs` function
 - [ ] Replace file-level merge with `config.EnsureDefaults(configPath)`
-- [ ] Move cldctl-specific catalogs into a `WithBaseConfig` call
-- [ ] Verify no cldctl catalog uses a reserved name (`local`, `official`)
-- [ ] Run `cldctl catalog index push --dry-run` to confirm no panic
+- [ ] Move mycli-specific catalogs into a `WithBaseConfig` call
+- [ ] Verify no mycli catalog uses a reserved name (`local`, `official`)
+- [ ] Run `mycli catalog index push --dry-run` to confirm no panic

--- a/docs/design/kubeconfig-provider-implementation-plan.md
+++ b/docs/design/kubeconfig-provider-implementation-plan.md
@@ -338,7 +338,7 @@ the plugin exists.
 
 - `pkg/kubeconfig.Manager` is constructed with the host binary name
   (`settings.Run.BinaryName`, falling back to `settings.CliBinaryName`) and
-  passes it as `exec_command` so embedders (e.g. `cldctl`) get correct kubeconfig
+  passes it as `exec_command` so embedders (e.g. `mycli`) get correct kubeconfig
   exec args. No hardcoded `scafctl`.
 - The fetch-then-register path uses the manager's configured binary name
   (`m.binaryName`) for the `plugin.ProviderConfig.BinaryName`, keeping plugin

--- a/docs/design/multi-profile-auth.md
+++ b/docs/design/multi-profile-auth.md
@@ -232,8 +232,8 @@ Handler     Profile     Status                  Identity
 -------     -------     ------                  --------
 entra       (built-in)  Authenticated           user@example.com
 entra       work        Authenticated           user@work.example.com  [active]
-github      (built-in)  Authenticated           abaker9
-github      work        Authenticated           abaker9-emu
+github      (built-in)  Authenticated           alice
+github      work        Authenticated           alice-emu
 github      personal    Not authenticated
 gcp         (built-in)  Authenticated           user@gmail.com
 gcp         internal    Authenticated           user@corp.google.com   [active]

--- a/docs/design/registry-credentials-and-profiles.md
+++ b/docs/design/registry-credentials-and-profiles.md
@@ -122,7 +122,7 @@ entries just have empty handler/profile fields.
 When bridging overwrites a credential with a different username, warn:
 
 ~~~
-WARNING: Replacing ghcr.io credentials (was: abaker9_ford, now: abaker-9)
+WARNING: Replacing ghcr.io credentials (was: alice-work, now: alice)
 ~~~
 
 #### 1c. Improve `auth status` display
@@ -135,8 +135,8 @@ Auth Handlers
 +-------------------------------------------------------------------+
 | Handler  Profile            Status          User             ... |
 |-------------------------------------------------------------------|
-| entra    built-in (active)  authenticated   abaker9@ford.com ... |
-| github   work (active)      authenticated   abaker9@ford.com ... |
+| entra    built-in (active)  authenticated   alice@example.com ... |
+| github   work (active)      authenticated   alice@example.com ... |
 | gcp      built-in (active)  authenticated   gcloud ADC       ... |
 +-------------------------------------------------------------------+
 
@@ -144,7 +144,7 @@ Registry Credentials
 +----------------------------------------------------------+
 | Registry          User              Source               |
 |----------------------------------------------------------|
-| ghcr.io           abaker9_ford      github / work        |
+| ghcr.io           alice-work      github / work        |
 | us-docker.pkg.dev oauth2accesstoken gcp / built-in       |
 +----------------------------------------------------------+
 ~~~
@@ -160,8 +160,8 @@ distinguish its type.
 Consolidated success line with profile:
 
 ~~~
-OK: Logged in to GitHub as abaker-9 [profile: personal]
--> Registry credentials stored for ghcr.io (user: abaker-9, via github handler)
+OK: Logged in to GitHub as alice [profile: personal]
+-> Registry credentials stored for ghcr.io (user: alice, via github handler)
 ~~~
 
 #### 1e. Inject profile into catalog operations

--- a/docs/design/state/persisted-resolvers-state-provider.md
+++ b/docs/design/state/persisted-resolvers-state-provider.md
@@ -26,18 +26,18 @@ This design adds two composable capabilities:
    overwrites it.
 
 Together these reproduce a legacy capability from the predecessor tool
-(`cldctl`): one resolver can explicitly read another resolver's previously saved
+(`mycli`): one resolver can explicitly read another resolver's previously saved
 value and do whatever it wants with it.
 
 ## Motivation
 
-We are converting existing `cldctl` solution files to scafctl. In `cldctl`,
+We are converting existing `mycli` solution files to scafctl. In `mycli`,
 every resolver's value was saved into state, and any resolver could explicitly
 read the saved value of another resolver from a prior run. scafctl's
 deterministic-replay model does not save arbitrary resolver values, so this
 legacy pattern currently has no equivalent.
 
-This is a required migration feature. Rather than reintroduce `cldctl`'s
+This is a required migration feature. Rather than reintroduce `mycli`'s
 save-everything model (which would erode scafctl's determinism guarantees), we
 add a narrow, explicit, opt-in mechanism: authors mark exactly the resolvers
 whose values need to survive, and read them back only through an explicit
@@ -262,7 +262,7 @@ sequenceDiagram
 ```
 
 On the next run, `prior_password` reads what was written as NEW here. This is the
-`cldctl` read-back semantic.
+`mycli` read-back semantic.
 
 ### DAG independence
 

--- a/docs/design/web-api-implementation-plan.md
+++ b/docs/design/web-api-implementation-plan.md
@@ -4,7 +4,7 @@
 
 Add a [Huma](https://github.com/danielgtaylor/huma)+[chi](https://github.com/go-chi/chi)-based REST API to scafctl, started via a new `scafctl serve` command. The API mirrors all major CLI features (run, render, lint, eval, catalog, solutions, providers, config, etc.) with Entra OIDC authentication, Prometheus metrics, OpenTelemetry tracing, audit logging, CEL-based filtering, and admin endpoints.
 
-Architecture follows the [jqapi](https://github.com/ford-cloud/jqapi) reference implementation: chi router → layered middleware → Huma endpoint registration → handler context with dependency injection. All operations are synchronous request-response initially, with an async task model planned as future work.
+Architecture follows the [jqapi](https://github.com/example-org/jqapi) reference implementation: chi router → layered middleware → Huma endpoint registration → handler context with dependency injection. All operations are synchronous request-response initially, with an async task model planned as future work.
 
 ---
 

--- a/docs/tutorials/auth-profiles-tutorial.md
+++ b/docs/tutorials/auth-profiles-tutorial.md
@@ -419,8 +419,8 @@ Example output:
 
 ```text
 #  Handler  Kind  Status         Flow         User               Expires  Profile
-1  github   auth  authenticated  device_code  abaker9@gmail.com           built-in
-2  github   auth  authenticated  pat          abaker9@ford.com            work
+1  github   auth  authenticated  device_code  alice@example.com           built-in
+2  github   auth  authenticated  pat          alice@example.com            work
 ```
 
 > **Tip:** Fine-grained PATs let you scope access to specific repositories and permissions. Use them for profiles that only need access to a subset of your org's repos.

--- a/examples/auth/kube-login.md
+++ b/examples/auth/kube-login.md
@@ -144,7 +144,7 @@ With either configured, all of these work:
 
 ```bash
 scafctl kube login lab                      # static alias
-scafctl kube login pd1020                    # from inventory
+scafctl kube login cluster-a                    # from inventory
 scafctl kube login https://api.x:6443 --handler oidc   # direct URL, no config
 ```
 

--- a/pkg/auth/hostname/cache_test.go
+++ b/pkg/auth/hostname/cache_test.go
@@ -25,7 +25,7 @@ func TestDiskCache_SetGetRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	c := newTestCache(t, time.Now)
-	entries := []Entry{{Name: "pd1020", URL: "https://api.pd1020.example.com:6443"}}
+	entries := []Entry{{Name: "cluster-a", URL: "https://api.cluster-a.example.com:6443"}}
 	c.Set(context.Background(), "key1", entries, time.Hour)
 
 	got, ok := c.Get(context.Background(), "key1")
@@ -89,8 +89,8 @@ func TestDiskCache_PeekAll(t *testing.T) {
 	c := newTestCache(t, func() time.Time { return current })
 
 	// Two inventories under different keys; one will expire.
-	c.Set(context.Background(), "auth-key", []Entry{{Name: "pd1010", URL: "https://api.pd1010.example.com:6443"}}, time.Minute)
-	c.Set(context.Background(), "kube-key", []Entry{{Name: "pd1020", URL: "https://api.pd1020.example.com:6443"}}, time.Minute)
+	c.Set(context.Background(), "auth-key", []Entry{{Name: "cluster-c", URL: "https://api.cluster-c.example.com:6443"}}, time.Minute)
+	c.Set(context.Background(), "kube-key", []Entry{{Name: "cluster-a", URL: "https://api.cluster-a.example.com:6443"}}, time.Minute)
 
 	// Advance past expiry: Get would miss + evict, but peekAll ignores TTL.
 	current = base.Add(2 * time.Minute)
@@ -101,8 +101,8 @@ func TestDiskCache_PeekAll(t *testing.T) {
 		names[e.Name] = e.URL
 	}
 	assert.Len(t, all, 2, "peekAll returns entries from all cache files, ignoring TTL")
-	assert.Equal(t, "https://api.pd1010.example.com:6443", names["pd1010"])
-	assert.Equal(t, "https://api.pd1020.example.com:6443", names["pd1020"])
+	assert.Equal(t, "https://api.cluster-c.example.com:6443", names["cluster-c"])
+	assert.Equal(t, "https://api.cluster-a.example.com:6443", names["cluster-a"])
 
 	// peekAll must not evict expired files.
 	_, statErr := os.Stat(c.path("auth-key"))

--- a/pkg/auth/hostname/hostname_test.go
+++ b/pkg/auth/hostname/hostname_test.go
@@ -50,7 +50,7 @@ func resolverCfg(authProvider string) *config.HostnameConfig {
 func TestResolveWith_Precedence(t *testing.T) {
 	t.Parallel()
 
-	inventory := []Entry{{Name: "pd1020", URL: "https://api.pd1020.example.com:6443"}}
+	inventory := []Entry{{Name: "cluster-a", URL: "https://api.cluster-a.example.com:6443"}}
 
 	tests := []struct {
 		name     string
@@ -88,19 +88,19 @@ func TestResolveWith_Precedence(t *testing.T) {
 		{
 			name:     "dynamic resolver lookup",
 			cfg:      resolverCfg(""),
-			selector: "pd1020",
-			want:     "https://api.pd1020.example.com:6443",
+			selector: "cluster-a",
+			want:     "https://api.cluster-a.example.com:6443",
 		},
 		{
 			name: "static alias overlays inventory entry with same name",
 			cfg: &config.HostnameConfig{
-				Aliases: map[string]string{"pd1020": "https://override.example.com:6443"},
+				Aliases: map[string]string{"cluster-a": "https://override.example.com:6443"},
 				Resolver: &config.HostnameResolverConfig{
 					Source:    config.HostnameResolverSource{URL: "https://inv.example.com"},
 					Transform: "_",
 				},
 			},
-			selector: "pd1020",
+			selector: "cluster-a",
 			want:     "https://override.example.com:6443",
 		},
 		{
@@ -152,7 +152,7 @@ func TestResolveWith_LoopGuard(t *testing.T) {
 		},
 	}
 
-	_, err := ResolveWith(context.Background(), cfg, "openshift", "pd1020", deps)
+	_, err := ResolveWith(context.Background(), cfg, "openshift", "cluster-a", deps)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrResolverLoop)
 }
@@ -171,7 +171,7 @@ func TestResolveWith_NoCredentials(t *testing.T) {
 		},
 	}
 
-	_, err := ResolveWith(context.Background(), cfg, "openshift", "pd1020", deps)
+	_, err := ResolveWith(context.Background(), cfg, "openshift", "cluster-a", deps)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrNoCredentials)
 	assert.False(t, fetchCalled, "fetch must not run when credentials are missing")
@@ -188,7 +188,7 @@ func TestResolveWith_TransformShapeError(t *testing.T) {
 		},
 	}
 
-	_, err := ResolveWith(context.Background(), cfg, "openshift", "pd1020", deps)
+	_, err := ResolveWith(context.Background(), cfg, "openshift", "cluster-a", deps)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrTransformShape)
 }
@@ -208,13 +208,13 @@ func TestResolveWith_TokenInjectedIntoFetch(t *testing.T) {
 			return []byte(`{}`), nil
 		},
 		Transform: func(context.Context, string, []byte) ([]Entry, error) {
-			return []Entry{{Name: "pd1020", URL: "https://api.pd1020.example.com:6443"}}, nil
+			return []Entry{{Name: "cluster-a", URL: "https://api.cluster-a.example.com:6443"}}, nil
 		},
 	}
 
-	got, err := ResolveWith(context.Background(), cfg, "openshift", "pd1020", deps)
+	got, err := ResolveWith(context.Background(), cfg, "openshift", "cluster-a", deps)
 	require.NoError(t, err)
-	assert.Equal(t, "https://api.pd1020.example.com:6443", got)
+	assert.Equal(t, "https://api.cluster-a.example.com:6443", got)
 	assert.Equal(t, "secret-token", gotBearer)
 }
 
@@ -225,7 +225,7 @@ func TestResolveWith_CacheHitSkipsFetch(t *testing.T) {
 	cache := &fakeCache{store: map[string][]Entry{}}
 	// Pre-seed the cache under the computed key.
 	key := cacheKey("openshift", cfg.Resolver)
-	cache.store[key] = []Entry{{Name: "pd1020", URL: "https://cached.example.com:6443"}}
+	cache.store[key] = []Entry{{Name: "cluster-a", URL: "https://cached.example.com:6443"}}
 
 	fetchCalled := false
 	deps := Deps{
@@ -239,7 +239,7 @@ func TestResolveWith_CacheHitSkipsFetch(t *testing.T) {
 		},
 	}
 
-	got, err := ResolveWith(context.Background(), cfg, "openshift", "pd1020", deps)
+	got, err := ResolveWith(context.Background(), cfg, "openshift", "cluster-a", deps)
 	require.NoError(t, err)
 	assert.Equal(t, "https://cached.example.com:6443", got)
 	assert.False(t, fetchCalled, "fetch must be skipped on cache hit")
@@ -254,11 +254,11 @@ func TestResolveWith_CacheMissStoresResult(t *testing.T) {
 		Cache: cache,
 		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) { return []byte(`{}`), nil },
 		Transform: func(context.Context, string, []byte) ([]Entry, error) {
-			return []Entry{{Name: "pd1020", URL: "https://api.pd1020.example.com:6443"}}, nil
+			return []Entry{{Name: "cluster-a", URL: "https://api.cluster-a.example.com:6443"}}, nil
 		},
 	}
 
-	_, err := ResolveWith(context.Background(), cfg, "openshift", "pd1020", deps)
+	_, err := ResolveWith(context.Background(), cfg, "openshift", "cluster-a", deps)
 	require.NoError(t, err)
 	assert.Equal(t, 1, cache.sets, "resolved inventory should be cached")
 }
@@ -294,7 +294,7 @@ func TestIsConcreteURL(t *testing.T) {
 	}{
 		{"https://api.example.com:6443", true},
 		{"http://localhost:8080", true},
-		{"pd1020", false},
+		{"cluster-a", false},
 		{"ftp://example.com", false},
 		{"", false},
 		{"api.example.com", false},
@@ -426,7 +426,7 @@ func TestResolveInventory(t *testing.T) {
 			return []byte("{}"), nil
 		},
 		Transform: func(context.Context, string, []byte) ([]Entry, error) {
-			return []Entry{{Name: "pd1020", URL: "https://api.pd:6443"}}, nil
+			return []Entry{{Name: "cluster-a", URL: "https://api.pd:6443"}}, nil
 		},
 		Cache: cache,
 	}
@@ -434,7 +434,7 @@ func TestResolveInventory(t *testing.T) {
 	entries, err := ResolveInventory(context.Background(), rc, "kube", deps)
 	require.NoError(t, err)
 	require.Len(t, entries, 1)
-	assert.Equal(t, "pd1020", entries[0].Name)
+	assert.Equal(t, "cluster-a", entries[0].Name)
 	assert.Equal(t, 1, cache.sets, "resolved inventory must be cached")
 }
 
@@ -455,12 +455,12 @@ func TestCachedInventory(t *testing.T) {
 	t.Run("hit returns cached entries without fetching", func(t *testing.T) {
 		t.Parallel()
 		cache := &fakeCache{store: map[string][]Entry{
-			cacheKey("kube", rc): {{Name: "pd1020", URL: "https://api.pd:6443"}},
+			cacheKey("kube", rc): {{Name: "cluster-a", URL: "https://api.pd:6443"}},
 		}}
 		// No Fetch provided: CachedInventory must never call it.
 		entries, ok := CachedInventory(context.Background(), rc, "kube", Deps{Cache: cache})
 		require.True(t, ok)
 		require.Len(t, entries, 1)
-		assert.Equal(t, "pd1020", entries[0].Name)
+		assert.Equal(t, "cluster-a", entries[0].Name)
 	})
 }

--- a/pkg/auth/hostname/label_test.go
+++ b/pkg/auth/hostname/label_test.go
@@ -13,9 +13,9 @@ func TestAliasForURL(t *testing.T) {
 	t.Parallel()
 
 	aliases := map[string]string{
-		"pd1020": "https://api.pd1020.caas.ford.com:6443",
-		"np0510": "https://api.np0510.caas.ford.com:6443",
-		"legacy": "api.pd1020.caas.ford.com", // bare host, same as pd1020
+		"cluster-a": "https://api.cluster-a.example.com:6443",
+		"cluster-b": "https://api.cluster-b.example.com:6443",
+		"legacy":    "api.cluster-a.example.com", // bare host, same as cluster-a
 	}
 
 	tests := []struct {
@@ -28,22 +28,22 @@ func TestAliasForURL(t *testing.T) {
 		{
 			name:      "exact url match",
 			aliases:   aliases,
-			url:       "https://api.np0510.caas.ford.com:6443",
-			wantAlias: "np0510",
+			url:       "https://api.cluster-b.example.com:6443",
+			wantAlias: "cluster-b",
 			wantOK:    true,
 		},
 		{
 			name:      "match ignores scheme and port",
 			aliases:   aliases,
-			url:       "https://api.np0510.caas.ford.com",
-			wantAlias: "np0510",
+			url:       "https://api.cluster-b.example.com",
+			wantAlias: "cluster-b",
 			wantOK:    true,
 		},
 		{
 			name:      "ambiguous match returns lexicographically first",
 			aliases:   aliases,
-			url:       "https://api.pd1020.caas.ford.com:6443",
-			wantAlias: "legacy",
+			url:       "https://api.cluster-a.example.com:6443",
+			wantAlias: "cluster-a",
 			wantOK:    true,
 		},
 		{
@@ -56,7 +56,7 @@ func TestAliasForURL(t *testing.T) {
 		{
 			name:      "empty aliases",
 			aliases:   nil,
-			url:       "https://api.pd1020.caas.ford.com",
+			url:       "https://api.cluster-a.example.com",
 			wantAlias: "",
 			wantOK:    false,
 		},
@@ -87,7 +87,7 @@ func TestDisplayHostFromURL(t *testing.T) {
 		url  string
 		want string
 	}{
-		{"https url with port", "https://api.pd1020.caas.ford.com:6443", "api.pd1020.caas.ford.com"},
+		{"https url with port", "https://api.cluster-a.example.com:6443", "api.cluster-a.example.com"},
 		{"http url with path", "http://host.example.com/some/path", "host.example.com"},
 		{"bare host", "host.example.com", "host.example.com"},
 		{"bare host with port", "host.example.com:8443", "host.example.com"},

--- a/pkg/auth/hostname/transform_test.go
+++ b/pkg/auth/hostname/transform_test.go
@@ -17,8 +17,8 @@ func TestDefaultTransform_MapKeyedShape(t *testing.T) {
 	// Mirrors the real clusters inventory: a top-level name-keyed map where each
 	// value carries an apiServerURL.
 	body := []byte(`{
-		"pd1020": {"clusterName": "pd1020", "apiServerURL": "https://api.pd1020.example.com:6443", "status": "in-use"},
-		"pd1030": {"clusterName": "pd1030", "apiServerURL": "https://api.pd1030.example.com:6443", "status": "in-use"}
+		"cluster-a": {"clusterName": "cluster-a", "apiServerURL": "https://api.cluster-a.example.com:6443", "status": "in-use"},
+		"cluster-d": {"clusterName": "cluster-d", "apiServerURL": "https://api.cluster-d.example.com:6443", "status": "in-use"}
 	}`)
 
 	cel := `_.map(k, {"name": k, "url": _[k].apiServerURL})`
@@ -31,8 +31,8 @@ func TestDefaultTransform_MapKeyedShape(t *testing.T) {
 	for _, e := range entries {
 		byName[e.Name] = e.URL
 	}
-	assert.Equal(t, "https://api.pd1020.example.com:6443", byName["pd1020"])
-	assert.Equal(t, "https://api.pd1030.example.com:6443", byName["pd1030"])
+	assert.Equal(t, "https://api.cluster-a.example.com:6443", byName["cluster-a"])
+	assert.Equal(t, "https://api.cluster-d.example.com:6443", byName["cluster-d"])
 }
 
 func TestDefaultTransform_FiltersWithCEL(t *testing.T) {

--- a/pkg/auth/statusrows/statusrows_test.go
+++ b/pkg/auth/statusrows/statusrows_test.go
@@ -101,10 +101,10 @@ func TestDedupInstanceTokens(t *testing.T) {
 func TestClusterLabel(t *testing.T) {
 	t.Parallel()
 
-	aliases := map[string]string{"pd1020": "https://api.pd1020.example.com:6443"}
+	aliases := map[string]string{"cluster-a": "https://api.cluster-a.example.com:6443"}
 
 	// Alias match -> short selector.
-	assert.Equal(t, "pd1020", ClusterLabel(aliases, "https://api.pd1020.example.com:6443"))
+	assert.Equal(t, "cluster-a", ClusterLabel(aliases, "https://api.cluster-a.example.com:6443"))
 	// No alias -> trimmed display host.
 	assert.Equal(t, "api.other.example.com", ClusterLabel(aliases, "https://api.other.example.com:6443"))
 	// No aliases at all -> display host.
@@ -117,9 +117,9 @@ func TestInstanceAliases(t *testing.T) {
 	// No config in context.
 	assert.Nil(t, InstanceAliases(context.Background(), "openshift"))
 
-	ctx := instanceConfigCtx("openshift", map[string]string{"pd1020": "https://api.pd1020.example.com"})
+	ctx := instanceConfigCtx("openshift", map[string]string{"cluster-a": "https://api.cluster-a.example.com"})
 	got := InstanceAliases(ctx, "openshift")
-	assert.Equal(t, "https://api.pd1020.example.com", got["pd1020"])
+	assert.Equal(t, "https://api.cluster-a.example.com", got["cluster-a"])
 
 	// Unknown handler -> nil.
 	assert.Nil(t, InstanceAliases(ctx, "other"))
@@ -131,7 +131,7 @@ func TestInstanceAliases(t *testing.T) {
 			Handlers: map[string]config.HandlerConfig{
 				"openshift": {
 					Hostname: &config.HostnameConfig{
-						Aliases:  map[string]string{"pd1020": "https://api.pd1020.example.com"},
+						Aliases:  map[string]string{"cluster-a": "https://api.cluster-a.example.com"},
 						Resolver: &config.HostnameResolverConfig{Transform: "_"},
 					},
 				},
@@ -139,7 +139,7 @@ func TestInstanceAliases(t *testing.T) {
 		},
 	})
 	resolved := InstanceAliases(resolverCtx, "openshift")
-	assert.Equal(t, "https://api.pd1020.example.com", resolved["pd1020"])
+	assert.Equal(t, "https://api.cluster-a.example.com", resolved["cluster-a"])
 }
 
 func TestExpand_NonInstanceHandler(t *testing.T) {
@@ -177,19 +177,19 @@ func TestExpand_TwoClusters(t *testing.T) {
 	h := auth.NewMockHandler("openshift")
 	h.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
 	h.ListCachedTokensResult = []*auth.CachedTokenInfo{
-		{Handler: "openshift", Hostname: "https://api.np0510.example.com:6443", Flow: auth.FlowInteractive, CachedAt: now.Add(-2 * time.Hour)},
-		{Handler: "openshift", Hostname: "https://api.pd1020.example.com:6443", Flow: auth.FlowInteractive, CachedAt: now}, // most recent -> active
+		{Handler: "openshift", Hostname: "https://api.cluster-b.example.com:6443", Flow: auth.FlowInteractive, CachedAt: now.Add(-2 * time.Hour)},
+		{Handler: "openshift", Hostname: "https://api.cluster-a.example.com:6443", Flow: auth.FlowInteractive, CachedAt: now}, // most recent -> active
 	}
-	ctx := instanceConfigCtx("openshift", map[string]string{"pd1020": "https://api.pd1020.example.com:6443"})
+	ctx := instanceConfigCtx("openshift", map[string]string{"cluster-a": "https://api.cluster-a.example.com:6443"})
 
 	sessions := Expand(ctx, "openshift", h, &auth.Status{Authenticated: true})
 	require.Len(t, sessions, 2)
 
-	// Sorted by hostname: np0510 < pd1020.
-	assert.Equal(t, "api.np0510.example.com", sessions[0].ClusterLabel)
-	assert.False(t, sessions[0].Active)
-	assert.Equal(t, "pd1020", sessions[1].ClusterLabel)
-	assert.True(t, sessions[1].Active, "most recent CachedAt is active")
+	// Sorted by hostname: cluster-a < cluster-b.
+	assert.Equal(t, "cluster-a", sessions[0].ClusterLabel)
+	assert.True(t, sessions[0].Active, "most recent CachedAt is active")
+	assert.Equal(t, "api.cluster-b.example.com", sessions[1].ClusterLabel)
+	assert.False(t, sessions[1].Active)
 }
 
 // TestExpand_DedupesPerCluster asserts several tokens for the same instance
@@ -201,8 +201,8 @@ func TestExpand_DedupesPerCluster(t *testing.T) {
 	h := auth.NewMockHandler("openshift")
 	h.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
 	h.ListCachedTokensResult = []*auth.CachedTokenInfo{
-		{Handler: "openshift", Hostname: "https://api.pd1020.example.com:6443", Flow: auth.FlowInteractive, CachedAt: now.Add(-time.Hour)},
-		{Handler: "openshift", Hostname: "https://api.pd1020.example.com:6443", Flow: auth.FlowServicePrincipal, CachedAt: now},
+		{Handler: "openshift", Hostname: "https://api.cluster-a.example.com:6443", Flow: auth.FlowInteractive, CachedAt: now.Add(-time.Hour)},
+		{Handler: "openshift", Hostname: "https://api.cluster-a.example.com:6443", Flow: auth.FlowServicePrincipal, CachedAt: now},
 	}
 
 	sessions := Expand(context.Background(), "openshift", h, &auth.Status{Authenticated: true})

--- a/pkg/catalog/enumerator.go
+++ b/pkg/catalog/enumerator.go
@@ -36,40 +36,25 @@ type registryEnumerator interface {
 // enumeratorConfig bundles values needed by selectEnumerator.
 // Avoids coupling enumerators to RemoteCatalogConfig.
 type enumeratorConfig struct {
-	authHandlerName string
-	authHandler     scafctlauth.Handler
-	authScope       string
-	registry        string
-	repository      string
-	client          *auth.Client
-	insecure        bool
-	logger          logr.Logger
+	authHandler scafctlauth.Handler
+	authScope   string
+	registry    string
+	repository  string
+	client      *auth.Client
+	insecure    bool
+	logger      logr.Logger
 }
 
-// selectEnumerator returns the appropriate enumerator based on the auth handler
-// name and registry URL. Falls back to OCI _catalog for unknown registries.
+// selectEnumerator returns the appropriate enumerator based on the registry
+// URL. Falls back to OCI _catalog for unknown registries.
+//
+// Selection is driven purely by generic hostname detection, which covers every
+// public registry with a vendor-specific enumeration API (GCP Artifact
+// Registry, Quay, GHCR). Registry-instance-specific selection (e.g. a private
+// Quay behind a custom hostname) is intentionally NOT hardcoded here -- that is
+// an embedder concern, not scafctl's.
 func selectEnumerator(cfg enumeratorConfig) registryEnumerator {
-	// Try auth handler name first (explicit config)
-	switch cfg.authHandlerName {
-	case "gcp":
-		if e, err := newGCPEnumerator(cfg); err == nil {
-			cfg.logger.V(1).Info("using GCP Artifact Registry enumerator",
-				"registry", cfg.registry)
-			return e
-		}
-	case "quay-registry":
-		cfg.logger.V(1).Info("using Quay API enumerator",
-			"registry", cfg.registry)
-		return newQuayEnumerator(cfg)
-	case "github":
-		if e, err := newGHCREnumerator(cfg); err == nil {
-			cfg.logger.V(1).Info("using GHCR Packages API enumerator",
-				"registry", cfg.registry)
-			return e
-		}
-	}
-
-	// Try hostname-based detection as fallback
+	// Hostname-based detection.
 	switch {
 	case strings.HasSuffix(cfg.registry, "-docker.pkg.dev"):
 		if e, err := newGCPEnumerator(cfg); err == nil {

--- a/pkg/catalog/enumerator.go
+++ b/pkg/catalog/enumerator.go
@@ -57,7 +57,7 @@ func selectEnumerator(cfg enumeratorConfig) registryEnumerator {
 				"registry", cfg.registry)
 			return e
 		}
-	case "ford-quay":
+	case "quay-registry":
 		cfg.logger.V(1).Info("using Quay API enumerator",
 			"registry", cfg.registry)
 		return newQuayEnumerator(cfg)
@@ -273,7 +273,7 @@ func (e *quayEnumerator) setClient(client *auth.Client) {
 
 func newQuayEnumerator(cfg enumeratorConfig) *quayEnumerator {
 	// Quay's namespace is the top-level org/user that owns the repositories.
-	// In catalog config this maps to the repository field (e.g. "ford-solutions").
+	// In catalog config this maps to the repository field (e.g. "my-solutions").
 	return &quayEnumerator{
 		registry:  cfg.registry,
 		namespace: cfg.repository,

--- a/pkg/catalog/enumerator_test.go
+++ b/pkg/catalog/enumerator_test.go
@@ -23,67 +23,46 @@ func TestSelectEnumerator(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name            string
-		authHandlerName string
-		registry        string
-		repository      string
-		wantType        string
+		name       string
+		registry   string
+		repository string
+		wantType   string
 	}{
 		{
-			name:            "gcp auth handler selects GCP enumerator",
-			authHandlerName: "gcp",
-			registry:        "us-central1-docker.pkg.dev",
-			repository:      "my-project/my-repo",
-			wantType:        "*catalog.gcpEnumerator",
+			name:       "GCP Artifact Registry hostname selects GCP enumerator",
+			registry:   "us-central1-docker.pkg.dev",
+			repository: "my-project/my-repo",
+			wantType:   "*catalog.gcpEnumerator",
 		},
 		{
-			name:            "quay-registry auth handler selects Quay enumerator",
-			authHandlerName: "quay-registry",
-			registry:        "registry.example.com",
-			repository:      "my-solutions",
-			wantType:        "*catalog.quayEnumerator",
+			name:       "GCP hostname detection in another region",
+			registry:   "us-east4-docker.pkg.dev",
+			repository: "my-project/my-repo",
+			wantType:   "*catalog.gcpEnumerator",
 		},
 		{
-			name:            "GCP hostname detection without auth handler",
-			authHandlerName: "",
-			registry:        "us-east4-docker.pkg.dev",
-			repository:      "my-project/my-repo",
-			wantType:        "*catalog.gcpEnumerator",
+			name:       "quay.io hostname selects Quay enumerator",
+			registry:   "quay.io",
+			repository: "myorg",
+			wantType:   "*catalog.quayEnumerator",
 		},
 		{
-			name:            "quay hostname detection without auth handler",
-			authHandlerName: "",
-			registry:        "quay.io",
-			repository:      "myorg",
-			wantType:        "*catalog.quayEnumerator",
+			name:       "quay.io subdomain selects Quay enumerator",
+			registry:   "cdn.quay.io",
+			repository: "myorg",
+			wantType:   "*catalog.quayEnumerator",
 		},
 		{
-			name:            "ghcr.io hostname selects GHCR enumerator",
-			authHandlerName: "",
-			registry:        "ghcr.io",
-			repository:      "myorg",
-			wantType:        "*catalog.ghcrEnumerator",
+			name:       "ghcr.io hostname selects GHCR enumerator",
+			registry:   "ghcr.io",
+			repository: "myorg",
+			wantType:   "*catalog.ghcrEnumerator",
 		},
 		{
-			name:            "github auth handler selects GHCR enumerator",
-			authHandlerName: "github",
-			registry:        "ghcr.io",
-			repository:      "myorg",
-			wantType:        "*catalog.ghcrEnumerator",
-		},
-		{
-			name:            "unknown registry falls back to OCI",
-			authHandlerName: "",
-			registry:        "registry.example.com",
-			repository:      "myorg/scafctl",
-			wantType:        "*catalog.ociCatalogEnumerator",
-		},
-		{
-			name:            "gcp auth handler with non-GCP host falls back to OCI",
-			authHandlerName: "gcp",
-			registry:        "registry.example.com",
-			repository:      "myorg",
-			wantType:        "*catalog.ociCatalogEnumerator",
+			name:       "unknown registry falls back to OCI",
+			registry:   "registry.example.com",
+			repository: "myorg/scafctl",
+			wantType:   "*catalog.ociCatalogEnumerator",
 		},
 	}
 
@@ -92,11 +71,10 @@ func TestSelectEnumerator(t *testing.T) {
 			t.Parallel()
 
 			cfg := enumeratorConfig{
-				authHandlerName: tc.authHandlerName,
-				registry:        tc.registry,
-				repository:      tc.repository,
-				client:          &orasauth.Client{},
-				logger:          logr.Discard(),
+				registry:   tc.registry,
+				repository: tc.repository,
+				client:     &orasauth.Client{},
+				logger:     logr.Discard(),
 			}
 
 			e := selectEnumerator(cfg)
@@ -825,11 +803,10 @@ func typeName(v any) string {
 
 func BenchmarkSelectEnumerator(b *testing.B) {
 	cfg := enumeratorConfig{
-		authHandlerName: "gcp",
-		registry:        "us-central1-docker.pkg.dev",
-		repository:      "my-project/my-repo",
-		client:          &orasauth.Client{},
-		logger:          logr.Discard(),
+		registry:   "us-central1-docker.pkg.dev",
+		repository: "my-project/my-repo",
+		client:     &orasauth.Client{},
+		logger:     logr.Discard(),
 	}
 
 	b.ResetTimer()

--- a/pkg/catalog/enumerator_test.go
+++ b/pkg/catalog/enumerator_test.go
@@ -37,10 +37,10 @@ func TestSelectEnumerator(t *testing.T) {
 			wantType:        "*catalog.gcpEnumerator",
 		},
 		{
-			name:            "ford-quay auth handler selects Quay enumerator",
-			authHandlerName: "ford-quay",
-			registry:        "fcr.ford.com",
-			repository:      "ford-solutions",
+			name:            "quay-registry auth handler selects Quay enumerator",
+			authHandlerName: "quay-registry",
+			registry:        "registry.example.com",
+			repository:      "my-solutions",
 			wantType:        "*catalog.quayEnumerator",
 		},
 		{
@@ -412,14 +412,14 @@ func TestQuayEnumerator(t *testing.T) {
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "/api/v1/repository", r.URL.Path)
-			assert.Equal(t, "ford-solutions", r.URL.Query().Get("namespace"))
+			assert.Equal(t, "my-solutions", r.URL.Query().Get("namespace"))
 			assert.Equal(t, "Bearer my-quay-token", r.Header.Get("Authorization"))
 
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]any{
 				"repositories": []any{
-					map[string]string{"namespace": "ford-solutions", "name": "solutions/starter-kit"},
-					map[string]string{"namespace": "ford-solutions", "name": "providers/terraform"},
+					map[string]string{"namespace": "my-solutions", "name": "solutions/starter-kit"},
+					map[string]string{"namespace": "my-solutions", "name": "providers/terraform"},
 				},
 			})
 		}))
@@ -428,7 +428,7 @@ func TestQuayEnumerator(t *testing.T) {
 		host := server.Listener.Addr().String()
 		e := &quayEnumerator{
 			registry:  host,
-			namespace: "ford-solutions",
+			namespace: "my-solutions",
 			client: &orasauth.Client{
 				Credential: func(_ context.Context, _ string) (orasauth.Credential, error) {
 					return orasauth.Credential{Password: "my-quay-token"}, nil
@@ -442,8 +442,8 @@ func TestQuayEnumerator(t *testing.T) {
 		repos, err := e.enumerate(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, []string{
-			"ford-solutions/solutions/starter-kit",
-			"ford-solutions/providers/terraform",
+			"my-solutions/solutions/starter-kit",
+			"my-solutions/providers/terraform",
 		}, repos)
 	})
 
@@ -451,7 +451,7 @@ func TestQuayEnumerator(t *testing.T) {
 		t.Parallel()
 
 		e := &quayEnumerator{
-			registry: "fcr.ford.com",
+			registry: "registry.example.com",
 			client:   &orasauth.Client{},
 			logger:   logr.Discard(),
 		}
@@ -473,7 +473,7 @@ func TestQuayEnumerator(t *testing.T) {
 		host := server.Listener.Addr().String()
 		e := &quayEnumerator{
 			registry:  host,
-			namespace: "ford-solutions",
+			namespace: "my-solutions",
 			client:    &orasauth.Client{Client: server.Client()},
 			insecure:  true,
 			logger:    logr.Discard(),
@@ -631,10 +631,10 @@ func TestParseGCPRegistryURL(t *testing.T) {
 		{
 			name:       "standard GCP AR",
 			registry:   "us-central1-docker.pkg.dev",
-			repository: "ford-6c2cb87c6f2cc16da4f2260c/cldctl-oci",
+			repository: "org-abc123/mycli-oci",
 			wantLoc:    "us-central1",
-			wantProj:   "ford-6c2cb87c6f2cc16da4f2260c",
-			wantRepo:   "cldctl-oci",
+			wantProj:   "org-abc123",
+			wantRepo:   "mycli-oci",
 		},
 		{
 			name:       "multi-region",

--- a/pkg/catalog/remote.go
+++ b/pkg/catalog/remote.go
@@ -187,14 +187,13 @@ func NewRemoteCatalog(cfg RemoteCatalogConfig) (*RemoteCatalog, error) {
 	catalogLogger := cfg.Logger.WithName("remote-catalog").WithValues("catalog", cfg.Name)
 
 	enumCfg := enumeratorConfig{
-		authHandlerName: authHandlerName(cfg.AuthHandler),
-		authHandler:     cfg.AuthHandler,
-		authScope:       cfg.AuthScope,
-		registry:        cfg.Registry,
-		repository:      cfg.Repository,
-		client:          client,
-		insecure:        cfg.Insecure,
-		logger:          catalogLogger,
+		authHandler: cfg.AuthHandler,
+		authScope:   cfg.AuthScope,
+		registry:    cfg.Registry,
+		repository:  cfg.Repository,
+		client:      client,
+		insecure:    cfg.Insecure,
+		logger:      catalogLogger,
 	}
 
 	rc.client = client

--- a/pkg/catalog/resolver_test.go
+++ b/pkg/catalog/resolver_test.go
@@ -316,7 +316,7 @@ func (m *mockCacher) Put(_, _, _, _ string, _, _ []byte) error {
 
 // TestSolutionResolver_EmbedderCatalog verifies the full catalog resolution
 // round-trip when the catalog lives at a non-default path (simulating an
-// embedder like "cldctl" that sets paths.SetAppName("cldctl")).
+// embedder like "mycli" that sets paths.SetAppName("mycli")).
 //
 // This catches regressions where catalog resolution depends on hardcoded
 // "scafctl" paths or tag formats.

--- a/pkg/cmd/scafctl/auth/handlers_test.go
+++ b/pkg/cmd/scafctl/auth/handlers_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 // TestAuthHandlerNameSet_EmbedderBinaryName is an embedder-scenario test: a
-// non-default binary name ("cldctl") must scope the installed-plugin scan to the
+// non-default binary name ("mycli") must scope the installed-plugin scan to the
 // embedder's own plugin cache (so 'auth handlers', completions, and root
 // enumeration surface it), and installed handlers must not leak across binary
 // names.
@@ -31,7 +31,7 @@ func TestAuthHandlerNameSet_EmbedderBinaryName(t *testing.T) {
 
 	// The package TestMain isolates xdg.CacheHome, so seeding under the embedder's
 	// binary-name subdir is hermetic. Layout: <cacheDir>/<key>/<ver>/<plat>/<key>.
-	const embedder = "cldctl"
+	const embedder = "mycli"
 	cacheDir := settings.PluginCacheDirFor(embedder)
 	platformDir := runtime.GOOS + "-" + runtime.GOARCH
 	pluginDir := filepath.Join(cacheDir, "auth-handler-openshift", "0.1.0", platformDir)
@@ -39,7 +39,7 @@ func TestAuthHandlerNameSet_EmbedderBinaryName(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(pluginDir, "auth-handler-openshift"), []byte("binary"), 0o600))
 
 	// The embedder's binary name comes from the Run settings in context, exactly
-	// as the root command wires it for embedders like cldctl.
+	// as the root command wires it for embedders like mycli.
 	embedderCtx := settings.IntoContext(context.Background(), &settings.Run{BinaryName: embedder})
 	assert.Contains(t, authHandlerNameSet(embedderCtx), "openshift",
 		"installed third-party plugin under the embedder's cache must surface")

--- a/pkg/cmd/scafctl/auth/list_test.go
+++ b/pkg/cmd/scafctl/auth/list_test.go
@@ -26,15 +26,15 @@ import (
 func TestCachedTokenInfoToMap_ClusterLabel(t *testing.T) {
 	t.Parallel()
 
-	aliases := map[string]string{"pd1020": "https://api.pd1020.example.com:6443"}
+	aliases := map[string]string{"cluster-a": "https://api.cluster-a.example.com:6443"}
 
 	// Hostname matches an alias -> short selector.
 	aliased := cachedTokenInfoToMap(&auth.CachedTokenInfo{
 		Handler:   "openshift",
 		TokenKind: "access",
-		Hostname:  "https://api.pd1020.example.com:6443",
+		Hostname:  "https://api.cluster-a.example.com:6443",
 	}, "scafctl", aliases)
-	assert.Equal(t, "pd1020", aliased["cluster"])
+	assert.Equal(t, "cluster-a", aliased["cluster"])
 
 	// Hostname without an alias -> trimmed host.
 	unaliased := cachedTokenInfoToMap(&auth.CachedTokenInfo{

--- a/pkg/cmd/scafctl/auth/login_hostname_test.go
+++ b/pkg/cmd/scafctl/auth/login_hostname_test.go
@@ -167,18 +167,18 @@ func hostnameTokenFixture(t *testing.T, hn *config.HostnameConfig) (context.Cont
 // requesting the token, mirroring the login path.
 func TestCommandToken_HostnameAliasResolved(t *testing.T) {
 	ctx, mock := hostnameTokenFixture(t, &config.HostnameConfig{
-		Aliases: map[string]string{"pd1020": "https://api.pd1020.example.com:6443"},
+		Aliases: map[string]string{"cluster-a": "https://api.cluster-a.example.com:6443"},
 	})
 
 	buf := &bytes.Buffer{}
 	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
 	cmd := CommandToken(settings.NewCliParams(), ioStreams, "scafctl/auth")
 	cmd.SetContext(ctx)
-	cmd.SetArgs([]string{"openshift", "--server", "pd1020", "--raw"})
+	cmd.SetArgs([]string{"openshift", "--server", "cluster-a", "--raw"})
 
 	require.NoError(t, cmd.Execute())
 	require.Len(t, mock.GetTokenCalls, 1)
-	assert.Equal(t, "https://api.pd1020.example.com:6443", mock.GetTokenCalls[0].Hostname,
+	assert.Equal(t, "https://api.cluster-a.example.com:6443", mock.GetTokenCalls[0].Hostname,
 		"a --server alias must be resolved to the concrete endpoint URL before GetToken")
 }
 
@@ -186,7 +186,7 @@ func TestCommandToken_HostnameAliasResolved(t *testing.T) {
 // --server URL is forwarded unchanged even when aliases exist.
 func TestCommandToken_HostnameConcreteURLPassthrough(t *testing.T) {
 	ctx, mock := hostnameTokenFixture(t, &config.HostnameConfig{
-		Aliases: map[string]string{"pd1020": "https://api.pd1020.example.com:6443"},
+		Aliases: map[string]string{"cluster-a": "https://api.cluster-a.example.com:6443"},
 	})
 
 	buf := &bytes.Buffer{}
@@ -204,7 +204,7 @@ func TestCommandToken_HostnameConcreteURLPassthrough(t *testing.T) {
 // selector fails with an invalid-input error and never calls the handler.
 func TestCommandToken_HostnameSelectorNotFound(t *testing.T) {
 	ctx, mock := hostnameTokenFixture(t, &config.HostnameConfig{
-		Aliases: map[string]string{"pd1020": "https://api.pd1020.example.com:6443"},
+		Aliases: map[string]string{"cluster-a": "https://api.cluster-a.example.com:6443"},
 	})
 
 	buf := &bytes.Buffer{}

--- a/pkg/cmd/scafctl/auth/logout_test.go
+++ b/pkg/cmd/scafctl/auth/logout_test.go
@@ -85,7 +85,7 @@ func TestCommandLogout_MultiClusterCachedSessions(t *testing.T) {
 	mock.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
 	mock.SetNotAuthenticated() // hostname-less base instance reports unauthenticated
 	mock.ListCachedTokensResult = []*auth.CachedTokenInfo{
-		{Handler: "openshift", Hostname: "https://api.pd1020.example.com:6443"},
+		{Handler: "openshift", Hostname: "https://api.cluster-a.example.com:6443"},
 	}
 
 	ctx = withTestHandler(ctx, mock)
@@ -115,7 +115,7 @@ func TestCommandLogout_BaseStatusErrorWithCachedSessions(t *testing.T) {
 	mock.CapabilitiesValue = []auth.Capability{auth.CapInstanceHostname}
 	mock.StatusErr = errors.New("no api server configured")
 	mock.ListCachedTokensResult = []*auth.CachedTokenInfo{
-		{Handler: "openshift", Hostname: "https://api.pd1020.example.com:6443"},
+		{Handler: "openshift", Hostname: "https://api.cluster-a.example.com:6443"},
 	}
 
 	ctx = withTestHandler(ctx, mock)

--- a/pkg/cmd/scafctl/auth/status_instance_test.go
+++ b/pkg/cmd/scafctl/auth/status_instance_test.go
@@ -94,14 +94,14 @@ func TestExpandInstanceRows_TwoClusters(t *testing.T) {
 	h.ListCachedTokensResult = []*auth.CachedTokenInfo{
 		{
 			Handler:   "openshift",
-			Hostname:  "https://api.np0510.caas.ford.com:6443",
+			Hostname:  "https://api.cluster-b.example.com:6443",
 			Flow:      auth.FlowInteractive,
 			ExpiresAt: now.Add(time.Hour),
 			CachedAt:  now.Add(-2 * time.Hour),
 		},
 		{
 			Handler:   "openshift",
-			Hostname:  "https://api.pd1020.caas.ford.com:6443",
+			Hostname:  "https://api.cluster-a.example.com:6443",
 			Flow:      auth.FlowInteractive,
 			ExpiresAt: now.Add(30 * time.Minute),
 			CachedAt:  now, // most recent -> active
@@ -110,16 +110,16 @@ func TestExpandInstanceRows_TwoClusters(t *testing.T) {
 	status := &auth.Status{Authenticated: true}
 
 	ctx := instanceConfigCtx(t, "openshift", map[string]string{
-		"pd1020": "https://api.pd1020.caas.ford.com:6443",
+		"cluster-a": "https://api.cluster-a.example.com:6443",
 	})
 
 	rows := expandInstanceRows(ctx, "openshift", h, status, baseStatusRow("openshift"))
 	require.Len(t, rows, 2)
 
-	// Deterministic order: sorted by hostname; np0510 < pd1020. For the built-in
+	// Deterministic order: sorted by hostname; cluster-a < cluster-b. For the built-in
 	// profile the cluster alias/label alone is shown (no redundant "built-in /").
-	assert.Equal(t, "api.np0510.caas.ford.com", rows[0]["profile"], "unaliased host trimmed")
-	assert.Equal(t, "pd1020 (active)", rows[1]["profile"], "aliased host + active marker (most recent CachedAt)")
+	assert.Equal(t, "cluster-a (active)", rows[0]["profile"], "aliased host + active marker (most recent CachedAt)")
+	assert.Equal(t, "api.cluster-b.example.com", rows[1]["profile"], "unaliased host trimmed")
 
 	// Shared identity fills the user column on every row.
 	assert.Equal(t, "user@example.com", rows[0]["user"])
@@ -143,13 +143,13 @@ func TestExpandInstanceRows_DedupesTokensPerCluster(t *testing.T) {
 	h.ListCachedTokensResult = []*auth.CachedTokenInfo{
 		{
 			Handler:  "openshift",
-			Hostname: "https://api.pd1020.caas.ford.com:6443",
+			Hostname: "https://api.cluster-a.example.com:6443",
 			Flow:     auth.FlowInteractive, // user login (older)
 			CachedAt: now.Add(-time.Hour),
 		},
 		{
 			Handler:  "openshift",
-			Hostname: "https://api.pd1020.caas.ford.com:6443",
+			Hostname: "https://api.cluster-a.example.com:6443",
 			Flow:     auth.FlowServicePrincipal, // minted SA token (newer)
 			CachedAt: now,
 		},
@@ -160,7 +160,7 @@ func TestExpandInstanceRows_DedupesTokensPerCluster(t *testing.T) {
 	require.Len(t, rows, 1, "multiple tokens for one cluster must collapse to a single row")
 	// The user/login flow wins over the newer machine flow.
 	assert.Equal(t, string(auth.FlowInteractive), rows[0]["flow"])
-	assert.Equal(t, "api.pd1020.caas.ford.com (active)", rows[0]["profile"])
+	assert.Equal(t, "api.cluster-a.example.com (active)", rows[0]["profile"])
 }
 
 // TestExpandInstanceRows_NamedProfilePrefix asserts that a non-default (named)
@@ -175,7 +175,7 @@ func TestExpandInstanceRows_NamedProfilePrefix(t *testing.T) {
 	h.ListCachedTokensResult = []*auth.CachedTokenInfo{
 		{
 			Handler:  "openshift",
-			Hostname: "https://api.pd1020.caas.ford.com:6443",
+			Hostname: "https://api.cluster-a.example.com:6443",
 			Flow:     auth.FlowInteractive,
 			CachedAt: now,
 		},
@@ -186,7 +186,7 @@ func TestExpandInstanceRows_NamedProfilePrefix(t *testing.T) {
 	base["profile"] = "work" // a named profile is active
 	rows := expandInstanceRows(context.Background(), "openshift", h, status, base)
 	require.Len(t, rows, 1)
-	assert.Equal(t, "work / api.pd1020.caas.ford.com (active)", rows[0]["profile"])
+	assert.Equal(t, "work / api.cluster-a.example.com (active)", rows[0]["profile"])
 }
 
 func TestExpandInstanceRows_ExpiredCluster(t *testing.T) {
@@ -198,7 +198,7 @@ func TestExpandInstanceRows_ExpiredCluster(t *testing.T) {
 	h.ListCachedTokensResult = []*auth.CachedTokenInfo{
 		{
 			Handler:   "openshift",
-			Hostname:  "https://api.pd1020.caas.ford.com:6443",
+			Hostname:  "https://api.cluster-a.example.com:6443",
 			IsExpired: true,
 			CachedAt:  now,
 		},

--- a/pkg/cmd/scafctl/auth/token.go
+++ b/pkg/cmd/scafctl/auth/token.go
@@ -220,7 +220,7 @@ func CommandToken(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ stri
 			// login path. Returns the value unchanged when it is already a URL or
 			// when the handler has no hostname config, so plain-hostname handlers
 			// and exec-info URLs are unaffected. Without this, a bare cluster
-			// selector (e.g. "pd1020") would reach the plugin unresolved and fail.
+			// selector (e.g. "cluster-a") would reach the plugin unresolved and fail.
 			if tokenHostname != "" {
 				resolved, rErr := hostnameresolver.Resolve(ctx, handlerName, tokenHostname)
 				if rErr != nil {

--- a/pkg/cmd/scafctl/catalog/catalog_test.go
+++ b/pkg/cmd/scafctl/catalog/catalog_test.go
@@ -139,21 +139,21 @@ func TestResolveAuthProvider_FromCatalogConfig(t *testing.T) {
 // TestResolveAuthProvider_InferenceTakesPriorityOverDefault verifies that
 // registry-host inference (e.g. *.pkg.dev → gcp) takes priority over the
 // default catalog's authProvider. Without this, a full OCI ref to a GCP
-// registry would incorrectly use the default catalog's handler (e.g. ford-quay).
+// registry would incorrectly use the default catalog's handler (e.g. quay-registry).
 func TestResolveAuthProvider_InferenceTakesPriorityOverDefault(t *testing.T) {
 	t.Parallel()
 
 	cfg := &appconfig.Config{
 		Catalogs: []appconfig.CatalogConfig{
 			{
-				Name:         "ford-solutions",
+				Name:         "my-solutions",
 				Type:         appconfig.CatalogTypeOCI,
 				URL:          "oci://quay.io/myorg",
 				AuthProvider: "quay",
 			},
 		},
 		Settings: appconfig.Settings{
-			DefaultCatalog: "ford-solutions",
+			DefaultCatalog: "my-solutions",
 		},
 	}
 

--- a/pkg/cmd/scafctl/catalog/catalog_test.go
+++ b/pkg/cmd/scafctl/catalog/catalog_test.go
@@ -139,7 +139,7 @@ func TestResolveAuthProvider_FromCatalogConfig(t *testing.T) {
 // TestResolveAuthProvider_InferenceTakesPriorityOverDefault verifies that
 // registry-host inference (e.g. *.pkg.dev → gcp) takes priority over the
 // default catalog's authProvider. Without this, a full OCI ref to a GCP
-// registry would incorrectly use the default catalog's handler (e.g. quay-registry).
+// registry would incorrectly use the default catalog's handler (e.g. quay).
 func TestResolveAuthProvider_InferenceTakesPriorityOverDefault(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cmd/scafctl/config/reset.go
+++ b/pkg/cmd/scafctl/config/reset.go
@@ -123,7 +123,7 @@ func (o *ResetOptions) Run(ctx context.Context) error {
 	}
 
 	// Re-create from defaults. Use embedder defaults when available so
-	// that an embedding CLI (e.g. cldctl) resets to its own defaults
+	// that an embedding CLI (e.g. mycli) resets to its own defaults
 	// rather than scafctl's built-in defaults.
 	baseDefaults := appconfig.BaseDefaultsFromContext(ctx)
 	var ensureErr error

--- a/pkg/cmd/scafctl/root_test.go
+++ b/pkg/cmd/scafctl/root_test.go
@@ -233,16 +233,16 @@ func TestRoot_CustomBinaryNameUpdatesSolutionDiscovery(t *testing.T) {
 	})
 
 	cmd, _ := Root(&RootOptions{
-		BinaryName: "cldctl",
+		BinaryName: "mycli",
 	})
 	require.NotNil(t, cmd)
-	if cmd.Use != "cldctl" {
-		t.Errorf("Root().Use = %q, want %q", cmd.Use, "cldctl")
+	if cmd.Use != "mycli" {
+		t.Errorf("Root().Use = %q, want %q", cmd.Use, "mycli")
 	}
 	// Verify package-level solution discovery vars were updated
-	expectedFolders := settings.SolutionFoldersFor("cldctl")
+	expectedFolders := settings.SolutionFoldersFor("mycli")
 	assert.Equal(t, expectedFolders, settings.GetRootSolutionFolders())
-	expectedNames := settings.SolutionFileNamesFor("cldctl")
+	expectedNames := settings.SolutionFileNamesFor("mycli")
 	assert.Equal(t, expectedNames, settings.GetSolutionFileNames())
 }
 

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -256,7 +256,7 @@ Examples:
   scafctl run resolver --action tag --action release -f ./my-solution.yaml
 
   # Run from catalog without -f (auto-fallback)
-  scafctl run resolver ford-proxy`, settings.CliBinaryName, cliParams.BinaryName),
+  scafctl run resolver my-proxy`, settings.CliBinaryName, cliParams.BinaryName),
 		Args: cobra.ArbitraryArgs,
 		PreRun: func(cCmd *cobra.Command, args []string) {
 			// Track which flags were explicitly set by the user

--- a/pkg/cmd/scafctl/run/resolver_test.go
+++ b/pkg/cmd/scafctl/run/resolver_test.go
@@ -2347,7 +2347,7 @@ func TestResolverOptions_Run_CatalogFallbackAfterAutoDiscoveryFailure(t *testing
 			PhaseTimeout:    5 * time.Minute,
 			registry:        testRegistry(),
 		},
-		Names: []string{"ford-proxy"},
+		Names: []string{"my-proxy"},
 	}
 
 	lgr := logger.Get(0)
@@ -2362,7 +2362,7 @@ func TestResolverOptions_Run_CatalogFallbackAfterAutoDiscoveryFailure(t *testing
 	// The run will fail (no catalog configured), but we should see the
 	// fallback path was taken: File should be set to the catalog ref.
 	assert.Error(t, err)
-	assert.Equal(t, "ford-proxy", opts.File, "fallback should set File to catalog ref after auto-discovery load failure")
+	assert.Equal(t, "my-proxy", opts.File, "fallback should set File to catalog ref after auto-discovery load failure")
 	assert.Empty(t, opts.Names, "fallback should consume the positional arg")
 }
 
@@ -3189,7 +3189,7 @@ func TestResolverOptions_Run_CatalogFallbackNotFiredForMalformedSolution(t *test
 			PhaseTimeout:    5 * time.Minute,
 			registry:        testRegistry(),
 		},
-		Names: []string{"ford-proxy"},
+		Names: []string{"my-proxy"},
 	}
 
 	lgr := logger.Get(0)
@@ -3204,7 +3204,7 @@ func TestResolverOptions_Run_CatalogFallbackNotFiredForMalformedSolution(t *test
 	assert.Error(t, err)
 	// Should get the validation error, NOT a catalog lookup error.
 	// The fallback should NOT have consumed the first name as a catalog ref.
-	assert.NotEqual(t, "ford-proxy", opts.File, "fallback should NOT fire for a malformed solution.yaml")
+	assert.NotEqual(t, "my-proxy", opts.File, "fallback should NOT fire for a malformed solution.yaml")
 }
 
 func TestResolverOptions_renderValidationDiagnostics_NilCliParamsNoPanic(t *testing.T) {

--- a/pkg/config/handlers_test.go
+++ b/pkg/config/handlers_test.go
@@ -27,7 +27,7 @@ auth:
     openshift:
       hostname:
         aliases:
-          pd1020: https://api.pd1020.example.com:6443
+          cluster-a: https://api.cluster-a.example.com:6443
         resolver:
           source:
             url: https://clusters.example.com
@@ -49,7 +49,7 @@ auth:
 
 	// Host-consumed hostname block parsed into typed fields.
 	require.NotNil(t, handler.Hostname)
-	assert.Equal(t, "https://api.pd1020.example.com:6443", handler.Hostname.Aliases["pd1020"])
+	assert.Equal(t, "https://api.cluster-a.example.com:6443", handler.Hostname.Aliases["cluster-a"])
 	require.NotNil(t, handler.Hostname.Resolver)
 	assert.Equal(t, "https://clusters.example.com", handler.Hostname.Resolver.Source.URL)
 	assert.Equal(t, "entra", handler.Hostname.Resolver.Source.AuthProvider)
@@ -78,7 +78,7 @@ auth:
     openshift:
       hostname:
         aliases:
-          pd1020: https://api.pd1020.example.com:6443
+          cluster-a: https://api.cluster-a.example.com:6443
       apiTimeout: 30
       nested:
         deeply:

--- a/pkg/kube/clusterconfig/resolver_test.go
+++ b/pkg/kube/clusterconfig/resolver_test.go
@@ -78,7 +78,7 @@ func TestResolver_ListCached_UsesCachedInventory(t *testing.T) {
 	deps := hostname.Deps{
 		Cache: &fakeCache{
 			hit:     true,
-			entries: []hostname.Entry{{Name: "pd1020", URL: "https://api.pd:6443"}},
+			entries: []hostname.Entry{{Name: "cluster-a", URL: "https://api.pd:6443"}},
 		},
 		Fetch: func(context.Context, config.HostnameResolverSource, string) ([]byte, error) {
 			t.Fatal("Fetch must not be called when the inventory is cached")
@@ -95,7 +95,7 @@ func TestResolver_ListCached_UsesCachedInventory(t *testing.T) {
 	for i, c := range list {
 		names[i] = c.Name
 	}
-	assert.ElementsMatch(t, []string{"lab", "pd1020"}, names)
+	assert.ElementsMatch(t, []string{"lab", "cluster-a"}, names)
 }
 
 func TestResolver_Enabled(t *testing.T) {
@@ -141,13 +141,13 @@ func TestResolver_Resolve_Inventory(t *testing.T) {
 	t.Parallel()
 
 	deps := inventoryDeps([]hostname.Entry{
-		{Name: "pd1020", URL: "https://api.pd.example.com:6443", DefaultHandler: "openshift", AuthType: "oauth", Audience: "pd-aud"},
+		{Name: "cluster-a", URL: "https://api.pd.example.com:6443", DefaultHandler: "openshift", AuthType: "oauth", Audience: "pd-aud"},
 	})
 	r := New(config.ClusterResolutionConfig{Resolver: resolverConfig()}, WithDeps(deps))
 
-	info, err := r.Resolve(context.Background(), "pd1020")
+	info, err := r.Resolve(context.Background(), "cluster-a")
 	require.NoError(t, err)
-	assert.Equal(t, "pd1020", info.Name)
+	assert.Equal(t, "cluster-a", info.Name)
 	assert.Equal(t, "https://api.pd.example.com:6443", info.APIServerURL)
 	assert.Equal(t, "openshift", info.DefaultHandler)
 	assert.Equal(t, kube.AuthTypeOAuth, info.AuthType)
@@ -188,7 +188,7 @@ func TestResolver_Resolve_InventoryMiss(t *testing.T) {
 	t.Parallel()
 
 	deps := inventoryDeps([]hostname.Entry{
-		{Name: "pd1020", URL: "https://api.pd.example.com:6443"},
+		{Name: "cluster-a", URL: "https://api.pd.example.com:6443"},
 	})
 	r := New(config.ClusterResolutionConfig{Resolver: resolverConfig()}, WithDeps(deps))
 

--- a/pkg/plugin/auth_grpc_client_test.go
+++ b/pkg/plugin/auth_grpc_client_test.go
@@ -233,12 +233,12 @@ func TestAuthHandlerGRPCClient_Login_ForwardsHostname(t *testing.T) {
 	client := &AuthHandlerGRPCClient{client: mock}
 
 	_, err := client.Login(context.Background(), "openshift", LoginRequest{
-		Hostname: "pd1020",
+		Hostname: "cluster-a",
 		Flow:     auth.FlowServicePrincipal,
 	}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, gotReq)
-	assert.Equal(t, "pd1020", gotReq.Hostname, "hostname must be mapped onto the proto LoginRequest")
+	assert.Equal(t, "cluster-a", gotReq.Hostname, "hostname must be mapped onto the proto LoginRequest")
 }
 
 func TestAuthHandlerGRPCClient_Login_ForwardsCallbackPort(t *testing.T) {

--- a/pkg/plugin/plugin_auth_test.go
+++ b/pkg/plugin/plugin_auth_test.go
@@ -876,10 +876,10 @@ func TestAuthHandlerWrapper_Login_ForwardsHostname(t *testing.T) {
 
 	_, err := w.Login(context.Background(), auth.LoginOptions{
 		Flow:     auth.FlowServicePrincipal,
-		Hostname: "pd1020",
+		Hostname: "cluster-a",
 	})
 	require.NoError(t, err)
-	assert.Equal(t, "pd1020", gotReq.Hostname, "hostname from LoginOptions must reach the plugin LoginRequest")
+	assert.Equal(t, "cluster-a", gotReq.Hostname, "hostname from LoginOptions must reach the plugin LoginRequest")
 }
 
 func TestAuthHandlerWrapper_Login_ForwardsCallbackPort(t *testing.T) {
@@ -951,11 +951,11 @@ func TestAuthHandlerGRPCServer_Login_ForwardsHostname(t *testing.T) {
 
 	err := server.Login(&proto.LoginRequest{
 		HandlerName: "openshift",
-		Hostname:    "pd1020",
+		Hostname:    "cluster-a",
 		Flow:        string(auth.FlowServicePrincipal),
 	}, stream)
 	require.NoError(t, err)
-	assert.Equal(t, "pd1020", gotReq.Hostname, "hostname from proto LoginRequest must reach the handler")
+	assert.Equal(t, "cluster-a", gotReq.Hostname, "hostname from proto LoginRequest must reach the handler")
 	require.NotEmpty(t, stream.messages, "server must send a result message")
 }
 

--- a/pkg/plugin/wrapper_auth_test.go
+++ b/pkg/plugin/wrapper_auth_test.go
@@ -97,7 +97,7 @@ func TestInjectAuthHandlerSettings(t *testing.T) {
 					Handlers: map[string]config.HandlerConfig{
 						"openshift": {
 							Hostname: &config.HostnameConfig{
-								Aliases: map[string]string{"pd1020": "https://api.example.com:6443"},
+								Aliases: map[string]string{"cluster-a": "https://api.example.com:6443"},
 							},
 						},
 					},

--- a/pkg/solution/example_solution.yaml
+++ b/pkg/solution/example_solution.yaml
@@ -13,7 +13,7 @@ metadata:
     - infrastructure
   maintainers:
     - name: Aeron Baker
-      email: abaker9@company.com
+      email: alice@example.com
   links:
     - name: Documentation
       url: https://docs.example.com/gcp-basic

--- a/pkg/solution/get/get.go
+++ b/pkg/solution/get/get.go
@@ -870,7 +870,7 @@ func (o *Getter) FindSolution() string {
 	o.lastDiscovery = DiscoveryResult{Mode: o.discoveryMode}
 
 	// In action mode, if the first match is a non-action file (e.g.,
-	// cldctl/solution.yaml), remember it as a fallback and keep searching
+	// mycli/solution.yaml), remember it as a fallback and keep searching
 	// remaining folders for an actual action file (e.g., ./actions.yaml).
 	var fallbackPath string
 	var fallbackFilename string

--- a/pkg/solution/get/get_test.go
+++ b/pkg/solution/get/get_test.go
@@ -638,24 +638,24 @@ func TestFindSolution(t *testing.T) {
 		getter := NewGetter(
 			WithStatFunc(customStatFunc),
 			WithSolutionDiscovery(
-				settings.SolutionFoldersFor("cldctl"),
-				settings.SolutionFileNamesFor("cldctl"),
+				settings.SolutionFoldersFor("mycli"),
+				settings.SolutionFileNamesFor("mycli"),
 			),
 		)
 		_ = getter.FindSolution()
 
-		// Should check cldctl/solution.yaml, not scafctl/solution.yaml
-		foundCldctl := false
+		// Should check mycli/solution.yaml, not scafctl/solution.yaml
+		foundMycli := false
 		foundScafctl := false
 		for _, p := range checkedPaths {
-			if p == "cldctl/solution.yaml" {
-				foundCldctl = true
+			if p == "mycli/solution.yaml" {
+				foundMycli = true
 			}
 			if p == "scafctl/solution.yaml" {
 				foundScafctl = true
 			}
 		}
-		assert.True(t, foundCldctl, "Should check for cldctl/solution.yaml")
+		assert.True(t, foundMycli, "Should check for mycli/solution.yaml")
 		assert.False(t, foundScafctl, "Should NOT check for scafctl/solution.yaml")
 	})
 }
@@ -1996,12 +1996,12 @@ func TestFindSolution_DiscoveryMode(t *testing.T) {
 	})
 
 	t.Run("action mode prefers root actions.yaml over subfolder solution.yaml", func(t *testing.T) {
-		// Simulates: cldctl/solution.yaml exists, root actions.yaml exists.
+		// Simulates: mycli/solution.yaml exists, root actions.yaml exists.
 		// In action mode, root actions.yaml should be preferred even though
 		// subfolder solution.yaml is found first in folder-priority order.
 		existingFiles := map[string]bool{
-			"cldctl/solution.yaml": true,
-			"actions.yaml":         true,
+			"mycli/solution.yaml": true,
+			"actions.yaml":        true,
 		}
 		customStatFunc := func(path string) (os.FileInfo, error) {
 			if existingFiles[path] {
@@ -2014,8 +2014,8 @@ func TestFindSolution_DiscoveryMode(t *testing.T) {
 			WithStatFunc(customStatFunc),
 			WithDiscoveryMode(settings.DiscoveryModeAction),
 			WithSolutionDiscovery(
-				[]string{"cldctl", ".cldctl", ""},
-				settings.ActionFileNamesFor("cldctl"),
+				[]string{"mycli", ".mycli", ""},
+				settings.ActionFileNamesFor("mycli"),
 			),
 		)
 		path := getter.FindSolution()
@@ -2024,12 +2024,12 @@ func TestFindSolution_DiscoveryMode(t *testing.T) {
 		result := getter.LastDiscoveryResult()
 		assert.True(t, result.IsActionFile)
 		// The subfolder solution.yaml should be recorded as the alternate path.
-		assert.Equal(t, "cldctl/solution.yaml", result.AlternatePath)
+		assert.Equal(t, "mycli/solution.yaml", result.AlternatePath)
 	})
 
 	t.Run("action mode uses subfolder solution.yaml when no action file exists anywhere", func(t *testing.T) {
 		existingFiles := map[string]bool{
-			"cldctl/solution.yaml": true,
+			"mycli/solution.yaml": true,
 		}
 		customStatFunc := func(path string) (os.FileInfo, error) {
 			if existingFiles[path] {
@@ -2042,13 +2042,13 @@ func TestFindSolution_DiscoveryMode(t *testing.T) {
 			WithStatFunc(customStatFunc),
 			WithDiscoveryMode(settings.DiscoveryModeAction),
 			WithSolutionDiscovery(
-				[]string{"cldctl", ".cldctl", ""},
-				settings.ActionFileNamesFor("cldctl"),
+				[]string{"mycli", ".mycli", ""},
+				settings.ActionFileNamesFor("mycli"),
 			),
 		)
 		path := getter.FindSolution()
 
-		assert.Equal(t, "cldctl/solution.yaml", path)
+		assert.Equal(t, "mycli/solution.yaml", path)
 		result := getter.LastDiscoveryResult()
 		assert.False(t, result.IsActionFile)
 	})

--- a/pkg/solution/prepare/prepare_test.go
+++ b/pkg/solution/prepare/prepare_test.go
@@ -521,14 +521,14 @@ func TestLoadSolutionWithBundle_InvalidStdin(t *testing.T) {
 func TestNewDefaultGetter_UsesContextBinaryName(t *testing.T) {
 	// Not parallel: os.Chdir is process-wide and would race with other tests.
 
-	// Create a temp directory with cldctl/solution.yaml
+	// Create a temp directory with mycli/solution.yaml
 	tmpDir := t.TempDir()
-	cldctlDir := filepath.Join(tmpDir, "cldctl")
-	require.NoError(t, os.MkdirAll(cldctlDir, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(cldctlDir, "solution.yaml"), []byte("name: test\nversion: 1.0.0\n"), 0o644))
+	mycliDir := filepath.Join(tmpDir, "mycli")
+	require.NoError(t, os.MkdirAll(mycliDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(mycliDir, "solution.yaml"), []byte("name: test\nversion: 1.0.0\n"), 0o644))
 
 	// Create a context with a custom binary name
-	run := &settings.Run{BinaryName: "cldctl"}
+	run := &settings.Run{BinaryName: "mycli"}
 	ctx := settings.IntoContext(context.Background(), run)
 	lgr := logr.Discard()
 	ctx = logger.WithLogger(ctx, &lgr)
@@ -536,14 +536,14 @@ func TestNewDefaultGetter_UsesContextBinaryName(t *testing.T) {
 	getter := NewDefaultGetter(ctx, false)
 	require.NotNil(t, getter, "getter should be created from context with custom binary name")
 
-	// chdir to tmpDir so FindSolution can discover cldctl/solution.yaml
+	// chdir to tmpDir so FindSolution can discover mycli/solution.yaml
 	origDir, err := os.Getwd()
 	require.NoError(t, err)
 	require.NoError(t, os.Chdir(tmpDir))
 	t.Cleanup(func() { _ = os.Chdir(origDir) })
 
 	found := getter.FindSolution()
-	assert.Equal(t, filepath.ToSlash(filepath.Join("cldctl", "solution.yaml")), found)
+	assert.Equal(t, filepath.ToSlash(filepath.Join("mycli", "solution.yaml")), found)
 }
 
 func TestNewDefaultGetter_DefaultBinaryName(t *testing.T) {
@@ -574,13 +574,13 @@ func TestNewDefaultGetter_DefaultBinaryName(t *testing.T) {
 func TestNewDefaultGetter_CustomBinaryDoesNotFindDefault(t *testing.T) {
 	// Not parallel: os.Chdir is process-wide and would race with other tests.
 
-	// Create a temp directory with only scafctl/solution.yaml (no cldctl/)
+	// Create a temp directory with only scafctl/solution.yaml (no mycli/)
 	tmpDir := t.TempDir()
 	scafctlDir := filepath.Join(tmpDir, settings.CliBinaryName)
 	require.NoError(t, os.MkdirAll(scafctlDir, 0o755))
 	require.NoError(t, os.WriteFile(filepath.Join(scafctlDir, "solution.yaml"), []byte("name: test\nversion: 1.0.0\n"), 0o644))
 
-	run := &settings.Run{BinaryName: "cldctl"}
+	run := &settings.Run{BinaryName: "mycli"}
 	ctx := settings.IntoContext(context.Background(), run)
 	lgr := logr.Discard()
 	ctx = logger.WithLogger(ctx, &lgr)
@@ -593,7 +593,7 @@ func TestNewDefaultGetter_CustomBinaryDoesNotFindDefault(t *testing.T) {
 	require.NoError(t, os.Chdir(tmpDir))
 	t.Cleanup(func() { _ = os.Chdir(origDir) })
 
-	// Should NOT find scafctl/solution.yaml when binary name is "cldctl"
+	// Should NOT find scafctl/solution.yaml when binary name is "mycli"
 	found := getter.FindSolution()
 	assert.Empty(t, found, "custom binary name getter should not discover default binary's solution folder")
 }

--- a/pkg/solution/soltesting/sandbox.go
+++ b/pkg/solution/soltesting/sandbox.go
@@ -56,9 +56,9 @@ func NewSandbox(solutionPath string, bundleFiles, testFiles []string) (*Sandbox,
 // directory structure for solutions that live in a subdirectory of a repository
 // and whose resolvers reference paths relative to the repository root.
 //
-// For example, with baseDir="cldctl":
-//   - solution.yaml  -> sandbox/cldctl/solution.yaml
-//   - output/data.json -> sandbox/cldctl/output/data.json
+// For example, with baseDir="mycli":
+//   - solution.yaml  -> sandbox/mycli/solution.yaml
+//   - output/data.json -> sandbox/mycli/output/data.json
 //
 // The process working directory (cmd.Dir) should be set to sandbox.Path()
 // (the root), so repo-root-relative paths resolve correctly.

--- a/pkg/solution/soltesting/types.go
+++ b/pkg/solution/soltesting/types.go
@@ -450,10 +450,10 @@ type TestCase struct {
 	// the directory structure so that repo-root-relative paths in resolvers
 	// resolve correctly.
 	//
-	// Example: if baseDir is "cldctl" and the solution references
-	// "./cldctl/output/data.json", the sandbox places the file at
-	// sandbox/cldctl/output/data.json and the solution at
-	// sandbox/cldctl/solution.yaml.
+	// Example: if baseDir is "mycli" and the solution references
+	// "./mycli/output/data.json", the sandbox places the file at
+	// sandbox/mycli/output/data.json and the solution at
+	// sandbox/mycli/solution.yaml.
 	BaseDir string `json:"baseDir,omitempty" yaml:"baseDir,omitempty" doc:"Subdirectory within sandbox for nesting solution files" maxLength:"500"`
 
 	// Inputs maps parameter names to values. Each entry is translated to a

--- a/scripts/auth_test.sh
+++ b/scripts/auth_test.sh
@@ -4,7 +4,7 @@
 
 # --- 1. Default profile status ---
 dist/scafctl auth status github
-# => authenticated, abaker9@gmail.com, Profile=built-in
+# => authenticated, alice@example.com, Profile=built-in
 
 # --- 2. Work profile status ---
 dist/scafctl auth status github --profile work


### PR DESCRIPTION
Removes internal/organization-specific references from the repository, replacing them with neutral placeholders, and refactors catalog enumerator selection to be driven purely by registry hostname.

## Reference scrub

Replaces internal references across code, tests, and docs with neutral equivalents:

- Internal domains/hostnames -> `example.com` / `registry.example.com` / `platform.example.com`
- Cluster names -> `cluster-a` / `cluster-b` / ...
- Internal CLI name -> `mycli`
- Internal user/identity references -> `alice` / `alice@example.com`
- Internal org/registry references -> `example-org` / `ghcr.io/example-org`

Sort-order-sensitive test assertions were adjusted where the cluster rename
flipped lexical ordering. No behavior changes from the scrub itself.

## Enumerator selection refactor (breaking)

Review flagged that one scrubbed string (`case "..."`) was a config-facing
contract -- the catalog enumerator selected a strategy by matching a
user-configured auth-handler name against hardcoded instance-specific values.
Rather than rename it (which would reintroduce an internal reference), the
entire handler-name selection switch is removed. Selection is now driven
solely by registry hostname:

- `*-docker.pkg.dev` -> Artifact Registry enumerator
- `*.quay.io` / `quay.io` -> Quay enumerator (namespace-scoped API; Quay does
  not implement the standard OCI `/v2/_catalog` endpoint)
- `ghcr.io` -> GHCR enumerator
- everything else -> generic OCI `_catalog` enumerator

Selecting a vendor enumerator for a private custom hostname is an embedder
concern, not a library one. `selectEnumerator` / `enumeratorConfig` are
unexported, so there is no public API change.

**BREAKING CHANGE:** catalog enumerator selection no longer honors a configured
auth-handler name; selection is determined purely by registry hostname.

## Binary removal

Removes a 42MB build-artifact binary (`push-index`) that had been accidentally
committed to the repository root.

## Verification

- `go build ./...` passes
- `go test ./pkg/catalog/... ./pkg/cmd/scafctl/catalog/...` passes
- `task lint:changed` reports no new issues
- grep confirms zero remaining internal references