### PR TITLE
fix(run): emit structured failure envelope on json/yaml output

### DIFF
--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -110,6 +110,14 @@ ACTION SELECTION:
 
 `+ResolverParametersHelp+`
 
+FAILURE OUTPUT (json/yaml):
+  On failure the structured output still emits a parseable document so callers
+  piping to jq/yq can detect and inspect the failure programmatically instead of
+  receiving empty stdout. Setup and resolver-phase failures emit a
+  {status: "failed", diagnostics: [...]} envelope; an action-execution failure
+  emits the full action result envelope (status: "failed" with per-action error
+  detail). Human formats (table/quiet) keep the prior stderr-only behavior.
+
 EXIT CODES:
   0  Success
   1  Resolver execution failed
@@ -417,7 +425,7 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 	start := time.Now()
 	resolverData, resolverCtx, err := o.executeResolvers(ctx, sol, resolvers, params, reg, withSeededResults(stateSeed))
 	if err != nil {
-		return o.exitWithCode(ctx, err, exitcode.GeneralError)
+		return o.failStructured(ctx, err, exitcode.GeneralError)
 	}
 	resolverElapsed := time.Since(start)
 
@@ -471,6 +479,21 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 
 	result, err := actionExecutor.Execute(actionCtx, workflow)
 	if err != nil && result != nil && result.FinalStatus != action.ExecutionPartialSuccess {
+		// An action failed hard. In structured output emit the full action
+		// envelope (status:"failed", per-action error, failedActions) before
+		// returning the non-zero exit so stdout stays parseable.
+		if o.isStructuredOutput() {
+			var executionData map[string]any
+			if o.ShowExecution {
+				executionData = resolverExecutionData
+			}
+			if writeErr := o.writeActionOutput(ctx, result, executionData); writeErr == nil {
+				if w := writer.FromContext(ctx); w != nil {
+					w.WarnStderrf("action execution failed: %v", err)
+				}
+				return exitcode.WithCode(fmt.Errorf("action execution failed: %w", err), exitcode.ActionFailed)
+			}
+		}
 		return o.exitWithCode(ctx, fmt.Errorf("action execution failed: %w", err), exitcode.ActionFailed)
 	}
 
@@ -497,6 +520,18 @@ func (o *ActionOptions) exitWithCode(ctx context.Context, err error, code int) e
 		w.Error(err.Error())
 	}
 	return exitcode.WithCode(err, code)
+}
+
+// failStructured delegates to SolutionOptions.failStructured so setup and
+// resolver-phase failures emit a parseable {status, diagnostics} document in
+// json/yaml instead of an empty stdout.
+func (o *ActionOptions) failStructured(ctx context.Context, err error, code int) error {
+	s := &SolutionOptions{
+		sharedResolverOptions: o.sharedResolverOptions,
+		Verbose:               o.Verbose,
+		ShowExecution:         o.ShowExecution,
+	}
+	return s.failStructured(ctx, err, code)
 }
 
 // executeDryRun delegates to SolutionOptions.executeDryRun which runs

--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -489,7 +489,7 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 			}
 			if writeErr := o.writeActionOutput(ctx, result, executionData); writeErr == nil {
 				if w := writer.FromContext(ctx); w != nil {
-					w.WarnStderrf("action execution failed: %v", err)
+					w.Errorf("action execution failed: %v", err)
 				}
 				return exitcode.WithCode(fmt.Errorf("action execution failed: %w", err), exitcode.ActionFailed)
 			}

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -296,15 +296,21 @@ func (o *sharedResolverOptions) exitWithCode(ctx context.Context, err error, cod
 }
 
 // isStructuredOutput reports whether the selected output format is a
-// machine-readable format (json/yaml/...) for which failures should still emit
-// a parseable document on stdout rather than an empty stdout with a stderr-only
-// error.
+// machine-readable format for which failures should still emit a parseable
+// document on stdout rather than an empty stdout with a stderr-only error.
+//
+// The structured failure contract is deliberately scoped to json and yaml only
+// (matching the command help text and MCP docs). It intentionally excludes the
+// other "structured" kvx formats (csv/toml/mermaid): the solution/action
+// envelope serializer only supports json/yaml, and injecting the resolver
+// failure keys into csv/toml/mermaid would change those formats' output shape
+// in a way the documented contract does not describe.
 func (o *sharedResolverOptions) isStructuredOutput() bool {
 	format, ok := kvx.ParseOutputFormat(o.Output)
 	if !ok {
 		return false
 	}
-	return kvx.IsStructuredFormat(format)
+	return format == kvx.OutputFormatJSON || format == kvx.OutputFormatYAML
 }
 
 // buildResolverOutputMap builds the output map from resolver data with format-aware redaction for sensitive values.

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -295,6 +295,18 @@ func (o *sharedResolverOptions) exitWithCode(ctx context.Context, err error, cod
 	return exitcode.WithCode(err, code)
 }
 
+// isStructuredOutput reports whether the selected output format is a
+// machine-readable format (json/yaml/...) for which failures should still emit
+// a parseable document on stdout rather than an empty stdout with a stderr-only
+// error.
+func (o *sharedResolverOptions) isStructuredOutput() bool {
+	format, ok := kvx.ParseOutputFormat(o.Output)
+	if !ok {
+		return false
+	}
+	return kvx.IsStructuredFormat(format)
+}
+
 // buildResolverOutputMap builds the output map from resolver data with format-aware redaction for sensitive values.
 // Sensitive values are redacted in table/interactive output (human-facing) but revealed in structured
 // output formats (json, yaml) since those are typically used for machine consumption.

--- a/pkg/cmd/scafctl/run/failure_envelope_cli_test.go
+++ b/pkg/cmd/scafctl/run/failure_envelope_cli_test.go
@@ -1,0 +1,379 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/celprovider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/staticprovider"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution/execute"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// solutionWithFailingResolver hard-fails during the transform phase at runtime:
+// int("hello") is a valid CEL expression that passes load-time validation but
+// errors when evaluated, so the failure occurs at the resolver-execution site
+// (not at solution load). It includes a workflow so the failure is not masked by
+// the "no workflow defined" guard.
+const solutionWithFailingResolver = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: failing-resolver-envelope
+  version: 1.0.0
+spec:
+  resolvers:
+    broken:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'int(__self)'
+  workflow:
+    actions:
+      greet:
+        provider: static
+        inputs:
+          value: world
+`
+
+// testRegistryWithCel returns a registry with the static and cel providers,
+// used to exercise runtime transform failures.
+func testRegistryWithCel(t *testing.T) *provider.Registry {
+	t.Helper()
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(staticprovider.New()))
+	require.NoError(t, reg.Register(celprovider.NewCelProvider()))
+	return reg
+}
+
+// TestResolverOptions_Run_ValidationFailure_StructuredEnvelope verifies that a
+// resolver validation failure attaches the reserved __status/__diagnostics keys
+// to the machine-readable stdout document so callers piping to jq can detect and
+// inspect the failure programmatically (issue: empty stdout on failure).
+func TestResolverOptions_Run_ValidationFailure_StructuredEnvelope(t *testing.T) {
+	t.Parallel()
+
+	for _, format := range []string{"json", "yaml"} {
+		format := format
+		t.Run(format, func(t *testing.T) {
+			t.Parallel()
+
+			solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+			require.NoError(t, os.WriteFile(solutionPath, []byte(failingValidationSolution), 0o600))
+
+			var stdout, stderr bytes.Buffer
+			opts := newResolverOptions(t, solutionPath, &stdout, &stderr)
+			opts.Output = format
+
+			ctx := logger.WithLogger(context.Background(), logger.Get(0))
+			err := opts.Run(ctx)
+
+			// Validation is non-fatal by default: exit 0, values still shown.
+			require.NoError(t, err)
+
+			decoded := decodeStructured(t, format, stdout.Bytes())
+			assert.Equal(t, execute.StatusFailed, decoded[execute.StatusKey],
+				"structured output must carry the reserved status key on failure")
+			diags, ok := decoded[execute.DiagnosticsKey].([]any)
+			require.True(t, ok, "structured output must carry the reserved diagnostics key")
+			assert.NotEmpty(t, diags, "diagnostics must not be empty on validation failure")
+			assert.Contains(t, stdout.String(), "Bob", "resolved values must still be present")
+		})
+	}
+}
+
+// TestResolverOptions_Run_ValidationFailure_TableUnchanged verifies that
+// non-structured output formats keep the prior stderr-only behavior and do not
+// inject the reserved envelope keys.
+func TestResolverOptions_Run_ValidationFailure_TableUnchanged(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(failingValidationSolution), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	opts := newResolverOptions(t, solutionPath, &stdout, &stderr)
+	opts.Output = "table"
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	require.NoError(t, opts.Run(ctx))
+
+	assert.NotContains(t, stdout.String(), execute.StatusKey,
+		"table output must not inject the reserved status key")
+	assert.NotContains(t, stdout.String(), execute.DiagnosticsKey,
+		"table output must not inject the reserved diagnostics key")
+	assert.Contains(t, stderr.String(), "failed validation",
+		"diagnostics must still be rendered to stderr")
+}
+
+// TestValidateResolver_Run_ValidationFailure_ExitNonZeroWithEnvelope verifies
+// that the gate mode (FailOnValidation) exits non-zero AND still emits the
+// structured failure envelope on stdout.
+func TestValidateResolver_Run_ValidationFailure_ExitNonZeroWithEnvelope(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(failingValidationSolution), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	opts := newResolverOptions(t, solutionPath, &stdout, &stderr)
+	opts.FailOnValidation = true
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	err := opts.Run(ctx)
+
+	require.Error(t, err, "gate mode must exit non-zero on validation failure")
+	decoded := decodeStructured(t, "json", stdout.Bytes())
+	assert.Equal(t, execute.StatusFailed, decoded[execute.StatusKey])
+	assert.NotEmpty(t, decoded[execute.DiagnosticsKey])
+}
+
+// TestSolutionOptions_Run_ResolverFailure_StructuredEnvelope verifies that a
+// hard resolver failure during `run solution` emits a parseable
+// {status, diagnostics} document on stdout instead of an empty stdout.
+func TestSolutionOptions_Run_ResolverFailure_StructuredEnvelope(t *testing.T) {
+	t.Parallel()
+
+	for _, format := range []string{"json", "yaml"} {
+		format := format
+		t.Run(format, func(t *testing.T) {
+			t.Parallel()
+
+			solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+			require.NoError(t, os.WriteFile(solutionPath, []byte(solutionWithFailingResolver), 0o600))
+
+			var stdout, stderr bytes.Buffer
+			streams := &terminal.IOStreams{In: nil, Out: &stdout, ErrOut: &stderr}
+			cliParams := settings.NewCliParams()
+			cliParams.ExitOnError = false
+
+			opts := &SolutionOptions{
+				sharedResolverOptions: sharedResolverOptions{
+					IOStreams:       streams,
+					CliParams:       cliParams,
+					File:            solutionPath,
+					KvxOutputFlags:  flags.KvxOutputFlags{Output: format},
+					ResolverTimeout: 30 * time.Second,
+					PhaseTimeout:    5 * time.Minute,
+					registry:        testRegistryWithCel(t),
+				},
+			}
+
+			ctx := logger.WithLogger(context.Background(), logger.Get(0))
+			ctx = writer.WithWriter(ctx, writer.New(streams, cliParams))
+			err := opts.Run(ctx)
+
+			require.Error(t, err, "a hard resolver failure must exit non-zero")
+			decoded := decodeStructured(t, format, stdout.Bytes())
+			assert.Equal(t, execute.StatusFailed, decoded[execute.StatusFieldKey],
+				"solution failure envelope must carry the status field")
+			assert.NotEmpty(t, decoded[execute.DiagnosticsFieldKey],
+				"solution failure envelope must carry diagnostics")
+			assert.NotEmpty(t, stderr.String(), "a human-readable error must still reach stderr")
+		})
+	}
+}
+
+// TestSolutionOptions_Run_ResolverFailure_TableUnchanged verifies the human
+// output path is unaffected by the structured envelope feature.
+func TestSolutionOptions_Run_ResolverFailure_TableUnchanged(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(solutionWithFailingResolver), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{In: nil, Out: &stdout, ErrOut: &stderr}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &SolutionOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "table"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistryWithCel(t),
+		},
+	}
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = writer.WithWriter(ctx, writer.New(streams, cliParams))
+	err := opts.Run(ctx)
+
+	require.Error(t, err)
+	assert.NotContains(t, stdout.String(), execute.DiagnosticsFieldKey,
+		"table output must not emit a structured failure envelope on stdout")
+}
+
+// TestSolutionOptions_Run_ResolverFailure_UnsupportedStructuredFormatFallsBack
+// verifies that a structured format the solution/action envelope cannot
+// serialize (csv/toml/mermaid -- only json/yaml are supported) falls back to the
+// stderr-only error path instead of emitting an empty stdout document.
+func TestSolutionOptions_Run_ResolverFailure_UnsupportedStructuredFormatFallsBack(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(solutionWithFailingResolver), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{In: nil, Out: &stdout, ErrOut: &stderr}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &SolutionOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: "csv"},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistryWithCel(t),
+		},
+	}
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = writer.WithWriter(ctx, writer.New(streams, cliParams))
+	err := opts.Run(ctx)
+
+	require.Error(t, err, "an unsupported structured format must still exit non-zero")
+	assert.Empty(t, bytes.TrimSpace(stdout.Bytes()),
+		"unsupported structured format must not emit a blank/partial stdout document")
+	assert.NotEmpty(t, stderr.String(), "the error must reach stderr")
+}
+
+// TestActionOptions_Run_ResolverFailure_StructuredEnvelope verifies the same
+// failure-envelope behavior for `run action`.
+func TestActionOptions_Run_ResolverFailure_StructuredEnvelope(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(solutionWithFailingResolver), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	streams := &terminal.IOStreams{In: nil, Out: &stdout, ErrOut: &stderr}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	opts := &ActionOptions{}
+	opts.IOStreams = streams
+	opts.CliParams = cliParams
+	opts.File = solutionPath
+	opts.Output = "json"
+	opts.ResolverTimeout = 30 * time.Second
+	opts.PhaseTimeout = 5 * time.Minute
+	opts.registry = testRegistryWithCel(t)
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = writer.WithWriter(ctx, writer.New(streams, cliParams))
+	err := opts.Run(ctx)
+
+	require.Error(t, err, "a hard resolver failure must exit non-zero")
+	decoded := decodeStructured(t, "json", stdout.Bytes())
+	assert.Equal(t, execute.StatusFailed, decoded[execute.StatusFieldKey])
+	assert.NotEmpty(t, decoded[execute.DiagnosticsFieldKey])
+}
+
+// sizeLimitSolution resolves a value that is small but larger than the byte
+// limit used by the value-size tests below.
+const sizeLimitSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: value-size-envelope
+  version: 1.0.0
+spec:
+  resolvers:
+    big:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: this-value-exceeds-the-limit
+`
+
+// TestResolverOptions_Run_ValueSizeFailure_StructuredEnvelope covers the
+// value-size failure branch of failStructured: the resolved values plus the
+// reserved __status/__diagnostics keys are emitted on stdout.
+func TestResolverOptions_Run_ValueSizeFailure_StructuredEnvelope(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(sizeLimitSolution), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	opts := newResolverOptions(t, solutionPath, &stdout, &stderr)
+	opts.MaxValueSize = 4 // bytes — forces checkValueSizes to fail
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	err := opts.Run(ctx)
+
+	require.Error(t, err, "exceeding max-value-size must exit non-zero")
+	decoded := decodeStructured(t, "json", stdout.Bytes())
+	assert.Equal(t, execute.StatusFailed, decoded[execute.StatusKey])
+	assert.NotEmpty(t, decoded[execute.DiagnosticsKey])
+}
+
+// TestResolverOptions_Run_ValueSizeFailure_TableUnchanged covers the
+// non-structured branch of failStructured: table output keeps the stderr-only
+// error behavior and does not inject the reserved keys.
+func TestResolverOptions_Run_ValueSizeFailure_TableUnchanged(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(sizeLimitSolution), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	opts := newResolverOptions(t, solutionPath, &stdout, &stderr)
+	opts.Output = "table"
+	opts.MaxValueSize = 4
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	err := opts.Run(ctx)
+
+	require.Error(t, err)
+	assert.NotContains(t, stdout.String(), execute.DiagnosticsKey,
+		"table output must not inject the reserved diagnostics key")
+	assert.NotContains(t, stdout.String(), execute.StatusKey,
+		"table output must not inject the reserved status key")
+}
+
+// decodeStructured parses JSON or YAML structured output into a map for
+// assertions. It fails the test if the payload is empty or unparseable, which is
+// the exact regression this feature guards against.
+func decodeStructured(t *testing.T, format string, data []byte) map[string]any {
+	t.Helper()
+	require.NotEmpty(t, bytes.TrimSpace(data), "structured output must not be empty on failure")
+
+	out := map[string]any{}
+	switch format {
+	case "yaml":
+		require.NoError(t, yaml.Unmarshal(data, &out))
+	default:
+		require.NoError(t, json.Unmarshal(data, &out))
+	}
+	return out
+}

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -847,7 +847,7 @@ func (o *ResolverOptions) failStructured(ctx context.Context, results map[string
 		return o.exitWithCode(ctx, err, code)
 	}
 	if w := writer.FromContext(ctx); w != nil {
-		w.WarnStderrf("%v", err)
+		w.Errorf("%v", err)
 	}
 	return exitcode.WithCode(err, code)
 }

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -172,6 +172,14 @@ OUTPUT FORMATS:
   yaml     YAML output (for piping/scripting)
   quiet    Suppress output (exit code only)
 
+FAILURE OUTPUT (json/yaml):
+  On a run failure the structured output still emits a parseable document so
+  callers piping to jq/yq can detect and inspect the failure programmatically
+  instead of receiving empty stdout. The resolved values map gains two reserved
+  keys: "__status": "failed" and "__diagnostics" (a list of {resolver, phase,
+  message}). Successful runs never include these keys. Human formats
+  (table/quiet) keep the prior stderr-only error behavior.
+
 EXIT CODES:
   0  Success
   1  Resolver execution failed
@@ -658,8 +666,10 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 	resolverData, resolverCtx, execErr := o.executeResolvers(ctx, sol, resolvers, params, reg, withSeededResults(stateSeed))
 	if execErr != nil && resolverCtx == nil {
 		// A hard failure occurred before any values could be produced
-		// (e.g., phase build error). Abort with the error.
-		return o.exitWithCode(ctx, execErr, exitcode.GeneralError)
+		// (e.g., phase build error). Emit a structured failure envelope in
+		// json/yaml so stdout stays parseable; otherwise abort with a
+		// stderr-only error.
+		return o.failStructured(ctx, nil, execErr, exitcode.GeneralError)
 	}
 
 	elapsed := time.Since(start)
@@ -677,7 +687,7 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 	// Build output and write
 	results := o.buildResolverOutputMap(resolverData, sol)
 	if err := o.checkValueSizes(results, *lgr); err != nil {
-		return o.exitWithCode(ctx, err, exitcode.ValidationFailed)
+		return o.failStructured(ctx, results, err, exitcode.ValidationFailed)
 	}
 
 	// Include __execution metadata only when --show-execution is set
@@ -716,6 +726,13 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 	// (on stdout) remain useful for troubleshooting and machine consumption.
 	if execErr != nil {
 		o.renderValidationDiagnostics(ctx, execErr)
+		// In structured output (json/yaml), also attach the failure envelope
+		// (__status/__diagnostics) to the stdout document so machine consumers
+		// can detect and inspect the validation failure programmatically, not
+		// just via exit code + stderr.
+		if o.isStructuredOutput() {
+			results = execute.InjectResolverFailureEnvelope(results, execErr)
+		}
 	}
 
 	// When -o test: generate a functional test definition instead of normal output.
@@ -811,6 +828,28 @@ func (o *ResolverOptions) runLintGate(ctx context.Context, sol *solution.Solutio
 	}
 
 	return nil
+}
+
+// failStructured renders a resolver-run failure so that machine-readable output
+// formats (json/yaml) still emit a parseable document on stdout instead of an
+// empty stdout with a stderr-only error. In structured mode it attaches a
+// failure envelope (__status/__diagnostics) to the (possibly nil or partial)
+// results map, writes it to stdout, emits a one-line human error to stderr, and
+// returns the coded error. For human formats (table/quiet/interactive) it falls
+// back to the stderr-only exitWithCode behavior.
+func (o *ResolverOptions) failStructured(ctx context.Context, results map[string]any, err error, code int) error {
+	if !o.isStructuredOutput() {
+		return o.exitWithCode(ctx, err, code)
+	}
+	results = execute.InjectResolverFailureEnvelope(results, err)
+	if writeErr := o.writeResolverOutput(ctx, results, o.BinaryName+" run resolver"); writeErr != nil {
+		// Fall back to the stderr-only path if the structured write itself fails.
+		return o.exitWithCode(ctx, err, code)
+	}
+	if w := writer.FromContext(ctx); w != nil {
+		w.WarnStderrf("%v", err)
+	}
+	return exitcode.WithCode(err, code)
 }
 
 // renderValidationDiagnostics writes a human-readable summary of resolver

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -145,6 +145,14 @@ OUTPUT FORMATS:
   yaml     YAML output (for piping/scripting)
   quiet    Suppress output (exit code only)
 
+FAILURE OUTPUT (json/yaml):
+  On failure the structured output still emits a parseable document so callers
+  piping to jq/yq can detect and inspect the failure programmatically instead of
+  receiving empty stdout. Setup and resolver-phase failures emit a
+  {status: "failed", diagnostics: [...]} envelope; an action-execution failure
+  emits the full action result envelope (status: "failed" with per-action error
+  detail). Human formats (table/quiet) keep the prior stderr-only behavior.
+
 INTERACTIVE MODE:
   Use -i/--interactive to launch a TUI for exploring results:
   - Navigate with arrow keys
@@ -534,7 +542,7 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 
 	resolverData, resolverCtx, err := o.executeResolvers(ctx, sol, resolvers, params, reg, withSeededResults(stateSeed))
 	if err != nil {
-		return o.exitWithCode(ctx, err, exitcode.GeneralError)
+		return o.failStructured(ctx, err, exitcode.GeneralError)
 	}
 
 	resolverElapsed := time.Since(start)
@@ -597,6 +605,21 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 
 	result, err := actionExecutor.Execute(actionCtx, workflow)
 	if err != nil && result != nil && result.FinalStatus != action.ExecutionPartialSuccess {
+		// An action failed hard. In structured output the full action envelope
+		// (status:"failed", per-action error, failedActions) is far more useful
+		// than an empty stdout, so emit it before returning the non-zero exit.
+		if o.isStructuredOutput() {
+			var executionData map[string]any
+			if o.ShowExecution {
+				executionData = resolverExecutionData
+			}
+			if writeErr := o.writeActionOutput(ctx, result, executionData); writeErr == nil {
+				if w := writer.FromContext(ctx); w != nil {
+					w.WarnStderrf("action execution failed: %v", err)
+				}
+				return exitcode.WithCode(fmt.Errorf("action execution failed: %w", err), exitcode.ActionFailed)
+			}
+		}
 		return o.exitWithCode(ctx, fmt.Errorf("action execution failed: %w", err), exitcode.ActionFailed)
 	}
 
@@ -891,7 +914,15 @@ func (o *SolutionOptions) writeVerboseActionStatus(w *writer.Writer, name string
 // writeActionOutputStructured writes action results as JSON or YAML (the full execution envelope).
 func (o *SolutionOptions) writeActionOutputStructured(ctx context.Context, result *action.ExecutionResult, executionData map[string]any, format string) error {
 	outputData := action.BuildOutputData(result, executionData)
+	return o.writeStructuredData(ctx, outputData, format)
+}
 
+// writeStructuredData marshals a structured map to JSON or YAML and writes it to
+// stdout. It is the shared serialization path for both the success envelope and
+// the failure envelope, so both honour the same format handling. Only json and
+// yaml are supported (matching writeActionOutput's dispatch); any other format
+// returns an error so callers can fall back rather than emit an empty document.
+func (o *SolutionOptions) writeStructuredData(ctx context.Context, outputData map[string]any, format string) error {
 	var data []byte
 	var marshalErr error
 
@@ -900,6 +931,8 @@ func (o *SolutionOptions) writeActionOutputStructured(ctx context.Context, resul
 		data, marshalErr = yaml.Marshal(outputData)
 	case "json":
 		data, marshalErr = json.MarshalIndent(outputData, "", "  ")
+	default:
+		return fmt.Errorf("unsupported output format: %s", format)
 	}
 
 	if marshalErr != nil {
@@ -910,6 +943,27 @@ func (o *SolutionOptions) writeActionOutputStructured(ctx context.Context, resul
 		w.Plainln(string(data))
 	}
 	return nil
+}
+
+// failStructured renders a solution/action failure so that machine-readable
+// output formats (json/yaml) still emit a parseable {status, diagnostics}
+// document on stdout instead of an empty stdout with a stderr-only error. It is
+// used for setup and resolver-phase failures that occur before an action
+// ExecutionResult exists; action-execution failures instead emit the full
+// action envelope via writeActionOutput. For human formats (table/quiet) it
+// falls back to the stderr-only exitWithCode behavior.
+func (o *SolutionOptions) failStructured(ctx context.Context, err error, code int) error {
+	if !o.isStructuredOutput() {
+		return o.exitWithCode(ctx, err, code)
+	}
+	envelope := execute.BuildFailureEnvelope(err)
+	if writeErr := o.writeStructuredData(ctx, envelope, o.Output); writeErr != nil {
+		return o.exitWithCode(ctx, err, code)
+	}
+	if w := writer.FromContext(ctx); w != nil {
+		w.WarnStderrf("%v", err)
+	}
+	return exitcode.WithCode(err, code)
 }
 
 // writeActionTestOutput generates a functional test definition from the action execution

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -615,7 +615,7 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 			}
 			if writeErr := o.writeActionOutput(ctx, result, executionData); writeErr == nil {
 				if w := writer.FromContext(ctx); w != nil {
-					w.WarnStderrf("action execution failed: %v", err)
+					w.Errorf("action execution failed: %v", err)
 				}
 				return exitcode.WithCode(fmt.Errorf("action execution failed: %w", err), exitcode.ActionFailed)
 			}
@@ -961,7 +961,7 @@ func (o *SolutionOptions) failStructured(ctx context.Context, err error, code in
 		return o.exitWithCode(ctx, err, code)
 	}
 	if w := writer.FromContext(ctx); w != nil {
-		w.WarnStderrf("%v", err)
+		w.Errorf("%v", err)
 	}
 	return exitcode.WithCode(err, code)
 }

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -393,6 +393,18 @@ Execution Metadata Flags:
     scafctl run resolver -f ./solution.yaml -o json --show-execution
     scafctl run solution -f ./solution.yaml --show-execution
 
+Structured Failure Output (json/yaml):
+  On failure, 'run resolver', 'run solution', and 'run action' still write a
+  parseable document to stdout (never empty stdout) so pipelines using jq/yq can
+  detect and inspect failures programmatically:
+    run resolver -- the values map gains reserved keys '__status': "failed" and
+      '__diagnostics' (list of {resolver, phase, message}). Successful runs omit
+      these keys.
+    run solution / run action -- setup and resolver-phase failures emit a
+      {status: "failed", diagnostics: [...]} envelope; an action-execution
+      failure emits the full action result envelope (per-action error detail).
+  Human formats (table/quiet) keep the prior stderr-only error behavior.
+
 CEL Context Variables (available in resolver conditions, inputs, and action when/inputs):
   _            Map of resolved resolver values (e.g., _.environment, _.config.port)
   __plan       Pre-execution resolver topology (available in resolvers, populated before any resolver runs):

--- a/pkg/solution/execute/execute.go
+++ b/pkg/solution/execute/execute.go
@@ -178,6 +178,66 @@ func DiagnosticsFromError(err error) []ResolverDiagnostic {
 	return []ResolverDiagnostic{{Message: err.Error()}}
 }
 
+// Reserved output keys and status values used to surface a structured failure
+// envelope in machine-readable output formats (json/yaml). The DiagnosticsKey
+// and StatusKey are double-underscore-prefixed so they never collide with a
+// user-defined resolver name in the resolver output map, mirroring the existing
+// __execution convention.
+const (
+	// DiagnosticsKey is the reserved key under which a []ResolverDiagnostic list
+	// is attached to the resolver output map on failure.
+	DiagnosticsKey = "__diagnostics"
+
+	// StatusKey is the reserved key under which the run status ("failed") is
+	// attached to the resolver output map on failure.
+	StatusKey = "__status"
+
+	// StatusFieldKey is the plain (non-underscore) status key used by the
+	// action/solution failure envelope, matching action.BuildOutputData's
+	// "status" field.
+	StatusFieldKey = "status"
+
+	// DiagnosticsFieldKey is the plain (non-underscore) diagnostics key used by
+	// the action/solution failure envelope, matching its sibling keys
+	// ("failedActions", "skippedActions").
+	DiagnosticsFieldKey = "diagnostics"
+
+	// StatusFailed is the status value written when a run fails.
+	StatusFailed = "failed"
+)
+
+// InjectResolverFailureEnvelope attaches a structured failure envelope to a
+// resolver output map so machine-readable output (json/yaml) remains parseable
+// even when the run fails. It sets StatusKey to StatusFailed and DiagnosticsKey
+// to the structured diagnostics derived from err. A nil results map is created;
+// a nil err is a no-op (the map is returned unchanged). Existing resolved values
+// in the map are preserved so partial results stay inspectable.
+func InjectResolverFailureEnvelope(results map[string]any, err error) map[string]any {
+	if err == nil {
+		return results
+	}
+	if results == nil {
+		results = make(map[string]any)
+	}
+	results[StatusKey] = StatusFailed
+	results[DiagnosticsKey] = DiagnosticsFromError(err)
+	return results
+}
+
+// BuildFailureEnvelope builds a standalone structured failure envelope for
+// commands whose output is a fixed-schema map (run solution / run action) rather
+// than a bare resolver map. It returns {status: "failed", diagnostics: [...]}
+// keyed to match action.BuildOutputData. Returns nil when err is nil.
+func BuildFailureEnvelope(err error) map[string]any {
+	if err == nil {
+		return nil
+	}
+	return map[string]any{
+		StatusFieldKey:      StatusFailed,
+		DiagnosticsFieldKey: DiagnosticsFromError(err),
+	}
+}
+
 // isValidationFailure reports whether a single resolver failure originated from
 // the validate phase. Resolve- and transform-phase failures (where no value
 // could be produced) return false so callers keep treating them as fatal.

--- a/pkg/solution/execute/failure_envelope_test.go
+++ b/pkg/solution/execute/failure_envelope_test.go
@@ -1,0 +1,54 @@
+package execute
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInjectResolverFailureEnvelope(t *testing.T) {
+	t.Run("nil error is a no-op", func(t *testing.T) {
+		results := map[string]any{"a": 1}
+		got := InjectResolverFailureEnvelope(results, nil)
+		assert.Equal(t, map[string]any{"a": 1}, got)
+		assert.NotContains(t, got, StatusKey)
+		assert.NotContains(t, got, DiagnosticsKey)
+	})
+
+	t.Run("nil map is created", func(t *testing.T) {
+		got := InjectResolverFailureEnvelope(nil, errors.New("boom"))
+		require.NotNil(t, got)
+		assert.Equal(t, StatusFailed, got[StatusKey])
+		diags, ok := got[DiagnosticsKey].([]ResolverDiagnostic)
+		require.True(t, ok)
+		require.Len(t, diags, 1)
+		assert.Equal(t, "boom", diags[0].Message)
+	})
+
+	t.Run("preserves existing values", func(t *testing.T) {
+		results := map[string]any{"resolverA": "value", "resolverB": 42}
+		got := InjectResolverFailureEnvelope(results, errors.New("failed"))
+		assert.Equal(t, "value", got["resolverA"])
+		assert.Equal(t, 42, got["resolverB"])
+		assert.Equal(t, StatusFailed, got[StatusKey])
+		assert.Contains(t, got, DiagnosticsKey)
+	})
+}
+
+func TestBuildFailureEnvelope(t *testing.T) {
+	t.Run("nil error returns nil", func(t *testing.T) {
+		assert.Nil(t, BuildFailureEnvelope(nil))
+	})
+
+	t.Run("builds status and diagnostics", func(t *testing.T) {
+		got := BuildFailureEnvelope(errors.New("kaboom"))
+		require.NotNil(t, got)
+		assert.Equal(t, StatusFailed, got[StatusFieldKey])
+		diags, ok := got[DiagnosticsFieldKey].([]ResolverDiagnostic)
+		require.True(t, ok)
+		require.Len(t, diags, 1)
+		assert.Equal(t, "kaboom", diags[0].Message)
+	})
+}

--- a/pkg/solution/execute/failure_envelope_test.go
+++ b/pkg/solution/execute/failure_envelope_test.go
@@ -1,3 +1,6 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
 package execute
 
 import (

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1224,6 +1224,109 @@ func TestIntegration_RunSolution_NoWorkflowErrors(t *testing.T) {
 	assert.Contains(t, stderr, "scafctl run resolver")
 }
 
+// failureEnvelopeSolution hard-fails at the transform phase at runtime:
+// int("hello") passes load-time validation but errors when evaluated. It carries
+// a workflow so `run solution`/`run action` reach the resolver-execution site.
+const failureEnvelopeSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: failure-envelope-integration
+  version: 1.0.0
+spec:
+  resolvers:
+    broken:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'int(__self)'
+  workflow:
+    actions:
+      greet:
+        provider: message
+        inputs:
+          message: "SHOULD_NOT_RUN"
+          type: info
+`
+
+// TestIntegration_RunResolver_FailureEnvelope_JSON verifies that a resolver
+// failure still writes a parseable JSON document (with the reserved
+// __status/__diagnostics keys) to stdout instead of empty stdout, so scripts
+// piping to jq keep working on failure.
+func TestIntegration_RunResolver_FailureEnvelope_JSON(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(failureEnvelopeSolution), 0o600))
+
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "resolver", "-f", solutionPath, "-o", "json",
+	)
+
+	t.Logf("stderr: %s", stderr)
+	assert.NotEqual(t, 0, exitCode, "resolver failure must exit non-zero")
+	require.NotEmpty(t, strings.TrimSpace(stdout), "stdout must not be empty on failure")
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &decoded), "stdout must be valid JSON")
+	assert.Equal(t, "failed", decoded["__status"])
+	assert.NotEmpty(t, decoded["__diagnostics"])
+}
+
+// TestIntegration_RunSolution_FailureEnvelope_JSON verifies the same guarantee
+// for `run solution`: a resolver-phase failure emits a {status, diagnostics}
+// document on stdout.
+func TestIntegration_RunSolution_FailureEnvelope_JSON(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(failureEnvelopeSolution), 0o600))
+
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "solution", "-f", solutionPath, "-o", "json",
+	)
+
+	t.Logf("stderr: %s", stderr)
+	assert.NotEqual(t, 0, exitCode, "solution resolver failure must exit non-zero")
+	require.NotEmpty(t, strings.TrimSpace(stdout), "stdout must not be empty on failure")
+	assert.NotContains(t, stdout, "SHOULD_NOT_RUN", "actions must not run when resolvers fail")
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &decoded), "stdout must be valid JSON")
+	assert.Equal(t, "failed", decoded["status"])
+	assert.NotEmpty(t, decoded["diagnostics"])
+}
+
+// TestIntegration_RunAction_FailureEnvelope_JSON verifies the same guarantee for
+// `run action`.
+func TestIntegration_RunAction_FailureEnvelope_JSON(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(failureEnvelopeSolution), 0o600))
+
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "action", "greet", "-f", solutionPath, "-o", "json",
+	)
+
+	t.Logf("stderr: %s", stderr)
+	assert.NotEqual(t, 0, exitCode, "action resolver failure must exit non-zero")
+	require.NotEmpty(t, strings.TrimSpace(stdout), "stdout must not be empty on failure")
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &decoded), "stdout must be valid JSON")
+	assert.Equal(t, "failed", decoded["status"])
+	assert.NotEmpty(t, decoded["diagnostics"])
+}
+
 // TestIntegration_RunSolution_DeferredValidationImmutableNotLocked verifies the
 // two-phase validation D1 guarantee: when a deferred (cross-resolver) validation
 // rule fails on an immutable resolver, execution stops before actions run and


### PR DESCRIPTION
## Problem

`scafctl run resolver -o json` (and `run solution` / `run action`) wrote nothing
to stdout when a run failed -- the error went only to stderr. Scripts piping
structured output to `jq`/`yq` received an empty document and could not
programmatically inspect *which* resolver/action failed or *why*.

## Change

For structured output formats (`json`/`yaml`), the three `run` commands now
always emit a parseable document on stdout, even on failure. stderr still carries
a one-line human-readable error. Non-structured formats (table/quiet/interactive)
keep their prior stderr-only behavior.

- **`run resolver`**: the bare resolver map gains reserved `__status: "failed"`
  and `__diagnostics: [{resolver, phase, message}]` keys on failure -- mirroring
  the existing `__execution` reserved-key convention and avoiding collisions with
  resolver names. Covers hard failures, value-size failures, and validation
  failures. `validate resolver` (gate mode) emits the same envelope with a
  non-zero exit.
- **`run solution` / `run action`**: emit a fixed-schema `{status, diagnostics}`
  envelope for setup/resolver-phase failures (matching `action.BuildOutputData`),
  and the full action envelope for action-execution failures.

Domain helpers `InjectResolverFailureEnvelope` and `BuildFailureEnvelope` live in
`pkg/solution/execute` and reuse the existing `DiagnosticsFromError`.

## Non-breaking

Success output is unchanged -- the reserved/envelope keys appear only on failure.
Exit codes are unchanged: failures still exit non-zero; partial-success exit-code
semantics are intentionally left as-is (tracked in #720).

Unsupported structured formats for `run solution`/`run action` (csv/toml/mermaid,
which the success path also does not serialize) fall back to the stderr-only
error path rather than emitting a blank document.

## Tests & docs

- Unit tests for the `execute` helpers and CLI-level failure paths (json + yaml,
  table-unchanged, value-size, validation, unsupported-format fallback).
- Integration tests for `run resolver` / `run solution` / `run action` asserting
  non-zero exit, non-empty valid-JSON stdout, and that no post-failure workflow
  action ran.
- Help text updated on all three commands; MCP `server.go` documents the
  structured failure contract.
