### PR TITLE
fix(state): treat absent or contentless backend state as a fresh first run

### DIFF
--- a/docs/design/state/state.md
+++ b/docs/design/state/state.md
@@ -357,6 +357,39 @@ State is read and written only by the backend provider (`file`, `http`, or
 
 ---
 
+## State Backend Load Response Contract
+
+Every `CapabilityState` backend returns a map from `state_load`. The core state
+loader interprets it as follows:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `success` | bool | Whether the operation succeeded. |
+| `data` | object | The decoded/serialized `Data` document read from storage. |
+| `found` | bool | Optional. Set to `false` to report that no state object exists yet (a first run). Absent defaults to `true`. |
+
+**Reporting absence (first run).** When the backing object does not exist (a
+missing file, an HTTP/GitHub 404), a backend MUST NOT return an empty or
+zero-version document as if it were a real state file -- that value decodes to
+`schemaVersion: 0` and would otherwise trip the schema-version floor with a
+misleading "delete the state file and recreate it" error before any file
+exists. Instead, report absence in one of two ways:
+
+1. **Preferred:** set `found: false`. The loader then starts from fresh empty
+   state (`state.NewData()`) without decoding or version-checking the payload.
+2. **Accepted:** return `state.NewData()` (or a contentless payload -- empty
+   bytes, `null`, or `{}`) as `data`. The loader treats a contentless payload as
+   fresh empty state as a safety net for backends that do not set `found`.
+
+The schema-version guard (`ErrIncompatibleSchemaVersion` /
+`ErrUnsupportedSchemaVersion`) applies only to a **non-empty document that
+carries real content**, so a genuine older state file is still rejected rather
+than silently accepted (which would discard immutable locks).
+
+The built-in `file` and `http` backends set `found: false` on absence.
+
+---
+
 ## File Provider State Operations
 
 The built-in `file` provider supports state persistence via `CapabilityState`. State operations use `state_load`, `state_save`, and `state_delete` as the `operation` input.
@@ -373,7 +406,7 @@ The built-in `file` provider supports state persistence via `CapabilityState`. S
 
 | Operation | Behavior |
 |-----------|----------|
-| `state_load` | Reads JSON from the resolved path (relative to solution directory). Returns empty state structure if file does not exist (first run). |
+| `state_load` | Reads JSON from the resolved path (relative to solution directory). Reports `found: false` (fresh state) if the file does not exist (first run). |
 | `state_save` | Writes `Data` as JSON to the resolved path. Creates directories as needed. Uses atomic write (temp + rename). |
 | `state_delete` | Removes the state file at the resolved path. |
 
@@ -447,7 +480,7 @@ This is semantically correct: state reflects what is committed/deployed, not wha
 
 | Operation | Behavior |
 |-----------|----------|
-| `state_load` | Read JSON file from `owner/repo/path@ref`. Return empty state on 404 (first run). |
+| `state_load` | Read JSON file from `owner/repo/path@ref`. Report `found: false` (fresh state) on 404 (first run). |
 | `state_save` | Fetch HEAD OID of `branch`, call `createCommitOnBranch` with state JSON as file addition. Fail on OID conflict. |
 | `state_delete` | Fetch HEAD OID of `branch`, call `createCommitOnBranch` with file deletion. Idempotent on missing file. |
 

--- a/pkg/provider/builtin/fileprovider/file.go
+++ b/pkg/provider/builtin/fileprovider/file.go
@@ -204,6 +204,7 @@ func NewFileProvider() *FileProvider {
 				provider.CapabilityState: schemahelper.ObjectSchema([]string{"success"}, map[string]*jsonschema.Schema{
 					"success": schemahelper.BoolProp("Whether the state operation succeeded"),
 					"data":    schemahelper.AnyProp("The loaded state data (for state_load operation)"),
+					"found":   schemahelper.BoolProp("Whether a state object exists (state_load operation). False on a first run when no state file exists yet; the loader then starts from fresh empty state. Absent defaults to true."),
 				}),
 				provider.CapabilityAction: schemahelper.ObjectSchema(nil, map[string]*jsonschema.Schema{
 					"success":      schemahelper.BoolProp("Whether the operation succeeded (for write/delete operations)"),

--- a/pkg/provider/builtin/fileprovider/file_state.go
+++ b/pkg/provider/builtin/fileprovider/file_state.go
@@ -17,11 +17,12 @@ import (
 // executeStateLoad loads state from a JSON file at the given absolute path.
 func (p *FileProvider) executeStateLoad(absPath string) (*provider.Output, error) {
 	if _, err := os.Stat(absPath); os.IsNotExist(err) {
-		// First run -- return empty state
+		// First run -- report absence so the loader starts from fresh state.
 		return &provider.Output{
 			Data: map[string]any{
-				"success": true,
-				"data":    state.NewData(),
+				"success":            true,
+				state.OutputKeyFound: false,
+				state.OutputKeyData:  state.NewData(),
 			},
 		}, nil
 	}

--- a/pkg/provider/builtin/fileprovider/file_state_test.go
+++ b/pkg/provider/builtin/fileprovider/file_state_test.go
@@ -31,7 +31,9 @@ func TestFileProvider_StateLoad_NotFound(t *testing.T) {
 
 	data := result.Data.(map[string]any)
 	assert.True(t, data["success"].(bool))
-	assert.NotNil(t, data["data"])
+	// A missing file reports absence so the loader starts from fresh state.
+	assert.Equal(t, false, data[state.OutputKeyFound])
+	assert.NotNil(t, data[state.OutputKeyData])
 }
 
 func TestFileProvider_StateLoad_IncompatibleSchemaVersion(t *testing.T) {

--- a/pkg/provider/builtin/httpprovider/http.go
+++ b/pkg/provider/builtin/httpprovider/http.go
@@ -334,6 +334,7 @@ func NewHTTPProvider() *HTTPProvider {
 				provider.CapabilityState: schemahelper.ObjectSchema([]string{"success"}, map[string]*jsonschema.Schema{
 					"success": schemahelper.BoolProp("Whether the state operation succeeded"),
 					"data":    schemahelper.AnyProp("The loaded state data (for state_load operation)"),
+					"found":   schemahelper.BoolProp("Whether a state object exists (state_load operation). False on a first run when the remote returns 404; the loader then starts from fresh empty state. Absent defaults to true."),
 				}),
 			},
 			Examples: []provider.Example{

--- a/pkg/provider/builtin/httpprovider/http_state.go
+++ b/pkg/provider/builtin/httpprovider/http_state.go
@@ -43,12 +43,13 @@ func (p *HTTPProvider) executeStateLoad(ctx context.Context, client *httpc.Clien
 		return nil, fmt.Errorf("state load: response body exceeds maximum size of %d bytes", limit)
 	}
 
-	// 404 means no state yet -- return empty state
+	// 404 means no state yet -- report absence so the loader starts fresh.
 	if resp.StatusCode == http.StatusNotFound {
 		return &provider.Output{
 			Data: map[string]any{
-				"success": true,
-				"data":    state.NewData(),
+				"success":            true,
+				state.OutputKeyFound: false,
+				state.OutputKeyData:  state.NewData(),
 			},
 		}, nil
 	}

--- a/pkg/provider/builtin/httpprovider/http_state_test.go
+++ b/pkg/provider/builtin/httpprovider/http_state_test.go
@@ -72,7 +72,9 @@ func TestHTTPProvider_StateLoad_NotFound(t *testing.T) {
 
 	data := result.Data.(map[string]any)
 	assert.True(t, data["success"].(bool))
-	assert.NotNil(t, data["data"])
+	// A 404 reports absence so the loader starts from fresh state.
+	assert.Equal(t, false, data[state.OutputKeyFound])
+	assert.NotNil(t, data[state.OutputKeyData])
 }
 
 func TestHTTPProvider_StateLoad_ServerError(t *testing.T) {

--- a/pkg/state/decode.go
+++ b/pkg/state/decode.go
@@ -4,6 +4,7 @@
 package state
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 )
@@ -15,18 +16,36 @@ import (
 // ErrIncompatibleSchemaVersion error rather than a cryptic Go reflection error
 // from a type-incompatible field aborting the strict full-struct decode.
 //
+// A contentless payload -- empty bytes, whitespace only, JSON null, or an empty
+// object -- means "no state written yet" (a first run), not a version-0 file.
+// Such a payload is returned as fresh empty state so a backend that reports an
+// absent object with an empty document does not trip the schema-version floor.
+// A document that carries any structure still goes through the full version
+// guard, so a genuine v0/v1 file is rejected rather than silently accepted
+// (which would discard immutable locks).
+//
 // All state load paths (file store, backend providers, and provider result
 // extraction) route through this helper so the version guard is enforced
 // consistently across every backend.
 func DecodeData(raw []byte) (*Data, error) {
+	if isContentless(raw) {
+		return NewData(), nil
+	}
+
 	var probe struct {
-		SchemaVersion int `json:"schemaVersion"`
+		SchemaVersion *int `json:"schemaVersion"`
 	}
 	if err := json.Unmarshal(raw, &probe); err != nil {
 		return nil, fmt.Errorf("read state schema version: %w", err)
 	}
 
-	if err := validateSchemaVersion(probe.SchemaVersion); err != nil {
+	version := 0
+	explicit := probe.SchemaVersion != nil
+	if explicit {
+		version = *probe.SchemaVersion
+	}
+
+	if err := validateSchemaVersion(version, explicit); err != nil {
 		return nil, err
 	}
 
@@ -39,17 +58,45 @@ func DecodeData(raw []byte) (*Data, error) {
 	return &sd, nil
 }
 
+// isContentless reports whether raw is a "no state written yet" payload: empty
+// bytes, whitespace only, JSON null, or an empty JSON object. Those payloads
+// decode to a zero-value document whose schemaVersion defaults to 0; treating
+// them as fresh empty state (rather than a version-0 file) lets a first run
+// proceed when a backend reports an absent object with an empty document.
+//
+// A payload with any JSON keys is NOT contentless even when those keys are
+// empty (e.g. {"parameters":{}}): it is a structured document and must go
+// through the schema-version guard so a genuine old file is rejected rather
+// than silently accepted.
+func isContentless(raw []byte) bool {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return true
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &obj); err == nil && len(obj) == 0 {
+		// Covers both JSON null (nil map) and an empty object {}.
+		return true
+	}
+	return false
+}
+
 // validateSchemaVersion enforces the supported schema-version bounds, returning
 // an actionable error for out-of-range versions. It is applied both when
 // decoding raw JSON (DecodeData) and when a backend provider returns an
 // already-decoded *Data, so the version floor is enforced at every trust
-// boundary.
-func validateSchemaVersion(version int) error {
+// boundary. explicit reports whether the document carried an explicit
+// schemaVersion field, which sharpens the message for older files.
+func validateSchemaVersion(version int, explicit bool) error {
 	if version > SchemaVersionCurrent {
 		return fmt.Errorf("%w: file version %d is newer than supported version %d; upgrade scafctl",
 			ErrUnsupportedSchemaVersion, version, SchemaVersionCurrent)
 	}
 	if version < SchemaVersionMinimum {
+		if !explicit {
+			return fmt.Errorf("%w: state document has content but no schemaVersion field (minimum supported version is %d); delete the state file and recreate it",
+				ErrIncompatibleSchemaVersion, SchemaVersionMinimum)
+		}
 		return fmt.Errorf("%w: file version %d is older than the minimum supported version %d; delete the state file and recreate it",
 			ErrIncompatibleSchemaVersion, version, SchemaVersionMinimum)
 	}
@@ -71,4 +118,21 @@ func normalizeData(sd *Data) {
 	if sd.Command.Parameters == nil {
 		sd.Command.Parameters = make(map[string]string)
 	}
+}
+
+// isEmptyData reports whether a decoded *Data carries no persisted content and
+// no explicit schema version -- the zero-value document a backend may return
+// in-process to signal "no state yet". It mirrors isContentless for the
+// direct-pointer path so an absent object is treated as fresh state rather than
+// a version-0 file. A document with any content (or a nonzero schema version)
+// is not empty and goes through the schema-version guard.
+func isEmptyData(sd *Data) bool {
+	return sd != nil &&
+		sd.SchemaVersion == 0 &&
+		len(sd.Parameters) == 0 &&
+		len(sd.Resolvers) == 0 &&
+		len(sd.Fingerprints) == 0 &&
+		sd.Metadata == (Metadata{}) &&
+		sd.Command.Subcommand == "" &&
+		len(sd.Command.Parameters) == 0
 }

--- a/pkg/state/decode_test.go
+++ b/pkg/state/decode_test.go
@@ -25,6 +25,39 @@ func TestDecodeData_ValidRoundTrip(t *testing.T) {
 	assert.NotNil(t, sd.Command.Parameters)
 }
 
+func TestDecodeData_ContentlessIsFreshState(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"empty":         ``,
+		"whitespace":    "  \n\t ",
+		"json null":     `null`,
+		"empty object":  `{}`,
+		"padded object": "  { }  ",
+	}
+	for name, raw := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			sd, err := DecodeData([]byte(raw))
+			require.NoError(t, err)
+			assert.Equal(t, SchemaVersionCurrent, sd.SchemaVersion)
+			assert.NotNil(t, sd.Parameters)
+			assert.NotNil(t, sd.Resolvers)
+			assert.NotNil(t, sd.Fingerprints)
+			assert.NotNil(t, sd.Command.Parameters)
+		})
+	}
+}
+
+// TestDecodeData_StructuredEmptyStillGuarded verifies that a document with keys
+// but no schemaVersion is NOT treated as contentless -- it must still be
+// rejected so a genuine old file is not silently accepted.
+func TestDecodeData_StructuredEmptyStillGuarded(t *testing.T) {
+	t.Parallel()
+	_, err := DecodeData([]byte(`{"parameters":{}}`))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrIncompatibleSchemaVersion)
+}
+
 func TestDecodeData_NewerVersionUnsupported(t *testing.T) {
 	t.Parallel()
 	raw := []byte(`{"schemaVersion":999,"parameters":{}}`)
@@ -95,20 +128,22 @@ func TestDecodeData_InRangeTypeMismatchStillRawError(t *testing.T) {
 func TestValidateSchemaVersion(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name    string
-		version int
-		wantErr error
+		name     string
+		version  int
+		explicit bool
+		wantErr  error
 	}{
-		{name: "current", version: SchemaVersionCurrent, wantErr: nil},
-		{name: "minimum", version: SchemaVersionMinimum, wantErr: nil},
-		{name: "too new", version: SchemaVersionCurrent + 1, wantErr: ErrUnsupportedSchemaVersion},
-		{name: "too old", version: SchemaVersionMinimum - 1, wantErr: ErrIncompatibleSchemaVersion},
-		{name: "zero", version: 0, wantErr: ErrIncompatibleSchemaVersion},
+		{name: "current", version: SchemaVersionCurrent, explicit: true, wantErr: nil},
+		{name: "minimum", version: SchemaVersionMinimum, explicit: true, wantErr: nil},
+		{name: "too new", version: SchemaVersionCurrent + 1, explicit: true, wantErr: ErrUnsupportedSchemaVersion},
+		{name: "too old", version: SchemaVersionMinimum - 1, explicit: true, wantErr: ErrIncompatibleSchemaVersion},
+		{name: "zero explicit", version: 0, explicit: true, wantErr: ErrIncompatibleSchemaVersion},
+		{name: "zero implicit", version: 0, explicit: false, wantErr: ErrIncompatibleSchemaVersion},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := validateSchemaVersion(tt.version)
+			err := validateSchemaVersion(tt.version, tt.explicit)
 			if tt.wantErr == nil {
 				require.NoError(t, err)
 				return
@@ -117,4 +152,34 @@ func TestValidateSchemaVersion(t *testing.T) {
 			assert.ErrorIs(t, err, tt.wantErr)
 		})
 	}
+}
+
+// TestValidateSchemaVersion_MessageDistinguishesMissingField verifies the
+// message differs for a document that carries an explicit older version versus
+// one that predates the schemaVersion field entirely.
+func TestValidateSchemaVersion_MessageDistinguishesMissingField(t *testing.T) {
+	t.Parallel()
+
+	explicitErr := validateSchemaVersion(1, true)
+	require.Error(t, explicitErr)
+	assert.Contains(t, explicitErr.Error(), "file version 1")
+
+	implicitErr := validateSchemaVersion(0, false)
+	require.Error(t, implicitErr)
+	assert.Contains(t, implicitErr.Error(), "no schemaVersion field")
+}
+
+func TestIsEmptyData(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, isEmptyData(&Data{}), "zero-value document is empty")
+
+	assert.False(t, isEmptyData(nil), "nil is not a fresh document")
+	assert.False(t, isEmptyData(NewData()), "NewData has a nonzero schema version")
+
+	withParam := &Data{Parameters: map[string]any{"env": "prod"}}
+	assert.False(t, isEmptyData(withParam), "content makes it non-empty")
+
+	withMeta := &Data{Metadata: Metadata{Solution: "app"}}
+	assert.False(t, isEmptyData(withMeta), "metadata makes it non-empty")
 }

--- a/pkg/state/manager.go
+++ b/pkg/state/manager.go
@@ -436,14 +436,27 @@ func extractStateData(result *provider.ExecutionResult) (*Data, error) {
 		return nil, fmt.Errorf("expected map output, got %T", result.Output.Data)
 	}
 
-	sd, ok := dataMap["data"]
+	// A backend reports an absent object (a first run) via found:false. Treat it
+	// as fresh empty state without decoding or version-checking the payload, so
+	// the misleading "delete the state file" guidance is never emitted before a
+	// file exists. Absent found defaults to true (the prior backend contract).
+	if found, ok := dataMap[OutputKeyFound]; ok && !isTruthy(found) {
+		return NewData(), nil
+	}
+
+	sd, ok := dataMap[OutputKeyData]
 	if !ok {
 		return nil, fmt.Errorf("missing 'data' field in backend output")
 	}
 
 	// Direct pointer — returned by in-process providers.
 	if stateData, ok := sd.(*Data); ok {
-		if err := validateSchemaVersion(stateData.SchemaVersion); err != nil {
+		// A zero-value document is the in-process equivalent of a contentless
+		// payload: treat it as fresh empty state rather than a version-0 file.
+		if isEmptyData(stateData) {
+			return NewData(), nil
+		}
+		if err := validateSchemaVersion(stateData.SchemaVersion, true); err != nil {
 			return nil, err
 		}
 		normalizeData(stateData)

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -819,6 +819,65 @@ func TestExtractStateData(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "expected *Data or map[string]any")
 	})
+
+	t.Run("found false yields fresh state without data", func(t *testing.T) {
+		t.Parallel()
+		// A backend that reports an absent object (found:false) must yield fresh
+		// empty state without a data field and without a version error.
+		result, err := extractStateData(&provider.ExecutionResult{
+			Output: provider.Output{Data: map[string]any{
+				"success":      true,
+				OutputKeyFound: false,
+			}},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, SchemaVersionCurrent, result.SchemaVersion)
+		assert.Empty(t, result.Parameters)
+	})
+
+	t.Run("found false wins over zero-version data", func(t *testing.T) {
+		t.Parallel()
+		// Even when a backend returns a zero-value document alongside found:false,
+		// the absence signal takes precedence and no version guard is applied.
+		result, err := extractStateData(&provider.ExecutionResult{
+			Output: provider.Output{Data: map[string]any{
+				"success":      true,
+				OutputKeyFound: false,
+				OutputKeyData:  &Data{},
+			}},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, SchemaVersionCurrent, result.SchemaVersion)
+	})
+
+	t.Run("direct pointer empty document is fresh state", func(t *testing.T) {
+		t.Parallel()
+		// A zero-value *Data (no found signal) is the in-process equivalent of a
+		// contentless payload and must be treated as fresh state, not a v0 file.
+		result, err := extractStateData(&provider.ExecutionResult{
+			Output: provider.Output{Data: map[string]any{
+				"success":     true,
+				OutputKeyData: &Data{},
+			}},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, SchemaVersionCurrent, result.SchemaVersion)
+		assert.NotNil(t, result.Resolvers)
+	})
+
+	t.Run("map fallback empty object is fresh state", func(t *testing.T) {
+		t.Parallel()
+		// A plugin backend that returns an empty map on not-found (instead of the
+		// found signal) must still produce fresh state rather than a v0 error.
+		result, err := extractStateData(&provider.ExecutionResult{
+			Output: provider.Output{Data: map[string]any{
+				"success":     true,
+				OutputKeyData: map[string]any{},
+			}},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, SchemaVersionCurrent, result.SchemaVersion)
+	})
 }
 
 func TestManagerLoad_ParamsAsParams(t *testing.T) {

--- a/pkg/state/types.go
+++ b/pkg/state/types.go
@@ -35,6 +35,20 @@ const (
 // partition logic reference it to avoid drift.
 const ReadProviderName = "state"
 
+const (
+	// OutputKeyData is the state_load output field that carries the decoded or
+	// serialized state document a backend read from its storage.
+	OutputKeyData = "data"
+
+	// OutputKeyFound is the state_load output field a backend sets to false to
+	// report that no state object exists yet (a first run). When absent it
+	// defaults to true, which preserves the prior backend contract. The core
+	// loader treats found:false as fresh empty state without decoding the
+	// payload or applying the schema-version guard, so the "delete the state
+	// file and recreate it" guidance is never emitted before a file exists.
+	OutputKeyFound = "found"
+)
+
 // Config is the solution-level state configuration.
 // It is a top-level peer to Spec, Catalog, Bundle, and Compose on the Solution struct.
 //

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1490,6 +1492,97 @@ spec:
 			assert.Contains(t, stderr, tc.wantHint, "the error should include the actionable remediation hint")
 			assert.NotContains(t, stderr, "cannot unmarshal",
 				"the version guard must fire before the strict decode, so no reflection error should leak")
+		})
+	}
+}
+
+// TestIntegration_RunSolution_FirstRunAbsentState verifies the first-run
+// contract: when a state backend reports no existing state (an HTTP 404, or a
+// contentless "{}" payload the way some remote backends answer a missing
+// object), the run must start from fresh empty state and succeed -- it must NOT
+// be misread as an out-of-range "schemaVersion 0" and rejected with an
+// "incompatible state schema version" error.
+func TestIntegration_RunSolution_FirstRunAbsentState(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		loadStatus int
+		loadBody   string
+	}{
+		{
+			name:       "remote 404 is a fresh first run",
+			loadStatus: http.StatusNotFound,
+			loadBody:   "not found",
+		},
+		{
+			name:       "contentless empty object is a fresh first run",
+			loadStatus: http.StatusOK,
+			loadBody:   "{}",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// state_load is a GET; state_save/delete use other methods.
+				if r.Method == http.MethodGet {
+					w.WriteHeader(tc.loadStatus)
+					_, _ = w.Write([]byte(tc.loadBody))
+					return
+				}
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"success": true}`))
+			}))
+			defer srv.Close()
+
+			solutionContent := fmt.Sprintf(`apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: first-run-absent-state
+  version: 1.0.0
+state:
+  enabled: true
+  backend:
+    provider: http
+    inputs:
+      url: %s
+spec:
+  resolvers:
+    region:
+      type: string
+      immutable: true
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: region
+              default: us-east1
+  workflow:
+    actions:
+      notify:
+        provider: message
+        inputs:
+          message: "ACTION_RAN"
+          type: info
+`, srv.URL)
+
+			tmpDir := t.TempDir()
+			solutionPath := filepath.Join(tmpDir, "solution.yaml")
+			require.NoError(t, os.WriteFile(solutionPath, []byte(solutionContent), 0o600))
+
+			// The http backend talks to an httptest server on 127.0.0.1, which the
+			// SSRF guard blocks unless private IPs are explicitly allowed.
+			configPath := filepath.Join(tmpDir, "config.yaml")
+			require.NoError(t, os.WriteFile(configPath, []byte("httpClient:\n  allowPrivateIPs: true\n"), 0o600))
+
+			stdout, stderr, exitCode := runScafctlInDir(t, tmpDir, "--config", configPath, "run", "solution", "-f", solutionPath)
+			assert.Equal(t, 0, exitCode, "a first run against an absent remote state must succeed")
+			assert.Contains(t, stdout, "ACTION_RAN", "the action should run on a fresh first run")
+			assert.NotContains(t, stderr, "incompatible state schema version",
+				"an absent/contentless first-run state must not be misread as an out-of-range schema version")
 		})
 	}
 }


### PR DESCRIPTION
## What

Make a **first run against an absent state backend** succeed instead of
failing with a cryptic `incompatible state schema version` error.

Previously, when a state backend reported "no state yet" as an empty or
contentless payload (an HTTP `404`, or a `{}` body the way some remote
backends answer a missing object), the decoder read the missing
`schemaVersion` as `0`, judged it "older than the minimum supported
version," and aborted the run telling the user to *delete the state file
and recreate it* -- on a run where no state file existed in the first
place.

## Why

"No state" and "a real, too-old state file" were indistinguishable at the
decode layer. Backends were implicitly expected to return a fresh
`NewData()` on absence, but that contract was undocumented and fragile: a
backend that answered with `{"success":true,"data":{}}` (or a bare `{}`)
tripped the version guard. This is exactly what a first run looks like, so
the tool rejected the common case.

## How -- defense in depth (modeled on Terraform's explicit-absence contract)

1. **Explicit absence signal.** State backends now report a `found` boolean
   on `state_load`. `found: false` means "no state object exists yet"; the
   loader starts from fresh empty state. `found` absent defaults to `true`
   for backward compatibility. The built-in file provider (missing file) and
   http provider (`404`) set `found: false`.
2. **Contentless-payload safety net.** `DecodeData` treats a truly-empty
   payload (`""`, whitespace, `null`, or `{}`) as fresh state before the
   version guard runs. This covers backends (including external plugins)
   that report absence with a contentless body rather than the `found`
   signal.
3. **Sharper diagnostics.** The version guard distinguishes an *explicit*
   old `schemaVersion` from a payload that has content but no
   `schemaVersion` field, so the error text matches the real situation.

Safety is preserved: a genuine v0/v1 file **with content** (e.g.
`{"parameters":{}}`) is still rejected, so the immutable-lock guarantee is
intact -- only genuinely empty payloads are treated as a fresh start.

## Changes

- `pkg/state/decode.go` -- `isContentless` fast-path, presence-aware
  `schemaVersion` probe (`*int`), `isEmptyData`, and a clearer
  `validateSchemaVersion` message.
- `pkg/state/types.go` -- `OutputKeyData` / `OutputKeyFound` load-response
  contract constants.
- `pkg/state/manager.go` -- `extractStateData` honors `found: false` and
  treats an empty direct-pointer document as fresh.
- `pkg/provider/builtin/fileprovider` and `.../httpprovider` -- emit
  `found: false` on absence and document the optional `found` output field
  in the `state` capability schema.
- `docs/design/state/state.md` -- new "State Backend Load Response Contract"
  section documenting `found` and the contentless-payload rule.

## Tests

- Unit: contentless-is-fresh, structured-empty-still-guarded,
  presence-aware version validation, `isEmptyData`, and
  `extractStateData` `found`/empty-document cases (100% on the new logic).
- Integration: `TestIntegration_RunSolution_FirstRunAbsentState` runs a
  solution against an `httptest` state backend returning `404` and a
  contentless `{}` and asserts the run succeeds with no
  `incompatible state schema version` error.
- `task test:e2e`: 916 passed, 0 failed. `task lint:changed`: 0 issues.
