### PR TITLE
feat: add --on-unknown-resolver policy for unknown -r keys

### DIFF
--- a/docs/tutorials/state-tutorial.md
+++ b/docs/tutorials/state-tutorial.md
@@ -252,7 +252,7 @@ After the third run, the state file contains:
 - `team` was added as a new key.
 
 > [!NOTE]
-> Only parameters that correspond to a declared resolver with `provider: parameter` are accepted. Passing an unknown key (e.g., `-r foo=bar` when no resolver uses `key: "foo"`) produces an error.
+> Only parameters that correspond to a declared resolver with `provider: parameter` are accepted. Passing an unknown key (e.g., `-r foo=bar` when no resolver uses `key: "foo"`) produces an error by default. To relax this (for example, when reusing a shared parameter file across solutions), pass `--on-unknown-resolver=warn` to proceed with a warning, or `--on-unknown-resolver=ignore` to accept unknown keys silently. The default policy can also be set via the `resolver.onUnknownResolver` config field.
 
 ### Merge Rules
 

--- a/examples/config/full-config.yaml
+++ b/examples/config/full-config.yaml
@@ -270,6 +270,13 @@ resolver:
   # Default: false
   # validateAll: true
 
+  # Policy for -r/--resolver parameters whose key is not consumed by any
+  # declared parameter resolver: "error" rejects them, "warn" proceeds with a
+  # warning, "ignore" accepts them silently. Overridden by the
+  # --on-unknown-resolver CLI flag.
+  # Default: "error"
+  # onUnknownResolver: "warn"
+
 # =============================================================================
 # Action - Configuration for action execution
 # =============================================================================

--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -361,19 +361,10 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 
 	lgr.V(1).Info("parsed parameters", "count", len(params))
 
-	// Validate parameter keys
-	if len(params) > 0 {
-		solResolvers := sol.Spec.ResolversToSlice()
-		// Skip typo detection when a resolver reads every supplied parameter
-		// (all: true) -- any -r key is valid in that case.
-		if !resolversAcceptAllParameters(solResolvers) {
-			paramKeys := extractParameterKeys(solResolvers)
-			if len(paramKeys) > 0 {
-				if err := flags.ValidateInputKeys(params, paramKeys, "solution"); err != nil {
-					return o.exitWithCode(ctx, err, exitcode.InvalidInput)
-				}
-			}
-		}
+	// Validate parameter keys against parameter provider 'key' inputs (early
+	// typo detection), honoring the --on-unknown-resolver policy.
+	if err := o.validateResolverParams(ctx, sol, params); err != nil {
+		return o.exitWithCode(ctx, err, exitcode.InvalidInput)
 	}
 
 	// Inject CLI overrides into context

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -22,6 +22,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	inputflags "github.com/oakwood-commons/scafctl/pkg/flags"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -206,6 +207,13 @@ type sharedResolverOptions struct {
 	// locked, and no state is saved afterward. Resolvers that read the state
 	// provider fall back to their defaults. Intended for CI/offline runs.
 	NoState bool
+
+	// OnUnknownResolver controls how -r/--resolver parameters whose key is not
+	// consumed by any declared parameter resolver are handled: "error"
+	// (default) rejects them, "warn" proceeds with a warning, "ignore" accepts
+	// them silently. Empty resolves to the config default, then the built-in
+	// strict default. Set via the --on-unknown-resolver flag.
+	OnUnknownResolver string
 
 	// nonFatalValidation, when true, makes executeResolvers treat resolver
 	// validation-only failures as non-fatal: it returns the populated values
@@ -965,6 +973,7 @@ func addSharedResolverFlags(cCmd *cobra.Command, o *sharedResolverOptions) {
 	cCmd.Flags().BoolVar(&o.PreRelease, "pre-release", false, "Include pre-release versions when resolving latest from catalog")
 	cCmd.Flags().BoolVar(&o.Strict, "strict", false, "Disable auto-resolution of official providers; require explicit bundle.plugins declarations")
 	cCmd.Flags().BoolVar(&o.NoState, "no-state", false, "Skip the entire state lifecycle: do not load, verify immutables, or save state (for CI/offline runs)")
+	cCmd.Flags().StringVar(&o.OnUnknownResolver, "on-unknown-resolver", string(settings.DefaultUnknownResolverPolicy), "Policy for -r keys not consumed by any declared parameter: error (reject), warn (proceed with warning), or ignore (accept silently)")
 }
 
 // writeMetrics outputs provider execution metrics to stderr
@@ -1081,6 +1090,77 @@ func (o *sharedResolverOptions) handleStateLoadError(ctx context.Context, loadEr
 		return o.exitWithCode(ctx, err, exitcode.GeneralError)
 	}
 	return o.exitWithCode(ctx, fmt.Errorf("state load: %w", loadErr), exitcode.GeneralError)
+}
+
+// validateResolverParams enforces the effective unknown-resolver policy for the
+// supplied -r/--resolver parameters. It centralizes the typo-detection logic
+// shared by run resolver, run solution, and run action.
+//
+// The policy is resolved from --on-unknown-resolver, falling back to the
+// resolver config default and then the strict built-in default. An invalid flag
+// or config value is reported as an error regardless of whether any parameters
+// were supplied.
+//
+// When the policy permits (warn/ignore), unknown keys do not fail the command:
+// warn emits a stderr warning naming the keys, ignore is silent. The strict
+// default (error) returns the validation error unchanged.
+func (o *sharedResolverOptions) validateResolverParams(ctx context.Context, sol *solution.Solution, params map[string]any) error {
+	policy, err := o.effectiveUnknownResolverPolicy(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(params) == 0 {
+		return nil
+	}
+
+	resolvers := sol.Spec.ResolversToSlice()
+	// Skip typo detection when a resolver reads every supplied parameter
+	// (all: true) -- any -r key is valid in that case.
+	if resolversAcceptAllParameters(resolvers) {
+		return nil
+	}
+
+	paramKeys := extractParameterKeys(resolvers)
+	if len(paramKeys) == 0 {
+		return nil
+	}
+
+	verr := inputflags.ValidateInputKeys(params, paramKeys, "solution")
+	if verr == nil {
+		return nil
+	}
+
+	switch policy {
+	case settings.UnknownResolverIgnore:
+		return nil
+	case settings.UnknownResolverWarn:
+		if w := writer.FromContext(ctx); w != nil {
+			w.WarnStderrf("%v", verr)
+		}
+		return nil
+	case settings.UnknownResolverError:
+		return verr
+	}
+	// Unreachable: effectiveUnknownResolverPolicy only returns known policies.
+	return verr
+}
+
+// effectiveUnknownResolverPolicy resolves the unknown-resolver policy honoring
+// precedence: the --on-unknown-resolver flag overrides the resolver config
+// default, which overrides the strict built-in default. It returns an error if
+// the resolved value is not a recognized policy.
+func (o *sharedResolverOptions) effectiveUnknownResolverPolicy(ctx context.Context) (settings.UnknownResolverPolicy, error) {
+	raw := o.OnUnknownResolver
+	// When the flag was not explicitly set, defer to config. flagsChanged is
+	// nil outside the command-execution flow (e.g. unit tests), in which case
+	// the value on the options struct is authoritative.
+	if o.flagsChanged != nil && !o.flagsChanged["on-unknown-resolver"] {
+		if cfg := config.FromContext(ctx); cfg != nil && cfg.Resolver.OnUnknownResolver != "" {
+			raw = cfg.Resolver.OnUnknownResolver
+		}
+	}
+	return settings.ParseUnknownResolverPolicy(raw)
 }
 
 // extractParameterKeys collects the CLI parameter keys accepted by a set of resolvers.

--- a/pkg/cmd/scafctl/run/common_test.go
+++ b/pkg/cmd/scafctl/run/common_test.go
@@ -390,3 +390,147 @@ func TestWarnStateSkipped(t *testing.T) {
 		})
 	})
 }
+
+// paramResolverSolution builds a solution whose single resolver reads the
+// parameter provider under the given key.
+func paramResolverSolution(key string) *solution.Solution {
+	return &solution.Solution{
+		Spec: solution.Spec{
+			Resolvers: map[string]*resolver.Resolver{
+				key: {
+					Name: key,
+					Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+						{Provider: "parameter", Inputs: map[string]*resolver.ValueRef{
+							"key": {Literal: key},
+						}},
+					}},
+				},
+			},
+		},
+	}
+}
+
+func TestValidateResolverParams(t *testing.T) {
+	sol := paramResolverSolution("name")
+
+	newCtx := func() (context.Context, *bytes.Buffer) {
+		var buf bytes.Buffer
+		ioStreams := terminal.NewIOStreams(nil, &buf, &buf, false)
+		w := writer.New(ioStreams, settings.NewCliParams())
+		return writer.WithWriter(context.Background(), w), &buf
+	}
+
+	t.Run("known key passes regardless of policy", func(t *testing.T) {
+		for _, policy := range []string{"error", "warn", "ignore"} {
+			ctx, buf := newCtx()
+			opts := &sharedResolverOptions{OnUnknownResolver: policy}
+			err := opts.validateResolverParams(ctx, sol, map[string]any{"name": "x"})
+			require.NoError(t, err, "policy %s", policy)
+			assert.Empty(t, buf.String(), "policy %s should not warn on known key", policy)
+		}
+	})
+
+	t.Run("unknown key with error policy rejects", func(t *testing.T) {
+		ctx, _ := newCtx()
+		opts := &sharedResolverOptions{OnUnknownResolver: "error"}
+		err := opts.validateResolverParams(ctx, sol, map[string]any{"foo": "bar"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "foo")
+	})
+
+	t.Run("unknown key defaults to error when policy empty", func(t *testing.T) {
+		ctx, _ := newCtx()
+		opts := &sharedResolverOptions{}
+		err := opts.validateResolverParams(ctx, sol, map[string]any{"foo": "bar"})
+		require.Error(t, err)
+	})
+
+	t.Run("unknown key with warn policy proceeds and warns", func(t *testing.T) {
+		ctx, buf := newCtx()
+		opts := &sharedResolverOptions{OnUnknownResolver: "warn"}
+		err := opts.validateResolverParams(ctx, sol, map[string]any{"foo": "bar"})
+		require.NoError(t, err)
+		assert.Contains(t, buf.String(), "foo")
+	})
+
+	t.Run("unknown key with ignore policy is silent", func(t *testing.T) {
+		ctx, buf := newCtx()
+		opts := &sharedResolverOptions{OnUnknownResolver: "ignore"}
+		err := opts.validateResolverParams(ctx, sol, map[string]any{"foo": "bar"})
+		require.NoError(t, err)
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("invalid policy errors even without params", func(t *testing.T) {
+		ctx, _ := newCtx()
+		opts := &sharedResolverOptions{OnUnknownResolver: "loud"}
+		err := opts.validateResolverParams(ctx, sol, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "valid: error, warn, ignore")
+	})
+
+	t.Run("all-mode solution accepts any key", func(t *testing.T) {
+		ctx, _ := newCtx()
+		allSol := &solution.Solution{
+			Spec: solution.Spec{
+				Resolvers: map[string]*resolver.Resolver{
+					"params": {
+						Name: "params",
+						Resolve: &resolver.ResolvePhase{With: []resolver.ProviderSource{
+							{Provider: "parameter", Inputs: map[string]*resolver.ValueRef{
+								"all": {Literal: true},
+							}},
+						}},
+					},
+				},
+			},
+		}
+		opts := &sharedResolverOptions{OnUnknownResolver: "error"}
+		err := opts.validateResolverParams(ctx, allSol, map[string]any{"anything": "goes"})
+		require.NoError(t, err)
+	})
+}
+
+func TestEffectiveUnknownResolverPolicy(t *testing.T) {
+	t.Run("flagsChanged nil uses options value", func(t *testing.T) {
+		opts := &sharedResolverOptions{OnUnknownResolver: "warn"}
+		got, err := opts.effectiveUnknownResolverPolicy(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, settings.UnknownResolverWarn, got)
+	})
+
+	t.Run("flag not set falls back to config default", func(t *testing.T) {
+		cfg := &config.Config{Resolver: config.ResolverConfig{OnUnknownResolver: "ignore"}}
+		ctx := config.WithConfig(context.Background(), cfg)
+		opts := &sharedResolverOptions{
+			OnUnknownResolver: string(settings.DefaultUnknownResolverPolicy),
+			flagsChanged:      map[string]bool{},
+		}
+		got, err := opts.effectiveUnknownResolverPolicy(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, settings.UnknownResolverIgnore, got)
+	})
+
+	t.Run("explicit flag overrides config", func(t *testing.T) {
+		cfg := &config.Config{Resolver: config.ResolverConfig{OnUnknownResolver: "ignore"}}
+		ctx := config.WithConfig(context.Background(), cfg)
+		opts := &sharedResolverOptions{
+			OnUnknownResolver: "warn",
+			flagsChanged:      map[string]bool{"on-unknown-resolver": true},
+		}
+		got, err := opts.effectiveUnknownResolverPolicy(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, settings.UnknownResolverWarn, got)
+	})
+
+	t.Run("invalid config value errors", func(t *testing.T) {
+		cfg := &config.Config{Resolver: config.ResolverConfig{OnUnknownResolver: "bogus"}}
+		ctx := config.WithConfig(context.Background(), cfg)
+		opts := &sharedResolverOptions{
+			OnUnknownResolver: string(settings.DefaultUnknownResolverPolicy),
+			flagsChanged:      map[string]bool{},
+		}
+		_, err := opts.effectiveUnknownResolverPolicy(ctx)
+		require.Error(t, err)
+	})
+}

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -576,18 +576,10 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		lgr.V(1).Info("--action resolved to resolver names", "actions", o.Actions, "resolvers", actionNames)
 	}
 
-	// Validate parameter keys against parameter provider 'key' inputs (early typo detection)
-	if len(params) > 0 {
-		// Skip typo detection when a resolver reads every supplied parameter
-		// (all: true) -- any -r key is valid in that case.
-		if !resolversAcceptAllParameters(allResolvers) {
-			paramKeys := extractParameterKeys(allResolvers)
-			if len(paramKeys) > 0 {
-				if err := flags.ValidateInputKeys(params, paramKeys, "solution"); err != nil {
-					return o.exitWithCode(ctx, err, exitcode.InvalidInput)
-				}
-			}
-		}
+	// Validate parameter keys against parameter provider 'key' inputs (early
+	// typo detection), honoring the --on-unknown-resolver policy.
+	if err := o.validateResolverParams(ctx, sol, params); err != nil {
+		return o.exitWithCode(ctx, err, exitcode.InvalidInput)
 	}
 
 	var lookup resolver.DescriptorLookup

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -465,19 +465,10 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 
 	lgr.V(1).Info("parsed parameters", "count", len(params))
 
-	// Validate parameter keys against parameter provider 'key' inputs (early typo detection)
-	if len(params) > 0 {
-		solResolvers := sol.Spec.ResolversToSlice()
-		// Skip typo detection when a resolver reads every supplied parameter
-		// (all: true) -- any -r key is valid in that case.
-		if !resolversAcceptAllParameters(solResolvers) {
-			paramKeys := extractParameterKeys(solResolvers)
-			if len(paramKeys) > 0 {
-				if err := flags.ValidateInputKeys(params, paramKeys, "solution"); err != nil {
-					return o.exitWithCode(ctx, err, exitcode.InvalidInput)
-				}
-			}
-		}
+	// Validate parameter keys against parameter provider 'key' inputs (early
+	// typo detection), honoring the --on-unknown-resolver policy.
+	if err := o.validateResolverParams(ctx, sol, params); err != nil {
+		return o.exitWithCode(ctx, err, exitcode.InvalidInput)
 	}
 
 	// Inject CLI overrides into context before dry-run or live execution,

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -394,6 +394,12 @@ type ResolverConfig struct {
 
 	// ValidateAll enables collecting all errors instead of stopping at first
 	ValidateAll bool `json:"validateAll,omitempty" yaml:"validateAll,omitempty" mapstructure:"validateAll" doc:"Collect all errors vs stop at first"`
+
+	// OnUnknownResolver sets the default policy for -r/--resolver parameters
+	// whose key is not consumed by any declared parameter resolver: "error"
+	// (default) rejects them, "warn" proceeds with a warning, "ignore" accepts
+	// them silently. Overridden by the --on-unknown-resolver CLI flag.
+	OnUnknownResolver string `json:"onUnknownResolver,omitempty" yaml:"onUnknownResolver,omitempty" mapstructure:"onUnknownResolver" doc:"Default policy for unknown -r keys (error|warn|ignore)" enum:"error,warn,ignore" example:"error"`
 }
 
 // ActionConfig holds action executor configuration.

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -146,6 +146,48 @@ const (
 	DefaultMaxValueSize = 10 * 1024 * 1024
 )
 
+// UnknownResolverPolicy controls how the run commands treat -r/--resolver
+// parameters whose key does not match any declared parameter (i.e. no resolver
+// consumes it). The strict default rejects them to catch typos and stale
+// inputs; callers driving a solution with a superset of inputs (e.g. a shared
+// parameter file) can relax it.
+type UnknownResolverPolicy string
+
+const (
+	// UnknownResolverError rejects unknown -r keys with an error (the strict
+	// default).
+	UnknownResolverError UnknownResolverPolicy = "error"
+
+	// UnknownResolverWarn proceeds after printing a warning that names the
+	// unknown -r keys (still surfaces likely typos).
+	UnknownResolverWarn UnknownResolverPolicy = "warn"
+
+	// UnknownResolverIgnore silently accepts unknown -r keys.
+	UnknownResolverIgnore UnknownResolverPolicy = "ignore"
+
+	// DefaultUnknownResolverPolicy is the strict default: unknown -r keys are
+	// treated as errors.
+	DefaultUnknownResolverPolicy = UnknownResolverError
+)
+
+// ParseUnknownResolverPolicy validates and normalizes a policy string. An empty
+// string resolves to DefaultUnknownResolverPolicy. Unrecognized values return
+// an error naming the valid choices.
+func ParseUnknownResolverPolicy(s string) (UnknownResolverPolicy, error) {
+	switch UnknownResolverPolicy(strings.ToLower(strings.TrimSpace(s))) {
+	case "":
+		return DefaultUnknownResolverPolicy, nil
+	case UnknownResolverError:
+		return UnknownResolverError, nil
+	case UnknownResolverWarn:
+		return UnknownResolverWarn, nil
+	case UnknownResolverIgnore:
+		return UnknownResolverIgnore, nil
+	default:
+		return "", fmt.Errorf("invalid unknown-resolver policy %q (valid: error, warn, ignore)", s)
+	}
+}
+
 // OTel / telemetry defaults
 const (
 	// DefaultOTelSamplerType is the default trace sampler. always_on means every

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -379,3 +379,39 @@ func TestFileNamesForMode_CustomActionFiles_NoMutation(t *testing.T) {
 
 	assert.Equal(t, original, custom, "FileNamesForMode must not mutate the input slice")
 }
+
+func TestParseUnknownResolverPolicy(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		want    UnknownResolverPolicy
+		wantErr bool
+	}{
+		{name: "empty resolves to default", input: "", want: DefaultUnknownResolverPolicy},
+		{name: "error", input: "error", want: UnknownResolverError},
+		{name: "warn", input: "warn", want: UnknownResolverWarn},
+		{name: "ignore", input: "ignore", want: UnknownResolverIgnore},
+		{name: "uppercase normalized", input: "WARN", want: UnknownResolverWarn},
+		{name: "whitespace trimmed", input: "  ignore  ", want: UnknownResolverIgnore},
+		{name: "invalid value", input: "loud", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseUnknownResolverPolicy(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "valid: error, warn, ignore")
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDefaultUnknownResolverPolicy_IsStrict(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, UnknownResolverError, DefaultUnknownResolverPolicy)
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -10157,6 +10157,52 @@ func TestIntegration_RunResolver_UnknownParamKeyNoSuggestion(t *testing.T) {
 	assert.Contains(t, stderr, "does not accept input")
 }
 
+func TestIntegration_RunResolver_UnknownParamKey_WarnPolicy(t *testing.T) {
+	t.Parallel()
+	// --on-unknown-resolver=warn downgrades the rejection to a warning and
+	// proceeds with execution.
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolvers/parameters.yaml",
+		"--on-unknown-resolver=warn",
+		"namee=Alice",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stderr, "does not accept input")
+	// The resolver output is still produced.
+	assert.Contains(t, stdout, "name")
+}
+
+func TestIntegration_RunResolver_UnknownParamKey_IgnorePolicy(t *testing.T) {
+	t.Parallel()
+	// --on-unknown-resolver=ignore accepts the unknown key silently.
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolvers/parameters.yaml",
+		"--on-unknown-resolver=ignore",
+		"namee=Alice",
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.NotContains(t, stderr, "does not accept input")
+	assert.Contains(t, stdout, "name")
+}
+
+func TestIntegration_RunResolver_InvalidUnknownResolverPolicy(t *testing.T) {
+	t.Parallel()
+	// An unrecognized policy value is rejected with a clear error.
+	_, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolvers/parameters.yaml",
+		"--on-unknown-resolver=loud",
+		"name=Alice",
+	)
+
+	assert.NotEqual(t, 0, exitCode)
+	assert.Contains(t, stderr, "valid: error, warn, ignore")
+}
+
 // TestIntegration_Lint_MissingFallbackSource verifies missing-fallback-source lint rule detects all-conditional resolvers.
 func TestIntegration_Lint_MissingFallbackSource(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Adds a tri-state `--on-unknown-resolver=error|warn|ignore` flag (default `error`) plus a `resolver.onUnknownResolver` config field, controlling how `scafctl run resolver|solution|action` treats `-r/--resolver` keys not consumed by any declared parameter resolver.

Previously unknown keys were always a hard error with no opt-out. `warn` proceeds with a stderr warning; `ignore` accepts silently -- supporting shared param files and external callers passing a superset of keys. Modeled on kubectl's `--validate=strict|warn|ignore`.

Precedence: built-in default (`error`) < config (`resolver.onUnknownResolver`) < CLI flag. The three previously-duplicated validation blocks in the run commands now share one helper.

## Changes
- `pkg/settings`: `UnknownResolverPolicy` type, constants, and `ParseUnknownResolverPolicy` (normalizes case/whitespace, whitelist error).
- `pkg/config`: `ResolverConfig.OnUnknownResolver` field with `enum`/`doc`/`example` tags.
- `pkg/cmd/scafctl/run`: `--on-unknown-resolver` flag + shared `validateResolverParams`/`effectiveUnknownResolverPolicy` helpers; `resolver.go`/`solution.go`/`action.go` now delegate to the helper.
- Tests: settings + run-helper unit tests (all precedence branches, all three policies, invalid values); integration tests for warn/ignore/invalid.
- Docs/examples: `state-tutorial.md` note and `examples/config/full-config.yaml` field.