### PR TITLE
feat(gotmpl): selectField accepts a map input and dotted key paths

### DIFF
--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -2103,29 +2103,35 @@ scafctl provides two functions for converting arbitrary strings into DNS-safe la
 ```yaml
 spec:
   resolvers:
-    project-name:
-      type: static
-      from:
-        value: "My Cool Project! (v2)"
+    projectName:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "My Cool Project! (v2)"
 
-    dns-label:
-      type: go-template
-      dependsOn: [project-name]
-      transform:
-        template: '{{ slugify .project-name }}'
-        name: slugify-demo
+    dnsLabel:
+      type: string
+      dependsOn: [projectName]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ slugify .projectName }}'
+              name: slugify-demo
 ```
 
 {{< tabs "go-templates-tutorial-cmd-28" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f slugify-demo.yaml -e _.dns-label
+scafctl run resolver -f slugify-demo.yaml -e _.dnsLabel
 # Output: my-cool-project-v2
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f slugify-demo.yaml -e _.dns-label
+scafctl run resolver -f slugify-demo.yaml -e _.dnsLabel
 # Output: my-cool-project-v2
 ```
 {{% /tab %}}
@@ -2146,7 +2152,7 @@ scafctl run resolver -f slugify-demo.yaml -e _.dns-label
 Two collection functions let you filter and project lists of maps without CEL:
 
 - **`where key value list`** — Returns items where `item[key] == value`
-- **`selectField key list`** — Returns a list of `item[key]` values (like SQL SELECT)
+- **`selectField key list`** — Returns a list of `item[key]` values (like SQL SELECT). Also accepts a single map, returning a one-element list (empty if the key is absent), and supports dotted key paths.
 
 ### Filtering with where
 
@@ -2154,22 +2160,27 @@ Two collection functions let you filter and project lists of maps without CEL:
 spec:
   resolvers:
     services:
-      type: static
-      from:
-        value:
-          - name: api
-            active: true
-          - name: legacy
-            active: false
-          - name: web
-            active: true
+      type: array
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - name: api
+                  active: true
+                - name: legacy
+                  active: false
+                - name: web
+                  active: true
 
-    active-only:
-      type: go-template
+    activeOnly:
       dependsOn: [services]
-      transform:
-        template: '{{ where "active" true .services | toYaml }}'
-        name: where-demo
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ where "active" true .services | toYaml }}'
+              name: where-demo
 ```
 
 Result: only `api` and `web` items are returned.
@@ -2177,12 +2188,14 @@ Result: only `api` and `web` items are returned.
 ### Projecting with selectField
 
 ```yaml
-    service-names:
-      type: go-template
+    serviceNames:
       dependsOn: [services]
-      transform:
-        template: '{{ selectField "name" .services | toYaml }}'
-        name: select-demo
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ selectField "name" .services | toYaml }}'
+              name: select-demo
 ```
 
 Result: `["api", "legacy", "web"]`
@@ -2190,15 +2203,59 @@ Result: `["api", "legacy", "web"]`
 ### Combining with pipes
 
 ```yaml
-    active-names:
-      type: go-template
+    activeNames:
       dependsOn: [services]
-      transform:
-        template: '{{ where "active" true .services | selectField "name" | toYaml }}'
-        name: combined-demo
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ where "active" true .services | selectField "name" | toYaml }}'
+              name: combined-demo
 ```
 
 Result: `["api", "web"]`
+
+### selectField on a map
+
+`selectField` also accepts a single map. It returns a one-element list holding
+the value at the key, or an empty list when the key is absent. Because an empty
+list is falsy, this makes `selectField` a convenient existence check:
+
+```yaml
+    metadata:
+      type: object
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                tags: [alpha, beta]
+                database:
+                  host: db.example.com
+
+    hasTags:
+      dependsOn: [metadata]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ if .metadata | selectField "tags" }}has tags{{ end }}'
+              name: exists-demo
+```
+
+Keys may use dotted paths to descend into nested maps (in both the map and list
+forms):
+
+```yaml
+    dbHost:
+      dependsOn: [metadata]
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ .metadata | selectField "database.host" | first }}'
+              name: dotted-demo
+```
 
 ---
 
@@ -2216,24 +2273,29 @@ The data argument becomes `_` in the CEL expression (same as the `expr` field co
 spec:
   resolvers:
     services:
-      type: static
-      from:
-        value:
-          - name: api
-            port: 8080
-            active: true
-          - name: legacy
-            port: 9090
-            active: false
+      type: array
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                - name: api
+                  port: 8080
+                  active: true
+                - name: legacy
+                  port: 9090
+                  active: false
 
     summary:
-      type: go-template
       dependsOn: [services]
-      transform:
-        template: |
-          Active services: {{ cel "size(_.services.filter(s, s.active == true))" . }}
-          Total ports: {{ cel "_.services.map(s, s.port).reduce(a, b, a + b)" . }}
-        name: cel-in-template
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              template: |
+                Active services: {{ cel "size(_.services.filter(s, s.active == true))" . }}
+                Highest port: {{ cel "math.greatest(_.services.map(s, s.port))" . }}
+              name: cel-in-template
 ```
 
 ### When to use cel vs pure Go template
@@ -2270,10 +2332,12 @@ Say you have a template that tries to range over a string:
 ```yaml
 resolvers:
   greeting:
-    type: go-template
-    transform:
-      template: '{{ range .name }}{{ . }}{{ end }}'
-      name: bad-range
+    resolve:
+      with:
+        - provider: go-template
+          inputs:
+            template: '{{ range .name }}{{ . }}{{ end }}'
+            name: bad-range
 ```
 
 If `.name` resolves to the string `"Alice"` instead of a list, the error output includes:

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -2152,7 +2152,7 @@ scafctl run resolver -f slugify-demo.yaml -e _.dnsLabel
 Two collection functions let you filter and project lists of maps without CEL:
 
 - **`where key value list`** — Returns items where `item[key] == value`
-- **`selectField key list`** — Returns a list of `item[key]` values (like SQL SELECT). Also accepts a single map, returning a one-element list (empty if the key is absent), and supports dotted key paths.
+- **`selectField key list`** -- Returns a list of `item[key]` values (like SQL SELECT). Also accepts a single map, returning a one-element list (empty if the key is absent), and supports dotted key paths.
 
 ### Filtering with where
 

--- a/examples/solutions/template-functions/solution.yaml
+++ b/examples/solutions/template-functions/solution.yaml
@@ -40,6 +40,20 @@ spec:
                   port: 9090
                   active: false
 
+    metadata:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                name: my-solution
+                tags:
+                  - alpha
+                  - beta
+                database:
+                  host: db.example.com
+                  port: 5432
+
     # slugify — convert any string to a DNS-safe slug
     slugified-name:
       dependsOn: [project-name]
@@ -115,6 +129,37 @@ spec:
               template: '{{ selectField "name" .services | toYaml }}'
               name: select-demo
       # Returns: ["api-gateway", "auth-service", "legacy-proxy"]
+
+    # selectField on a map — existence check + dotted key path
+    has-tags:
+      dependsOn: [metadata]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ if .metadata | selectField "tags" }}yes{{ else }}no{{ end }}'
+              name: select-map-demo
+      # Returns "yes": a map input yields a one-element list (empty if absent)
+
+    db-host:
+      dependsOn: [metadata]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ .metadata | selectField "database.host" | first }}'
+              name: select-dotted-demo
+      # Returns "db.example.com": dotted paths descend into nested maps
 
     # cel — inline CEL expression in a Go template
     active-count:

--- a/pkg/gotmpl/ext/collections/collections.go
+++ b/pkg/gotmpl/ext/collections/collections.go
@@ -9,6 +9,7 @@ package collections
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"text/template"
 
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
@@ -46,16 +47,21 @@ func WhereFunc() gotmpl.ExtFunction {
 	}
 }
 
-// SelectFunc returns an ExtFunction that projects a single field from a list of maps.
+// SelectFunc returns an ExtFunction that projects a single field from a list of
+// maps, or extracts a single value from a map.
 //
 // Example usage in a Go template:
 //
 //	{{ .items | selectField "name" }}
+//	{{ .metadata | selectField "tags" }}
 func SelectFunc() gotmpl.ExtFunction {
 	return gotmpl.ExtFunction{
 		Name: "selectField",
-		Description: "Extracts a single field from each map in a list, returning a flat list of values. " +
-			"Non-map entries are skipped. Entries missing the key produce nil in the output.",
+		Description: "Extracts a single field from data. Given a list of maps, returns a flat list of " +
+			"the field's values (non-map entries are skipped; entries missing the key produce nil). " +
+			"Given a single map, returns a one-element list holding the value, or an empty list if the " +
+			"key is absent -- making it useful as an existence check in an if. Keys may use dotted paths " +
+			"(e.g. \"a.b.c\") to descend into nested maps.",
 		Custom: true,
 		Examples: []gotmpl.Example{
 			{
@@ -69,6 +75,14 @@ func SelectFunc() gotmpl.ExtFunction {
 			{
 				Description: "Extract nested field for further processing",
 				Template:    `{{ range (.items | selectField "email") }}{{ . }}{{ end }}`,
+			},
+			{
+				Description: "Use against a map as an existence check",
+				Template:    `{{ if .metadata | selectField "tags" }}has tags{{ end }}`,
+			},
+			{
+				Description: "Descend into a nested map with a dotted path",
+				Template:    `{{ .config | selectField "database.host" }}`,
 			},
 		},
 		Func: template.FuncMap{
@@ -108,15 +122,33 @@ func Where(key string, value, list any) ([]any, error) {
 	return result, nil
 }
 
-// SelectField extracts a single field from each map in a list.
+// SelectField extracts a single field from a map or from each map in a list.
 //
-// The list can be []any, []map[string]any, or any slice type.
-// Non-map entries are silently skipped. If a map doesn't have the specified
-// key, nil is included in the output to preserve positional alignment.
+// When the input is a map, SelectField returns a one-element list holding the
+// value at key, or an empty list if the key is absent. This mirrors the legacy
+// select helper and makes selectField usable as an existence check inside an if.
+//
+// When the input is a list ([]any, []map[string]any, or any slice type),
+// SelectField projects key from each map element. Non-map entries are silently
+// skipped. If a map doesn't have the specified key, nil is included in the
+// output to preserve positional alignment.
+//
+// In both modes, key may be a dotted path (e.g. "a.b.c") to descend into nested
+// maps; descent stops (yielding a missing value) when an intermediate value is
+// not a map or the key is absent.
 //
 // Returns an empty []any if the input is nil or empty.
-func SelectField(key string, list any) ([]any, error) {
-	items, err := toSlice(list)
+func SelectField(key string, input any) ([]any, error) {
+	// Map input: return a one-element list (existence-check friendly), or an
+	// empty list when the key path is absent. This matches legacy select.
+	if m, ok := toMap(input); ok {
+		if v, found := lookupKey(m, key); found {
+			return []any{v}, nil
+		}
+		return []any{}, nil
+	}
+
+	items, err := toSlice(input)
 	if err != nil {
 		return nil, fmt.Errorf("selectField: %w", err)
 	}
@@ -127,13 +159,49 @@ func SelectField(key string, list any) ([]any, error) {
 		if !ok {
 			continue
 		}
-		result = append(result, m[key])
+		v, _ := lookupKey(m, key)
+		result = append(result, v)
 	}
 
 	if result == nil {
 		return []any{}, nil
 	}
 	return result, nil
+}
+
+// lookupKey resolves a (possibly dotted) key path against a map, returning the
+// value and whether the full path was found. A single segment with no dots is
+// the common case: a direct map lookup. Dotted paths (e.g. "a.b.c") descend
+// through nested maps; descent fails (found == false) as soon as an
+// intermediate value is not a string-keyed map or a segment is absent.
+func lookupKey(m map[string]any, path string) (any, bool) {
+	// Fast path: a plain key with no dotted descent is by far the common case.
+	// Handling it directly avoids the segment-slice allocation and the toMap
+	// indirection, keeping list projection allocation-free per element.
+	if !strings.Contains(path, ".") {
+		v, ok := m[path]
+		return v, ok
+	}
+
+	// Dotted path: descend one segment at a time. strings.Cut avoids allocating
+	// a slice of segments.
+	cur := any(m)
+	for rest := path; ; {
+		segment, remainder, more := strings.Cut(rest, ".")
+		cm, ok := toMap(cur)
+		if !ok {
+			return nil, false
+		}
+		v, exists := cm[segment]
+		if !exists {
+			return nil, false
+		}
+		cur = v
+		if !more {
+			return cur, true
+		}
+		rest = remainder
+	}
 }
 
 // toSlice converts any slice or array to []any using reflection.

--- a/pkg/gotmpl/ext/collections/collections.go
+++ b/pkg/gotmpl/ext/collections/collections.go
@@ -173,7 +173,10 @@ func SelectField(key string, input any) ([]any, error) {
 // value and whether the full path was found. A single segment with no dots is
 // the common case: a direct map lookup. Dotted paths (e.g. "a.b.c") descend
 // through nested maps; descent fails (found == false) as soon as an
-// intermediate value is not a string-keyed map or a segment is absent.
+// intermediate value is not a string-keyed map or a segment is absent. Malformed
+// paths with empty segments (leading, trailing, or doubled dots such as ".a",
+// "a.", or "a..b") also return found == false rather than matching an
+// empty-string key.
 func lookupKey(m map[string]any, path string) (any, bool) {
 	// Fast path: a plain key with no dotted descent is by far the common case.
 	// Handling it directly avoids the segment-slice allocation and the toMap
@@ -188,6 +191,12 @@ func lookupKey(m map[string]any, path string) (any, bool) {
 	cur := any(m)
 	for rest := path; ; {
 		segment, remainder, more := strings.Cut(rest, ".")
+		// An empty segment means the path had a leading, trailing, or doubled
+		// dot (e.g. ".a", "a.", "a..b"). Treat these malformed paths as a clean
+		// "not found" rather than looking up an empty-string key.
+		if segment == "" {
+			return nil, false
+		}
 		cm, ok := toMap(cur)
 		if !ok {
 			return nil, false

--- a/pkg/gotmpl/ext/collections/collections_benchmark_test.go
+++ b/pkg/gotmpl/ext/collections/collections_benchmark_test.go
@@ -80,4 +80,22 @@ func BenchmarkSelectField(b *testing.B) {
 			_, _ = SelectField("name", items)
 		}
 	})
+
+	b.Run("map", func(b *testing.B) {
+		m := map[string]any{"name": "alice", "age": 30, "email": "alice@example.com"}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_, _ = SelectField("name", m)
+		}
+	})
+
+	b.Run("mapDottedPath", func(b *testing.B) {
+		m := map[string]any{"meta": map[string]any{"nested": map[string]any{"id": 1}}}
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_, _ = SelectField("meta.nested.id", m)
+		}
+	})
 }

--- a/pkg/gotmpl/ext/collections/collections_test.go
+++ b/pkg/gotmpl/ext/collections/collections_test.go
@@ -207,6 +207,15 @@ func TestSelectField(t *testing.T) {
 		assert.Equal(t, []any{}, got)
 	})
 
+	t.Run("map input with malformed dotted path returns empty list", func(t *testing.T) {
+		m := map[string]any{"": "empty-key", "database": map[string]any{"host": "db.example.com", "": "nested-empty"}}
+		for _, path := range []string{".database", "database.", "database..host"} {
+			got, err := SelectField(path, m)
+			require.NoError(t, err, "path %q", path)
+			assert.Equal(t, []any{}, got, "path %q should not match an empty-string key", path)
+		}
+	})
+
 	t.Run("typed map input", func(t *testing.T) {
 		m := map[string]string{"name": "alice"}
 		got, err := SelectField("name", m)

--- a/pkg/gotmpl/ext/collections/collections_test.go
+++ b/pkg/gotmpl/ext/collections/collections_test.go
@@ -162,6 +162,67 @@ func TestSelectField(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []any{"alice", "bob"}, got)
 	})
+
+	t.Run("map input with present key returns one-element list", func(t *testing.T) {
+		m := map[string]any{"name": "x", "tags": []any{"a", "b"}}
+		got, err := SelectField("tags", m)
+		require.NoError(t, err)
+		assert.Equal(t, []any{[]any{"a", "b"}}, got)
+	})
+
+	t.Run("map input with absent key returns empty list", func(t *testing.T) {
+		m := map[string]any{"name": "x"}
+		got, err := SelectField("tags", m)
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, got)
+	})
+
+	t.Run("map input with present nil value returns one-element list", func(t *testing.T) {
+		// A key that exists with a nil value is "present": selectField returns a
+		// length-1 (truthy) list, so it reports the key as existing.
+		m := map[string]any{"tags": nil}
+		got, err := SelectField("tags", m)
+		require.NoError(t, err)
+		assert.Equal(t, []any{nil}, got)
+	})
+
+	t.Run("map input with dotted path descends nested maps", func(t *testing.T) {
+		m := map[string]any{"database": map[string]any{"host": "db.example.com"}}
+		got, err := SelectField("database.host", m)
+		require.NoError(t, err)
+		assert.Equal(t, []any{"db.example.com"}, got)
+	})
+
+	t.Run("map input with dotted path missing segment returns empty list", func(t *testing.T) {
+		m := map[string]any{"database": map[string]any{"host": "db.example.com"}}
+		got, err := SelectField("database.port", m)
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, got)
+	})
+
+	t.Run("map input with dotted path through non-map returns empty list", func(t *testing.T) {
+		m := map[string]any{"database": "not-a-map"}
+		got, err := SelectField("database.host", m)
+		require.NoError(t, err)
+		assert.Equal(t, []any{}, got)
+	})
+
+	t.Run("typed map input", func(t *testing.T) {
+		m := map[string]string{"name": "alice"}
+		got, err := SelectField("name", m)
+		require.NoError(t, err)
+		assert.Equal(t, []any{"alice"}, got)
+	})
+
+	t.Run("list input with dotted path descends per element", func(t *testing.T) {
+		list := []any{
+			map[string]any{"meta": map[string]any{"id": 1}},
+			map[string]any{"meta": map[string]any{"id": 2}},
+		}
+		got, err := SelectField("meta.id", list)
+		require.NoError(t, err)
+		assert.Equal(t, []any{1, 2}, got)
+	})
 }
 
 func TestWhereFunc(t *testing.T) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -10059,6 +10059,84 @@ spec:
 	assert.Contains(t, stdout, "legacy")
 }
 
+// TestIntegration_RunResolver_TemplateFunctions_SelectFieldMap verifies selectField
+// accepts a map input (legacy select parity): it works as an existence check and
+// supports dotted key paths for descending into nested maps.
+func TestIntegration_RunResolver_TemplateFunctions_SelectFieldMap(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	solutionFile := filepath.Join(tmpDir, "solution.yaml")
+
+	solutionContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: select-map-test
+  version: 1.0.0
+spec:
+  resolvers:
+    metadata:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                name: my-solution
+                tags: [alpha, beta]
+                database:
+                  host: db.example.com
+                  port: 5432
+    hasTags:
+      dependsOn: [metadata]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ if .metadata | selectField "tags" }}yes{{ else }}no{{ end }}'
+              name: exists-test
+    hasMissing:
+      dependsOn: [metadata]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ if .metadata | selectField "absent" }}yes{{ else }}no{{ end }}'
+              name: absent-test
+    dbHost:
+      dependsOn: [metadata]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ .metadata | selectField "database.host" | first }}'
+              name: dotted-test
+`
+	require.NoError(t, os.WriteFile(solutionFile, []byte(solutionContent), 0o644))
+
+	stdout, stderr, exitCode := runScafctl(t, "run", "resolver", "-f", solutionFile, "-o", "json")
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+
+	assert.Equal(t, 0, exitCode, "expected exit code 0, got %d\nstdout: %s\nstderr: %s", exitCode, stdout, stderr)
+	assert.Contains(t, stdout, `"hasTags": "yes"`)
+	assert.Contains(t, stdout, `"hasMissing": "no"`)
+	assert.Contains(t, stdout, `"dbHost": "db.example.com"`)
+}
+
 func TestIntegration_RunResolver_PositionalParams(t *testing.T) {
 	t.Parallel()
 	stdout, stderr, exitCode := runScafctl(t,

--- a/tests/integration/solutions/providers/template-functions/solution.yaml
+++ b/tests/integration/solutions/providers/template-functions/solution.yaml
@@ -31,6 +31,20 @@ spec:
                   port: 9090
                   active: false
 
+    metadata:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                name: my-solution
+                tags:
+                  - alpha
+                  - beta
+                database:
+                  host: db.example.com
+                  port: 5432
+
     # slugify test
     slugified:
       dependsOn: [project-name]
@@ -90,6 +104,35 @@ spec:
               template: '{{ selectField "name" .services | toYaml }}'
               name: select-test
 
+    # selectField on a map (existence check + dotted path)
+    has-tags:
+      dependsOn: [metadata]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ if .metadata | selectField "tags" }}yes{{ else }}no{{ end }}'
+              name: select-map-exists-test
+
+    db-host:
+      dependsOn: [metadata]
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: placeholder
+      transform:
+        with:
+          - provider: go-template
+            inputs:
+              template: '{{ .metadata | selectField "database.host" | first }}'
+              name: select-map-dotted-test
+
     # cel inline test
     active-count:
       dependsOn: [services]
@@ -144,3 +187,22 @@ spec:
             message: "selectField should extract api-gateway"
           - expression: '__output["service-names"].contains("legacy-proxy")'
             message: "selectField should extract legacy-proxy"
+
+      test-select-map-exists:
+        description: Verify selectField on a map works as an existence check
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: '__output["has-tags"] == "yes"'
+            message: "selectField on a map should detect the present key"
+
+      test-select-map-dotted:
+        description: Verify selectField on a map supports dotted key paths
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: '__output["db-host"] == "db.example.com"'
+            message: "selectField should descend a dotted path into a nested map"
+


### PR DESCRIPTION
`selectField` previously errored when given a map (`toSlice` rejected non-list
input). It now accepts a single map and returns a one-element list holding the
value at the key (or an empty list when the key is absent), making it a natural
existence/truthiness check that matches legacy cldctl `select`. Keys may use
dotted paths (e.g. `"database.host"`) to descend into nested maps, in both the
map and list forms, via a new `lookupKey` helper. The list hot path stays
allocation-free (no-dot fast path plus `strings.Cut`) -- the 1000-item list case
drops from ~1012 to 12 allocs/op; map and dotted-map lookups are 1 alloc/op.

## Why

The issue (gotemplate-selectField-should-accept-map-like-legacy-select) asked
for parity with legacy cldctl `select`, which accepted a map and made
`{{- if .data | selectField "tags" }}...{{ end }}` a convenient existence check.
scafctl's `selectField` only accepted lists, so that pattern failed.

## What changed

- `pkg/gotmpl/ext/collections/collections.go`: map branch returns `[v]`/`[]`;
  new `lookupKey` supports dotted paths for both map and list inputs and
  rejects malformed paths with empty segments (`.a`, `a.`, `a..b`);
  `SelectFunc()` description/examples updated (source of truth for the MCP
  `list_go_template_functions` tool).
- Unit subtests, sub-benchmarks, an integration test
  (`TestIntegration_RunResolver_TemplateFunctions_SelectFieldMap`), and
  example/functional-test coverage for the map and dotted-path behavior.

## Tutorial corrections (bundled)

While documenting the feature, the go-templates tutorial's collections,
inline-CEL, slugify, and debugging sections were found to be pre-existing broken
(unrelated to this feature). This PR also fixes them, each validated by running:

- Invalid resolver shorthand (`type:`/`from:`/`transform.template`) converted to
  the correct `resolve.with: [{ provider: ... }]` schema.
- Hyphenated resolver names that break `-e _.x` CEL access and `.x` template
  accessors de-hyphenated (`projectName`, `dnsLabel`, `activeOnly`,
  `serviceNames`, `activeNames`, `hasTags`, `dbHost`).
- Invalid CEL `reduce` (scafctl CEL has no `reduce`/`sum`) replaced with
  `math.greatest`.

## Validation

- `task lint:changed` -> 0 issues
- Collections unit tests + benchmarks, `SelectFieldMap` integration test, and the
  template-functions functional suite (9/9) pass.
- Full `task test:e2e` green.
