### PR TITLE
feat(auth): add interactive display schema for alias list

### DIFF
--- a/pkg/cmd/scafctl/auth/alias.go
+++ b/pkg/cmd/scafctl/auth/alias.go
@@ -4,11 +4,13 @@
 package auth
 
 import (
+	_ "embed"
 	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
@@ -21,19 +23,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// aliasListSchema drives table rendering for 'auth alias list'. The root is an
-// array because the command writes a bare []map[string]any (one entry per
-// alias) to kvx.
-var aliasListSchema = []byte(`{
-	"type": "array",
-	"items": {
-		"type": "object",
-		"properties": {
-			"selector": { "type": "string", "title": "Selector", "maxLength": 40 },
-			"url":      { "type": "string", "title": "Endpoint URL", "maxLength": 80 }
-		}
-	}
-}`)
+// aliasListColumnHints controls table column display for 'auth alias list'.
+var aliasListColumnHints = map[string]tui.ColumnHint{
+	"selector": {MaxWidth: 40, DisplayName: "Selector"},
+	"url":      {MaxWidth: 80, DisplayName: "Endpoint URL"},
+}
+
+//go:embed alias_list_schema.json
+var aliasListDisplaySchema []byte
 
 // CommandAlias creates the 'auth alias' command group for managing static
 // hostname aliases (auth.handlers.<name>.hostname.aliases).
@@ -179,7 +176,8 @@ func commandAliasList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ 
 			outputOpts := flags.ToKvxOutputOptions(&outputFlags,
 				kvx.WithIOStreams(ioStreams),
 				kvx.WithOutputColumnOrder([]string{"selector", "url"}),
-				kvx.WithOutputSchemaJSON(aliasListSchema),
+				kvx.WithOutputColumnHints(aliasListColumnHints),
+				kvx.WithOutputDisplaySchemaJSON(aliasListDisplaySchema),
 			)
 			return outputOpts.Write(items)
 		},

--- a/pkg/cmd/scafctl/auth/alias_list_schema.json
+++ b/pkg/cmd/scafctl/auth/alias_list_schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Hostname Aliases",
+  "description": "Static hostname aliases for a scafctl auth handler",
+  "type": "array",
+
+  "x-kvx-icon": "🔗",
+  "x-kvx-collectionTitle": "Hostname Aliases",
+
+  "x-kvx-list": {
+    "titleField": "selector",
+    "subtitleField": "url",
+    "subtitleMaxLines": 1
+  },
+
+  "x-kvx-detail": {
+    "titleField": "selector",
+    "hiddenFields": [],
+    "sections": [
+      {
+        "title": "",
+        "fields": ["selector", "url"],
+        "layout": "inline"
+      }
+    ]
+  },
+
+  "items": {
+    "type": "object",
+    "required": ["selector", "url"],
+    "properties": {
+      "selector": {
+        "type": "string",
+        "title": "Selector",
+        "description": "Short alias name for the hostname",
+        "maxLength": 40
+      },
+      "url": {
+        "type": "string",
+        "title": "Endpoint URL",
+        "description": "Full endpoint URL the alias resolves to",
+        "maxLength": 80
+      }
+    }
+  }
+}

--- a/pkg/cmd/scafctl/auth/alias_test.go
+++ b/pkg/cmd/scafctl/auth/alias_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/adrg/xdg"
+	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -202,4 +203,20 @@ func TestCommandAliasSet_Embedder(t *testing.T) {
 	cfg, err := config.NewManager("").Load()
 	require.NoError(t, err)
 	assert.Equal(t, "https://api.prod.example.com:6443", cfg.Auth.Handlers["openshift"].Hostname.Aliases["prod"])
+}
+
+// TestAliasListDisplaySchema_IsValidJSON verifies alias_list_schema.json is valid JSON.
+func TestAliasListDisplaySchema_IsValidJSON(t *testing.T) {
+	t.Parallel()
+	assert.True(t, json.Valid(aliasListDisplaySchema), "alias_list_schema.json must be valid JSON")
+}
+
+// TestAliasListDisplaySchema_ParsesWithDisplay verifies alias_list_schema.json
+// is a valid display schema with list/detail extensions.
+func TestAliasListDisplaySchema_ParsesWithDisplay(t *testing.T) {
+	t.Parallel()
+	hints, ds, err := tui.ParseSchemaWithDisplay(aliasListDisplaySchema)
+	require.NoError(t, err, "alias_list_schema.json must parse without error")
+	assert.NotNil(t, hints, "should produce column hints")
+	assert.NotNil(t, ds, "should produce display schema")
 }


### PR DESCRIPTION
## Description

Add alias_list_schema.json with `x-kvx-list`/`x-kvx-detail` extensions so `auth alias list <handler> -i` renders a card/detail TUI. Replace the inline JSON table schema with programmatic column hints (`aliasListColumnHints`) since the display schema now covers the JSON Schema role.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My commits follow conventional commit format
- [x] I have added/updated tests for my changes
- [x] `go test ./...` passes
- [x] `task lint` passes
- [x] I have signed off my commits (`git commit -s -S`)
