### PR TITLE
feat: add solution-author-defined Go template functions (spec.functions)

### DIFF
--- a/.github/skills/go-template-patterns/SKILL.md
+++ b/.github/skills/go-template-patterns/SKILL.md
@@ -186,6 +186,21 @@ rather than failing. Use `explain_lint_rule template-unknown-accessor` for detai
 
 - `pkg/gotmpl/`: Template execution, options, missing key modes
 - `pkg/provider/builtin/gotmplprovider/`: Go template provider for transform phase
+- `pkg/authorfuncs/`: Author-defined template helpers (`spec.functions`)
+
+## Author-Defined Functions (`spec.functions`)
+
+Solutions can declare reusable named template helpers under `spec.functions`,
+callable from the Go templates the solution renders through the `go-template`
+provider (in resolvers and actions) as `{{ name arg... }}`.
+
+- Ordered, positional, typed `params`; exposed inside the body under the `args`
+  namespace (`_.args.name` in CEL bodies, `{{ .args.name }}` in template bodies).
+- Exactly one body per function: `cel:` XOR `template:`.
+- Template bodies can call sibling author functions and all built-ins; CEL
+  bodies cannot call author functions. Acyclicity is enforced at compile time.
+- Run `explain function` (MCP `explain_kind kind=function`) for the field
+  reference. See `examples/resolvers/author-functions.yaml`.
 
 ## See Also
 

--- a/docs/tutorials/go-templates-tutorial.md
+++ b/docs/tutorials/go-templates-tutorial.md
@@ -35,7 +35,8 @@ This tutorial walks you through using Go templates in scafctl to generate struct
 18. [Filtering Lists with where / selectField](#filtering-lists-with-where--selectfield)
 19. [Inline CEL with cel](#inline-cel-with-cel)
 20. [Debugging Template Type Errors](#debugging-template-type-errors)
-21. [Discovering Available Functions](#discovering-available-functions)
+21. [Author-Defined Functions](#author-defined-functions)
+22. [Discovering Available Functions](#discovering-available-functions)
 
 ---
 
@@ -2367,6 +2368,67 @@ Hints: The 'range' action received a non-iterable value. Ensure the variable
 > `data` expression, or add an explicit `dependsOn`. The `template-unknown-accessor`
 > lint rule warns about bare accessors that match no resolver, data key, or
 > alias (likely typos, since they render empty rather than failing).
+
+---
+
+## Author-Defined Functions
+
+Beyond the built-in Sprig and custom functions, a solution can declare its own
+reusable named template helpers under `spec.functions`. Once declared, a function
+is callable from the Go templates the solution renders through the `go-template`
+provider (in resolvers and actions) as `{{ name arg... }}`.
+
+Each function has:
+
+- **Ordered, positional, typed `params`.** They are bound by position at each
+  call site, coerced to the declared `type`, and exposed inside the body under
+  the `args` namespace (`_.args.name` in a CEL body, `{{ .args.name }}` in a
+  template body). A param may declare a `default` or be `required`.
+- **Exactly one body:** a CEL expression (`cel:`) or a Go template (`template:`).
+  A template body can call sibling author functions and every built-in; a CEL
+  body cannot call author functions. Functions must be acyclic (enforced when
+  the solution is loaded).
+
+```yaml
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: author-functions-demo
+spec:
+  functions:
+    # CEL-bodied helper: params exposed as _.args.<name>
+    greet:
+      description: "Uppercase a name and add a friendly prefix"
+      params:
+        - name: name
+          type: string
+          required: true
+      cel: '"HELLO " + _.args.name.upperAscii() + "!"'
+
+    # Template-bodied helper: calls the sibling greet function
+    shout:
+      description: "Compose greet with an exclamation"
+      params:
+        - name: who
+          type: string
+          required: true
+      template: '{{ greet .args.who }} ({{ .args.who | upper }})'
+
+  resolvers:
+    greeting:
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: greeting
+              template: '{{ shout "world" }}'
+```
+
+Running this resolves `greeting` to `HELLO WORLD! (WORLD)`.
+
+Run `scafctl explain function` for the full field reference. A complete,
+runnable example lives in `examples/resolvers/author-functions.yaml`.
 
 ---
 

--- a/examples/resolvers/README.md
+++ b/examples/resolvers/README.md
@@ -49,6 +49,7 @@ This directory contains practical examples demonstrating various resolver patter
 | [go-template-extensions.yaml](go-template-extensions.yaml) | Custom extension functions: toHcl, toHclValue, toYaml, fromYaml |
 | [go-template-sprig.yaml](go-template-sprig.yaml) | Sprig template functions (strings, type conversion, etc.) |
 | [go-template-ignored-blocks.yaml](go-template-ignored-blocks.yaml) | Using scafctl:ignore blocks to skip template rendering |
+| [author-functions.yaml](author-functions.yaml) | Author-defined template helpers via `spec.functions` (CEL + template bodies, composition) |
 | [template-dependency-inference.yaml](template-dependency-inference.yaml) | How go-template deps are inferred; data keys and forEach aliases vs `_.` refs |
 
 ### Integration

--- a/examples/resolvers/author-functions.yaml
+++ b/examples/resolvers/author-functions.yaml
@@ -1,0 +1,88 @@
+# Run: scafctl run resolver -f examples/resolvers/author-functions.yaml -o json
+# Run: scafctl run resolver -f examples/resolvers/author-functions.yaml -o yaml
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: author-functions-showcase
+  displayName: Author-Defined Template Functions Showcase
+  category: resolvers
+  tags:
+    - resolver-example
+    - template
+    - functions
+  description: |
+    Solution-author-defined Go template helper functions declared under
+    spec.functions. Each function is callable from every Go template the
+    solution renders as {{ name arg... }}. Functions have ordered, positional,
+    typed parameters (exposed inside the body under the "args" namespace) and
+    exactly one body: a CEL expression (cel) or a Go template (template).
+
+spec:
+  # ─────────────────────────────────────────────
+  # spec.functions - author-defined template helpers
+  # ─────────────────────────────────────────────
+  functions:
+    # A CEL-bodied function. Parameters are exposed under _.args.<name>.
+    # CEL bodies CANNOT call sibling author functions.
+    greet:
+      description: "Uppercase a name and add a friendly prefix"
+      params:
+        - name: name
+          type: string
+          required: true
+      cel: '"HELLO " + _.args.name.upperAscii() + "!"'
+
+    # A CEL-bodied function with a typed numeric parameter and a default.
+    doubled:
+      description: "Double an integer"
+      params:
+        - name: value
+          type: integer
+          default: 0
+      cel: "_.args.value * 2"
+
+    # A template-bodied function. Template bodies CAN call sibling author
+    # functions and all built-ins (sprig + custom). Parameters are exposed
+    # under {{ .args.<name> }}.
+    shout:
+      description: "Compose greet with an exclamation using a sibling function"
+      params:
+        - name: who
+          type: string
+          required: true
+      template: '{{ greet .args.who }} ({{ .args.who | upper }})'
+
+  resolvers:
+    # Call a CEL-bodied author function from a template.
+    greeting:
+      description: "Uses the greet author function"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: greeting
+              template: '{{ greet "scaf" }}'
+
+    # Call a numeric author function.
+    forty_two:
+      description: "Uses the doubled author function"
+      type: integer
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: forty-two
+              template: '{{ doubled 21 }}'
+
+    # Compose author functions (template body calling a sibling function).
+    composed:
+      description: "Uses the shout author function, which calls greet"
+      type: string
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              name: composed
+              template: '{{ shout "world" }}'

--- a/pkg/action/executor.go
+++ b/pkg/action/executor.go
@@ -78,6 +78,11 @@ type Executor struct {
 
 	// dedupMemo is a per-run memo for opt-in call de-duplication.
 	dedupMemo *call.Memo
+
+	// templateFuncBinder holds the solution's author-defined template helper
+	// functions (spec.functions), injected into provider context so templates
+	// rendered by actions can invoke them.
+	templateFuncBinder provider.TemplateFuncBinder
 }
 
 // ExecutorOption configures the executor.
@@ -174,6 +179,15 @@ func WithNoCache(noCache bool) ExecutorOption {
 func WithCalls(calls map[string]*spec.Call) ExecutorOption {
 	return func(e *Executor) {
 		e.calls = calls
+	}
+}
+
+// WithTemplateFuncBinder sets the solution's author-defined template helper
+// functions (spec.functions) so templates rendered by actions can invoke them
+// as {{ name arg... }}. A nil binder is a no-op.
+func WithTemplateFuncBinder(binder provider.TemplateFuncBinder) ExecutorOption {
+	return func(e *Executor) {
+		e.templateFuncBinder = binder
 	}
 }
 
@@ -786,6 +800,11 @@ func (e *Executor) executeAction(ctx context.Context, graph *Graph, actionName s
 			execCtx = provider.WithResolverContext(execCtx, maps.Clone(callPlan.ResolverData))
 		case e.resolverData != nil:
 			execCtx = provider.WithResolverContext(execCtx, maps.Clone(e.resolverData))
+		}
+		// Expose the author-defined template functions to providers that render
+		// Go templates (e.g. go-template, file) during action execution.
+		if e.templateFuncBinder != nil {
+			execCtx = provider.WithTemplateFuncBinder(execCtx, e.templateFuncBinder)
 		}
 		return e.callProvider(execCtx, providerName, resolvedInputs)
 	}

--- a/pkg/authorfuncs/authorfuncs.go
+++ b/pkg/authorfuncs/authorfuncs.go
@@ -1,0 +1,233 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package authorfuncs compiles solution-author-defined Go template helper
+// functions (spec.functions) into a bindable library of template.FuncMap
+// entries.
+//
+// Each declared function has ordered, typed parameters and exactly one body:
+//
+//   - a CEL expression (spec-idiomatic; returns any typed value), evaluated with
+//     the bound arguments under the args namespace (_.args.name), or
+//   - a Go template body (Helm-style named template; returns a string), rendered
+//     with the bound arguments as {{ .args.name }} and able to call sibling
+//     author functions and all built-in helpers.
+//
+// Compilation validates names, parameters, bodies, and -- for template bodies --
+// the acyclicity of the author-function call graph, which guarantees rendering
+// terminates. The compiled Library implements provider.TemplateFuncBinder so it
+// can be injected into go-template provider execution via the provider context
+// without the provider or executor packages importing this package.
+package authorfuncs
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+
+	"github.com/oakwood-commons/scafctl/pkg/call"
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+)
+
+// argsNamespace is the key under which bound arguments are exposed inside a
+// function body (_.args.name in CEL, {{ .args.name }} in a template). It mirrors
+// the Call args namespace for consistency across author-facing features.
+const argsNamespace = call.ArgsNamespace
+
+// compiledFn is a validated author function ready to be bound.
+type compiledFn struct {
+	name   string
+	params []*spec.ParamDef
+	isCel  bool
+	body   string
+	// refs holds the names of sibling author functions this function's template
+	// body invokes. It is empty for CEL bodies (CEL cannot call author funcs).
+	refs []string
+}
+
+// Library is a compiled, immutable set of author functions. Its zero value is
+// not usable; construct one with Compile. A nil *Library is valid and behaves as
+// an empty library (Bind returns nil, Fingerprint returns "").
+type Library struct {
+	order       []string // function names in stable (sorted) order
+	fns         map[string]*compiledFn
+	fingerprint string
+	// render renders template-bodied functions. It is created in Compile rather
+	// than at package init so it captures the extension (sprig + custom) function
+	// set after the application has installed the func-map factory; a package-
+	// level service would snapshot an empty extension set. It is stateless
+	// (author funcs are supplied per call via TemplateOptions.Funcs) and safe for
+	// concurrent use.
+	render *gotmpl.Service
+}
+
+// Compile validates the given function definitions and returns a Library. It
+// returns (nil, nil) when functions is empty. All validation problems are
+// aggregated into a single error so authors see every issue at once.
+func Compile(functions map[string]*spec.Function) (*Library, error) {
+	if len(functions) == 0 {
+		return nil, nil
+	}
+
+	names := make([]string, 0, len(functions))
+	for name := range functions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	lib := &Library{
+		order:  names,
+		fns:    make(map[string]*compiledFn, len(functions)),
+		render: gotmpl.NewService(nil),
+	}
+
+	var problems []string
+	for _, name := range names {
+		cf, errs := compileOne(name, functions[name], names)
+		problems = append(problems, errs...)
+		if cf != nil {
+			lib.fns[name] = cf
+		}
+	}
+
+	// Reject cycles among template-bodied functions so rendering is guaranteed
+	// to terminate. Only run when every referenced function compiled cleanly, to
+	// avoid noise from already-reported problems.
+	if len(problems) == 0 {
+		if cycle := detectCycle(lib.fns, names); cycle != "" {
+			problems = append(problems, cycle)
+		}
+	}
+
+	if len(problems) > 0 {
+		sort.Strings(problems)
+		return nil, fmt.Errorf("invalid spec.functions: %s", strings.Join(problems, "; "))
+	}
+
+	lib.fingerprint = computeFingerprint(functions, names)
+	return lib, nil
+}
+
+// Bind returns the author functions as a template.FuncMap whose closures capture
+// ctx for CEL evaluation and nested template rendering. It returns nil for a nil
+// or empty library.
+func (l *Library) Bind(ctx context.Context) template.FuncMap {
+	if l == nil || len(l.fns) == 0 {
+		return nil
+	}
+
+	fm := make(template.FuncMap, len(l.fns))
+	for _, name := range l.order {
+		cf := l.fns[name]
+		// fm is captured by reference; by the time any closure runs (at template
+		// execution) the loop has populated every sibling, so template bodies can
+		// call each other. The compile-time acyclicity check guarantees this
+		// mutual reference terminates.
+		fm[name] = l.makeInvoker(ctx, cf, fm)
+	}
+	return fm
+}
+
+// Fingerprint returns a stable identifier for the function implementations so
+// template caches distinguish same-named functions with different bodies.
+func (l *Library) Fingerprint() string {
+	if l == nil {
+		return ""
+	}
+	return l.fingerprint
+}
+
+// Names returns the declared function names in stable order.
+func (l *Library) Names() []string {
+	if l == nil {
+		return nil
+	}
+	out := make([]string, len(l.order))
+	copy(out, l.order)
+	return out
+}
+
+// makeInvoker builds the template.FuncMap closure for a single function. The
+// closure accepts positional arguments, binds them to the declared parameters,
+// and evaluates the body.
+func (l *Library) makeInvoker(ctx context.Context, cf *compiledFn, authorFuncs template.FuncMap) func(...any) (any, error) {
+	return func(args ...any) (any, error) {
+		bound, err := bindArgs(cf, args)
+		if err != nil {
+			return nil, fmt.Errorf("function %q: %w", cf.name, err)
+		}
+
+		data := map[string]any{argsNamespace: bound}
+
+		if cf.isCel {
+			result, evalErr := celexp.EvaluateExpression(ctx, cf.body, data, nil)
+			if evalErr != nil {
+				return nil, fmt.Errorf("function %q: evaluating cel body: %w", cf.name, evalErr)
+			}
+			return result, nil
+		}
+
+		res, execErr := l.render.Execute(ctx, gotmpl.TemplateOptions{
+			Content:          cf.body,
+			Name:             "function:" + cf.name,
+			Data:             data,
+			Funcs:            authorFuncs,
+			FuncsFingerprint: l.fingerprint,
+			MissingKey:       gotmpl.MissingKeyError,
+		})
+		if execErr != nil {
+			return nil, fmt.Errorf("function %q: rendering template body: %w", cf.name, execErr)
+		}
+		return res.Output, nil
+	}
+}
+
+// bindArgs maps positional call arguments to the function's declared parameters,
+// applying defaults for omitted optional parameters and coercing each value to
+// its declared type.
+func bindArgs(cf *compiledFn, args []any) (map[string]any, error) {
+	if len(args) > len(cf.params) {
+		return nil, fmt.Errorf("expected at most %d argument(s), got %d", len(cf.params), len(args))
+	}
+
+	bound := make(map[string]any, len(cf.params))
+	for i, p := range cf.params {
+		var raw any
+		switch {
+		case i < len(args):
+			raw = args[i]
+		case p.Required:
+			return nil, fmt.Errorf("missing required argument %q (position %d)", p.Name, i+1)
+		default:
+			raw = p.Default
+		}
+
+		coerced, err := spec.CoerceType(raw, p.Type)
+		if err != nil {
+			return nil, fmt.Errorf("argument %q (position %d): %w", p.Name, i+1, err)
+		}
+		bound[p.Name] = coerced
+	}
+	return bound, nil
+}
+
+// computeFingerprint produces a stable hex digest of every function's name,
+// parameters, body kind, and body content, so any change to an implementation
+// changes the fingerprint (and thereby template cache keys).
+func computeFingerprint(functions map[string]*spec.Function, sortedNames []string) string {
+	h := sha256.New()
+	for _, name := range sortedNames {
+		fn := functions[name]
+		fmt.Fprintf(h, "fn:%s\x00", name)
+		for _, p := range fn.Params {
+			fmt.Fprintf(h, "param:%s:%s:%t:%v\x00", p.Name, p.Type, p.Required, p.Default)
+		}
+		fmt.Fprintf(h, "cel:%s\x00template:%s\x00", fn.Cel, fn.Template)
+	}
+	return fmt.Sprintf("%x", h.Sum(nil))
+}

--- a/pkg/authorfuncs/authorfuncs.go
+++ b/pkg/authorfuncs/authorfuncs.go
@@ -23,6 +23,7 @@ package authorfuncs
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -225,9 +226,23 @@ func computeFingerprint(functions map[string]*spec.Function, sortedNames []strin
 		fn := functions[name]
 		fmt.Fprintf(h, "fn:%s\x00", name)
 		for _, p := range fn.Params {
-			fmt.Fprintf(h, "param:%s:%s:%t:%v\x00", p.Name, p.Type, p.Required, p.Default)
+			fmt.Fprintf(h, "param:%s:%s:%t:%s\x00", p.Name, p.Type, p.Required, fingerprintDefault(p.Default))
 		}
 		fmt.Fprintf(h, "cel:%s\x00template:%s\x00", fn.Cel, fn.Template)
 	}
 	return fmt.Sprintf("%x", h.Sum(nil))
+}
+
+// fingerprintDefault serializes a parameter default deterministically for the
+// fingerprint. json.Marshal sorts map keys, so a map/object default hashes the
+// same across runs (unlike fmt %v, whose map iteration order is randomized). It
+// falls back to %v only if the value is not JSON-serializable.
+func fingerprintDefault(def any) string {
+	if def == nil {
+		return "null"
+	}
+	if b, err := json.Marshal(def); err == nil {
+		return string(b)
+	}
+	return fmt.Sprintf("%v", def)
 }

--- a/pkg/authorfuncs/authorfuncs_benchmark_test.go
+++ b/pkg/authorfuncs/authorfuncs_benchmark_test.go
@@ -1,0 +1,83 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package authorfuncs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+)
+
+// benchFunctions returns a small library exercising both body kinds and
+// composition (a template body calling a sibling CEL function).
+func benchFunctions() map[string]*spec.Function {
+	return map[string]*spec.Function{
+		"greet": {
+			Params: []*spec.ParamDef{{Name: "name", Type: spec.TypeString, Required: true}},
+			Cel:    `"HELLO " + _.args.name + "!"`,
+		},
+		"shout": {
+			Params:   []*spec.ParamDef{{Name: "who", Type: spec.TypeString, Required: true}},
+			Template: `{{ greet .args.who }} ({{ .args.who | upper }})`,
+		},
+	}
+}
+
+// BenchmarkCompile measures the cost of compiling a function library
+// (parameter validation, body compilation, cycle detection, fingerprinting).
+func BenchmarkCompile(b *testing.B) {
+	fns := benchFunctions()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := Compile(fns); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkInvokeCel measures repeated invocation of a CEL-bodied author
+// function (the per-render hot path: bindArgs + coercion + CEL eval).
+func BenchmarkInvokeCel(b *testing.B) {
+	lib, err := Compile(benchFunctions())
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	funcs := lib.Bind(ctx)
+	greet, ok := funcs["greet"].(func(...any) (any, error))
+	if !ok {
+		b.Fatalf("greet has unexpected type %T", funcs["greet"])
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := greet("world"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkInvokeTemplate measures repeated invocation of a template-bodied
+// author function that composes a sibling function (nested template render).
+func BenchmarkInvokeTemplate(b *testing.B) {
+	lib, err := Compile(benchFunctions())
+	if err != nil {
+		b.Fatal(err)
+	}
+	ctx := context.Background()
+	funcs := lib.Bind(ctx)
+	shout, ok := funcs["shout"].(func(...any) (any, error))
+	if !ok {
+		b.Fatalf("shout has unexpected type %T", funcs["shout"])
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := shout("world"); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/authorfuncs/authorfuncs_test.go
+++ b/pkg/authorfuncs/authorfuncs_test.go
@@ -1,0 +1,204 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package authorfuncs
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	gotmplext "github.com/oakwood-commons/scafctl/pkg/gotmpl/ext"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMain installs the extension (sprig + custom) function factory so template
+// bodies that call built-in helpers (e.g. upper) resolve during tests. In
+// production this is done during application initialization.
+func TestMain(m *testing.M) {
+	gotmpl.SetExtensionFuncMapFactory(gotmplext.AllFuncMap)
+	os.Exit(m.Run())
+}
+
+func TestCompile_Empty(t *testing.T) {
+	lib, err := Compile(nil)
+	require.NoError(t, err)
+	assert.Nil(t, lib)
+
+	lib, err = Compile(map[string]*spec.Function{})
+	require.NoError(t, err)
+	assert.Nil(t, lib)
+}
+
+func TestCompile_Names(t *testing.T) {
+	lib, err := Compile(map[string]*spec.Function{
+		"beta":  {Cel: "1"},
+		"alpha": {Cel: "2"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, lib)
+	assert.Equal(t, []string{"alpha", "beta"}, lib.Names())
+}
+
+func TestBind_CelBody(t *testing.T) {
+	lib, err := Compile(map[string]*spec.Function{
+		"doubled": {
+			Params: []*spec.ParamDef{{Name: "n", Type: spec.TypeInt, Required: true}},
+			Cel:    "_.args.n * 2",
+		},
+	})
+	require.NoError(t, err)
+
+	fm := lib.Bind(context.Background())
+	require.Contains(t, fm, "doubled")
+
+	fn, ok := fm["doubled"].(func(...any) (any, error))
+	require.True(t, ok)
+
+	got, err := fn(21)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), got)
+}
+
+func TestBind_TemplateBody(t *testing.T) {
+	lib, err := Compile(map[string]*spec.Function{
+		"greet": {
+			Params:   []*spec.ParamDef{{Name: "who", Type: spec.TypeString, Required: true}},
+			Template: "HELLO {{ .args.who | upper }}!",
+		},
+	})
+	require.NoError(t, err)
+
+	fm := lib.Bind(context.Background())
+	fn := fm["greet"].(func(...any) (any, error))
+
+	got, err := fn("scaf")
+	require.NoError(t, err)
+	assert.Equal(t, "HELLO SCAF!", got)
+}
+
+func TestBind_TemplateCallsSibling(t *testing.T) {
+	lib, err := Compile(map[string]*spec.Function{
+		"greet": {
+			Params:   []*spec.ParamDef{{Name: "who", Type: spec.TypeString, Required: true}},
+			Template: "HELLO {{ .args.who | upper }}!",
+		},
+		"doubled": {
+			Params: []*spec.ParamDef{{Name: "n", Type: spec.TypeInt, Required: true}},
+			Cel:    "_.args.n * 2",
+		},
+		"shout": {
+			Params:   []*spec.ParamDef{{Name: "name", Type: spec.TypeString, Default: "world"}},
+			Template: `{{ greet .args.name }} ({{ doubled 21 }})`,
+		},
+	})
+	require.NoError(t, err)
+
+	fm := lib.Bind(context.Background())
+	fn := fm["shout"].(func(...any) (any, error))
+
+	got, err := fn("scaf")
+	require.NoError(t, err)
+	assert.Equal(t, "HELLO SCAF! (42)", got)
+}
+
+func TestBind_DefaultApplied(t *testing.T) {
+	lib, err := Compile(map[string]*spec.Function{
+		"greet": {
+			Params:   []*spec.ParamDef{{Name: "name", Type: spec.TypeString, Default: "world"}},
+			Template: "hi {{ .args.name }}",
+		},
+	})
+	require.NoError(t, err)
+
+	fn := lib.Bind(context.Background())["greet"].(func(...any) (any, error))
+
+	got, err := fn() // omit optional arg -> default
+	require.NoError(t, err)
+	assert.Equal(t, "hi world", got)
+}
+
+func TestBind_TypeCoercion(t *testing.T) {
+	lib, err := Compile(map[string]*spec.Function{
+		"asInt": {
+			Params: []*spec.ParamDef{{Name: "v", Type: spec.TypeInt}},
+			Cel:    "_.args.v + 1",
+		},
+	})
+	require.NoError(t, err)
+
+	fn := lib.Bind(context.Background())["asInt"].(func(...any) (any, error))
+
+	got, err := fn("41") // string coerced to int
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), got)
+}
+
+func TestBind_MissingRequiredArg(t *testing.T) {
+	lib, err := Compile(map[string]*spec.Function{
+		"need": {
+			Params: []*spec.ParamDef{{Name: "x", Type: spec.TypeString, Required: true}},
+			Cel:    "_.args.x",
+		},
+	})
+	require.NoError(t, err)
+
+	fn := lib.Bind(context.Background())["need"].(func(...any) (any, error))
+
+	_, err = fn()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required argument")
+}
+
+func TestBind_TooManyArgs(t *testing.T) {
+	lib, err := Compile(map[string]*spec.Function{
+		"one": {
+			Params: []*spec.ParamDef{{Name: "x", Type: spec.TypeString}},
+			Cel:    "_.args.x",
+		},
+	})
+	require.NoError(t, err)
+
+	fn := lib.Bind(context.Background())["one"].(func(...any) (any, error))
+
+	_, err = fn("a", "b")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at most 1 argument")
+}
+
+func TestBind_NilAndEmptyLibrary(t *testing.T) {
+	var nilLib *Library
+	assert.Nil(t, nilLib.Bind(context.Background()))
+	assert.Equal(t, "", nilLib.Fingerprint())
+	assert.Nil(t, nilLib.Names())
+}
+
+func TestFingerprint_Stability(t *testing.T) {
+	defs := map[string]*spec.Function{
+		"greet": {
+			Params:   []*spec.ParamDef{{Name: "who", Type: spec.TypeString}},
+			Template: "hi {{ .args.who }}",
+		},
+	}
+	a, err := Compile(defs)
+	require.NoError(t, err)
+	b, err := Compile(defs)
+	require.NoError(t, err)
+	assert.Equal(t, a.Fingerprint(), b.Fingerprint())
+	assert.NotEmpty(t, a.Fingerprint())
+}
+
+func TestFingerprint_ChangesWithBody(t *testing.T) {
+	a, err := Compile(map[string]*spec.Function{
+		"f": {Params: []*spec.ParamDef{{Name: "x"}}, Template: "a {{ .args.x }}"},
+	})
+	require.NoError(t, err)
+	b, err := Compile(map[string]*spec.Function{
+		"f": {Params: []*spec.ParamDef{{Name: "x"}}, Template: "b {{ .args.x }}"},
+	})
+	require.NoError(t, err)
+	assert.NotEqual(t, a.Fingerprint(), b.Fingerprint())
+}

--- a/pkg/authorfuncs/authorfuncs_test.go
+++ b/pkg/authorfuncs/authorfuncs_test.go
@@ -202,3 +202,55 @@ func TestFingerprint_ChangesWithBody(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, a.Fingerprint(), b.Fingerprint())
 }
+
+// TestFingerprint_MapDefaultDeterministic guards the determinism of the
+// parameter-default serialization: a map default must hash identically across
+// Compile calls despite Go's randomized map iteration order. Recompiling the
+// same definition many times must always yield the same fingerprint.
+func TestFingerprint_MapDefaultDeterministic(t *testing.T) {
+	newDefs := func() map[string]*spec.Function {
+		return map[string]*spec.Function{
+			"f": {
+				Params: []*spec.ParamDef{{
+					Name: "opts",
+					Type: spec.TypeObject,
+					Default: map[string]any{
+						"alpha":   1,
+						"bravo":   "two",
+						"charlie": true,
+						"delta":   3.14,
+						"echo":    []any{"x", "y"},
+					},
+				}},
+				Template: "{{ .args.opts }}",
+			},
+		}
+	}
+
+	first, err := Compile(newDefs())
+	require.NoError(t, err)
+	want := first.Fingerprint()
+	assert.NotEmpty(t, want)
+
+	for i := 0; i < 50; i++ {
+		lib, err := Compile(newDefs())
+		require.NoError(t, err)
+		assert.Equal(t, want, lib.Fingerprint(), "fingerprint must be stable across recompiles (iteration %d)", i)
+	}
+}
+
+// TestFingerprint_ChangesWithMapDefault confirms different map defaults still
+// produce different fingerprints (the deterministic serialization did not
+// collapse distinct values).
+func TestFingerprint_ChangesWithMapDefault(t *testing.T) {
+	mk := func(def map[string]any) map[string]*spec.Function {
+		return map[string]*spec.Function{
+			"f": {Params: []*spec.ParamDef{{Name: "opts", Type: spec.TypeObject, Default: def}}, Template: "{{ .args.opts }}"},
+		}
+	}
+	a, err := Compile(mk(map[string]any{"a": 1}))
+	require.NoError(t, err)
+	b, err := Compile(mk(map[string]any{"a": 2}))
+	require.NoError(t, err)
+	assert.NotEqual(t, a.Fingerprint(), b.Fingerprint())
+}

--- a/pkg/authorfuncs/validate.go
+++ b/pkg/authorfuncs/validate.go
@@ -1,0 +1,225 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package authorfuncs
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+)
+
+// identifierPattern matches a valid function or parameter identifier. It mirrors
+// the pattern documented on spec.ParamDef.Name.
+var identifierPattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// knownParamTypes is the set of accepted parameter type strings (canonical names
+// plus the aliases spec.CoerceType/normalizeType understand). The empty type is
+// allowed separately and means "pass through unchanged".
+var knownParamTypes = map[string]struct{}{
+	"string": {}, "int": {}, "integer": {}, "float": {}, "number": {},
+	"bool": {}, "boolean": {}, "array": {}, "object": {}, "map": {},
+	"time": {}, "timestamp": {}, "datetime": {}, "duration": {}, "any": {},
+}
+
+// compileOne validates a single function definition and, on success, returns a
+// compiledFn. All problems are returned (rather than short-circuiting) so authors
+// see every issue for the function at once. cf is non-nil only when there are no
+// problems that would make binding unsafe.
+func compileOne(name string, fn *spec.Function, allNames []string) (*compiledFn, []string) {
+	var problems []string
+	add := func(format string, args ...any) {
+		problems = append(problems, fmt.Sprintf("function %q: "+format, append([]any{name}, args...)...))
+	}
+
+	if !identifierPattern.MatchString(name) {
+		add("name is not a valid identifier (must match %s)", identifierPattern.String())
+	}
+	if strings.HasPrefix(name, "__") {
+		add("name may not start with %q (reserved prefix)", "__")
+	}
+	if gotmpl.IsBuiltinFunc(name) {
+		add("name collides with a built-in template function")
+	}
+
+	if fn == nil {
+		add("definition is empty")
+		return nil, problems
+	}
+
+	problems = append(problems, validateParams(name, fn.Params)...)
+
+	// Exactly one body.
+	switch {
+	case fn.HasCel() && fn.HasTemplate():
+		add("cel and template are mutually exclusive; set exactly one")
+	case !fn.HasCel() && !fn.HasTemplate():
+		add("must set exactly one of cel or template")
+	}
+
+	// Body syntax + reference extraction. Only attempt when a single body is set;
+	// a malformed declaration above already produced a problem.
+	var refs []string
+	switch {
+	case fn.HasCel() && !fn.HasTemplate():
+		if err := celexp.ValidateSyntax(context.Background(), fn.Cel); err != nil {
+			add("invalid cel body: %v", err)
+		}
+	case fn.HasTemplate() && !fn.HasCel():
+		calls, err := gotmpl.ExtractFunctionCalls(fn.Template, "", "", allNames)
+		if err != nil {
+			add("invalid template body: %v", err)
+		} else {
+			refs = filterAuthorRefs(calls, allNames)
+		}
+	}
+
+	if len(problems) > 0 {
+		return nil, problems
+	}
+
+	return &compiledFn{
+		name:   name,
+		params: fn.Params,
+		isCel:  fn.HasCel(),
+		body:   bodyOf(fn),
+		refs:   refs,
+	}, nil
+}
+
+// validateParams checks that parameter names are valid and unique, that required
+// parameters do not also declare a default, and that declared types are known.
+func validateParams(fnName string, params []*spec.ParamDef) []string {
+	var problems []string
+	add := func(format string, args ...any) {
+		problems = append(problems, fmt.Sprintf("function %q: "+format, append([]any{fnName}, args...)...))
+	}
+
+	seen := make(map[string]struct{}, len(params))
+	sawOptional := false
+	for i, p := range params {
+		if p == nil {
+			add("parameter at position %d is empty", i+1)
+			continue
+		}
+		if !identifierPattern.MatchString(p.Name) {
+			add("parameter %q (position %d) is not a valid identifier", p.Name, i+1)
+		}
+		if _, dup := seen[p.Name]; dup {
+			add("parameter name %q is declared more than once", p.Name)
+		}
+		seen[p.Name] = struct{}{}
+
+		if p.Required && p.Default != nil {
+			add("parameter %q is required and may not declare a default", p.Name)
+		}
+
+		// Parameters are bound by position, so a required parameter that follows
+		// an optional one is unreachable: callers cannot supply the later
+		// required argument without also supplying the earlier optional one,
+		// defeating its default. Reject required-after-optional.
+		if p.Required && sawOptional {
+			add("required parameter %q must not follow an optional parameter (positional binding)", p.Name)
+		}
+		if !p.Required {
+			sawOptional = true
+		}
+
+		if p.Type != "" {
+			if _, ok := knownParamTypes[strings.ToLower(string(p.Type))]; !ok {
+				add("parameter %q has unknown type %q", p.Name, p.Type)
+			}
+		}
+	}
+	return problems
+}
+
+// bodyOf returns the function's single body string.
+func bodyOf(fn *spec.Function) string {
+	if fn.HasCel() {
+		return fn.Cel
+	}
+	return fn.Template
+}
+
+// filterAuthorRefs narrows a set of invoked function names to those that are
+// author-declared (i.e. present in allNames). Self-references are kept so that a
+// function whose template body calls itself is reported as a cycle.
+func filterAuthorRefs(calls, allNames []string) []string {
+	nameSet := make(map[string]struct{}, len(allNames))
+	for _, n := range allNames {
+		nameSet[n] = struct{}{}
+	}
+	var refs []string
+	for _, c := range calls {
+		if _, ok := nameSet[c]; ok {
+			refs = append(refs, c)
+		}
+	}
+	sort.Strings(refs)
+	return refs
+}
+
+// detectCycle looks for a cycle in the author-function call graph (template
+// bodies referencing sibling functions). It returns a human-readable problem
+// describing the first cycle found, or "" when the graph is acyclic. Acyclicity
+// guarantees that nested template rendering terminates.
+func detectCycle(fns map[string]*compiledFn, order []string) string {
+	const (
+		white = 0 // unvisited
+		gray  = 1 // on the current DFS stack
+		black = 2 // fully explored
+	)
+	color := make(map[string]int, len(fns))
+
+	var stack []string
+	var visit func(name string) string
+	visit = func(name string) string {
+		color[name] = gray
+		stack = append(stack, name)
+		cf := fns[name]
+		if cf != nil {
+			for _, dep := range cf.refs {
+				switch color[dep] {
+				case gray:
+					return formatCycle(stack, dep)
+				case white:
+					if cyc := visit(dep); cyc != "" {
+						return cyc
+					}
+				}
+			}
+		}
+		stack = stack[:len(stack)-1]
+		color[name] = black
+		return ""
+	}
+
+	for _, name := range order {
+		if color[name] == white {
+			if cyc := visit(name); cyc != "" {
+				return cyc
+			}
+		}
+	}
+	return ""
+}
+
+// formatCycle renders the cycle path from the point dep re-enters the DFS stack.
+func formatCycle(stack []string, dep string) string {
+	start := 0
+	for i, n := range stack {
+		if n == dep {
+			start = i
+			break
+		}
+	}
+	cycle := append(append([]string{}, stack[start:]...), dep)
+	return fmt.Sprintf("functions form a cycle: %s (template bodies may not call each other cyclically)", strings.Join(cycle, " -> "))
+}

--- a/pkg/authorfuncs/validate_test.go
+++ b/pkg/authorfuncs/validate_test.go
@@ -1,0 +1,177 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package authorfuncs
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompile_InvalidName(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"1bad": {Cel: "1"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid identifier")
+}
+
+func TestCompile_ReservedPrefix(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"__hidden": {Cel: "1"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reserved prefix")
+}
+
+func TestCompile_BuiltinCollision(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"upper": {Params: []*spec.ParamDef{{Name: "x"}}, Cel: "_.args.x"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "collides with a built-in")
+}
+
+func TestCompile_NoBody(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"f": {Params: []*spec.ParamDef{{Name: "x"}}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must set exactly one of cel or template")
+}
+
+func TestCompile_BothBodies(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"f": {Cel: "1", Template: "x"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestCompile_InvalidCelBody(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"f": {Cel: "_.args.x +"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid cel body")
+}
+
+func TestCompile_InvalidTemplateBody(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"f": {Template: "{{ notAFunc }}"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid template body")
+}
+
+func TestCompile_DuplicateParam(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"f": {
+			Params: []*spec.ParamDef{{Name: "x"}, {Name: "x"}},
+			Cel:    "_.args.x",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "declared more than once")
+}
+
+func TestCompile_RequiredWithDefault(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"f": {
+			Params: []*spec.ParamDef{{Name: "x", Required: true, Default: "v"}},
+			Cel:    "_.args.x",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "may not declare a default")
+}
+
+func TestCompile_RequiredAfterOptional(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"f": {
+			Params: []*spec.ParamDef{
+				{Name: "a", Default: "v"},
+				{Name: "b", Required: true},
+			},
+			Cel: "_.args.a",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must not follow an optional parameter")
+}
+
+func TestCompile_UnknownParamType(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"f": {
+			Params: []*spec.ParamDef{{Name: "x", Type: spec.Type("nope")}},
+			Cel:    "_.args.x",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown type")
+}
+
+func TestCompile_InvalidParamName(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"f": {
+			Params: []*spec.ParamDef{{Name: "1x"}},
+			Cel:    "1",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid identifier")
+}
+
+func TestCompile_NilParam(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"f": {
+			Params: []*spec.ParamDef{nil},
+			Cel:    "1",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is empty")
+}
+
+func TestCompile_DirectCycle(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"self": {
+			Params:   []*spec.ParamDef{{Name: "x"}},
+			Template: "{{ self .args.x }}",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cycle")
+}
+
+func TestCompile_IndirectCycle(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"a": {Params: []*spec.ParamDef{{Name: "x"}}, Template: "{{ b .args.x }}"},
+		"b": {Params: []*spec.ParamDef{{Name: "x"}}, Template: "{{ a .args.x }}"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "a -> b -> a")
+}
+
+func TestCompile_AcyclicChainOK(t *testing.T) {
+	lib, err := Compile(map[string]*spec.Function{
+		"a": {Params: []*spec.ParamDef{{Name: "x"}}, Template: "{{ b .args.x }}"},
+		"b": {Params: []*spec.ParamDef{{Name: "x"}}, Template: "B:{{ .args.x }}"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, lib)
+}
+
+func TestCompile_AggregatesProblems(t *testing.T) {
+	_, err := Compile(map[string]*spec.Function{
+		"1bad":     {Cel: "1"},
+		"__hidden": {Cel: "1"},
+	})
+	require.Error(t, err)
+	// Both problems are surfaced together.
+	assert.Contains(t, err.Error(), "not a valid identifier")
+	assert.Contains(t, err.Error(), "reserved prefix")
+}

--- a/pkg/cmd/scafctl/defaults.go
+++ b/pkg/cmd/scafctl/defaults.go
@@ -4,11 +4,16 @@
 package scafctl
 
 import (
+	"context"
+	"maps"
+	"text/template"
+
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/celexp/env"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	gotmplext "github.com/oakwood-commons/scafctl/pkg/gotmpl/ext"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl/ext/celeval"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 )
 
 // RegisterDefaults registers the default CEL environment, cache, and Go
@@ -26,5 +31,31 @@ func RegisterDefaults() {
 	celexp.SetEnvFactory(env.New)
 	celexp.SetCacheFactory(env.GlobalCache)
 	gotmpl.SetExtensionFuncMapFactory(gotmplext.AllFuncMap)
-	gotmpl.SetContextFuncBinderFactory(celeval.CelFuncWithContext)
+	gotmpl.SetContextFuncBinderFactory(contextTemplateFuncs)
+}
+
+// contextTemplateFuncs produces the context-aware Go template functions applied
+// to each template clone right before execution: the context-bound `cel`
+// function plus any solution-author-defined helpers (spec.functions) carried on
+// the provider context. Rebinding these per execution (rather than relying on
+// the closures captured at parse time, which are frozen into the shared
+// template cache) ensures every render uses the current request's context --
+// its cancellation, timeouts, and CEL cost limits -- instead of the context
+// from whichever execution first populated the cache entry.
+func contextTemplateFuncs(ctx context.Context) template.FuncMap {
+	celFuncs := celeval.CelFuncWithContext(ctx)
+
+	binder, ok := provider.TemplateFuncBinderFromContext(ctx)
+	if !ok || binder == nil {
+		return celFuncs
+	}
+	authorFuncs := binder.Bind(ctx)
+	if len(authorFuncs) == 0 {
+		return celFuncs
+	}
+
+	merged := make(template.FuncMap, len(celFuncs)+len(authorFuncs))
+	maps.Copy(merged, authorFuncs)
+	maps.Copy(merged, celFuncs)
+	return merged
 }

--- a/pkg/cmd/scafctl/defaults_test.go
+++ b/pkg/cmd/scafctl/defaults_test.go
@@ -4,7 +4,11 @@
 package scafctl
 
 import (
+	"context"
 	"testing"
+	"text/template"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 )
 
 func TestRegisterDefaults(t *testing.T) {
@@ -13,4 +17,84 @@ func TestRegisterDefaults(t *testing.T) {
 	// RegisterDefaults should not panic and should be idempotent.
 	RegisterDefaults()
 	RegisterDefaults() // call twice to verify idempotency
+}
+
+// fakeTemplateFuncBinder is a minimal TemplateFuncBinder for exercising
+// contextTemplateFuncs without pulling in the full authorfuncs library.
+type fakeTemplateFuncBinder struct {
+	funcs template.FuncMap
+}
+
+func (f fakeTemplateFuncBinder) Bind(context.Context) template.FuncMap { return f.funcs }
+func (f fakeTemplateFuncBinder) Fingerprint() string                   { return "fake" }
+
+func TestContextTemplateFuncs_NoBinder(t *testing.T) {
+	t.Parallel()
+
+	funcs := contextTemplateFuncs(context.Background())
+
+	// Without an author-function binder on the context, only the context-bound
+	// cel helper is present.
+	if _, ok := funcs["cel"]; !ok {
+		t.Fatalf("expected 'cel' function to be present, got keys %v", keysOf(funcs))
+	}
+	if _, ok := funcs["greet"]; ok {
+		t.Fatalf("did not expect an author function without a binder")
+	}
+}
+
+func TestContextTemplateFuncs_MergesAuthorFuncs(t *testing.T) {
+	t.Parallel()
+
+	binder := fakeTemplateFuncBinder{funcs: template.FuncMap{
+		"greet": func() string { return "hi" },
+	}}
+	ctx := provider.WithTemplateFuncBinder(context.Background(), binder)
+
+	funcs := contextTemplateFuncs(ctx)
+
+	if _, ok := funcs["cel"]; !ok {
+		t.Fatalf("expected 'cel' function to be present, got keys %v", keysOf(funcs))
+	}
+	if _, ok := funcs["greet"]; !ok {
+		t.Fatalf("expected author function 'greet' to be merged, got keys %v", keysOf(funcs))
+	}
+}
+
+func TestContextTemplateFuncs_CelWinsOnCollision(t *testing.T) {
+	t.Parallel()
+
+	// An author function named "cel" must not shadow the built-in context-bound
+	// cel helper: cel is copied last and wins.
+	binder := fakeTemplateFuncBinder{funcs: template.FuncMap{
+		"cel": func() string { return "author-cel" },
+	}}
+	ctx := provider.WithTemplateFuncBinder(context.Background(), binder)
+
+	funcs := contextTemplateFuncs(ctx)
+	builtin := contextTemplateFuncs(context.Background())
+
+	if len(funcs) != len(builtin) {
+		t.Fatalf("expected collision to not add a key: got %d, builtin %d", len(funcs), len(builtin))
+	}
+}
+
+func TestContextTemplateFuncs_EmptyBinder(t *testing.T) {
+	t.Parallel()
+
+	binder := fakeTemplateFuncBinder{funcs: nil}
+	ctx := provider.WithTemplateFuncBinder(context.Background(), binder)
+
+	funcs := contextTemplateFuncs(ctx)
+	if _, ok := funcs["cel"]; !ok {
+		t.Fatalf("expected 'cel' function to be present with an empty binder")
+	}
+}
+
+func keysOf(m template.FuncMap) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }

--- a/pkg/cmd/scafctl/render/solution.go
+++ b/pkg/cmd/scafctl/render/solution.go
@@ -504,6 +504,11 @@ func (o *SolutionOptions) runSnapshot(ctx context.Context, lgr logr.Logger) erro
 	if sol.Spec.HasCalls() {
 		extraOpts = append(extraOpts, resolver.WithCalls(sol.Spec.Calls))
 	}
+	if binder, binderErr := sol.TemplateFuncBinder(); binderErr != nil {
+		return fmt.Errorf("compiling spec.functions: %w", binderErr)
+	} else if binder != nil {
+		extraOpts = append(extraOpts, resolver.WithTemplateFuncBinder(binder))
+	}
 	if len(stateSeed) > 0 {
 		extraOpts = append(extraOpts, resolver.WithSeededResults(stateSeed))
 	}

--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -453,6 +453,11 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 	actionCfg := o.getEffectiveActionConfig(ctx)
 	resolverExecutionData := execute.BuildExecutionData(resolverCtx, resolvers, resolverElapsed)
 
+	funcBinder, err := sol.TemplateFuncBinder()
+	if err != nil {
+		return fmt.Errorf("compiling spec.functions: %w", err)
+	}
+
 	actionExecutor := action.NewExecutor(
 		action.WithRegistry(actionAdapter),
 		action.WithResolverData(resolverData),
@@ -467,6 +472,9 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 		action.WithNoCache(o.SkipFingerprint),
 		action.WithCalls(sol.Spec.Calls),
 	)
+	if funcBinder != nil {
+		action.WithTemplateFuncBinder(funcBinder)(actionExecutor)
+	}
 
 	result, err := actionExecutor.Execute(actionCtx, workflow)
 	if err != nil && result != nil && result.FinalStatus != action.ExecutionPartialSuccess {

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -584,6 +584,12 @@ func (o *sharedResolverOptions) executeResolvers(
 		executorOpts = append(executorOpts, resolver.WithCalls(sol.Spec.Calls))
 	}
 
+	if binder, binderErr := sol.TemplateFuncBinder(); binderErr != nil {
+		return nil, nil, fmt.Errorf("compiling spec.functions: %w", binderErr)
+	} else if binder != nil {
+		executorOpts = append(executorOpts, resolver.WithTemplateFuncBinder(binder))
+	}
+
 	// Seed results from an earlier pass (e.g. the state two-phase pre-load) so
 	// those resolvers are reused rather than re-executed.
 	if len(execCfg.seed) > 0 {

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -579,6 +579,11 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	// regardless of whether --show-execution is set for resolver output display.
 	resolverExecutionData := execute.BuildExecutionData(resolverCtx, resolvers, resolverElapsed)
 
+	funcBinder, funcBinderErr := sol.TemplateFuncBinder()
+	if funcBinderErr != nil {
+		return fmt.Errorf("compiling spec.functions: %w", funcBinderErr)
+	}
+
 	actionExecutor := action.NewExecutor(
 		action.WithRegistry(actionAdapter),
 		action.WithResolverData(resolverData),
@@ -593,6 +598,9 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 		action.WithNoCache(o.SkipFingerprint),
 		action.WithCalls(sol.Spec.Calls),
 	)
+	if funcBinder != nil {
+		action.WithTemplateFuncBinder(funcBinder)(actionExecutor)
+	}
 
 	result, err := actionExecutor.Execute(actionCtx, workflow)
 	if err != nil && result != nil && result.FinalStatus != action.ExecutionPartialSuccess {

--- a/pkg/gotmpl/cache.go
+++ b/pkg/gotmpl/cache.go
@@ -315,9 +315,15 @@ type TemplateStat struct {
 
 // generateTemplateCacheKey creates a unique cache key from template content and options.
 // The key is based on a SHA-256 hash of: content, delimiters, missingKey option,
-// and sorted function map keys. This ensures different configurations produce
-// different keys while identical configurations share cache entries.
-func generateTemplateCacheKey(content, leftDelim, rightDelim string, missingKey MissingKeyOption, funcMapKeys []string) string {
+// sorted function map keys, and an optional funcsFingerprint. This ensures
+// different configurations produce different keys while identical configurations
+// share cache entries.
+//
+// funcsFingerprint disambiguates entries whose function *names* match but whose
+// *implementations* differ (e.g. author-defined helpers of the same name but
+// different bodies across solutions). Function bodies are not otherwise part of
+// the key, so without this two such templates would collide.
+func generateTemplateCacheKey(content, leftDelim, rightDelim string, missingKey MissingKeyOption, funcMapKeys []string, funcsFingerprint string) string {
 	h := sha256.New()
 
 	// Hash template content
@@ -334,6 +340,9 @@ func generateTemplateCacheKey(content, leftDelim, rightDelim string, missingKey 
 	copy(sorted, funcMapKeys)
 	sort.Strings(sorted)
 	fmt.Fprintf(h, "funcs:%s", strings.Join(sorted, ","))
+
+	// Hash the function-implementation fingerprint (empty when not supplied)
+	fmt.Fprintf(h, "funcsfp:%s", funcsFingerprint)
 
 	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/pkg/gotmpl/cache_benchmark_test.go
+++ b/pkg/gotmpl/cache_benchmark_test.go
@@ -133,7 +133,7 @@ func BenchmarkTemplateCacheHit(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			key := generateTemplateCacheKey(content, "{{", "}}", MissingKeyDefault, nil)
+			key := generateTemplateCacheKey(content, "{{", "}}", MissingKeyDefault, nil, "")
 			cache.Put(key, tmpl, name)
 
 			b.ReportAllocs()
@@ -213,14 +213,14 @@ func BenchmarkCacheKeyGeneration(b *testing.B) {
 	b.Run("no_funcs", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			_ = generateTemplateCacheKey("Hello {{.Name}}", "{{", "}}", MissingKeyDefault, nil)
+			_ = generateTemplateCacheKey("Hello {{.Name}}", "{{", "}}", MissingKeyDefault, nil, "")
 		}
 	})
 
 	b.Run("with_funcs", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			_ = generateTemplateCacheKey("Hello {{.Name}}", "{{", "}}", MissingKeyDefault, funcKeys)
+			_ = generateTemplateCacheKey("Hello {{.Name}}", "{{", "}}", MissingKeyDefault, funcKeys, "")
 		}
 	})
 
@@ -228,7 +228,7 @@ func BenchmarkCacheKeyGeneration(b *testing.B) {
 		b.ReportAllocs()
 		content := benchTemplates["complex"]
 		for i := 0; i < b.N; i++ {
-			_ = generateTemplateCacheKey(content, "{{", "}}", MissingKeyDefault, funcKeys)
+			_ = generateTemplateCacheKey(content, "{{", "}}", MissingKeyDefault, funcKeys, "")
 		}
 	})
 }
@@ -332,7 +332,7 @@ func BenchmarkTemplateCacheParallelHit(b *testing.B) {
 	cache := NewTemplateCache(100)
 	content := benchTemplates["complex"]
 	tmpl, _ := template.New("bench").Parse(content)
-	key := generateTemplateCacheKey(content, "{{", "}}", MissingKeyDefault, nil)
+	key := generateTemplateCacheKey(content, "{{", "}}", MissingKeyDefault, nil, "")
 	cache.Put(key, tmpl, "bench")
 
 	b.ReportAllocs()
@@ -357,7 +357,7 @@ func BenchmarkTemplateCacheMissEviction(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		content := fmt.Sprintf("Template variant %d: {{.Name}}", i)
-		key := generateTemplateCacheKey(content, "{{", "}}", MissingKeyDefault, nil)
+		key := generateTemplateCacheKey(content, "{{", "}}", MissingKeyDefault, nil, "")
 		tmpl, _ := template.New("bench").Parse(content)
 		cache.Put(key, tmpl, "bench")
 	}

--- a/pkg/gotmpl/cache_test.go
+++ b/pkg/gotmpl/cache_test.go
@@ -319,38 +319,50 @@ func TestTemplateCache_ConcurrentAccess(t *testing.T) {
 
 func TestGenerateTemplateCacheKey(t *testing.T) {
 	t.Run("same inputs produce same key", func(t *testing.T) {
-		key1 := generateTemplateCacheKey("Hello {{.Name}}", "{{", "}}", MissingKeyDefault, []string{"upper", "lower"})
-		key2 := generateTemplateCacheKey("Hello {{.Name}}", "{{", "}}", MissingKeyDefault, []string{"upper", "lower"})
+		key1 := generateTemplateCacheKey("Hello {{.Name}}", "{{", "}}", MissingKeyDefault, []string{"upper", "lower"}, "")
+		key2 := generateTemplateCacheKey("Hello {{.Name}}", "{{", "}}", MissingKeyDefault, []string{"upper", "lower"}, "")
 		assert.Equal(t, key1, key2)
 	})
 
 	t.Run("different content produces different key", func(t *testing.T) {
-		key1 := generateTemplateCacheKey("Hello {{.Name}}", "{{", "}}", MissingKeyDefault, nil)
-		key2 := generateTemplateCacheKey("Goodbye {{.Name}}", "{{", "}}", MissingKeyDefault, nil)
+		key1 := generateTemplateCacheKey("Hello {{.Name}}", "{{", "}}", MissingKeyDefault, nil, "")
+		key2 := generateTemplateCacheKey("Goodbye {{.Name}}", "{{", "}}", MissingKeyDefault, nil, "")
 		assert.NotEqual(t, key1, key2)
 	})
 
 	t.Run("different delimiters produce different key", func(t *testing.T) {
-		key1 := generateTemplateCacheKey("Hello", "{{", "}}", MissingKeyDefault, nil)
-		key2 := generateTemplateCacheKey("Hello", "<<", ">>", MissingKeyDefault, nil)
+		key1 := generateTemplateCacheKey("Hello", "{{", "}}", MissingKeyDefault, nil, "")
+		key2 := generateTemplateCacheKey("Hello", "<<", ">>", MissingKeyDefault, nil, "")
 		assert.NotEqual(t, key1, key2)
 	})
 
 	t.Run("different missingKey produces different key", func(t *testing.T) {
-		key1 := generateTemplateCacheKey("Hello", "{{", "}}", MissingKeyDefault, nil)
-		key2 := generateTemplateCacheKey("Hello", "{{", "}}", MissingKeyError, nil)
+		key1 := generateTemplateCacheKey("Hello", "{{", "}}", MissingKeyDefault, nil, "")
+		key2 := generateTemplateCacheKey("Hello", "{{", "}}", MissingKeyError, nil, "")
 		assert.NotEqual(t, key1, key2)
 	})
 
 	t.Run("different func maps produce different key", func(t *testing.T) {
-		key1 := generateTemplateCacheKey("Hello", "{{", "}}", MissingKeyDefault, []string{"upper"})
-		key2 := generateTemplateCacheKey("Hello", "{{", "}}", MissingKeyDefault, []string{"lower"})
+		key1 := generateTemplateCacheKey("Hello", "{{", "}}", MissingKeyDefault, []string{"upper"}, "")
+		key2 := generateTemplateCacheKey("Hello", "{{", "}}", MissingKeyDefault, []string{"lower"}, "")
 		assert.NotEqual(t, key1, key2)
 	})
 
 	t.Run("func map order does not matter", func(t *testing.T) {
-		key1 := generateTemplateCacheKey("Hello", "{{", "}}", MissingKeyDefault, []string{"upper", "lower"})
-		key2 := generateTemplateCacheKey("Hello", "{{", "}}", MissingKeyDefault, []string{"lower", "upper"})
+		key1 := generateTemplateCacheKey("Hello", "{{", "}}", MissingKeyDefault, []string{"upper", "lower"}, "")
+		key2 := generateTemplateCacheKey("Hello", "{{", "}}", MissingKeyDefault, []string{"lower", "upper"}, "")
+		assert.Equal(t, key1, key2)
+	})
+
+	t.Run("different funcs fingerprint produces different key", func(t *testing.T) {
+		key1 := generateTemplateCacheKey("Hello {{ greet .Name }}", "{{", "}}", MissingKeyDefault, []string{"greet"}, "fp-a")
+		key2 := generateTemplateCacheKey("Hello {{ greet .Name }}", "{{", "}}", MissingKeyDefault, []string{"greet"}, "fp-b")
+		assert.NotEqual(t, key1, key2)
+	})
+
+	t.Run("same funcs fingerprint produces same key", func(t *testing.T) {
+		key1 := generateTemplateCacheKey("Hello {{ greet .Name }}", "{{", "}}", MissingKeyDefault, []string{"greet"}, "fp-a")
+		key2 := generateTemplateCacheKey("Hello {{ greet .Name }}", "{{", "}}", MissingKeyDefault, []string{"greet"}, "fp-a")
 		assert.Equal(t, key1, key2)
 	})
 }

--- a/pkg/gotmpl/funcnames.go
+++ b/pkg/gotmpl/funcnames.go
@@ -1,0 +1,162 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gotmpl
+
+import (
+	"fmt"
+	"sort"
+	"text/template/parse"
+)
+
+// BuiltinFuncNames returns the sorted set of function names that are always
+// available to a Go template rendered through the gotmpl service: the
+// text/template builtins (and, index, printf, ...) plus every extension
+// function (sprig + custom + embedder-registered), honoring the current
+// env-function stripping policy.
+//
+// It is the authoritative name set for detecting collisions with
+// solution-author-defined helper functions and for producing "available
+// functions" diagnostics. The returned slice is a fresh copy the caller may
+// mutate.
+func BuiltinFuncNames() []string {
+	ext := getExtensionFuncMap()
+	seen := make(map[string]struct{}, len(ext)+len(goTemplateBuiltins))
+	for name := range ext {
+		seen[name] = struct{}{}
+	}
+	for _, name := range goTemplateBuiltins {
+		seen[name] = struct{}{}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// IsBuiltinFunc reports whether name is a built-in function (a text/template
+// builtin or a registered extension function) available to every gotmpl
+// template. Author-defined helper functions must not collide with these names.
+func IsBuiltinFunc(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, b := range goTemplateBuiltins {
+		if b == name {
+			return true
+		}
+	}
+	_, ok := getExtensionFuncMap()[name]
+	return ok
+}
+
+// ExtractFunctionCalls parses a Go template body and returns the sorted, unique
+// set of function names invoked within it (the identifier at the head of a
+// command, e.g. "upper" in {{ upper .x }} or "myHelper" in {{ myHelper .x }}).
+//
+// declaredFuncs must include every author function name the body may reference.
+// The text/template builtins and all extension functions (sprig + custom +
+// embedder-registered) are always recognized and need not be supplied; unknown
+// identifiers otherwise cause a parse error.
+//
+// It is used to build the author-function call graph for cycle detection. The
+// returned names are not filtered -- callers narrow them to the set of interest
+// (e.g. sibling author functions).
+func ExtractFunctionCalls(content, leftDelim, rightDelim string, declaredFuncs []string) ([]string, error) {
+	if leftDelim == "" {
+		leftDelim = DefaultLeftDelim
+	}
+	if rightDelim == "" {
+		rightDelim = DefaultRightDelim
+	}
+
+	ext := getExtensionFuncMap()
+	funcNames := make(map[string]any, len(declaredFuncs)+len(goTemplateBuiltins)+len(ext))
+	for _, name := range goTemplateBuiltins {
+		funcNames[name] = true
+	}
+	for name := range ext {
+		funcNames[name] = true
+	}
+	for _, name := range declaredFuncs {
+		funcNames[name] = true
+	}
+
+	trees, err := parse.Parse("author-function", content, leftDelim, rightDelim, funcNames)
+	if err != nil {
+		return nil, fmt.Errorf("parsing template body: %w", err)
+	}
+
+	calls := make(map[string]struct{})
+	for _, tree := range trees {
+		if tree.Root != nil {
+			collectFunctionCalls(tree.Root, calls)
+		}
+	}
+
+	names := make([]string, 0, len(calls))
+	for name := range calls {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// collectFunctionCalls recursively walks a parse tree collecting the identifier
+// at the head of every command node -- i.e. the function names invoked.
+func collectFunctionCalls(node parse.Node, calls map[string]struct{}) {
+	switch n := node.(type) {
+	case *parse.ListNode:
+		if n == nil {
+			return
+		}
+		for _, child := range n.Nodes {
+			collectFunctionCalls(child, calls)
+		}
+	case *parse.ActionNode:
+		collectPipeFunctionCalls(n.Pipe, calls)
+	case *parse.IfNode:
+		collectPipeFunctionCalls(n.Pipe, calls)
+		collectFunctionCalls(n.List, calls)
+		collectFunctionCalls(n.ElseList, calls)
+	case *parse.RangeNode:
+		collectPipeFunctionCalls(n.Pipe, calls)
+		collectFunctionCalls(n.List, calls)
+		collectFunctionCalls(n.ElseList, calls)
+	case *parse.WithNode:
+		collectPipeFunctionCalls(n.Pipe, calls)
+		collectFunctionCalls(n.List, calls)
+		collectFunctionCalls(n.ElseList, calls)
+	case *parse.TemplateNode:
+		collectPipeFunctionCalls(n.Pipe, calls)
+	}
+}
+
+// collectPipeFunctionCalls walks a pipe, recording each command's head
+// identifier (a function call) and recursing into nested pipes carried as
+// command arguments.
+func collectPipeFunctionCalls(pipe *parse.PipeNode, calls map[string]struct{}) {
+	if pipe == nil {
+		return
+	}
+	for _, cmd := range pipe.Cmds {
+		if cmd == nil {
+			continue
+		}
+		for i, arg := range cmd.Args {
+			switch a := arg.(type) {
+			case *parse.IdentifierNode:
+				// The head of a command (index 0) is a function invocation.
+				// An identifier can only appear at the head of a command in a
+				// valid tree, but guard on position for clarity.
+				if i == 0 {
+					calls[a.Ident] = struct{}{}
+				}
+			case *parse.PipeNode:
+				collectPipeFunctionCalls(a, calls)
+			}
+		}
+	}
+}

--- a/pkg/gotmpl/funcnames_test.go
+++ b/pkg/gotmpl/funcnames_test.go
@@ -1,0 +1,76 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gotmpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsBuiltinFunc(t *testing.T) {
+	assert.True(t, IsBuiltinFunc("printf"), "text/template builtin")
+	assert.True(t, IsBuiltinFunc("index"), "text/template builtin")
+	assert.False(t, IsBuiltinFunc(""), "empty name")
+	assert.False(t, IsBuiltinFunc("definitelyNotAFunction123"))
+}
+
+func TestBuiltinFuncNames_Sorted(t *testing.T) {
+	names := BuiltinFuncNames()
+	require.NotEmpty(t, names)
+	assert.Contains(t, names, "printf")
+	assert.IsIncreasing(t, names)
+}
+
+func TestExtractFunctionCalls_Simple(t *testing.T) {
+	calls, err := ExtractFunctionCalls(`{{ myHelper .x }}`, "", "", []string{"myHelper"})
+	require.NoError(t, err)
+	assert.Contains(t, calls, "myHelper")
+}
+
+func TestExtractFunctionCalls_Nested(t *testing.T) {
+	content := `{{ if gt (myLen .items) 0 }}{{ range .items }}{{ myFmt . }}{{ end }}{{ end }}`
+	calls, err := ExtractFunctionCalls(content, "", "", []string{"myLen", "myFmt"})
+	require.NoError(t, err)
+	assert.Contains(t, calls, "myLen")
+	assert.Contains(t, calls, "myFmt")
+}
+
+func TestExtractFunctionCalls_ExtensionFuncsRecognized(t *testing.T) {
+	// upper is a sprig extension function; it must be recognized without being
+	// declared so bodies that mix author + built-in helpers parse.
+	initExtensionFactory(t)
+	calls, err := ExtractFunctionCalls(`{{ myHelper .x | upper }}`, "", "", []string{"myHelper"})
+	require.NoError(t, err)
+	assert.Contains(t, calls, "myHelper")
+}
+
+func TestExtractFunctionCalls_UndeclaredFails(t *testing.T) {
+	_, err := ExtractFunctionCalls(`{{ notDeclared .x }}`, "", "", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not defined")
+}
+
+func TestExtractFunctionCalls_SortedUnique(t *testing.T) {
+	content := `{{ a }}{{ b }}{{ a }}`
+	calls, err := ExtractFunctionCalls(content, "", "", []string{"a", "b"})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, calls)
+}
+
+func TestValidateSyntaxWithFuncs(t *testing.T) {
+	// An author function name is recognized when supplied.
+	err := ValidateSyntaxWithFuncs(`{{ myHelper .x }}`, "", "", []string{"myHelper"})
+	assert.NoError(t, err)
+
+	// Without declaring it, the same template fails to parse.
+	err = ValidateSyntaxWithFuncs(`{{ myHelper .x }}`, "", "", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not defined")
+
+	// A genuine syntax error is still reported even with declared funcs.
+	err = ValidateSyntaxWithFuncs(`{{ myHelper .x `, "", "", []string{"myHelper"})
+	require.Error(t, err)
+}

--- a/pkg/gotmpl/gotmpl.go
+++ b/pkg/gotmpl/gotmpl.go
@@ -91,6 +91,18 @@ type TemplateOptions struct {
 	// These are added to the template's function map
 	Funcs template.FuncMap `json:"-" yaml:"-" doc:"Custom template functions to make available"`
 
+	// FuncsFingerprint is an optional stable identifier for the *implementations*
+	// supplied in Funcs. Funcs are bound into the parsed template at parse time
+	// and the parsed template is cached, but the cache key only records function
+	// *names* -- not their bodies. When two distinct function sets share the same
+	// names (e.g. author-defined helpers with identical names but different
+	// bodies across solutions), a name-only key would collide and return a
+	// template bound to the wrong implementations. Callers that supply
+	// content-dependent Funcs must set FuncsFingerprint to a value that changes
+	// with those implementations so cache entries stay isolated. Empty when Funcs
+	// is nil or fully determined by its names.
+	FuncsFingerprint string `json:"-" yaml:"-" doc:"Stable identifier for the implementations in Funcs; disambiguates cache entries when function names collide"`
+
 	// MissingKey controls the behavior when a map key is missing
 	// Default: MissingKeyError (stops execution with an error)
 	// Options: MissingKeyDefault, MissingKeyZero, MissingKeyError
@@ -468,7 +480,7 @@ func (s *Service) createTemplate(ctx context.Context, name, content string, opts
 
 	// Check the cache
 	cache := s.getCache()
-	cacheKey := generateTemplateCacheKey(content, leftDelim, rightDelim, missingKey, funcMapKeys)
+	cacheKey := generateTemplateCacheKey(content, leftDelim, rightDelim, missingKey, funcMapKeys, opts.FuncsFingerprint)
 
 	if cached, ok := cache.Get(cacheKey); ok {
 		lgr.V(2).Info("template cache hit", "name", name, "key", cacheKey[:12])
@@ -703,7 +715,27 @@ func Execute(ctx context.Context, opts TemplateOptions) (*ExecuteResult, error) 
 // Use leftDelim/rightDelim to override the default "{{" / "}}" delimiters
 // (pass empty strings for defaults).
 func ValidateSyntax(content, leftDelim, rightDelim string) error {
-	tmpl := template.New("validate").Funcs(getExtensionFuncMap())
+	return ValidateSyntaxWithFuncs(content, leftDelim, rightDelim, nil)
+}
+
+// ValidateSyntaxWithFuncs is like ValidateSyntax but additionally recognizes the
+// given function names during parsing. It is used to validate templates that may
+// invoke solution-author-defined helper functions (spec.functions), which are
+// not part of the built-in extension set. Extra names are registered as no-op
+// stubs solely so parsing succeeds; they never execute here. Built-in extension
+// functions win on collision, so a stub cannot shadow a real function.
+func ValidateSyntaxWithFuncs(content, leftDelim, rightDelim string, extraFuncNames []string) error {
+	funcMap := getExtensionFuncMap()
+	if len(extraFuncNames) > 0 {
+		stub := func(_ ...any) any { return nil }
+		for _, name := range extraFuncNames {
+			if _, exists := funcMap[name]; !exists {
+				funcMap[name] = stub
+			}
+		}
+	}
+
+	tmpl := template.New("validate").Funcs(funcMap)
 
 	switch {
 	case leftDelim != "" && rightDelim != "":

--- a/pkg/gotmpl/gotmpl_test.go
+++ b/pkg/gotmpl/gotmpl_test.go
@@ -828,6 +828,47 @@ func TestSetContextFuncBinderFactory(t *testing.T) {
 	assert.Contains(t, fm, "ctxFunc")
 }
 
+// TestContextFuncBinder_RebindsOnCacheHit guards against a regression where a
+// context-aware function bound at first parse gets frozen into the shared
+// template cache: a second render of the same template must use the CURRENT
+// context's binding, not the one captured when the cache entry was created.
+func TestContextFuncBinder_RebindsOnCacheHit(t *testing.T) {
+	contextFuncBinderMu.Lock()
+	orig := contextFuncBinderFactory
+	contextFuncBinderMu.Unlock()
+	defer func() {
+		contextFuncBinderMu.Lock()
+		contextFuncBinderFactory = orig
+		contextFuncBinderMu.Unlock()
+	}()
+
+	type ctxKey struct{}
+	// The factory reads a value from the current context so the bound function's
+	// output depends on which context is active at execution time.
+	SetContextFuncBinderFactory(func(ctx context.Context) template.FuncMap {
+		val, _ := ctx.Value(ctxKey{}).(string)
+		return template.FuncMap{"whoami": func() string { return val }}
+	})
+
+	svc := NewService(nil)
+	content := "{{ whoami }}"
+
+	// The name must be registered at parse time (Go validates function names
+	// during Parse); the real ctx-bound closure is substituted at execution.
+	parseFuncs := template.FuncMap{"whoami": func() string { return "" }}
+
+	ctx1 := context.WithValue(context.Background(), ctxKey{}, "first")
+	out1, err := svc.Execute(ctx1, TemplateOptions{Content: content, Name: "rebind", Funcs: parseFuncs})
+	require.NoError(t, err)
+	assert.Equal(t, "first", out1.Output)
+
+	// Same content/name => cache hit. The output must reflect ctx2, not ctx1.
+	ctx2 := context.WithValue(context.Background(), ctxKey{}, "second")
+	out2, err := svc.Execute(ctx2, TemplateOptions{Content: content, Name: "rebind", Funcs: parseFuncs})
+	require.NoError(t, err)
+	assert.Equal(t, "second", out2.Output)
+}
+
 func TestNewServiceRaw(t *testing.T) {
 	svc := NewServiceRaw(nil)
 	assert.NotNil(t, svc)

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/cel-go/cel"
 	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/authorfuncs"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/paths"
@@ -122,6 +123,7 @@ func Solution(sol *solution.Solution, filePath string, registry *provider.Regist
 	lintTemplateAccessors(sol, result)
 	lintWorkflow(sol, result, registry)
 	lintCalls(sol, result, registry)
+	lintFunctions(sol, result)
 	lintState(sol, result, registry)
 	lintImmutableResolvers(sol, result)
 	lintParameterNumericMatches(sol, result)
@@ -470,7 +472,7 @@ func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Re
 				}
 
 				lintNilInputs(step.Inputs, stepLocation, result)
-				lintExpressions(step.Inputs, stepLocation, result)
+				lintExpressions(step.Inputs, stepLocation, result, declaredFunctionNames(sol))
 
 				// forEach on a resolve step is a valid fan-out, but it requires
 				// forEach.in: the resolve phase has no __self to default the
@@ -1106,12 +1108,12 @@ func lintWorkflow(sol *solution.Solution, result *Result, registry *provider.Reg
 
 	for name, act := range workflow.Actions {
 		location := fmt.Sprintf("workflow.actions.%s", name)
-		lintAction(act, location, actionNames, result, registry)
+		lintAction(act, location, actionNames, result, registry, declaredFunctionNames(sol))
 	}
 
 	for name, act := range workflow.Finally {
 		location := fmt.Sprintf("workflow.finally.%s", name)
-		lintAction(act, location, finallyNames, result, registry)
+		lintAction(act, location, finallyNames, result, registry, declaredFunctionNames(sol))
 
 		if act.ForEach != nil {
 			result.addFinding(SeverityError, "validation", location,
@@ -1202,7 +1204,7 @@ func (r *registryAdapter) Has(name string) bool {
 	return r.registry.Has(name)
 }
 
-func lintAction(act *action.Action, location string, validDeps map[string]bool, result *Result, registry *provider.Registry) {
+func lintAction(act *action.Action, location string, validDeps map[string]bool, result *Result, registry *provider.Registry, declaredFuncs []string) {
 	if act.Description == "" {
 		result.addFinding(SeverityInfo, "documentation", location,
 			"action lacks description",
@@ -1238,7 +1240,7 @@ func lintAction(act *action.Action, location string, validDeps map[string]bool, 
 		}
 	}
 
-	lintExpressions(act.Inputs, location, result)
+	lintExpressions(act.Inputs, location, result, declaredFuncs)
 
 	if act.When != nil && act.When.Expr != nil {
 		if err := validateCELSyntax(string(*act.When.Expr)); err != nil {
@@ -1325,7 +1327,7 @@ func lintNilInputs(inputs map[string]*spec.ValueRef, location string, result *Re
 	}
 }
 
-func lintExpressions(inputs map[string]*spec.ValueRef, location string, result *Result) {
+func lintExpressions(inputs map[string]*spec.ValueRef, location string, result *Result, declaredFuncs []string) {
 	for key, val := range inputs {
 		if val == nil {
 			continue
@@ -1347,7 +1349,7 @@ func lintExpressions(inputs map[string]*spec.ValueRef, location string, result *
 
 		if val.Tmpl != nil && string(*val.Tmpl) != "" {
 			tmplStr := string(*val.Tmpl)
-			if err := validateTemplateSyntax(tmplStr); err != nil {
+			if err := validateTemplateSyntax(tmplStr, declaredFuncs); err != nil {
 				result.addFinding(SeverityError, "template", inputLoc,
 					fmt.Sprintf("invalid Go template: %v", err),
 					"Fix the template syntax",
@@ -1575,10 +1577,48 @@ func hyphensToCamelCase(name string) string {
 }
 
 // validateTemplateSyntax checks if a Go template is syntactically valid.
-// Delegates to gotmpl.ValidateSyntax so that sprig and custom extension
-// functions are registered during parsing, matching runtime behavior.
-func validateTemplateSyntax(tmpl string) error {
-	return gotmpl.ValidateSyntax(tmpl, "", "")
+// Delegates to gotmpl.ValidateSyntaxWithFuncs so that sprig, custom extension
+// functions, and solution-author-defined helper functions (declaredFuncs) are
+// all recognized during parsing, matching runtime behavior.
+func validateTemplateSyntax(tmpl string, declaredFuncs []string) error {
+	return gotmpl.ValidateSyntaxWithFuncs(tmpl, "", "", declaredFuncs)
+}
+
+// declaredFunctionNames returns the sorted names of the solution's
+// author-defined template functions (spec.functions). Templates may invoke
+// these, so they must be recognized during lint-time syntax validation to avoid
+// false "function not defined" errors.
+func declaredFunctionNames(sol *solution.Solution) []string {
+	if sol == nil || !sol.Spec.HasFunctions() {
+		return nil
+	}
+	names := make([]string, 0, len(sol.Spec.Functions))
+	for name := range sol.Spec.Functions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// lintFunctions validates the solution's author-defined template functions
+// (spec.functions) by compiling them, surfacing each definition problem (invalid
+// name, built-in collision, missing/duplicate body, invalid body, parameter
+// errors, or a call-graph cycle) as an error finding. This mirrors what
+// execution enforces so authors see problems at lint time.
+func lintFunctions(sol *solution.Solution, result *Result) {
+	if sol == nil || !sol.Spec.HasFunctions() {
+		return
+	}
+
+	if _, err := authorfuncs.Compile(sol.Spec.Functions); err != nil {
+		msg := strings.TrimPrefix(err.Error(), "invalid spec.functions: ")
+		for _, problem := range strings.Split(msg, "; ") {
+			result.addFinding(SeverityError, "functions", "spec.functions",
+				problem,
+				"Fix the function definition so it compiles",
+				"invalid-function")
+		}
+	}
 }
 
 // lintUndefinedOptionalRefs emits an INFO finding for each optional CEL

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -406,6 +406,11 @@ func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Re
 		return
 	}
 
+	// Computed once and reused for every resolve step below: the sorted name
+	// slice is identical across all steps, so recomputing it per step would
+	// needlessly re-sort and re-allocate on large solutions.
+	declaredFuncs := declaredFunctionNames(sol)
+
 	reservedNames := map[string]bool{
 		"__actions": true,
 		"__error":   true,
@@ -472,7 +477,7 @@ func lintResolvers(sol *solution.Solution, result *Result, registry *provider.Re
 				}
 
 				lintNilInputs(step.Inputs, stepLocation, result)
-				lintExpressions(step.Inputs, stepLocation, result, declaredFunctionNames(sol))
+				lintExpressions(step.Inputs, stepLocation, result, declaredFuncs)
 
 				// forEach on a resolve step is a valid fan-out, but it requires
 				// forEach.in: the resolve phase has no __self to default the
@@ -1106,14 +1111,17 @@ func lintWorkflow(sol *solution.Solution, result *Result, registry *provider.Reg
 		finallyNames[name] = true
 	}
 
+	// Computed once and reused for every action below (see lintResolvers).
+	declaredFuncs := declaredFunctionNames(sol)
+
 	for name, act := range workflow.Actions {
 		location := fmt.Sprintf("workflow.actions.%s", name)
-		lintAction(act, location, actionNames, result, registry, declaredFunctionNames(sol))
+		lintAction(act, location, actionNames, result, registry, declaredFuncs)
 	}
 
 	for name, act := range workflow.Finally {
 		location := fmt.Sprintf("workflow.finally.%s", name)
-		lintAction(act, location, finallyNames, result, registry, declaredFunctionNames(sol))
+		lintAction(act, location, finallyNames, result, registry, declaredFuncs)
 
 		if act.ForEach != nil {
 			result.addFinding(SeverityError, "validation", location,

--- a/pkg/lint/lint_extra_test.go
+++ b/pkg/lint/lint_extra_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/action"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/duration"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
@@ -214,14 +215,93 @@ func TestOrValueSuggestion(t *testing.T) {
 // ---- validateTemplateSyntax ----
 
 func TestValidateTemplateSyntax_Valid(t *testing.T) {
-	assert.NoError(t, validateTemplateSyntax("Hello, {{ .Name }}!"))
-	assert.NoError(t, validateTemplateSyntax("plain text"))
-	assert.NoError(t, validateTemplateSyntax("{{ if .Cond }}yes{{ end }}"))
+	assert.NoError(t, validateTemplateSyntax("Hello, {{ .Name }}!", nil))
+	assert.NoError(t, validateTemplateSyntax("plain text", nil))
+	assert.NoError(t, validateTemplateSyntax("{{ if .Cond }}yes{{ end }}", nil))
+	assert.NoError(t, validateTemplateSyntax("{{ myHelper .Name }}", []string{"myHelper"}))
 }
 
 func TestValidateTemplateSyntax_Invalid(t *testing.T) {
-	err := validateTemplateSyntax("{{ .Name")
+	err := validateTemplateSyntax("{{ .Name", nil)
 	assert.Error(t, err)
+}
+
+// ---- lintFunctions ----
+
+func TestLintFunctions_NoFunctions(t *testing.T) {
+	sol := &solution.Solution{Spec: solution.Spec{}}
+	result := &Result{}
+	lintFunctions(sol, result)
+	assert.Empty(t, result.Findings)
+}
+
+func TestLintFunctions_Valid(t *testing.T) {
+	sol := &solution.Solution{Spec: solution.Spec{
+		Functions: map[string]*spec.Function{
+			"doubled": {
+				Params: []*spec.ParamDef{{Name: "n", Type: spec.TypeInt, Required: true}},
+				Cel:    "_.args.n * 2",
+			},
+		},
+	}}
+	result := &Result{}
+	lintFunctions(sol, result)
+	assert.Empty(t, result.Findings)
+}
+
+func TestLintFunctions_ReportsProblems(t *testing.T) {
+	sol := &solution.Solution{Spec: solution.Spec{
+		Functions: map[string]*spec.Function{
+			"printf": {Cel: "1"}, // built-in collision
+		},
+	}}
+	result := &Result{}
+	lintFunctions(sol, result)
+	require.NotEmpty(t, result.Findings)
+	assert.True(t, hasRuleName(result.Findings, "invalid-function"))
+}
+
+func TestLintFunctions_ReportsCycle(t *testing.T) {
+	sol := &solution.Solution{Spec: solution.Spec{
+		Functions: map[string]*spec.Function{
+			"a": {Params: []*spec.ParamDef{{Name: "x"}}, Template: "{{ b .args.x }}"},
+			"b": {Params: []*spec.ParamDef{{Name: "x"}}, Template: "{{ a .args.x }}"},
+		},
+	}}
+	result := &Result{}
+	lintFunctions(sol, result)
+	require.True(t, hasRuleName(result.Findings, "invalid-function"))
+	assert.Contains(t, result.Findings[0].Message, "cycle")
+}
+
+func TestDeclaredFunctionNames(t *testing.T) {
+	assert.Nil(t, declaredFunctionNames(nil))
+	assert.Nil(t, declaredFunctionNames(&solution.Solution{Spec: solution.Spec{}}))
+
+	sol := &solution.Solution{Spec: solution.Spec{
+		Functions: map[string]*spec.Function{
+			"beta":  {Cel: "1"},
+			"alpha": {Cel: "1"},
+		},
+	}}
+	assert.Equal(t, []string{"alpha", "beta"}, declaredFunctionNames(sol))
+}
+
+func TestLintExpressions_AuthorFuncNotFalsePositive(t *testing.T) {
+	tmplContent := gotmpl.GoTemplatingContent(`{{ myHelper .x }}`)
+	inputs := map[string]*spec.ValueRef{
+		"test": {Tmpl: &tmplContent},
+	}
+
+	// Without declaring the function, the template is flagged as invalid.
+	undeclared := &Result{}
+	lintExpressions(inputs, "test.resolvers.r", undeclared, nil)
+	assert.True(t, hasRuleName(undeclared.Findings, "invalid-template"))
+
+	// Declaring the author function suppresses the false positive.
+	declared := &Result{}
+	lintExpressions(inputs, "test.resolvers.r", declared, []string{"myHelper"})
+	assert.False(t, hasRuleName(declared.Findings, "invalid-template"))
 }
 
 // ---- isCoveredByBundleInclude ----
@@ -296,7 +376,7 @@ func doLintAction(act *action.Action) *Result {
 	reg := provider.NewRegistry()
 	_ = reg.Register(newFakeProvider("known-provider", nil))
 	result := &Result{}
-	lintAction(act, "workflow.actions.myaction", map[string]bool{"step1": true}, result, reg)
+	lintAction(act, "workflow.actions.myaction", map[string]bool{"step1": true}, result, reg, nil)
 	return result
 }
 

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -1175,7 +1175,7 @@ func TestLintExpressions_AllPaths(t *testing.T) {
 	}
 
 	result := &Result{Findings: make([]*Finding, 0)}
-	lintExpressions(inputs, "test.resolvers.myresolver", result)
+	lintExpressions(inputs, "test.resolvers.myresolver", result, nil)
 
 	// Should have findings for invalid CEL and invalid template
 	findingRules := make([]string, 0, len(result.Findings))
@@ -1207,7 +1207,7 @@ func TestLintExpressions_SprigFunctionsNotFalsePositive(t *testing.T) {
 			"test": {Tmpl: &tmplContent},
 		}
 		result := &Result{Findings: make([]*Finding, 0)}
-		lintExpressions(inputs, "test.resolvers.myresolver", result)
+		lintExpressions(inputs, "test.resolvers.myresolver", result, nil)
 
 		for _, f := range result.Findings {
 			assert.NotEqual(t, "invalid-template", f.RuleName,

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -198,6 +198,14 @@ var KnownRules = map[string]RuleMeta{
 		Why:         "Invalid Go templates will cause runtime failures. Common issues include unclosed actions (missing '}}'), unclosed control blocks (if/range/with without end), and unknown functions.",
 		Fix:         "Use validate_expression with type 'go-template' to check the template syntax. Use evaluate_go_template to test the template with sample data.",
 	},
+	"invalid-function": {
+		Rule:        "invalid-function",
+		Severity:    string(SeverityError),
+		Category:    "functions",
+		Description: "A solution-author-defined template function (spec.functions) is invalid: bad name, collision with a built-in function, missing or ambiguous body (must set exactly one of cel/template), invalid body, a parameter error, or a call-graph cycle.",
+		Why:         "Invalid function definitions fail solution loading. Reporting each problem as a finding lets a single lint pass surface every issue at once instead of one at a time.",
+		Fix:         "Give the function a unique, non-built-in identifier name; set exactly one of cel or template; ensure parameters have valid unique names and known types; and avoid template bodies that call each other cyclically.",
+	},
 	"invalid-dependency": {
 		Rule:        "invalid-dependency",
 		Severity:    string(SeverityError),

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -32,8 +32,8 @@ func TestKnownRulesHaveRequiredFields(t *testing.T) {
 }
 
 func TestKnownRulesCount(t *testing.T) {
-	// We expect exactly 67 rules — update this when new rules are added
-	assert.Equal(t, 67, len(KnownRules), "expected 67 known lint rules")
+	// We expect exactly 68 rules — update this when new rules are added
+	assert.Equal(t, 68, len(KnownRules), "expected 68 known lint rules")
 }
 
 func TestListRules(t *testing.T) {

--- a/pkg/mcp/tools_schema.go
+++ b/pkg/mcp/tools_schema.go
@@ -35,7 +35,7 @@ func (s *Server) registerSchemaTools() {
 
 	// explain_kind — introspect any registered kind (solution, resolver, action, etc.)
 	explainKindTool := mcp.NewTool("explain_kind",
-		mcp.WithDescription("Get detailed field documentation for a scafctl type (kind). Works like 'kubectl explain' — shows field names, types, descriptions, validation rules, and examples. Available kinds: solution, resolver, action, workflow, spec, provider, schema, retry."),
+		mcp.WithDescription("Get detailed field documentation for a scafctl type (kind). Works like 'kubectl explain' — shows field names, types, descriptions, validation rules, and examples. Available kinds: solution, resolver, action, workflow, spec, provider, schema, retry, function."),
 		mcp.WithTitleAnnotation("Explain Kind"),
 		mcp.WithToolIcons(toolIcons["schema"]),
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -44,7 +44,7 @@ func (s *Server) registerSchemaTools() {
 		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithString("kind",
 			mcp.Required(),
-			mcp.Description("The kind to explain: solution, resolver, action, workflow, spec, provider, schema, retry"),
+			mcp.Description("The kind to explain: solution, resolver, action, workflow, spec, provider, schema, retry, function"),
 		),
 		mcp.WithString("field",
 			mcp.Description("Optional field path to drill into (dot-separated, e.g., 'metadata', 'resolve.with')"),

--- a/pkg/provider/builtin/gotmplprovider/gotmpl.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl.go
@@ -6,6 +6,7 @@ package gotmplprovider
 import (
 	"context"
 	"fmt"
+	"html/template"
 	"maps"
 	"path/filepath"
 	"strings"
@@ -428,15 +429,20 @@ func (p *GoTemplateProvider) executeRender(ctx context.Context, inputs map[strin
 
 	replacements := buildIgnoredBlockReplacements(templateStr, ignoredBlocksCfg)
 
+	// Bind any solution-author-defined helper functions (spec.functions).
+	authorFuncs, authorFuncsFP := authorTemplateFuncs(ctx)
+
 	// Execute the template
 	result, err := p.service.Execute(ctx, gotmpl.TemplateOptions{
-		Content:      templateStr,
-		Name:         templateName,
-		Data:         templateData,
-		MissingKey:   missingKey,
-		LeftDelim:    leftDelim,
-		RightDelim:   rightDelim,
-		Replacements: replacements,
+		Content:          templateStr,
+		Name:             templateName,
+		Data:             templateData,
+		MissingKey:       missingKey,
+		LeftDelim:        leftDelim,
+		RightDelim:       rightDelim,
+		Replacements:     replacements,
+		Funcs:            authorFuncs,
+		FuncsFingerprint: authorFuncsFP,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", ProviderName, err)
@@ -537,6 +543,10 @@ func (p *GoTemplateProvider) executeRenderTree(ctx context.Context, inputs map[s
 	// Build base template data from resolver context + additional data
 	baseData := p.buildTemplateData(ctx, inputs)
 
+	// Bind any solution-author-defined helper functions (spec.functions) once
+	// for the whole tree.
+	authorFuncs, authorFuncsFP := authorTemplateFuncs(ctx)
+
 	lgr.V(1).Info("executing render-tree",
 		"name", templateName,
 		"entryCount", len(entries),
@@ -618,13 +628,15 @@ func (p *GoTemplateProvider) executeRenderTree(ctx context.Context, inputs map[s
 		// Render the entry content as a Go template
 		entryTemplateName := fmt.Sprintf("%s/%s", templateName, entryPath)
 		result, renderErr := p.service.Execute(ctx, gotmpl.TemplateOptions{
-			Content:      entryContent,
-			Name:         entryTemplateName,
-			Data:         templateData,
-			MissingKey:   missingKey,
-			LeftDelim:    leftDelim,
-			RightDelim:   rightDelim,
-			Replacements: replacements,
+			Content:          entryContent,
+			Name:             entryTemplateName,
+			Data:             templateData,
+			MissingKey:       missingKey,
+			LeftDelim:        leftDelim,
+			RightDelim:       rightDelim,
+			Replacements:     replacements,
+			Funcs:            authorFuncs,
+			FuncsFingerprint: authorFuncsFP,
 		})
 		if renderErr != nil {
 			return nil, fmt.Errorf("%s: failed to render %s: %w", ProviderName, entryPath, renderErr)
@@ -723,6 +735,18 @@ func (p *GoTemplateProvider) parseRenderingOptions(inputs map[string]any) (gotmp
 	}
 
 	return missingKey, leftDelim, rightDelim, nil
+}
+
+// authorTemplateFuncs binds the solution-author-defined helper functions
+// (spec.functions) carried on the provider context, if any. It returns the
+// bound FuncMap and its fingerprint (used to isolate template cache entries),
+// or (nil, "") when no functions are declared.
+func authorTemplateFuncs(ctx context.Context) (template.FuncMap, string) {
+	binder, ok := provider.TemplateFuncBinderFromContext(ctx)
+	if !ok || binder == nil {
+		return nil, ""
+	}
+	return binder.Bind(ctx), binder.Fingerprint()
 }
 
 // buildTemplateData constructs the template data map from resolver context, iteration context, and additional data.

--- a/pkg/provider/builtin/gotmplprovider/gotmpl.go
+++ b/pkg/provider/builtin/gotmplprovider/gotmpl.go
@@ -6,10 +6,10 @@ package gotmplprovider
 import (
 	"context"
 	"fmt"
-	"html/template"
 	"maps"
 	"path/filepath"
 	"strings"
+	"text/template"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/bmatcuk/doublestar/v4"

--- a/pkg/provider/builtin/solutionprovider/solution.go
+++ b/pkg/provider/builtin/solutionprovider/solution.go
@@ -335,6 +335,11 @@ func (p *SolutionProvider) executeResolversOnly(ctx context.Context, sol *soluti
 		if sol.Spec.HasCalls() {
 			execOpts = append(execOpts, resolver.WithCalls(sol.Spec.Calls))
 		}
+		if binder, binderErr := sol.TemplateFuncBinder(); binderErr != nil {
+			return nil, fmt.Errorf("solution %q: compiling spec.functions: %w", in.Source, binderErr)
+		} else if binder != nil {
+			execOpts = append(execOpts, resolver.WithTemplateFuncBinder(binder))
+		}
 		executor := resolver.NewExecutor(adapter, execOpts...)
 
 		resultCtx, err := executor.Execute(ctx, resolvers, in.Inputs)
@@ -378,6 +383,13 @@ func (p *SolutionProvider) executeWithWorkflow(ctx context.Context, sol *solutio
 		defer cancel()
 	}
 
+	// Compile the sub-solution's author-defined template functions once for both
+	// the resolver and workflow phases.
+	funcBinder, err := sol.TemplateFuncBinder()
+	if err != nil {
+		return nil, fmt.Errorf("solution %q: compiling spec.functions: %w", in.Source, err)
+	}
+
 	resolverData := make(map[string]any)
 	var resolverErrors []ResolverError
 
@@ -410,6 +422,9 @@ func (p *SolutionProvider) executeWithWorkflow(ctx context.Context, sol *solutio
 		}
 		if sol.Spec.HasCalls() {
 			resolverOpts = append(resolverOpts, resolver.WithCalls(sol.Spec.Calls))
+		}
+		if funcBinder != nil {
+			resolverOpts = append(resolverOpts, resolver.WithTemplateFuncBinder(funcBinder))
 		}
 		resolverExec := resolver.NewExecutor(adapter, resolverOpts...)
 
@@ -445,6 +460,9 @@ func (p *SolutionProvider) executeWithWorkflow(ctx context.Context, sol *solutio
 		action.WithResolverData(resolverData),
 		action.WithCalls(sol.Spec.Calls),
 	)
+	if funcBinder != nil {
+		action.WithTemplateFuncBinder(funcBinder)(actionExec)
+	}
 
 	execResult, err := actionExec.Execute(ctx, sol.Spec.Workflow)
 

--- a/pkg/provider/context.go
+++ b/pkg/provider/context.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"text/template"
 
 	sdkprovider "github.com/oakwood-commons/scafctl-plugin-sdk/provider"
 )
@@ -174,4 +175,43 @@ func WithExecutionSettings(ctx context.Context, settings map[string]json.RawMess
 func ExecutionSettingsFromContext(ctx context.Context) (map[string]json.RawMessage, bool) {
 	settings, ok := ctx.Value(executionSettingsKey).(map[string]json.RawMessage)
 	return settings, ok
+}
+
+// TemplateFuncBinder supplies solution-author-defined Go template helper
+// functions to the go-template provider. It is implemented by the authorfuncs
+// library compiled from a solution's spec.functions. Keeping the provider layer
+// dependent only on this interface (rather than the concrete library) avoids an
+// import cycle between the provider/executor packages and the higher-level
+// solution/authorfuncs packages.
+type TemplateFuncBinder interface {
+	// Bind returns the author-defined functions as a template.FuncMap whose
+	// closures capture ctx (for CEL evaluation and nested rendering). It returns
+	// nil when there are no functions to bind.
+	Bind(ctx context.Context) template.FuncMap
+
+	// Fingerprint returns a stable identifier for the function *implementations*
+	// so template caches can distinguish same-named functions with different
+	// bodies. It returns an empty string when there are no functions.
+	Fingerprint() string
+}
+
+// templateFuncBinderKey is a scafctl-only context key carrying the author
+// function binder into provider execution.
+const templateFuncBinderKey scafctlContextKey = "scafctl.provider.templateFuncBinder"
+
+// WithTemplateFuncBinder returns a new context carrying the author-defined
+// template function binder. A nil binder is not attached, so downstream lookups
+// behave as if no functions were declared.
+func WithTemplateFuncBinder(ctx context.Context, binder TemplateFuncBinder) context.Context {
+	if binder == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, templateFuncBinderKey, binder)
+}
+
+// TemplateFuncBinderFromContext retrieves the author-defined template function
+// binder. Returns the binder and true if present, nil and false otherwise.
+func TemplateFuncBinderFromContext(ctx context.Context) (TemplateFuncBinder, bool) {
+	binder, ok := ctx.Value(templateFuncBinderKey).(TemplateFuncBinder)
+	return binder, ok
 }

--- a/pkg/resolver/executor.go
+++ b/pkg/resolver/executor.go
@@ -73,6 +73,7 @@ type Executor struct {
 	seededResults      map[string]*ExecutionResult // Pre-computed results (e.g. state pre-load phase) reused without re-execution
 	calls              map[string]*spec.Call       // Reusable call definitions invoked via call + args
 	dedupMemo          *call.Memo                  // Per-run memo for opt-in call de-duplication
+	templateFuncBinder provider.TemplateFuncBinder // Author-defined template helper functions (spec.functions)
 }
 
 // ExecutorOption is a functional option for configuring the Executor
@@ -209,6 +210,15 @@ func WithCalls(calls map[string]*spec.Call) ExecutorOption {
 	}
 }
 
+// WithTemplateFuncBinder registers the solution's author-defined template helper
+// functions (spec.functions) so that Go templates rendered during resolution can
+// invoke them as {{ name arg... }}. A nil binder is a no-op.
+func WithTemplateFuncBinder(binder provider.TemplateFuncBinder) ExecutorOption {
+	return func(e *Executor) {
+		e.templateFuncBinder = binder
+	}
+}
+
 // NewExecutor creates a new resolver executor
 func NewExecutor(registry RegistryInterface, opts ...ExecutorOption) *Executor {
 	executor := &Executor{
@@ -320,6 +330,12 @@ func (e *Executor) Execute(ctx context.Context, resolvers []*Resolver, params ma
 
 	// Add parameters to context for parameter provider
 	ctx = provider.WithParameters(ctx, params)
+
+	// Inject the author-defined template function binder (spec.functions) so the
+	// go-template provider can expose the solution's helpers to its templates.
+	if e.templateFuncBinder != nil {
+		ctx = provider.WithTemplateFuncBinder(ctx, e.templateFuncBinder)
+	}
 
 	// Also add parameters directly to resolver context for CEL expressions
 	for key, value := range params {

--- a/pkg/schema/kinds.go
+++ b/pkg/schema/kinds.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
 )
 
 // KindDefinition holds metadata and type information for an explainable kind.
@@ -253,6 +254,16 @@ It uses the standard JSON Schema specification to define types, validation rules
 			Description: `RetryConfig defines automatic retry behavior for failed actions.
 It configures the number of attempts, backoff strategy, and delays.`,
 			TypeInstance: (*action.RetryConfig)(nil),
+		},
+		{
+			Name:    "function",
+			Aliases: []string{"functions", "func", "fn"},
+			Description: `Function is a solution-author-defined, named Go template helper declared 
+under spec.functions and callable from the Go templates the solution renders 
+through the go-template provider as {{ name arg... }}. It has ordered, positional, 
+typed parameters (exposed inside the body under the args namespace) and exactly 
+one body: a CEL expression (cel) or a Go template (template).`,
+			TypeInstance: (*spec.Function)(nil),
 		},
 	}
 }

--- a/pkg/schema/kinds_test.go
+++ b/pkg/schema/kinds_test.go
@@ -21,7 +21,7 @@ func TestEnsureBuiltinKinds(t *testing.T) {
 	err := ensureBuiltinKinds()
 	require.NoError(t, err)
 
-	// Verify all 8 built-in kinds are registered
+	// Verify all built-in kinds are registered
 	defs := builtinKindDefinitions()
 	for _, def := range defs {
 		got, ok := globalKindRegistry.Get(def.Name)
@@ -101,7 +101,7 @@ func TestBuiltinKindDefinitions_ReturnsExpectedKinds(t *testing.T) {
 
 	expectedNames := []string{
 		"provider", "solution", "action", "workflow",
-		"resolver", "spec", "schema", "retry",
+		"resolver", "spec", "schema", "retry", "function",
 	}
 	assert.Len(t, defs, len(expectedNames))
 

--- a/pkg/solution/execute/execute.go
+++ b/pkg/solution/execute/execute.go
@@ -349,6 +349,11 @@ func Resolvers(
 	if sol.Spec.HasCalls() {
 		executorOpts = append(executorOpts, resolver.WithCalls(sol.Spec.Calls))
 	}
+	if binder, binderErr := sol.TemplateFuncBinder(); binderErr != nil {
+		return nil, fmt.Errorf("compiling spec.functions: %w", binderErr)
+	} else if binder != nil {
+		executorOpts = append(executorOpts, resolver.WithTemplateFuncBinder(binder))
+	}
 	executor := resolver.NewExecutor(adapter, executorOpts...)
 
 	// Apply solution-level CEL cost limit if configured

--- a/pkg/solution/functions.go
+++ b/pkg/solution/functions.go
@@ -1,0 +1,45 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package solution
+
+import (
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/authorfuncs"
+)
+
+// TemplateFuncBinder compiles the solution's author-defined template functions
+// (spec.functions) into a binder that can be injected into go-template provider
+// execution. It returns (nil, nil) when the solution declares no functions, and
+// an error when the declarations are invalid.
+//
+// Callers wire the returned binder into resolver/action execution once at setup
+// (mirroring how spec.calls are wired), so template rendering can invoke the
+// author's helpers as {{ name arg... }}.
+func (s *Solution) TemplateFuncBinder() (*authorfuncs.Library, error) {
+	if s == nil || !s.Spec.HasFunctions() {
+		return nil, nil
+	}
+	return authorfuncs.Compile(s.Spec.Functions)
+}
+
+// validateFunctions validates the solution's author-defined template functions,
+// returning a problem string per validation failure. It reuses the authorfuncs
+// compiler so the validation surfaced here matches what execution enforces.
+func (s *Solution) validateFunctions() []string {
+	if s == nil || !s.Spec.HasFunctions() {
+		return nil
+	}
+
+	_, err := authorfuncs.Compile(s.Spec.Functions)
+	if err == nil {
+		return nil
+	}
+
+	// Compile aggregates problems into a single error prefixed with
+	// "invalid spec.functions: " and joined by "; ". Split it back into
+	// individual problems so they align with the surrounding validation output.
+	msg := strings.TrimPrefix(err.Error(), "invalid spec.functions: ")
+	return strings.Split(msg, "; ")
+}

--- a/pkg/solution/functions_test.go
+++ b/pkg/solution/functions_test.go
@@ -1,0 +1,107 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package solution
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateFuncBinder_None(t *testing.T) {
+	s := &Solution{Spec: Spec{}}
+	binder, err := s.TemplateFuncBinder()
+	require.NoError(t, err)
+	assert.Nil(t, binder)
+
+	var nilSol *Solution
+	binder, err = nilSol.TemplateFuncBinder()
+	require.NoError(t, err)
+	assert.Nil(t, binder)
+}
+
+func TestTemplateFuncBinder_Valid(t *testing.T) {
+	s := &Solution{Spec: Spec{
+		Functions: map[string]*spec.Function{
+			"doubled": {
+				Params: []*spec.ParamDef{{Name: "n", Type: spec.TypeInt, Required: true}},
+				Cel:    "_.args.n * 2",
+			},
+		},
+	}}
+	binder, err := s.TemplateFuncBinder()
+	require.NoError(t, err)
+	require.NotNil(t, binder)
+	assert.Equal(t, []string{"doubled"}, binder.Names())
+}
+
+func TestTemplateFuncBinder_Invalid(t *testing.T) {
+	s := &Solution{Spec: Spec{
+		Functions: map[string]*spec.Function{
+			"printf": {Cel: "1"}, // collides with built-in
+		},
+	}}
+	binder, err := s.TemplateFuncBinder()
+	require.Error(t, err)
+	assert.Nil(t, binder)
+}
+
+func TestHasFunctions(t *testing.T) {
+	assert.False(t, (&Spec{}).HasFunctions())
+	assert.False(t, (&Spec{Functions: map[string]*spec.Function{}}).HasFunctions())
+	assert.True(t, (&Spec{Functions: map[string]*spec.Function{"f": {Cel: "1"}}}).HasFunctions())
+
+	var nilSpec *Spec
+	assert.False(t, nilSpec.HasFunctions())
+}
+
+func TestValidateFunctions(t *testing.T) {
+	tests := []struct {
+		name    string
+		funcs   map[string]*spec.Function
+		wantSub string
+	}{
+		{
+			name:    "no functions",
+			funcs:   nil,
+			wantSub: "",
+		},
+		{
+			name: "valid",
+			funcs: map[string]*spec.Function{
+				"f": {Params: []*spec.ParamDef{{Name: "x"}}, Cel: "_.args.x"},
+			},
+			wantSub: "",
+		},
+		{
+			name: "builtin collision",
+			funcs: map[string]*spec.Function{
+				"printf": {Cel: "1"},
+			},
+			wantSub: "collides with a built-in",
+		},
+		{
+			name: "no body",
+			funcs: map[string]*spec.Function{
+				"f": {Params: []*spec.ParamDef{{Name: "x"}}},
+			},
+			wantSub: "must set exactly one",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Solution{Spec: Spec{Functions: tt.funcs}}
+			problems := s.validateFunctions()
+			if tt.wantSub == "" {
+				assert.Empty(t, problems)
+				return
+			}
+			require.NotEmpty(t, problems)
+			assert.Contains(t, joinProblems(problems), tt.wantSub)
+		})
+	}
+}

--- a/pkg/solution/render/render.go
+++ b/pkg/solution/render/render.go
@@ -156,6 +156,11 @@ func runResolvers(ctx context.Context, sol *solution.Solution, resolvers []*reso
 	if sol.Spec.HasCalls() {
 		opts = append(opts, resolver.WithCalls(sol.Spec.Calls))
 	}
+	if binder, binderErr := sol.TemplateFuncBinder(); binderErr != nil {
+		return nil, fmt.Errorf("compiling spec.functions: %w", binderErr)
+	} else if binder != nil {
+		opts = append(opts, resolver.WithTemplateFuncBinder(binder))
+	}
 	opts = append(opts, extraOpts...)
 	executor := NewResolverExecutor(registry, cfg, opts...)
 

--- a/pkg/solution/spec.go
+++ b/pkg/solution/spec.go
@@ -25,6 +25,12 @@ type Spec struct {
 	// invoked from any resolve/transform/validate step or action via call + args.
 	Calls map[string]*spec.Call `json:"calls,omitempty" yaml:"calls,omitempty" doc:"Reusable, provider-agnostic call definitions keyed by name"`
 
+	// Functions is a map of solution-author-defined Go template helper functions
+	// keyed by name. Each function declares ordered, typed parameters and exactly
+	// one body (a CEL expression or a Go template) and becomes callable from every
+	// Go template the solution renders as {{ name arg... }}.
+	Functions map[string]*spec.Function `json:"functions,omitempty" yaml:"functions,omitempty" doc:"Author-defined Go template helper functions keyed by name"`
+
 	// Workflow defines the action execution specification.
 	// Actions consume resolved data from resolvers and perform side-effect operations.
 	// All resolvers are evaluated before any action execution begins.
@@ -79,6 +85,12 @@ func (s *Spec) HasResolvers() bool {
 // HasCalls returns true if the spec contains any call definitions.
 func (s *Spec) HasCalls() bool {
 	return s != nil && len(s.Calls) > 0
+}
+
+// HasFunctions returns true if the spec contains any author-defined function
+// definitions.
+func (s *Spec) HasFunctions() bool {
+	return s != nil && len(s.Functions) > 0
 }
 
 // HasWorkflow returns true if the spec contains a workflow definition.

--- a/pkg/solution/spec_validation.go
+++ b/pkg/solution/spec_validation.go
@@ -19,10 +19,11 @@ func (s *Solution) ValidateSpec() error {
 	}
 
 	// Skip only when there is nothing to validate: no resolvers, no call
-	// definitions, and no workflow actions. Workflow actions may contain call
-	// sites (action.call / args) even in a solution with no resolvers or
-	// spec.calls block, and those still need call-site validation.
-	if !s.Spec.HasResolvers() && !s.Spec.HasCalls() && !s.Spec.HasActions() {
+	// definitions, no author functions, and no workflow actions. Workflow
+	// actions may contain call sites (action.call / args) even in a solution
+	// with no resolvers or spec.calls block, and those still need call-site
+	// validation.
+	if !s.Spec.HasResolvers() && !s.Spec.HasCalls() && !s.Spec.HasFunctions() && !s.Spec.HasActions() {
 		return nil
 	}
 
@@ -31,6 +32,10 @@ func (s *Solution) ValidateSpec() error {
 	// Validate call definitions and call sites independently of resolvers so
 	// that call-only solutions (or workflow-only call sites) are still checked.
 	problems = append(problems, s.validateCalls()...)
+
+	// Validate author-defined template functions independently of resolvers so
+	// that function-only solutions are still checked.
+	problems = append(problems, s.validateFunctions()...)
 
 	// If there are no resolvers, the remaining resolver-specific checks do not
 	// apply; report any call problems and return.

--- a/pkg/spec/function.go
+++ b/pkg/spec/function.go
@@ -1,0 +1,79 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package spec
+
+// ParamDef declares a single positional, typed parameter accepted by a Function
+// definition. Unlike a Call's ArgDef (which is keyed by name and supplied by
+// name at the call site), a Function parameter is positional: it is bound to the
+// argument at the same index when the helper is invoked from a Go template
+// (e.g. {{ myHelper .a .b }} binds .a to the first parameter and .b to the
+// second). The parameter's Name is how the value is referenced inside the
+// function body under the args namespace (_.args.name in CEL, {{ .args.name }}
+// in a Go template body).
+type ParamDef struct {
+	// Name is the parameter's identifier. It is how the bound value is
+	// referenced inside the function body under the args namespace. Names must
+	// be unique within a function and be valid identifiers.
+	Name string `json:"name" yaml:"name" doc:"Parameter name; referenced inside the body as _.args.name (CEL) or {{ .args.name }} (template)" maxLength:"100" example:"value" pattern:"^[a-zA-Z_][a-zA-Z0-9_]*$" patternDescription:"Must start with a letter or underscore, followed by letters, numbers, or underscores"`
+
+	// Type is the parameter's declared type. Supplied values are coerced to this
+	// type via CoerceType. When omitted, the value passes through unchanged.
+	// Supported types: string, int, float (alias: number), bool, array, object,
+	// time, duration, and any.
+	Type Type `json:"type,omitempty" yaml:"type,omitempty" doc:"Parameter type (string, int, float, number, bool, array, object, time, duration, any)" example:"string"`
+
+	// Required marks the parameter as mandatory at every call site.
+	// A required parameter cannot declare a Default.
+	Required bool `json:"required,omitempty" yaml:"required,omitempty" doc:"Whether the parameter must be supplied at every call site"`
+
+	// Default is applied when the argument is omitted at a call site.
+	// Only valid when Required is false.
+	Default any `json:"default,omitempty" yaml:"default,omitempty" doc:"Default value applied when the argument is omitted (only valid when required is false)"`
+
+	// Description documents the parameter for readers and tooling.
+	Description string `json:"description,omitempty" yaml:"description,omitempty" doc:"Human-readable description of the parameter" maxLength:"500"`
+}
+
+// Function is a solution-author-defined, named Go template helper. It is
+// declared once under spec.functions and becomes callable from the Go templates
+// the solution renders through the go-template provider (in resolvers and
+// actions) as {{ name arg... }}. A function declares ordered, typed parameters
+// and exactly one body:
+//
+//   - Cel: a CEL expression evaluated with the bound arguments available under
+//     the args namespace (_.args.name). The expression's result is returned to
+//     the template verbatim (any type), fitting scafctl's CEL-first design.
+//   - Template: a Go template body rendered with the bound arguments available
+//     as {{ .args.name }}. It returns the rendered string, in the style of
+//     Helm named templates. A template body may call sibling functions and all
+//     built-in (sprig + custom) helpers.
+//
+// Cel and Template are mutually exclusive; exactly one must be set. This
+// invariant is enforced by validation, not by the type system.
+type Function struct {
+	// Description documents the function for readers and tooling.
+	Description string `json:"description,omitempty" yaml:"description,omitempty" doc:"Human-readable description of the function" maxLength:"500"`
+
+	// Params declares the ordered, positional parameters the function accepts.
+	// Arguments supplied at a call site are bound to parameters by position.
+	Params []*ParamDef `json:"params,omitempty" yaml:"params,omitempty" doc:"Ordered, positional parameter declarations bound by position at the call site"`
+
+	// Cel is a CEL expression body. The bound arguments are available under the
+	// args namespace (_.args.name). Mutually exclusive with Template.
+	Cel string `json:"cel,omitempty" yaml:"cel,omitempty" doc:"CEL expression body; bound arguments available as _.args.name. Mutually exclusive with template." maxLength:"65536" example:"_.args.value.upperAscii()"`
+
+	// Template is a Go template body. The bound arguments are available as
+	// {{ .args.name }}. Mutually exclusive with Cel.
+	Template string `json:"template,omitempty" yaml:"template,omitempty" doc:"Go template body; bound arguments available as {{ .args.name }}. Mutually exclusive with cel." maxLength:"65536" example:"{{ .args.value | upper }}"`
+}
+
+// HasCel reports whether the function declares a CEL expression body.
+func (f *Function) HasCel() bool {
+	return f != nil && f.Cel != ""
+}
+
+// HasTemplate reports whether the function declares a Go template body.
+func (f *Function) HasTemplate() bool {
+	return f != nil && f.Template != ""
+}

--- a/pkg/spec/function_test.go
+++ b/pkg/spec/function_test.go
@@ -1,0 +1,46 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package spec
+
+import "testing"
+
+func TestFunction_HasCel(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   *Function
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty", &Function{}, false},
+		{"cel set", &Function{Cel: "1"}, true},
+		{"template only", &Function{Template: "x"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fn.HasCel(); got != tt.want {
+				t.Errorf("HasCel() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFunction_HasTemplate(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   *Function
+		want bool
+	}{
+		{"nil", nil, false},
+		{"empty", &Function{}, false},
+		{"template set", &Function{Template: "x"}, true},
+		{"cel only", &Function{Cel: "1"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.fn.HasTemplate(); got != tt.want {
+				t.Errorf("HasTemplate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -2228,6 +2228,27 @@ func TestIntegration_RunResolver_PlanDataNotInOutput(t *testing.T) {
 	assert.NotContains(t, stdout, `"__plan"`)
 }
 
+// TestIntegration_RunResolver_AuthorFunctions exercises solution-author-defined
+// Go template helpers (spec.functions) end to end: a CEL-bodied function, a
+// numeric function with a typed parameter, and a template-bodied function that
+// composes a sibling author function.
+func TestIntegration_RunResolver_AuthorFunctions(t *testing.T) {
+	t.Parallel()
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "examples/resolvers/author-functions.yaml",
+		"-o", "json",
+	)
+
+	require.Equal(t, 0, exitCode, "expected exit code 0\nstdout: %s\nstderr: %s", stdout, stderr)
+	// greet (CEL body) uppercases and prefixes.
+	assert.Contains(t, stdout, `"greeting": "HELLO SCAF!"`)
+	// doubled (typed numeric param) returns 21*2.
+	assert.Contains(t, stdout, `"forty_two": 42`)
+	// shout (template body) calls the sibling greet function.
+	assert.Contains(t, stdout, `"composed": "HELLO WORLD! (WORLD)"`)
+}
+
 func TestIntegration_RunResolver_GraphASCII(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,


### PR DESCRIPTION
Solutions can now declare reusable, named Go template helper functions under
`spec.functions`, callable from the templates the go-template provider renders
(in resolvers and actions) as `{{ name arg... }}`. This closes the gap where
authors had to repeat the same CEL/template snippet across every resolver.

## What a function looks like

Each function declares ordered, positional, typed `params` (exposed inside the
body under the `args` namespace) and exactly one body:

- `cel:` -- a CEL expression evaluated with the bound arguments available as
  `_.args.name`; the result is returned verbatim (any type).
- `template:` -- a Go template body rendered with `{{ .args.name }}`, returning
  the rendered string (Helm named-template style). A template body may call
  sibling author functions and all built-in (sprig + custom) helpers.

`cel` and `template` are mutually exclusive; exactly one must be set. Functions
must be acyclic -- cycles are detected and rejected when the solution loads.
Because parameters bind positionally, a required parameter may not follow an
optional one.

```yaml
spec:
  functions:
    greet:
      params:
        - name: name
          type: string
          required: true
      cel: '"HELLO " + _.args.name.upperAscii() + "!"'
    shout:
      params:
        - name: who
          type: string
          required: true
      template: '{{ greet .args.who }} ({{ .args.who | upper }})'
```

## Implementation

- New `pkg/authorfuncs` package compiles the declared functions into a bindable
  library: it validates parameter names/types/ordering, compiles each body,
  detects cycles (DFS), and fingerprints the set to isolate template-cache
  entries when author-function names collide across solutions.
- Author functions flow to renderers via a new
  `provider.TemplateFuncBinder` carried on the context; the resolver and action
  executors expose `WithTemplateFuncBinder` and inject it, and the go-template
  provider binds it at render time.
- Author functions are re-bound per execution through the same context-function
  mechanism `cel` uses, so a cached (cloned) template always evaluates author
  bodies with the *current* request's context (cancellation, timeouts, CEL cost
  limits) rather than the context frozen into the shared template cache when the
  entry was first created.
- Lint gains an `invalid-function` rule that surfaces compile problems (invalid
  names, both/neither body, bad CEL/template syntax, cycles) at
  `spec.functions`, and threads declared function names into template-syntax
  linting so `{{ myFn }}` is not falsely flagged as an unknown function.
- `explain` / MCP `explain_kind` gain a `function` kind.

## Docs, examples, and tests

- `examples/resolvers/author-functions.yaml` demonstrates CEL, typed-numeric,
  and composing template-bodied functions; the resolvers README and the Go
  Templates tutorial document the feature; the `go-template-patterns` skill
  points at it.
- Unit tests cover the new packages (authorfuncs ~97%), a cache-hit rebinding
  regression test, lint author-awareness, and the schema kind; an integration
  test drives the example end to end via `run resolver`; benchmarks cover the
  compile and invocation hot paths.
