### PR TITLE
fix(run): preserve resolved values when a resolver fails in the resolve/transform phase

### DIFF
--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -460,7 +460,9 @@ Resolvers execute through three ordered phases: **resolve -> transform -> valida
 
 > **Validation is non-fatal in `run resolver`.** Because `run resolver` is an inspection and troubleshooting command, validation failures never withhold the produced values. The resolved values are still printed, validation diagnostics are written to stderr, and the command exits `0`. To make validation failures exit non-zero (for example, in CI), pass `--fail-on-validation`. To gate on validation as the primary intent, use the dedicated [`scafctl validate resolver`](#validate-resolver) command, which presets fatal validation.
 >
-> **Dependents keep running too.** Because a resolver that fails only a validation rule still produces a usable value, its dependent resolvers continue to execute and read that value -- they are not skipped. (Resolve and transform failures remain fatal: dependents of those are skipped because no value was produced.)
+> **Dependents keep running too.** Because a resolver that fails only a validation rule still produces a usable value, its dependent resolvers continue to execute and read that value -- they are not skipped. (Resolve and transform failures still exit non-zero and their dependents are skipped because no value was produced.)
+>
+> **Partial values survive a resolve/transform failure.** When a resolver hard-fails in the resolve or transform phase, `run resolver` still prints the values of every resolver that *did* resolve successfully, together with a `__status: failed` / `__diagnostics` envelope naming the failed resolver(s) on stdout and a diagnostic on stderr. Unlike a validation-only failure, a resolve/transform failure always exits non-zero (exit `1`) regardless of `--fail-on-validation` -- but the successful values are no longer discarded.
 
 Create a file called `phases-demo.yaml`. This example resolves a port number, transforms it by adding `8000`, then validates the result is within the valid port range. The input value of `60000` is intentionally too high -- after the transform, the result (`68000`) exceeds the valid range:
 

--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -462,7 +462,7 @@ Resolvers execute through three ordered phases: **resolve -> transform -> valida
 >
 > **Dependents keep running too.** Because a resolver that fails only a validation rule still produces a usable value, its dependent resolvers continue to execute and read that value -- they are not skipped. (Resolve and transform failures still exit non-zero and their dependents are skipped because no value was produced.)
 >
-> **Partial values survive a resolve/transform failure.** When a resolver hard-fails in the resolve or transform phase, `run resolver` still prints the values of every resolver that *did* resolve successfully, together with a `__status: failed` / `__diagnostics` envelope naming the failed resolver(s) on stdout and a diagnostic on stderr. Unlike a validation-only failure, a resolve/transform failure always exits non-zero (exit `1`) regardless of `--fail-on-validation` -- but the successful values are no longer discarded.
+> **Partial values survive a resolve/transform failure.** When a resolver hard-fails in the resolve or transform phase, `run resolver` still emits the values of every resolver that *did* resolve successfully on stdout, plus a failure summary on stderr. In structured output (`-o json`/`-o yaml`) the stdout document additionally carries a `__status: failed` / `__diagnostics` envelope naming the failed resolver(s); table output shows only the successful values on stdout (the failure detail stays on stderr). Unlike a validation-only failure, a resolve/transform failure always exits non-zero (exit `1`) regardless of `--fail-on-validation` -- but the successful values are no longer discarded.
 
 Create a file called `phases-demo.yaml`. This example resolves a port number, transforms it by adding `8000`, then validates the result is within the valid port range. The input value of `60000` is intentionally too high -- after the transform, the result (`68000`) exceeds the valid range:
 
@@ -522,7 +522,7 @@ Diagnostics on stderr:
 ```
 Warning: 1 resolver(s) failed validation:
   - port: Port must be between 1024 and 65535
-(values shown above; pass --fail-on-validation to exit non-zero)
+(resolved values are still emitted on stdout; pass --fail-on-validation to exit non-zero)
 ```
 
 You can see the resolved value (`68000`) directly, and the diagnostic explains why it is invalid -- no flags required.

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -654,13 +654,17 @@ func (o *sharedResolverOptions) executeResolvers(
 	}
 
 	if err != nil {
-		// In non-fatal mode, return the populated values and context alongside
-		// the error so the caller can render values plus diagnostics instead of
-		// aborting -- but only for pure validation failures. Resolve- and
-		// transform-phase failures (where no value exists) remain fatal and
-		// discard partial results so the caller surfaces a hard failure. In
-		// fatal mode (run solution / run action), all errors are fatal.
-		if o.nonFatalValidation && execute.IsValidationOnlyFailure(err) {
+		// In non-fatal mode (run resolver / validate resolver), return the
+		// populated values and context alongside the error for ALL failure
+		// kinds so the caller can render the successfully-resolved values plus
+		// diagnostics instead of dropping them. The caller classifies the error
+		// with execute.IsValidationOnlyFailure to choose the exit code:
+		// validation-only failures are a soft gate (exit 0 unless
+		// --fail-on-validation), while resolve- and transform-phase failures
+		// remain a hard failure (non-zero exit) -- but the partial values stay
+		// inspectable in the structured output either way. In fatal mode (run
+		// solution / run action), all errors discard partial results.
+		if o.nonFatalValidation {
 			return resolverData, resolverCtx, fmt.Errorf("resolver execution failed: %w", err)
 		}
 		return nil, nil, fmt.Errorf("resolver execution failed: %w", err)

--- a/pkg/cmd/scafctl/run/failure_envelope_cli_test.go
+++ b/pkg/cmd/scafctl/run/failure_envelope_cli_test.go
@@ -13,9 +13,11 @@ import (
 	"time"
 
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/celprovider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/gotmplprovider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/staticprovider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution/execute"
@@ -359,6 +361,147 @@ func TestResolverOptions_Run_ValueSizeFailure_TableUnchanged(t *testing.T) {
 		"table output must not inject the reserved diagnostics key")
 	assert.NotContains(t, stdout.String(), execute.StatusKey,
 		"table output must not inject the reserved status key")
+}
+
+// solutionWithGoodAndBadResolvers has two independent resolvers: "good" resolves
+// to a plain string, while "bad" hard-fails in the resolve phase (an undefined
+// Go-template function fails to parse, so the source produces no value at all).
+// This mirrors the issue's exact repro and exercises the
+// partial-values-on-resolve-failure path for `run resolver`.
+const solutionWithGoodAndBadResolvers = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: good-and-bad-resolvers
+  version: 1.0.0
+spec:
+  resolvers:
+    good:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: i-resolved
+    bad:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              template: "{{ undefinedFunc .x }}"
+              data:
+                x: hello
+`
+
+// testRegistryWithGoTemplate returns a registry with the static and go-template
+// providers, used to trigger a resolve-phase failure that produces no value.
+func testRegistryWithGoTemplate(t *testing.T) *provider.Registry {
+	t.Helper()
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(staticprovider.New()))
+	require.NoError(t, reg.Register(gotmplprovider.NewGoTemplateProvider()))
+	return reg
+}
+
+// newResolverOptionsForResolveFailure builds ResolverOptions wired with the
+// static+go-template registry (needed to trigger a resolve-phase failure) and
+// the given output format.
+func newResolverOptionsForResolveFailure(t *testing.T, solutionPath string, stdout, stderr *bytes.Buffer, format string) *ResolverOptions {
+	t.Helper()
+	streams := &terminal.IOStreams{In: nil, Out: stdout, ErrOut: stderr}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	return &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:       streams,
+			CliParams:       cliParams,
+			File:            solutionPath,
+			KvxOutputFlags:  flags.KvxOutputFlags{Output: format},
+			ResolverTimeout: 30 * time.Second,
+			PhaseTimeout:    5 * time.Minute,
+			registry:        testRegistryWithGoTemplate(t),
+		},
+	}
+}
+
+// TestResolverOptions_Run_ResolvePhaseFailure_PreservesValues verifies that a
+// resolve/transform-phase failure keeps every successfully-resolved value in the
+// machine-readable output (alongside __status/__diagnostics) instead of dropping
+// the entire values map -- while still exiting non-zero, since a resolver that
+// could not produce a value is a hard failure (issue: run resolver -o json drops
+// the values map on a resolve-phase error).
+func TestResolverOptions_Run_ResolvePhaseFailure_PreservesValues(t *testing.T) {
+	t.Parallel()
+
+	for _, format := range []string{"json", "yaml"} {
+		format := format
+		t.Run(format, func(t *testing.T) {
+			t.Parallel()
+
+			solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+			require.NoError(t, os.WriteFile(solutionPath, []byte(solutionWithGoodAndBadResolvers), 0o600))
+
+			var stdout, stderr bytes.Buffer
+			opts := newResolverOptionsForResolveFailure(t, solutionPath, &stdout, &stderr, format)
+
+			ctx := logger.WithLogger(context.Background(), logger.Get(0))
+			ctx = writer.WithWriter(ctx, writer.New(opts.IOStreams, opts.CliParams))
+			err := opts.Run(ctx)
+
+			// A resolve/transform failure is a HARD failure: it exits non-zero
+			// even without --fail-on-validation, unlike a validation-only failure.
+			require.Error(t, err, "a resolve/transform failure must exit non-zero")
+			assert.Equal(t, exitcode.GeneralError, exitcode.GetCode(err),
+				"a resolve/transform failure must use the general-error exit code")
+
+			decoded := decodeStructured(t, format, stdout.Bytes())
+			assert.Equal(t, "i-resolved", decoded["good"],
+				"a successfully-resolved value must survive a sibling resolve/transform failure")
+			assert.NotContains(t, decoded, "bad",
+				"a resolver that produced no value must be absent from the values map")
+			assert.Equal(t, execute.StatusFailed, decoded[execute.StatusKey],
+				"structured output must carry the reserved status key on failure")
+
+			diags, ok := decoded[execute.DiagnosticsKey].([]any)
+			require.True(t, ok, "structured output must carry the reserved diagnostics key")
+			require.NotEmpty(t, diags, "diagnostics must not be empty on a resolve/transform failure")
+			var namedBad bool
+			for _, d := range diags {
+				if m, ok := d.(map[string]any); ok && m["resolver"] == "bad" {
+					namedBad = true
+				}
+			}
+			assert.True(t, namedBad, "diagnostics must name the failed resolver 'bad'")
+		})
+	}
+}
+
+// TestResolverOptions_Run_ResolvePhaseFailure_TableShowsValues verifies that the
+// human (table) output still renders the successfully-resolved values on stdout
+// and summarizes the failure on stderr (as a plain failure, not a "validation"
+// failure), while exiting non-zero and not injecting the reserved envelope keys.
+func TestResolverOptions_Run_ResolvePhaseFailure_TableShowsValues(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(solutionWithGoodAndBadResolvers), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	opts := newResolverOptionsForResolveFailure(t, solutionPath, &stdout, &stderr, "table")
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = writer.WithWriter(ctx, writer.New(opts.IOStreams, opts.CliParams))
+	err := opts.Run(ctx)
+
+	require.Error(t, err, "a resolve/transform failure must exit non-zero")
+	assert.Equal(t, exitcode.GeneralError, exitcode.GetCode(err))
+	assert.Contains(t, stdout.String(), "i-resolved",
+		"resolved values must still be shown on stdout in human output")
+	assert.Contains(t, stderr.String(), "resolver(s) failed",
+		"a hard failure must be summarized on stderr")
+	assert.NotContains(t, stderr.String(), "failed validation",
+		"a resolve/transform failure must not be mislabeled as a validation failure")
+	assert.NotContains(t, stdout.String(), execute.DiagnosticsKey,
+		"table output must not inject the reserved diagnostics key")
 }
 
 // decodeStructured parses JSON or YAML structured output into a map for

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -714,14 +714,14 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		results["__execution"] = executionData
 	}
 
-	// Surface non-fatal validation diagnostics on stderr so the resolved values
+	// Surface non-fatal diagnostics on stderr so the resolved values
 	// (on stdout) remain useful for troubleshooting and machine consumption.
 	if execErr != nil {
-		o.renderValidationDiagnostics(ctx, execErr)
+		o.renderResolverDiagnostics(ctx, execErr)
 		// In structured output (json/yaml), also attach the failure envelope
 		// (__status/__diagnostics) to the stdout document so machine consumers
-		// can detect and inspect the validation failure programmatically, not
-		// just via exit code + stderr.
+		// can detect and inspect the failure programmatically, and still see
+		// every successfully-resolved value, not just via exit code + stderr.
 		if o.isStructuredOutput() {
 			results = execute.InjectResolverFailureEnvelope(results, execErr)
 		}
@@ -736,10 +736,20 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		return err
 	}
 
-	// In non-fatal mode the values are always shown. When --fail-on-validation
-	// is set, exit non-zero so CI/gating callers detect the failure.
-	if execErr != nil && o.FailOnValidation {
-		return exitcode.WithCode(execErr, exitcode.ValidationFailed)
+	// Choose the exit code by failure kind. The resolved values were already
+	// written to stdout above (with the failure envelope in structured mode),
+	// so returning a coded error here only sets the process exit status.
+	//   - Resolve/transform failures are a HARD failure: a resolver could not
+	//     produce a value, so exit non-zero regardless of --fail-on-validation.
+	//   - Validation-only failures are a SOFT gate in this inspection command:
+	//     exit 0 by default, and non-zero only when --fail-on-validation is set.
+	if execErr != nil {
+		if !execute.IsValidationOnlyFailure(execErr) {
+			return exitcode.WithCode(execErr, exitcode.GeneralError)
+		}
+		if o.FailOnValidation {
+			return exitcode.WithCode(execErr, exitcode.ValidationFailed)
+		}
 	}
 
 	// Gate mode ('validate resolver'): after resolver validation passes, run
@@ -844,11 +854,13 @@ func (o *ResolverOptions) failStructured(ctx context.Context, results map[string
 	return exitcode.WithCode(err, code)
 }
 
-// renderValidationDiagnostics writes a human-readable summary of resolver
-// validation-only failures to stderr. It is used by the non-fatal inspection
-// path so the resolved values on stdout are not polluted. Resolve- and
-// transform-phase failures remain fatal and are reported earlier.
-func (o *ResolverOptions) renderValidationDiagnostics(ctx context.Context, execErr error) {
+// renderResolverDiagnostics writes a human-readable summary of resolver
+// failures to stderr. It is used by the non-fatal inspection path so the
+// resolved values on stdout are not polluted. It handles both validation-only
+// failures (a soft gate) and resolve/transform failures (a hard failure): the
+// heading and the --fail-on-validation hint adapt to the failure kind so the
+// message never claims a hard failure is merely a validation issue.
+func (o *ResolverOptions) renderResolverDiagnostics(ctx context.Context, execErr error) {
 	w := writer.FromContext(ctx)
 	if w == nil {
 		// Fall back to a writer built from the command's IO streams so
@@ -868,12 +880,21 @@ func (o *ResolverOptions) renderValidationDiagnostics(ctx context.Context, execE
 	}
 
 	diags := execute.DiagnosticsFromError(execErr)
+	validationOnly := execute.IsValidationOnlyFailure(execErr)
 	if len(diags) == 0 {
-		w.WarnStderrf("resolver validation failed: %v", execErr)
+		if validationOnly {
+			w.WarnStderrf("resolver validation failed: %v", execErr)
+		} else {
+			w.WarnStderrf("resolver execution failed: %v", execErr)
+		}
 		return
 	}
 
-	w.WarnStderrf("%d resolver(s) failed validation:", len(diags))
+	if validationOnly {
+		w.WarnStderrf("%d resolver(s) failed validation:", len(diags))
+	} else {
+		w.WarnStderrf("%d resolver(s) failed:", len(diags))
+	}
 	for _, d := range diags {
 		if d.Resolver != "" {
 			w.PlainStderrf("  - %s: %s", d.Resolver, d.Message)
@@ -881,7 +902,10 @@ func (o *ResolverOptions) renderValidationDiagnostics(ctx context.Context, execE
 			w.PlainStderrf("  - %s", d.Message)
 		}
 	}
-	if !o.FailOnValidation {
+	// The --fail-on-validation hint only applies to validation-only failures,
+	// which exit 0 by default. Resolve/transform failures always exit non-zero,
+	// so suppress the hint to avoid implying the exit code is opt-in.
+	if validationOnly && !o.FailOnValidation {
 		w.PlainStderrf("(values shown above; pass --fail-on-validation to exit non-zero)")
 	}
 }

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -906,7 +906,7 @@ func (o *ResolverOptions) renderResolverDiagnostics(ctx context.Context, execErr
 	// which exit 0 by default. Resolve/transform failures always exit non-zero,
 	// so suppress the hint to avoid implying the exit code is opt-in.
 	if validationOnly && !o.FailOnValidation {
-		w.PlainStderrf("(values shown above; pass --fail-on-validation to exit non-zero)")
+		w.PlainStderrf("(resolved values are still emitted on stdout; pass --fail-on-validation to exit non-zero)")
 	}
 }
 

--- a/pkg/cmd/scafctl/run/resolver_test.go
+++ b/pkg/cmd/scafctl/run/resolver_test.go
@@ -3207,7 +3207,7 @@ func TestResolverOptions_Run_CatalogFallbackNotFiredForMalformedSolution(t *test
 	assert.NotEqual(t, "my-proxy", opts.File, "fallback should NOT fire for a malformed solution.yaml")
 }
 
-func TestResolverOptions_renderValidationDiagnostics_NilCliParamsNoPanic(t *testing.T) {
+func TestResolverOptions_renderResolverDiagnostics_NilCliParamsNoPanic(t *testing.T) {
 	t.Parallel()
 
 	var stdout, stderr bytes.Buffer
@@ -3230,13 +3230,15 @@ func TestResolverOptions_renderValidationDiagnostics_NilCliParamsNoPanic(t *test
 	// No writer seeded into the context forces the IOStreams fallback path.
 	ctx := context.Background()
 
+	// A generic error is not validation-only, so it renders as a plain
+	// "resolver(s) failed" summary rather than a validation failure.
 	assert.NotPanics(t, func() {
-		opts.renderValidationDiagnostics(ctx, assert.AnError)
+		opts.renderResolverDiagnostics(ctx, assert.AnError)
 	})
-	assert.Contains(t, stderr.String(), "failed validation")
+	assert.Contains(t, stderr.String(), "resolver(s) failed")
 }
 
-func TestResolverOptions_renderValidationDiagnostics_NoIOStreamsNoPanic(t *testing.T) {
+func TestResolverOptions_renderResolverDiagnostics_NoIOStreamsNoPanic(t *testing.T) {
 	t.Parallel()
 
 	// Without a context writer and without IOStreams there is nowhere to write,
@@ -3244,6 +3246,6 @@ func TestResolverOptions_renderValidationDiagnostics_NoIOStreamsNoPanic(t *testi
 	opts := &ResolverOptions{}
 
 	assert.NotPanics(t, func() {
-		opts.renderValidationDiagnostics(context.Background(), assert.AnError)
+		opts.renderResolverDiagnostics(context.Background(), assert.AnError)
 	})
 }

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -995,8 +995,10 @@ func (s *Server) handlePreviewResolvers(_ context.Context, request mcp.CallToolR
 		response["plan"] = planRaw
 	}
 
-	// Surface non-fatal validation diagnostics so agents can troubleshoot while
-	// still seeing the resolved values. When strict is requested, report the
+	// Surface non-fatal diagnostics so agents can troubleshoot while still
+	// seeing the resolved values. This covers both validation-only failures and
+	// resolve/transform failures -- in every case the successfully-resolved
+	// values remain in the response. When strict is requested, report the
 	// result as an error (values remain included for context).
 	diags := execute.DiagnosticsFromError(result.Diagnostics)
 	if len(diags) > 0 {

--- a/pkg/mcp/tools_solution_test.go
+++ b/pkg/mcp/tools_solution_test.go
@@ -743,6 +743,69 @@ spec:
 		name := resolvers["name"].(map[string]any)
 		assert.Equal(t, "Bob", name["value"], "values must still be included in strict mode")
 	})
+
+	t.Run("resolve-phase failure preserves successfully-resolved values plus diagnostics", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		solFile := filepath.Join(tmpDir, "resolve-fail.yaml")
+		// "good" resolves to a plain string; "bad" hard-fails in the resolve
+		// phase (an undefined Go-template function fails to parse, so the source
+		// produces no value). The successful value must survive.
+		solContent := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: resolve-fail
+  version: 1.0.0
+spec:
+  resolvers:
+    good:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: i-resolved
+    bad:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              template: "{{ undefinedFunc .x }}"
+              data:
+                x: hello
+`
+		require.NoError(t, os.WriteFile(solFile, []byte(solContent), 0o644))
+
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "preview_resolvers"
+		request.Params.Arguments = map[string]any{
+			"path": solFile,
+		}
+
+		result, err := srv.handlePreviewResolvers(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError,
+			"a resolve-phase failure must be non-fatal by default (values preserved)")
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+
+		assert.Equal(t, false, parsed["valid"], "valid should be false on a resolve-phase failure")
+		diagnostics, ok := parsed["diagnostics"].([]any)
+		require.True(t, ok, "diagnostics should be present on a resolve-phase failure")
+		assert.NotEmpty(t, diagnostics)
+
+		resolvers := parsed["resolvers"].(map[string]any)
+		good := resolvers["good"].(map[string]any)
+		assert.Equal(t, "i-resolved", good["value"],
+			"a successfully-resolved value must survive a sibling resolve-phase failure")
+		assert.Equal(t, "resolved", good["status"])
+
+		bad := resolvers["bad"].(map[string]any)
+		assert.Equal(t, "failed", bad["status"], "the failed resolver must be reported as failed")
+	})
 }
 
 // TestHandlePreviewResolvers_RelativeToSolution verifies that resolver file

--- a/pkg/solution/execute/execute.go
+++ b/pkg/solution/execute/execute.go
@@ -384,13 +384,15 @@ func Resolvers(
 	}
 
 	if execErr != nil {
-		if cfg.NonFatalValidation && IsValidationOnlyFailure(execErr) {
+		if cfg.NonFatalValidation {
 			// Non-fatal: return the populated values plus diagnostics instead of
-			// aborting, so the inspection path remains useful. Only pure
-			// validation failures are suppressed; resolve/transform failures
-			// (where no value exists) remain fatal below.
+			// aborting, so the inspection path remains useful for ALL failure
+			// kinds. Callers classify the error with IsValidationOnlyFailure to
+			// decide status/exit behavior: validation-only failures are a soft
+			// gate, while resolve/transform failures are a hard failure -- but
+			// the partial values stay inspectable either way.
 			if lgr != nil {
-				lgr.V(1).Info("resolver execution completed with validation diagnostics",
+				lgr.V(1).Info("resolver execution completed with diagnostics",
 					"resolvedCount", len(resolverData))
 			}
 			return &ResolverExecutionResult{

--- a/pkg/solution/execute/nonfatal_test.go
+++ b/pkg/solution/execute/nonfatal_test.go
@@ -182,7 +182,13 @@ metadata:
   version: 0.0.1
 spec:
   resolvers:
-    data:
+    good:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "i-resolved"
+    bad:
       resolve:
         with:
           - provider: solution
@@ -190,7 +196,7 @@ spec:
               file: "./nonexistent.yaml"
 `
 
-func TestResolvers_NonFatalValidation_ResolvePhaseStaysFatal(t *testing.T) {
+func TestResolvers_NonFatalValidation_ResolvePhasePreservesValues(t *testing.T) {
 	ctx := context.Background()
 	reg, err := builtin.DefaultRegistry(ctx)
 	require.NoError(t, err)
@@ -199,14 +205,44 @@ func TestResolvers_NonFatalValidation_ResolvePhaseStaysFatal(t *testing.T) {
 	sol, err := inspect.LoadSolution(ctx, solFile)
 	require.NoError(t, err)
 
-	cfg := ResolverExecutionConfig{
-		Timeout:            ResolverExecutionConfigFromContext(ctx).Timeout,
-		PhaseTimeout:       ResolverExecutionConfigFromContext(ctx).PhaseTimeout,
-		NonFatalValidation: true,
-	}
+	t.Run("non-fatal preserves successfully-resolved values plus diagnostics", func(t *testing.T) {
+		cfg := ResolverExecutionConfig{
+			Timeout:            ResolverExecutionConfigFromContext(ctx).Timeout,
+			PhaseTimeout:       ResolverExecutionConfigFromContext(ctx).PhaseTimeout,
+			NonFatalValidation: true,
+		}
 
-	_, err = Resolvers(ctx, sol, nil, reg, cfg)
-	require.Error(t, err, "resolve-phase failures must remain fatal even in non-fatal mode")
+		result, err := Resolvers(ctx, sol, nil, reg, cfg)
+		require.NoError(t, err, "non-fatal mode must not return a top-level error on a resolve-phase failure")
+		require.NotNil(t, result)
+		assert.Equal(t, "i-resolved", result.Data["good"],
+			"a resolver that resolved successfully must survive a sibling resolve-phase failure")
+		assert.NotContains(t, result.Data, "bad",
+			"a resolver that failed in the resolve phase produced no value and must be absent")
+
+		require.Error(t, result.Diagnostics, "diagnostics must be populated on a resolve-phase failure")
+		assert.False(t, IsValidationOnlyFailure(result.Diagnostics),
+			"a resolve-phase failure must not be classified as validation-only")
+
+		diags := DiagnosticsFromError(result.Diagnostics)
+		require.NotEmpty(t, diags)
+		names := make([]string, 0, len(diags))
+		for _, d := range diags {
+			names = append(names, d.Resolver)
+		}
+		assert.Contains(t, names, "bad", "diagnostics must name the failed resolver")
+	})
+
+	t.Run("fatal mode discards values and returns an error", func(t *testing.T) {
+		cfg := ResolverExecutionConfig{
+			Timeout:      ResolverExecutionConfigFromContext(ctx).Timeout,
+			PhaseTimeout: ResolverExecutionConfigFromContext(ctx).PhaseTimeout,
+		}
+
+		result, err := Resolvers(ctx, sol, nil, reg, cfg)
+		require.Error(t, err, "fatal mode must return an error on a resolve-phase failure")
+		assert.Nil(t, result, "fatal mode discards partial results")
+	})
 }
 
 func TestIsValidationOnlyFailure(t *testing.T) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1329,7 +1329,62 @@ func TestIntegration_RunAction_FailureEnvelope_JSON(t *testing.T) {
 	assert.NotEmpty(t, decoded["diagnostics"])
 }
 
-// TestIntegration_RunSolution_DeferredValidationImmutableNotLocked verifies the
+// partialFailureSolution has one resolver that resolves successfully ("good")
+// and one that hard-fails in the resolve phase ("bad"): an undefined
+// Go-template function fails to parse, so no value is produced. This is the
+// exact shape from the bug report -- a resolve-phase error must not discard the
+// sibling that already resolved.
+const partialFailureSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: partial-failure-integration
+  version: 1.0.0
+spec:
+  resolvers:
+    good:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: i-resolved
+    bad:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              template: "{{ undefinedFunc .x }}"
+              data:
+                x: hello
+`
+
+// TestIntegration_RunResolver_ResolvePhaseFailure_PreservesValues verifies that
+// a resolve-phase failure in one resolver preserves the values of every
+// resolver that resolved successfully, alongside the __status/__diagnostics
+// envelope, instead of collapsing stdout to just the envelope.
+func TestIntegration_RunResolver_ResolvePhaseFailure_PreservesValues(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(partialFailureSolution), 0o600))
+
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "resolver", "-f", solutionPath, "-o", "json",
+	)
+
+	t.Logf("stderr: %s", stderr)
+	assert.NotEqual(t, 0, exitCode, "resolve-phase failure must exit non-zero")
+	require.NotEmpty(t, strings.TrimSpace(stdout), "stdout must not be empty on failure")
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &decoded), "stdout must be valid JSON")
+	assert.Equal(t, "i-resolved", decoded["good"],
+		"a successfully-resolved value must survive a sibling resolve-phase failure")
+	assert.NotContains(t, decoded, "bad", "the failed resolver produced no value and must be absent")
+	assert.Equal(t, "failed", decoded["__status"])
+	assert.NotEmpty(t, decoded["__diagnostics"])
+}
+
 // two-phase validation D1 guarantee: when a deferred (cross-resolver) validation
 // rule fails on an immutable resolver, execution stops before actions run and
 // the immutable value is NOT persisted to state. A subsequent run whose deferred


### PR DESCRIPTION
## Summary

Previously, `scafctl run resolver -o json` dropped the **entire** values map when a resolver hard-failed during the **resolve** or **transform** phase, emitting only the `__status: failed` / `__diagnostics` envelope. A **validation-only** failure, by contrast, correctly preserved every resolved value alongside the diagnostics.

Now a resolve/transform-phase failure **also preserves** the values of every resolver that resolved successfully, printed on stdout alongside the `__status`/`__diagnostics` envelope. This mirrors partial-success prior art (HTTP 207, terraform, kubectl): the caller sees the work that succeeded plus a machine-readable record of what failed.

## Design decision: value preservation vs. exit code

Value preservation is the only behavior matched to the validation path. **Exit-code semantics remain distinct by design** (this deliberately diverges from the reporter's suggestion to fully mirror the validation soft-fail path):

| Failure kind | Values on stdout | Exit code |
| --- | --- | --- |
| Validation-only | preserved | 0 by default; non-zero with `--fail-on-validation` (soft gate) |
| Resolve / transform | preserved | always non-zero, exit 1 (hard failure) -- `--fail-on-validation` irrelevant |

A resolve/transform failure means a resolver could not produce a value, so it stays a hard failure. Note: a **transform**-phase failure keeps the pre-transform partial value (resolver present); a **resolve**-phase failure produces no value (resolver absent), and `__diagnostics` names it either way.

## Implementation

- The change lives in the **shared non-fatal execution path**, so both the CLI (`run resolver`) and the MCP `preview_resolvers` tool benefit.
- Non-fatal mode now returns partial resolver data + context for **all** failure kinds (previously validation-only); fatal mode (`run solution`/`run action`) is unchanged and still discards values.
- Exit-code classification happens at the CLI boundary via `execute.IsValidationOnlyFailure`.
- `renderValidationDiagnostics` -> `renderResolverDiagnostics` with an adaptive heading (validation vs. generic failure wording); the `--fail-on-validation` hint is shown only for validation-only failures.
- State persistence stays gated on success, so partially-resolved siblings are never persisted.

## Tests

- CLI: json / yaml / table cases asserting preserved values + exit code + envelope.
- MCP: `preview_resolvers` resolve-phase case (values preserved, `valid: false`, diagnostics).
- Integration: real-binary test proving a sibling value survives a resolve-phase failure.
- Rewritten non-fatal execution unit tests (preserve vs. fatal-discard).
- Tutorial updated with a partial-value note.

## Quality gate

- `go-reviewer`: APPROVE (0 critical/high/medium).
- `artifact-auditor`: PASS.
- `task lint:changed`: 0 issues.
- All affected unit + integration tests pass; `go build ./...` clean.

Fixes the bug described in `local/issues/bug-run-resolver-drops-values-on-resolve-error.md`.
