### PR TITLE
fix: accept CEL optional access/chaining in expression syntax validation

### DIFF
--- a/docs/design/mcp-server-enhancements.md
+++ b/docs/design/mcp-server-enhancements.md
@@ -171,7 +171,9 @@ scafctl eval validate --expression '{{ .name }}' --type go-template
 | `-o` | string | No | Output format |
 
 **Implementation:**
-- CEL: use `cel.NewEnv().Parse()` to syntax-check
+- CEL: use `celexp.ValidateSyntax()` to syntax-check (routes through the shared
+  parse environment so optional access/chaining like `_.?name` parses the same
+  way the runtime evaluates it)
 - Go template: use `template.New().Parse()` + `gotmpl.Service.GetReferences()`
 - Report: valid/invalid, error details, referenced variables
 

--- a/docs/design/mcp-server-enhancements.md
+++ b/docs/design/mcp-server-enhancements.md
@@ -171,9 +171,9 @@ scafctl eval validate --expression '{{ .name }}' --type go-template
 | `-o` | string | No | Output format |
 
 **Implementation:**
-- CEL: use `celexp.ValidateSyntax()` to syntax-check (routes through the shared
-  parse environment so optional access/chaining like `_.?name` parses the same
-  way the runtime evaluates it)
+- CEL: use `celexp.ValidateSyntax(ctx, expr)` to syntax-check (routes through the
+  shared parse environment so optional access/chaining like `_.?name` parses the
+  same way the runtime evaluates it)
 - Go template: use `template.New().Parse()` + `gotmpl.Service.GetReferences()`
 - Report: valid/invalid, error details, referenced variables
 

--- a/pkg/celexp/celexp.go
+++ b/pkg/celexp/celexp.go
@@ -76,7 +76,8 @@ func SetDefaultCostLimit(limit uint64) {
 // This should be called once during application initialization by the env package.
 // It allows celexp to use environments with all custom extensions without circular dependencies.
 //
-// This function is thread-safe and uses sync.Once to ensure it's only set once.
+// This function is thread-safe: it is guarded by a mutex and an initialized flag
+// so only the first call takes effect.
 func SetEnvFactory(factory func(context.Context, ...cel.EnvOption) (*cel.Env, error)) {
 	envFactoryMu.Lock()
 	defer envFactoryMu.Unlock()
@@ -98,7 +99,8 @@ func getEnvFactory() func(context.Context, ...cel.EnvOption) (*cel.Env, error) {
 // This should be called once during application initialization by the env package.
 // It allows celexp to use the global cache without circular dependencies.
 //
-// This function is thread-safe and uses sync.Once to ensure it's only set once.
+// This function is thread-safe: it is guarded by a mutex and an initialized flag
+// so only the first call takes effect.
 //
 // Example (called by env package during initialization):
 //

--- a/pkg/celexp/celexp.go
+++ b/pkg/celexp/celexp.go
@@ -793,13 +793,40 @@ func formatCelType(t *cel.Type) string {
 	}
 }
 
-// ValidateSyntax checks a CEL expression for parse errors without executing it
-// or requiring any variable declarations. It uses a minimal CEL environment for
-// fast syntax validation. Returns nil if the expression is syntactically valid.
-func ValidateSyntax(expression string) error {
-	env, err := cel.NewEnv()
+// NewParseEnv builds a CEL environment for parse-only AST inspection and syntax
+// validation. It uses the registered environment factory -- which includes all
+// custom extensions and optional types -- when available, so the parser
+// recognizes exactly the same syntax the evaluation/runtime engine does. When no
+// factory is registered (e.g. white-box unit tests within celexp), it falls back
+// to a minimal environment with optional types enabled so optional access
+// (_.?name, _[?"name"]) still parses.
+//
+// Routing every parse-only environment through this single constructor keeps
+// syntax validation and evaluation from drifting apart.
+func NewParseEnv(ctx context.Context) (*cel.Env, error) {
+	if factory := getEnvFactory(); factory != nil {
+		env, err := factory(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+		}
+		return env, nil
+	}
+	env, err := cel.NewEnv(cel.OptionalTypes())
 	if err != nil {
-		return fmt.Errorf("creating CEL environment: %w", err)
+		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+	return env, nil
+}
+
+// ValidateSyntax checks a CEL expression for parse errors without executing it
+// or requiring any variable declarations. It parses with the same environment
+// the runtime uses (via NewParseEnv), so any expression that evaluates
+// successfully -- including optional access and chaining (_.?name) -- also
+// validates successfully. Returns nil if the expression is syntactically valid.
+func ValidateSyntax(ctx context.Context, expression string) error {
+	env, err := NewParseEnv(ctx)
+	if err != nil {
+		return err
 	}
 
 	_, issues := env.Parse(expression)

--- a/pkg/celexp/celexp_negative_test.go
+++ b/pkg/celexp/celexp_negative_test.go
@@ -4,6 +4,7 @@
 package celexp
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/cel-go/cel"
@@ -555,14 +556,21 @@ func TestValidateSyntax(t *testing.T) {
 		{name: "valid_function", expr: "size('hello')", wantErr: false},
 		{name: "valid_ternary", expr: "x > 0 ? 'pos' : 'neg'", wantErr: false},
 		{name: "valid_boolean", expr: "true && false", wantErr: false},
+		// Optional access and chaining must parse: the parse env enables
+		// optional types, matching runtime evaluation (regression for
+		// validate_expression reporting valid '.?' syntax as an error).
+		{name: "valid_optional_access", expr: `_.?name.orValue("fallback")`, wantErr: false},
+		{name: "valid_optional_chaining", expr: "msg.?field.?nested", wantErr: false},
+		{name: "valid_optional_index", expr: `m[?"key"].orValue("x")`, wantErr: false},
 		{name: "invalid_unclosed_paren", expr: "size('hello'", wantErr: true},
 		{name: "invalid_missing_operand", expr: "1 +", wantErr: true},
 		{name: "invalid_unclosed_string", expr: "'hello", wantErr: true},
 		{name: "empty_expression", expr: "", wantErr: true},
 	}
+	ctx := context.Background()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateSyntax(tt.expr)
+			err := ValidateSyntax(ctx, tt.expr)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -573,7 +581,8 @@ func TestValidateSyntax(t *testing.T) {
 }
 
 func BenchmarkValidateSyntax(b *testing.B) {
+	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
-		ValidateSyntax("x > 0 ? size(name) : 0")
+		ValidateSyntax(ctx, "x > 0 ? size(name) : 0")
 	}
 }

--- a/pkg/celexp/celexp_test.go
+++ b/pkg/celexp/celexp_test.go
@@ -437,6 +437,65 @@ func TestSetEnvFactory(t *testing.T) {
 	assert.False(t, called2, "second SetEnvFactory call should be ignored")
 }
 
+func TestNewParseEnv(t *testing.T) {
+	// Save and restore original factory state so subtests can swap it freely.
+	origFactory := envFactory
+	origInitialized := envFactoryInitialized
+	t.Cleanup(func() {
+		envFactoryMu.Lock()
+		envFactory = origFactory
+		envFactoryInitialized = origInitialized
+		envFactoryMu.Unlock()
+	})
+
+	setFactory := func(f func(context.Context, ...cel.EnvOption) (*cel.Env, error)) {
+		envFactoryMu.Lock()
+		envFactory = f
+		envFactoryInitialized = true
+		envFactoryMu.Unlock()
+	}
+
+	t.Run("fallback env parses optional syntax", func(t *testing.T) {
+		// No factory registered -> NewParseEnv must fall back to an env with
+		// OptionalTypes so optional access (.?) still parses.
+		setFactory(nil)
+
+		env, err := NewParseEnv(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, env)
+
+		_, issues := env.Parse(`_.?name.orValue("fallback")`)
+		if issues != nil {
+			assert.NoError(t, issues.Err())
+		}
+	})
+
+	t.Run("uses registered factory", func(t *testing.T) {
+		called := false
+		setFactory(func(ctx context.Context, opts ...cel.EnvOption) (*cel.Env, error) {
+			called = true
+			return cel.NewEnv(opts...)
+		})
+
+		env, err := NewParseEnv(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, env)
+		assert.True(t, called, "NewParseEnv should use the registered factory")
+	})
+
+	t.Run("wraps factory error", func(t *testing.T) {
+		setFactory(func(ctx context.Context, opts ...cel.EnvOption) (*cel.Env, error) {
+			return nil, assert.AnError
+		})
+
+		env, err := NewParseEnv(context.Background())
+		require.Error(t, err)
+		assert.Nil(t, env)
+		assert.Contains(t, err.Error(), "failed to create CEL environment")
+		assert.ErrorIs(t, err, assert.AnError)
+	})
+}
+
 func TestSetCacheFactory(t *testing.T) {
 	// Reset state so we can set it fresh
 	ResetForTesting()

--- a/pkg/celexp/env/env_parity_test.go
+++ b/pkg/celexp/env/env_parity_test.go
@@ -1,0 +1,71 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package env
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/celexp/ext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateSyntaxRuntimeParity asserts the core contract from the
+// validate-expression optional-chaining bug: every expression the runtime
+// evaluation environment can parse, celexp.ValidateSyntax must also accept.
+//
+// It registers the real runtime factory (New) -- the same environment used to
+// evaluate expressions -- so celexp.ValidateSyntax parses through the production
+// code path rather than a minimal fallback. The corpus is the documented set of
+// optionalTypes examples (the syntax the bug incorrectly rejected), plus a few
+// explicit optional-access and chaining cases.
+func TestValidateSyntaxRuntimeParity(t *testing.T) {
+	// Register the runtime factory so celexp.NewParseEnv (used by ValidateSyntax)
+	// builds the same environment the evaluator uses. SetEnvFactory is guarded by
+	// sync.Once; registering New here is the production configuration.
+	celexp.SetEnvFactory(New)
+
+	ctx := context.Background()
+
+	// Gather the documented optional-types examples -- the exact syntax the bug
+	// rejected during validation while accepting it during evaluation.
+	var corpus []string
+	for _, fn := range ext.All() {
+		if fn.Name != "optionalTypes" {
+			continue
+		}
+		for _, ex := range fn.Examples {
+			if ex.Expression != "" {
+				corpus = append(corpus, ex.Expression)
+			}
+		}
+	}
+	require.NotEmpty(t, corpus, "expected optionalTypes examples to form a parity corpus")
+
+	// Explicit optional-access and chaining cases (regression for the reported
+	// '.?' false negative), including the exact expression from the issue.
+	corpus = append(corpus,
+		`_.?name.orValue("fallback")`,
+		`_.?config.?host.orValue("localhost")`,
+		`_[?"name"].orValue("x")`,
+	)
+
+	// Build the runtime environment once for the parity comparison.
+	runtimeEnv, err := New(ctx)
+	require.NoError(t, err)
+
+	for _, expr := range corpus {
+		t.Run(expr, func(t *testing.T) {
+			// The runtime environment must be able to parse the expression...
+			_, issues := runtimeEnv.Parse(expr)
+			require.NoError(t, issues.Err(), "runtime env failed to parse: %s", expr)
+
+			// ...and so must ValidateSyntax, or the two have drifted apart.
+			assert.NoError(t, celexp.ValidateSyntax(ctx, expr),
+				"ValidateSyntax rejected an expression the runtime accepts: %s", expr)
+		})
+	}
+}

--- a/pkg/celexp/env/env_parity_test.go
+++ b/pkg/celexp/env/env_parity_test.go
@@ -24,8 +24,9 @@ import (
 // explicit optional-access and chaining cases.
 func TestValidateSyntaxRuntimeParity(t *testing.T) {
 	// Register the runtime factory so celexp.NewParseEnv (used by ValidateSyntax)
-	// builds the same environment the evaluator uses. SetEnvFactory is guarded by
-	// sync.Once; registering New here is the production configuration.
+	// builds the same environment the evaluator uses. SetEnvFactory is guarded by a
+	// mutex and an initialized flag so it only takes effect once; registering New
+	// here is the production configuration.
 	celexp.SetEnvFactory(New)
 
 	ctx := context.Background()

--- a/pkg/celexp/equality.go
+++ b/pkg/celexp/equality.go
@@ -70,7 +70,7 @@ func (e Expression) paramEqualitiesWithPrefix(ctx context.Context, prefix string
 		prefix = "_."
 	}
 
-	env, err := newParseEnv(ctx)
+	env, err := NewParseEnv(ctx)
 	if err != nil {
 		return nil, false, false
 	}
@@ -96,15 +96,6 @@ func (e Expression) paramEqualitiesWithPrefix(ctx context.Context, prefix string
 		found[name] = dedupeSortValues(vals)
 	}
 	return found, reducible, true
-}
-
-// newParseEnv builds a CEL environment for parse-only AST inspection, reusing
-// the registered extension factory when available so custom functions parse.
-func newParseEnv(ctx context.Context) (*cel.Env, error) {
-	if factory := getEnvFactory(); factory != nil {
-		return factory(ctx)
-	}
-	return cel.NewEnv(cel.OptionalTypes())
 }
 
 // collectEqualities recursively walks call nodes, accumulating discovered

--- a/pkg/celexp/refs.go
+++ b/pkg/celexp/refs.go
@@ -34,20 +34,10 @@ func (e Expression) GetVariablesWithPrefix(ctx context.Context, prefix string) (
 		prefix = "_."
 	}
 
-	// Create a CEL environment for parsing
-	// Use the environment factory if available to include custom extensions
-	var env *cel.Env
-	var err error
-	factory := getEnvFactory()
-	if factory != nil {
-		env, err = factory(ctx)
-	} else {
-		// Enable optional types so optional access (_.?name, _[?"name"]) parses
-		// even when no extension factory is registered (e.g. white-box tests).
-		env, err = cel.NewEnv(cel.OptionalTypes())
-	}
+	// Create a CEL environment for parsing (shared with runtime via NewParseEnv).
+	env, err := NewParseEnv(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+		return nil, err
 	}
 
 	// Parse the expression to get the AST
@@ -112,7 +102,7 @@ func (e Expression) GetUnderscoreVariables(ctx context.Context) ([]string, error
 //	// hard == []string{"a"}, optional == []string{"b"}
 //	// (a is hard despite the _.?a use; b is optional-only)
 func (e Expression) GetUnderscoreVariablesByOptionality(ctx context.Context) (hard, optional []string, err error) {
-	env, err := e.parseEnv(ctx)
+	env, err := NewParseEnv(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -155,25 +145,6 @@ func (e Expression) GetUnderscoreVariablesByOptionality(ctx context.Context) (ha
 	return hard, optional, nil
 }
 
-// parseEnv builds a CEL environment for parsing, using the registered
-// environment factory (with custom extensions) when available and falling back
-// to a minimal environment with optional types enabled so optional access
-// (_.?name, _[?"name"]) parses in white-box tests.
-func (e Expression) parseEnv(ctx context.Context) (*cel.Env, error) {
-	if factory := getEnvFactory(); factory != nil {
-		env, err := factory(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create CEL environment: %w", err)
-		}
-		return env, nil
-	}
-	env, err := cel.NewEnv(cel.OptionalTypes())
-	if err != nil {
-		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
-	}
-	return env, nil
-}
-
 // MapLiteralKeys parses the CEL expression and, if its top-level node is a map
 // literal with constant string keys (e.g. {"a": _.x, "b": proj}), returns the
 // list of those keys and true. For any other expression shape -- a function
@@ -194,14 +165,7 @@ func (e Expression) parseEnv(ctx context.Context) (*cel.Env, error) {
 //	keys, ok := celexp.Expression(`map.merge(_.a, _.b)`).MapLiteralKeys(ctx)
 //	// keys == nil, ok == false
 func (e Expression) MapLiteralKeys(ctx context.Context) ([]string, bool) {
-	var env *cel.Env
-	var err error
-	factory := getEnvFactory()
-	if factory != nil {
-		env, err = factory(ctx)
-	} else {
-		env, err = cel.NewEnv(cel.OptionalTypes())
-	}
+	env, err := NewParseEnv(ctx)
 	if err != nil {
 		return nil, false
 	}
@@ -272,20 +236,10 @@ func (e Expression) MapLiteralKeys(ctx context.Context) ([]string, bool) {
 //	vars, err = expr.RequiredVariables(ctx)
 //	// Returns: []string{}, nil (x is a comprehension variable, not external)
 func (e Expression) RequiredVariables(ctx context.Context) ([]string, error) {
-	// Create a CEL environment for parsing
-	// Use the environment factory if available to include custom extensions
-	var env *cel.Env
-	var err error
-	factory := getEnvFactory()
-	if factory != nil {
-		env, err = factory(ctx)
-	} else {
-		// Enable optional types so optional access (_.?name, _[?"name"]) parses
-		// even when no extension factory is registered (e.g. white-box tests).
-		env, err = cel.NewEnv(cel.OptionalTypes())
-	}
+	// Create a CEL environment for parsing (shared with runtime via NewParseEnv).
+	env, err := NewParseEnv(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+		return nil, err
 	}
 
 	// Parse the expression to get the AST

--- a/pkg/cmd/scafctl/eval/validate.go
+++ b/pkg/cmd/scafctl/eval/validate.go
@@ -10,7 +10,7 @@ import (
 	"text/template"
 
 	"github.com/MakeNowJust/heredoc/v2"
-	"github.com/google/cel-go/cel"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
@@ -105,7 +105,7 @@ func (o *ValidateOptions) Run(ctx context.Context) error {
 
 	switch o.Type {
 	case "cel":
-		result = validateCEL(o.Expression)
+		result = validateCEL(ctx, o.Expression)
 	case "go-template", "gotemplate", "template":
 		result = validateGoTemplate(o.Expression)
 	default:
@@ -136,26 +136,20 @@ func (o *ValidateOptions) Run(ctx context.Context) error {
 	return nil
 }
 
-// validateCEL validates a CEL expression for syntax errors.
-func validateCEL(expr string) *ValidateResult {
+// validateCEL validates a CEL expression for syntax errors. It delegates to
+// celexp.ValidateSyntax so the CLI parses with the same environment the runtime
+// uses -- including optional access and chaining (_.?name) -- rather than a
+// bare environment that would reject valid optional syntax.
+func validateCEL(ctx context.Context, expr string) *ValidateResult {
 	result := &ValidateResult{
 		Expression: expr,
 		Type:       "cel",
 		Valid:      true,
 	}
 
-	env, err := cel.NewEnv()
-	if err != nil {
+	if err := celexp.ValidateSyntax(ctx, expr); err != nil {
 		result.Valid = false
-		result.Error = fmt.Sprintf("failed to create CEL environment: %v", err)
-		return result
-	}
-
-	_, issues := env.Parse(expr)
-	if issues != nil && issues.Err() != nil {
-		result.Valid = false
-		result.Error = issues.Err().Error()
-		return result
+		result.Error = err.Error()
 	}
 
 	return result

--- a/pkg/cmd/scafctl/eval/validate_test.go
+++ b/pkg/cmd/scafctl/eval/validate_test.go
@@ -4,6 +4,7 @@
 package eval
 
 import (
+	"context"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -58,6 +59,40 @@ func TestCommandValidate_RequiredFlags(t *testing.T) {
 
 	err := cmd.Execute()
 	assert.Error(t, err, "should fail without required --expression and --type flags")
+}
+
+func TestValidateCEL(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name      string
+		expr      string
+		wantValid bool
+	}{
+		{name: "simple valid", expr: "1 + 2 == 3", wantValid: true},
+		{name: "function call", expr: "size('hello') > 3", wantValid: true},
+		// Regression: optional access and chaining must validate on the CLI
+		// surface, matching runtime evaluation (previously rejected with
+		// "unsupported syntax '.?'").
+		{name: "optional access", expr: `_.?name.orValue("fallback")`, wantValid: true},
+		{name: "optional chaining", expr: "msg.?field.?nested", wantValid: true},
+		{name: "unbalanced parens", expr: "size('hello'", wantValid: false},
+		{name: "empty", expr: "", wantValid: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateCEL(ctx, tt.expr)
+			require.NotNil(t, result)
+			assert.Equal(t, "cel", result.Type)
+			assert.Equal(t, tt.wantValid, result.Valid, "expr: %s", tt.expr)
+			if tt.wantValid {
+				assert.Empty(t, result.Error)
+			} else {
+				assert.NotEmpty(t, result.Error)
+			}
+		})
+	}
 }
 
 func BenchmarkCommandValidate(b *testing.B) {

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -6,6 +6,7 @@
 package lint
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -1394,11 +1395,11 @@ func lintTemplateUnderscorePrefix(tmpl, location string, result *Result) {
 }
 
 // celLintEnv holds the shared CEL environment used for all lint-time parsing.
-// It enables cel.OptionalTypes() so optional access syntax (_.?name, _[?"name"])
-// parses successfully, matching the env used by the reference collector and
-// runtime evaluation in pkg/celexp. The env is immutable and safe for
-// concurrent use, so it is built once and reused across every expression
-// instead of being rebuilt per call.
+// It is built once via celexp.NewParseEnv -- the same constructor the reference
+// collector and runtime evaluation use -- so optional access syntax (_.?name,
+// _[?"name"]) and every custom extension parse identically to evaluation and
+// cannot drift. The env is immutable and safe for concurrent use, so it is built
+// once and reused across every expression instead of being rebuilt per call.
 var (
 	celLintEnv     *cel.Env
 	celLintEnvErr  error
@@ -1408,7 +1409,7 @@ var (
 // lintCELEnv returns the shared lint CEL environment, building it on first use.
 func lintCELEnv() (*cel.Env, error) {
 	celLintEnvOnce.Do(func() {
-		celLintEnv, celLintEnvErr = cel.NewEnv(cel.OptionalTypes())
+		celLintEnv, celLintEnvErr = celexp.NewParseEnv(context.Background())
 	})
 	return celLintEnv, celLintEnvErr
 }

--- a/pkg/mcp/tools_sprint6_test.go
+++ b/pkg/mcp/tools_sprint6_test.go
@@ -155,6 +155,30 @@ func TestHandleValidateExpressions(t *testing.T) {
 		assert.Equal(t, float64(2), summary["invalid"])
 	})
 
+	t.Run("cel optional chaining is valid", func(t *testing.T) {
+		// Regression: the batch path (validateCELExpressionDirect) must accept
+		// optional access (.?) just like the single-expression handler.
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+		request := mcp.CallToolRequest{}
+		request.Params.Arguments = map[string]any{
+			"expressions": []any{
+				map[string]any{"expression": `_.?name.orValue("fallback")`, "type": "cel"},
+				map[string]any{"expression": "msg.?field.?nested", "type": "cel"},
+			},
+		}
+		result, err := srv.handleValidateExpressions(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+		text := extractText(t, result)
+		var data map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &data))
+		summary := data["summary"].(map[string]any)
+		assert.Equal(t, float64(2), summary["total"])
+		assert.Equal(t, float64(2), summary["valid"])
+		assert.Equal(t, float64(0), summary["invalid"])
+	})
+
 	t.Run("empty expressions", func(t *testing.T) {
 		srv, err := NewServer(WithServerVersion("test"))
 		require.NoError(t, err)

--- a/pkg/mcp/tools_template.go
+++ b/pkg/mcp/tools_template.go
@@ -238,7 +238,7 @@ func (s *Server) handleListGoTemplateFunctions(_ context.Context, request mcp.Ca
 }
 
 // handleValidateExpression validates a CEL expression or Go template for syntax errors.
-func (s *Server) handleValidateExpression(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (s *Server) handleValidateExpression(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	expression, err := request.RequireString("expression")
 	if err != nil {
 		return newStructuredError(ErrCodeInvalidInput, err.Error(),
@@ -257,7 +257,7 @@ func (s *Server) handleValidateExpression(_ context.Context, request mcp.CallToo
 
 	switch exprType {
 	case "cel":
-		return s.validateCELExpression(expression)
+		return s.validateCELExpression(ctx, expression)
 	case "go-template":
 		leftDelim := request.GetString("left_delim", "")
 		rightDelim := request.GetString("right_delim", "")
@@ -271,8 +271,8 @@ func (s *Server) handleValidateExpression(_ context.Context, request mcp.CallToo
 }
 
 // validateCELExpression checks a CEL expression for syntax errors without executing it.
-func (s *Server) validateCELExpression(expression string) (*mcp.CallToolResult, error) {
-	if err := celexp.ValidateSyntax(expression); err != nil {
+func (s *Server) validateCELExpression(ctx context.Context, expression string) (*mcp.CallToolResult, error) {
+	if err := celexp.ValidateSyntax(ctx, expression); err != nil {
 		return mcp.NewToolResultJSON(map[string]any{
 			"valid":      false,
 			"type":       "cel",
@@ -335,7 +335,7 @@ func (s *Server) validateGoTemplate(content, leftDelim, rightDelim string) (*mcp
 }
 
 // handleValidateExpressions batch-validates multiple CEL and Go-template expressions.
-func (s *Server) handleValidateExpressions(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (s *Server) handleValidateExpressions(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	args := request.GetArguments()
 	exprsRaw, ok := args["expressions"]
 	if !ok || exprsRaw == nil {
@@ -407,7 +407,7 @@ func (s *Server) handleValidateExpressions(_ context.Context, request mcp.CallTo
 
 		switch exprType {
 		case "cel":
-			valid, errMsg := s.validateCELExpressionDirect(expr)
+			valid, errMsg := s.validateCELExpressionDirect(ctx, expr)
 			entry.Valid = valid
 			if errMsg != "" {
 				entry.Error = errMsg
@@ -445,8 +445,8 @@ func (s *Server) handleValidateExpressions(_ context.Context, request mcp.CallTo
 }
 
 // validateCELExpressionDirect validates a CEL expression and returns (valid, errorMsg).
-func (s *Server) validateCELExpressionDirect(expression string) (bool, string) {
-	if err := celexp.ValidateSyntax(expression); err != nil {
+func (s *Server) validateCELExpressionDirect(ctx context.Context, expression string) (bool, string) {
+	if err := celexp.ValidateSyntax(ctx, expression); err != nil {
 		return false, err.Error()
 	}
 	return true, ""

--- a/pkg/mcp/tools_template_test.go
+++ b/pkg/mcp/tools_template_test.go
@@ -175,6 +175,27 @@ func TestHandleValidateExpression(t *testing.T) {
 		assert.Equal(t, false, output["valid"])
 	})
 
+	t.Run("valid CEL optional chaining", func(t *testing.T) {
+		// Regression: optional access (.?) must validate the same way it
+		// evaluates -- previously reported as "unsupported syntax '.?'".
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "validate_expression"
+		request.Params.Arguments = map[string]any{
+			"expression": `_.?name.orValue("fallback")`,
+			"type":       "cel",
+		}
+
+		result, err := srv.handleValidateExpression(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		assert.Equal(t, true, output["valid"])
+		assert.Equal(t, "cel", output["type"])
+	})
+
 	t.Run("valid Go template", func(t *testing.T) {
 		request := mcp.CallToolRequest{}
 		request.Params.Name = "validate_expression"

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -8876,6 +8876,31 @@ func TestIntegration_EvalValidate_CELValid(t *testing.T) {
 	assert.Contains(t, stdout, "valid")
 }
 
+// TestIntegration_EvalValidate_CELOptionalChaining is a regression test: CEL
+// optional access/chaining (_.?name) must validate as syntactically valid on
+// the CLI, matching the runtime evaluation environment. Previously the
+// validator used a bare CEL environment without OptionalTypes and rejected it.
+func TestIntegration_EvalValidate_CELOptionalChaining(t *testing.T) {
+	t.Parallel()
+	for _, expr := range []string{
+		`_.?name.orValue("fallback")`,
+		"msg.?field.?nested",
+		`_[?"name"].orValue("x")`,
+	} {
+		expr := expr
+		t.Run(expr, func(t *testing.T) {
+			t.Parallel()
+			stdout, _, exitCode := runScafctl(t, "eval", "validate", "--expression", expr, "--type", "cel", "-o", "json")
+			assert.Equal(t, 0, exitCode)
+
+			var result map[string]any
+			require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+			assert.Equal(t, true, result["valid"], "expr %q should be valid", expr)
+			assert.Equal(t, "cel", result["type"])
+		})
+	}
+}
+
 func TestIntegration_EvalValidate_CELInvalid(t *testing.T) {
 	t.Parallel()
 	_, _, exitCode := runScafctl(t, "eval", "validate", "--expression", "invalid +++ (", "--type", "cel")


### PR DESCRIPTION
## Problem

CEL syntax validation used a bare `cel.NewEnv()` with **no** `cel.OptionalTypes()` option, so valid optional access/chaining -- e.g. `_.?name.orValue("x")`, `msg.?field.?nested`, `_[?"name"].orValue("x")` -- was rejected as a syntax error even though the runtime evaluates those expressions fine.

The factory-or-fallback environment construction was also copy-pasted across ~5 call sites in `celexp`, which is exactly what let this path drift out of parity with evaluation.

The bug affected every code path that syntax-checks a CEL expression:
- MCP `validate_expression` and `validate_expressions` tools
- CLI `scafctl eval validate --type cel`

## Fix

Add a single canonical constructor `celexp.NewParseEnv(ctx)` that:
- uses the registered runtime env factory when present (full parity with evaluation, including all extensions + optional types), and
- falls back to `cel.NewEnv(cel.OptionalTypes())` otherwise (e.g. white-box unit tests).

Route every parse-only site through it:
- `celexp.ValidateSyntax` (now `ctx`-aware)
- `refs.go` (4 duplicated blocks consolidated)
- `equality.go` (removed local `newParseEnv`)
- `lint.go`'s `lintCELEnv` singleton (build-once preserved)

Thread the request `ctx` through both MCP `validate_expression` handlers (previously discarded), and fix the CLI `eval validate` path, which had the identical bare-env bug.

## Tests

- **Parity regression** (`pkg/celexp/env`): asserts every optional-types example the runtime env can `Parse` is also accepted by `celexp.ValidateSyntax`.
- **`NewParseEnv`** unit test: factory / fallback / error-wrap branches.
- Optional-syntax cases for `celexp`, MCP single + batch handlers, the CLI unit test, and a **CLI integration test** exercising `scafctl eval validate` through the production binary (env factory registered).

## Notes

- Breaking (allowed): `ValidateSyntax` signature gains a leading `ctx context.Context`.