### PR TITLE
fix(catalog): distinguish unreachable catalogs from not-found in chain resolution

### DIFF
--- a/pkg/catalog/chain.go
+++ b/pkg/catalog/chain.go
@@ -59,26 +59,39 @@ func (c *ChainCatalog) Store(ctx context.Context, ref Reference, content, bundle
 }
 
 // catalogOutcome records the result of trying one catalog in a chain, used
-// to build an aggregated error that distinguishes "unreachable" catalogs
-// from "checked and reported not found" catalogs.
+// to build an aggregated error that distinguishes "unreachable" catalogs,
+// catalogs that were "checked and reported not found", and catalogs that
+// failed with some other (non-not-found, non-unreachable) error such as an
+// auth failure or malformed manifest.
 type catalogOutcome struct {
 	catalog string
 	err     error
 }
 
 // aggregateChainError builds a final error from the per-catalog outcomes of
-// a failed chain operation. When one or more catalogs were unreachable
-// (network/transport failure), the message calls that out explicitly and
-// separately from catalogs that were reached and genuinely reported the
-// artifact does not exist — this is the fix for the misleading "not found"
-// message when the real problem is that a catalog (often the official one,
-// always last in the chain) could not be contacted. When no catalog was
-// unreachable, the message is unchanged from before this behavior existed,
+// a failed chain operation, classifying each outcome into one of three
+// buckets: unreachable (network/transport failure), not-found (the catalog
+// was reached and reported errors.Is(err, ErrArtifactNotFound)), or other
+// (any other error, e.g. auth failure or malformed data). When one or more
+// catalogs were unreachable, the message calls that out explicitly and
+// separately from catalogs that genuinely reported the artifact does not
+// exist — this is the fix for the misleading "not found" message when the
+// real problem is that a catalog (often the official one, always last in
+// the chain) could not be contacted. When there are "other" errors and no
+// unreachable ones, the representative other error is surfaced directly
+// instead of being folded into "not found". When every outcome is a genuine
+// not-found, the returned error wraps ErrArtifactNotFound so callers using
+// errors.Is/IsNotFound still recognize an ordinary chain miss. When no
+// catalog was unreachable and none had an "other" error, the message is
+// unchanged from before this behavior existed, so existing "not found"
+// tests continue to pass unmodified.
 // so existing "not found" tests continue to pass unmodified.
 func aggregateChainError(subject string, outcomes []catalogOutcome) error {
 	var unreachable []string
 	var notFound []string
+	var other []string
 	var firstUnreachableErr error
+	var firstOtherErr error
 
 	for _, o := range outcomes {
 		if o.err == nil {
@@ -91,19 +104,35 @@ func aggregateChainError(subject string, outcomes []catalogOutcome) error {
 			}
 			continue
 		}
-		notFound = append(notFound, o.catalog)
+		if errors.Is(o.err, ErrArtifactNotFound) {
+			notFound = append(notFound, o.catalog)
+			continue
+		}
+		other = append(other, o.catalog)
+		if firstOtherErr == nil {
+			firstOtherErr = o.err
+		}
+	}
+
+	if len(unreachable) == 0 && len(other) == 0 {
+		return fmt.Errorf("artifact %q not found in any catalog: %w", subject, ErrArtifactNotFound)
 	}
 
 	if len(unreachable) == 0 {
-		return fmt.Errorf("artifact %q not found in any catalog", subject)
+		// Only "other" (non-not-found, non-unreachable) errors: surface the
+		// representative cause instead of masking it as a plain not-found.
+		return fmt.Errorf("%q failed in %s: %w", subject, strings.Join(other, ", "), firstOtherErr)
 	}
 
-	if len(notFound) == 0 {
+	if len(notFound) == 0 && len(other) == 0 {
 		return fmt.Errorf("%q unavailable: %s: %w", subject, strings.Join(unreachable, "; "), firstUnreachableErr)
 	}
 
+	checked := make([]string, 0, len(notFound)+len(other))
+	checked = append(checked, notFound...)
+	checked = append(checked, other...)
 	return fmt.Errorf("%q unavailable: %s; not found in %s: %w",
-		subject, strings.Join(unreachable, "; "), strings.Join(notFound, ", "), firstUnreachableErr)
+		subject, strings.Join(unreachable, "; "), strings.Join(checked, ", "), firstUnreachableErr)
 }
 
 // Fetch tries each catalog in order, returning the first successful result.

--- a/pkg/catalog/chain.go
+++ b/pkg/catalog/chain.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 )
@@ -57,9 +58,57 @@ func (c *ChainCatalog) Store(ctx context.Context, ref Reference, content, bundle
 	return c.catalogs[0].Store(ctx, ref, content, bundleData, annotations, force)
 }
 
+// catalogOutcome records the result of trying one catalog in a chain, used
+// to build an aggregated error that distinguishes "unreachable" catalogs
+// from "checked and reported not found" catalogs.
+type catalogOutcome struct {
+	catalog string
+	err     error
+}
+
+// aggregateChainError builds a final error from the per-catalog outcomes of
+// a failed chain operation. When one or more catalogs were unreachable
+// (network/transport failure), the message calls that out explicitly and
+// separately from catalogs that were reached and genuinely reported the
+// artifact does not exist — this is the fix for the misleading "not found"
+// message when the real problem is that a catalog (often the official one,
+// always last in the chain) could not be contacted. When no catalog was
+// unreachable, the message is unchanged from before this behavior existed,
+// so existing "not found" tests continue to pass unmodified.
+func aggregateChainError(subject string, outcomes []catalogOutcome) error {
+	var unreachable []string
+	var notFound []string
+	var firstUnreachableErr error
+
+	for _, o := range outcomes {
+		if o.err == nil {
+			continue
+		}
+		if _, ok := IsCatalogUnreachable(o.err); ok {
+			unreachable = append(unreachable, o.catalog)
+			if firstUnreachableErr == nil {
+				firstUnreachableErr = o.err
+			}
+			continue
+		}
+		notFound = append(notFound, o.catalog)
+	}
+
+	if len(unreachable) == 0 {
+		return fmt.Errorf("artifact %q not found in any catalog", subject)
+	}
+
+	if len(notFound) == 0 {
+		return fmt.Errorf("%q unavailable: %s: %w", subject, strings.Join(unreachable, "; "), firstUnreachableErr)
+	}
+
+	return fmt.Errorf("%q unavailable: %s; not found in %s: %w",
+		subject, strings.Join(unreachable, "; "), strings.Join(notFound, ", "), firstUnreachableErr)
+}
+
 // Fetch tries each catalog in order, returning the first successful result.
 func (c *ChainCatalog) Fetch(ctx context.Context, ref Reference) ([]byte, ArtifactInfo, error) {
-	var lastErr error
+	var outcomes []catalogOutcome
 	for _, cat := range c.catalogs {
 		content, info, err := cat.Fetch(ctx, ref)
 		if err == nil {
@@ -69,14 +118,14 @@ func (c *ChainCatalog) Fetch(ctx context.Context, ref Reference) ([]byte, Artifa
 		if !errors.Is(err, ErrArtifactNotFound) {
 			c.logger.V(1).Info("catalog fetch error (non-404)", "catalog", cat.Name(), "ref", ref.String(), "error", err)
 		}
-		lastErr = err
+		outcomes = append(outcomes, catalogOutcome{catalog: cat.Name(), err: err})
 	}
-	return nil, ArtifactInfo{}, fmt.Errorf("artifact %q not found in any catalog: %w", ref.String(), lastErr)
+	return nil, ArtifactInfo{}, aggregateChainError(ref.String(), outcomes)
 }
 
 // FetchWithBundle tries each catalog in order.
 func (c *ChainCatalog) FetchWithBundle(ctx context.Context, ref Reference) ([]byte, []byte, ArtifactInfo, error) {
-	var lastErr error
+	var outcomes []catalogOutcome
 	for _, cat := range c.catalogs {
 		content, bundle, info, err := cat.FetchWithBundle(ctx, ref)
 		if err == nil {
@@ -85,14 +134,14 @@ func (c *ChainCatalog) FetchWithBundle(ctx context.Context, ref Reference) ([]by
 		if !errors.Is(err, ErrArtifactNotFound) {
 			c.logger.V(1).Info("catalog fetch error (non-404)", "catalog", cat.Name(), "ref", ref.String(), "error", err)
 		}
-		lastErr = err
+		outcomes = append(outcomes, catalogOutcome{catalog: cat.Name(), err: err})
 	}
-	return nil, nil, ArtifactInfo{}, fmt.Errorf("artifact %q not found in any catalog: %w", ref.String(), lastErr)
+	return nil, nil, ArtifactInfo{}, aggregateChainError(ref.String(), outcomes)
 }
 
 // Resolve tries each catalog in order, returning the first successful result.
 func (c *ChainCatalog) Resolve(ctx context.Context, ref Reference) (ArtifactInfo, error) {
-	var lastErr error
+	var outcomes []catalogOutcome
 	for _, cat := range c.catalogs {
 		info, err := cat.Resolve(ctx, ref)
 		if err == nil {
@@ -102,9 +151,9 @@ func (c *ChainCatalog) Resolve(ctx context.Context, ref Reference) (ArtifactInfo
 		if !errors.Is(err, ErrArtifactNotFound) {
 			c.logger.V(1).Info("catalog resolve error (non-404)", "catalog", cat.Name(), "ref", ref.String(), "error", err)
 		}
-		lastErr = err
+		outcomes = append(outcomes, catalogOutcome{catalog: cat.Name(), err: err})
 	}
-	return ArtifactInfo{}, fmt.Errorf("artifact %q not found in any catalog: %w", ref.String(), lastErr)
+	return ArtifactInfo{}, aggregateChainError(ref.String(), outcomes)
 }
 
 // List returns artifacts from all catalogs (deduplicated by name+version).
@@ -130,15 +179,30 @@ func (c *ChainCatalog) List(ctx context.Context, kind ArtifactKind, name string)
 	return results, nil
 }
 
-// Exists returns true if the artifact exists in any catalog.
+// Exists returns true if the artifact exists in any catalog. If every
+// catalog errors, the aggregated error distinguishes unreachable catalogs
+// from ones that could not confirm existence.
 func (c *ChainCatalog) Exists(ctx context.Context, ref Reference) (bool, error) {
+	var outcomes []catalogOutcome
 	for _, cat := range c.catalogs {
 		ok, err := cat.Exists(ctx, ref)
 		if err != nil {
+			outcomes = append(outcomes, catalogOutcome{catalog: cat.Name(), err: err})
 			continue
 		}
 		if ok {
 			return true, nil
+		}
+	}
+	if len(outcomes) == 0 {
+		return false, nil
+	}
+	// At least one catalog couldn't determine existence; surface that if any
+	// were unreachable, otherwise treat as a clean "not found" (false, nil)
+	// to preserve prior behavior for benign resolve errors.
+	for _, o := range outcomes {
+		if _, ok := IsCatalogUnreachable(o.err); ok {
+			return false, aggregateChainError(ref.String(), outcomes)
 		}
 	}
 	return false, nil
@@ -156,12 +220,14 @@ func (c *ChainCatalog) Delete(ctx context.Context, ref Reference) error {
 // because the artifact is known to be multi-platform and the platform is
 // genuinely unavailable.
 func (c *ChainCatalog) FetchByPlatform(ctx context.Context, ref Reference, platform string) ([]byte, ArtifactInfo, error) {
-	var lastErr error
+	var outcomes []catalogOutcome
+	supported := false
 	for _, cat := range c.catalogs {
 		pac, ok := cat.(PlatformAwareCatalog)
 		if !ok {
 			continue
 		}
+		supported = true
 		data, info, err := pac.FetchByPlatform(ctx, ref, platform)
 		if err == nil {
 			c.logger.V(1).Info("fetched platform artifact", "catalog", cat.Name(), "ref", ref.String(), "platform", platform)
@@ -173,23 +239,25 @@ func (c *ChainCatalog) FetchByPlatform(ctx context.Context, ref Reference, platf
 		if !errors.Is(err, ErrArtifactNotFound) {
 			c.logger.V(1).Info("catalog platform fetch error (non-404)", "catalog", cat.Name(), "ref", ref.String(), "platform", platform, "error", err)
 		}
-		lastErr = err
+		outcomes = append(outcomes, catalogOutcome{catalog: cat.Name(), err: err})
 	}
-	if lastErr == nil {
+	if !supported {
 		return nil, ArtifactInfo{}, fmt.Errorf("no catalog supports platform-aware fetch for %q", ref.String())
 	}
-	return nil, ArtifactInfo{}, fmt.Errorf("platform artifact %q (%s) not found in any catalog: %w", ref.String(), platform, lastErr)
+	return nil, ArtifactInfo{}, aggregateChainError(fmt.Sprintf("%s (%s)", ref.String(), platform), outcomes)
 }
 
 // ListPlatforms tries each catalog that implements PlatformAwareCatalog in
 // order, returning the first successful result.
 func (c *ChainCatalog) ListPlatforms(ctx context.Context, ref Reference) ([]string, error) {
-	var lastErr error
+	var outcomes []catalogOutcome
+	supported := false
 	for _, cat := range c.catalogs {
 		pac, ok := cat.(PlatformAwareCatalog)
 		if !ok {
 			continue
 		}
+		supported = true
 		platforms, err := pac.ListPlatforms(ctx, ref)
 		if err == nil {
 			return platforms, nil
@@ -197,10 +265,10 @@ func (c *ChainCatalog) ListPlatforms(ctx context.Context, ref Reference) ([]stri
 		if !errors.Is(err, ErrArtifactNotFound) {
 			c.logger.V(1).Info("catalog list platforms error (non-404)", "catalog", cat.Name(), "ref", ref.String(), "error", err)
 		}
-		lastErr = err
+		outcomes = append(outcomes, catalogOutcome{catalog: cat.Name(), err: err})
 	}
-	if lastErr == nil {
+	if !supported {
 		return nil, fmt.Errorf("no catalog supports platform listing for %q", ref.String())
 	}
-	return nil, fmt.Errorf("platforms for %q not found in any catalog: %w", ref.String(), lastErr)
+	return nil, aggregateChainError(ref.String(), outcomes)
 }

--- a/pkg/catalog/chain_test.go
+++ b/pkg/catalog/chain_test.go
@@ -98,6 +98,8 @@ func TestChainCatalog_Fetch_NotFound(t *testing.T) {
 	_, _, err = chain.Fetch(context.Background(), ref)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found in any catalog")
+	assert.True(t, errors.Is(err, ErrArtifactNotFound))
+	assert.True(t, IsNotFound(err))
 }
 
 func TestChainCatalog_Fetch_SingleCatalogUnreachable(t *testing.T) {
@@ -223,8 +225,32 @@ func TestAggregateChainError(t *testing.T) {
 			{catalog: "c1", err: ErrArtifactNotFound},
 			{catalog: "c2", err: ErrArtifactNotFound},
 		})
-		assert.Equal(t, `artifact "subject" not found in any catalog`, err.Error())
+		assert.Contains(t, err.Error(), `artifact "subject" not found in any catalog`)
 		assert.False(t, errors.Is(err, ErrCatalogUnreachable))
+		assert.True(t, errors.Is(err, ErrArtifactNotFound))
+	})
+
+	t.Run("other error, no unreachable", func(t *testing.T) {
+		cause := fmt.Errorf("permission denied")
+		err := aggregateChainError("subject", []catalogOutcome{
+			{catalog: "c1", err: cause},
+		})
+		assert.False(t, errors.Is(err, ErrCatalogUnreachable))
+		assert.False(t, errors.Is(err, ErrArtifactNotFound))
+		assert.Contains(t, err.Error(), "c1")
+		assert.Contains(t, err.Error(), "permission denied")
+	})
+
+	t.Run("other error mixed with not found, no unreachable", func(t *testing.T) {
+		cause := fmt.Errorf("permission denied")
+		err := aggregateChainError("subject", []catalogOutcome{
+			{catalog: "c1", err: ErrArtifactNotFound},
+			{catalog: "c2", err: cause},
+		})
+		assert.False(t, errors.Is(err, ErrCatalogUnreachable))
+		assert.False(t, errors.Is(err, ErrArtifactNotFound))
+		assert.Contains(t, err.Error(), "c2")
+		assert.Contains(t, err.Error(), "permission denied")
 	})
 
 	t.Run("single unreachable, no not-found", func(t *testing.T) {
@@ -253,7 +279,8 @@ func TestAggregateChainError(t *testing.T) {
 
 	t.Run("no outcomes with errors", func(t *testing.T) {
 		err := aggregateChainError("subject", nil)
-		assert.Equal(t, `artifact "subject" not found in any catalog`, err.Error())
+		assert.Contains(t, err.Error(), `artifact "subject" not found in any catalog`)
+		assert.True(t, errors.Is(err, ErrArtifactNotFound))
 	})
 }
 

--- a/pkg/catalog/chain_test.go
+++ b/pkg/catalog/chain_test.go
@@ -5,6 +5,7 @@ package catalog
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -97,6 +98,163 @@ func TestChainCatalog_Fetch_NotFound(t *testing.T) {
 	_, _, err = chain.Fetch(context.Background(), ref)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found in any catalog")
+}
+
+func TestChainCatalog_Fetch_SingleCatalogUnreachable(t *testing.T) {
+	cause := fmt.Errorf("dial tcp: lookup ghcr.io: no such host")
+	c1 := NewMockCatalog("official", WithFetchFunc(func(_ context.Context, _ Reference) ([]byte, ArtifactInfo, error) {
+		return nil, ArtifactInfo{}, &UnreachableError{Catalog: "official", Cause: cause}
+	}))
+
+	chain, err := NewChainCatalog(logr.Discard(), c1)
+	require.NoError(t, err)
+
+	ref := testRef("my-plugin", "1.0.0")
+	_, _, err = chain.Fetch(context.Background(), ref)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrCatalogUnreachable))
+	assert.Contains(t, err.Error(), "official")
+	assert.Contains(t, err.Error(), cause.Error())
+	assert.NotContains(t, err.Error(), "not found in")
+}
+
+func TestChainCatalog_Fetch_OfficialUnreachableOthersNotFound(t *testing.T) {
+	// Reproduces the issue #728 scenario: local catalogs report not-found
+	// normally, but the official (always-last) catalog is unreachable.
+	cause := fmt.Errorf("dial tcp: lookup ghcr.io: no such host")
+	c1 := newMockCatalog("local")
+	c2 := NewMockCatalog("official", WithFetchFunc(func(_ context.Context, _ Reference) ([]byte, ArtifactInfo, error) {
+		return nil, ArtifactInfo{}, &UnreachableError{Catalog: "official", Cause: cause}
+	}))
+
+	chain, err := NewChainCatalog(logr.Discard(), c1, c2)
+	require.NoError(t, err)
+
+	ref := testRef("missing", "1.0.0")
+	_, _, err = chain.Fetch(context.Background(), ref)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrCatalogUnreachable))
+	assert.Contains(t, err.Error(), "official")
+	assert.Contains(t, err.Error(), cause.Error())
+	assert.Contains(t, err.Error(), "not found in")
+	assert.Contains(t, err.Error(), "local")
+}
+
+func TestChainCatalog_Fetch_AllCatalogsUnreachable(t *testing.T) {
+	cause1 := fmt.Errorf("dial tcp: lookup c1: no such host")
+	cause2 := fmt.Errorf("connection refused")
+	c1 := NewMockCatalog("c1", WithFetchFunc(func(_ context.Context, _ Reference) ([]byte, ArtifactInfo, error) {
+		return nil, ArtifactInfo{}, &UnreachableError{Catalog: "c1", Cause: cause1}
+	}))
+	c2 := NewMockCatalog("c2", WithFetchFunc(func(_ context.Context, _ Reference) ([]byte, ArtifactInfo, error) {
+		return nil, ArtifactInfo{}, &UnreachableError{Catalog: "c2", Cause: cause2}
+	}))
+
+	chain, err := NewChainCatalog(logr.Discard(), c1, c2)
+	require.NoError(t, err)
+
+	ref := testRef("my-plugin", "1.0.0")
+	_, _, err = chain.Fetch(context.Background(), ref)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrCatalogUnreachable))
+	assert.Contains(t, err.Error(), "c1")
+	assert.Contains(t, err.Error(), "c2")
+	// Only the first unreachable catalog's cause is inlined (via the wrapped
+	// error) to avoid duplicating text; other catalog names still appear.
+	assert.Contains(t, err.Error(), cause1.Error())
+	assert.NotContains(t, err.Error(), "not found in")
+}
+
+func TestChainCatalog_Resolve_CatalogUnreachable(t *testing.T) {
+	cause := fmt.Errorf("i/o timeout")
+	c1 := NewMockCatalog("official", WithResolveFunc(func(_ context.Context, _ Reference) (ArtifactInfo, error) {
+		return ArtifactInfo{}, &UnreachableError{Catalog: "official", Cause: cause}
+	}))
+
+	chain, err := NewChainCatalog(logr.Discard(), c1)
+	require.NoError(t, err)
+
+	ref := testRef("my-plugin", "1.0.0")
+	_, err = chain.Resolve(context.Background(), ref)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrCatalogUnreachable))
+	assert.Contains(t, err.Error(), "official")
+	assert.Contains(t, err.Error(), cause.Error())
+}
+
+func TestChainCatalog_Exists_CatalogUnreachable(t *testing.T) {
+	cause := fmt.Errorf("connection refused")
+	c1 := NewMockCatalog("official", WithExistsFunc(func(_ context.Context, _ Reference) (bool, error) {
+		return false, &UnreachableError{Catalog: "official", Cause: cause}
+	}))
+
+	chain, err := NewChainCatalog(logr.Discard(), c1)
+	require.NoError(t, err)
+
+	ref := testRef("my-plugin", "1.0.0")
+	ok, err := chain.Exists(context.Background(), ref)
+	assert.False(t, ok)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrCatalogUnreachable))
+	assert.Contains(t, err.Error(), "official")
+	assert.Contains(t, err.Error(), cause.Error())
+}
+
+func TestChainCatalog_Exists_AllNotFoundNoError(t *testing.T) {
+	c1 := NewMockCatalog("c1", WithExistsFunc(func(_ context.Context, _ Reference) (bool, error) {
+		return false, nil
+	}))
+	c2 := NewMockCatalog("c2", WithExistsFunc(func(_ context.Context, _ Reference) (bool, error) {
+		return false, nil
+	}))
+
+	chain, err := NewChainCatalog(logr.Discard(), c1, c2)
+	require.NoError(t, err)
+
+	ref := testRef("my-plugin", "1.0.0")
+	ok, err := chain.Exists(context.Background(), ref)
+	assert.False(t, ok)
+	assert.NoError(t, err)
+}
+
+func TestAggregateChainError(t *testing.T) {
+	t.Run("no unreachable, all not found", func(t *testing.T) {
+		err := aggregateChainError("subject", []catalogOutcome{
+			{catalog: "c1", err: ErrArtifactNotFound},
+			{catalog: "c2", err: ErrArtifactNotFound},
+		})
+		assert.Equal(t, `artifact "subject" not found in any catalog`, err.Error())
+		assert.False(t, errors.Is(err, ErrCatalogUnreachable))
+	})
+
+	t.Run("single unreachable, no not-found", func(t *testing.T) {
+		cause := fmt.Errorf("boom")
+		err := aggregateChainError("subject", []catalogOutcome{
+			{catalog: "c1", err: &UnreachableError{Catalog: "c1", Cause: cause}},
+		})
+		assert.True(t, errors.Is(err, ErrCatalogUnreachable))
+		assert.Contains(t, err.Error(), "c1")
+		assert.Contains(t, err.Error(), "boom")
+		assert.NotContains(t, err.Error(), "not found in")
+	})
+
+	t.Run("unreachable and not found mixed", func(t *testing.T) {
+		cause := fmt.Errorf("boom")
+		err := aggregateChainError("subject", []catalogOutcome{
+			{catalog: "local", err: ErrArtifactNotFound},
+			{catalog: "official", err: &UnreachableError{Catalog: "official", Cause: cause}},
+		})
+		assert.True(t, errors.Is(err, ErrCatalogUnreachable))
+		assert.Contains(t, err.Error(), "official")
+		assert.Contains(t, err.Error(), "boom")
+		assert.Contains(t, err.Error(), "not found in")
+		assert.Contains(t, err.Error(), "local")
+	})
+
+	t.Run("no outcomes with errors", func(t *testing.T) {
+		err := aggregateChainError("subject", nil)
+		assert.Equal(t, `artifact "subject" not found in any catalog`, err.Error())
+	})
 }
 
 func TestChainCatalog_FetchWithBundle_Fallback(t *testing.T) {

--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -115,6 +115,52 @@ func IsInvalidReference(err error) bool {
 	return errors.Is(err, ErrInvalidReference)
 }
 
+// ErrCatalogUnreachable is returned when a catalog could not be contacted
+// (network, DNS, timeout, or other transport-level failure), as distinct
+// from the catalog being reachable and reporting that the artifact does not
+// exist. Distinguishing the two lets callers (e.g. ChainCatalog) tell "this
+// artifact genuinely does not exist anywhere" apart from "one catalog could
+// not be reached, so we cannot say either way."
+var ErrCatalogUnreachable = errors.New("catalog unreachable")
+
+// UnreachableError provides details about a catalog that could not be
+// contacted due to a network/transport-level failure.
+type UnreachableError struct {
+	// Catalog is the name of the catalog that could not be reached.
+	Catalog string
+	// Cause is the underlying transport error (DNS failure, connection
+	// refused, timeout, etc.).
+	Cause error
+}
+
+// Error implements the error interface.
+func (e *UnreachableError) Error() string {
+	return fmt.Sprintf("catalog %q unreachable: %v", e.Catalog, e.Cause)
+}
+
+// Unwrap returns the underlying transport error so callers can inspect the
+// root cause (e.g. errors.As for *net.DNSError).
+func (e *UnreachableError) Unwrap() error {
+	return e.Cause
+}
+
+// Is reports whether target is ErrCatalogUnreachable, allowing
+// errors.Is(err, ErrCatalogUnreachable) to match without needing to unwrap
+// to Cause (which may be an arbitrary transport error, not the sentinel).
+func (e *UnreachableError) Is(target error) bool {
+	return target == ErrCatalogUnreachable //nolint:errorlint // intentional sentinel identity check
+}
+
+// IsCatalogUnreachable reports whether err (or any error it wraps) is a
+// UnreachableError, returning the typed value when it is.
+func IsCatalogUnreachable(err error) (*UnreachableError, bool) {
+	var e *UnreachableError
+	if errors.As(err, &e) {
+		return e, true
+	}
+	return nil, false
+}
+
 // ErrEnumerationNotSupported is returned when a registry does not support
 // the _catalog endpoint for repository enumeration.
 var ErrEnumerationNotSupported = errors.New("registry does not support repository enumeration")

--- a/pkg/catalog/errors_test.go
+++ b/pkg/catalog/errors_test.go
@@ -195,6 +195,80 @@ func TestNewAuthDegradedError(t *testing.T) {
 	})
 }
 
+func TestUnreachableError(t *testing.T) {
+	cause := errors.New("dial tcp: lookup ghcr.io: no such host")
+
+	t.Run("error message includes catalog and cause", func(t *testing.T) {
+		err := &UnreachableError{Catalog: "official", Cause: cause}
+		assert.Contains(t, err.Error(), "official")
+		assert.Contains(t, err.Error(), cause.Error())
+	})
+
+	t.Run("unwrap returns cause", func(t *testing.T) {
+		err := &UnreachableError{Catalog: "official", Cause: cause}
+		assert.Same(t, cause, errors.Unwrap(err))
+	})
+
+	t.Run("errors.Is matches sentinel", func(t *testing.T) {
+		err := &UnreachableError{Catalog: "official", Cause: cause}
+		assert.True(t, errors.Is(err, ErrCatalogUnreachable))
+	})
+
+	t.Run("errors.Is does not match unrelated sentinel", func(t *testing.T) {
+		err := &UnreachableError{Catalog: "official", Cause: cause}
+		assert.False(t, errors.Is(err, ErrArtifactNotFound))
+	})
+
+	t.Run("errors.Is matches sentinel through wrapping", func(t *testing.T) {
+		err := &UnreachableError{Catalog: "official", Cause: cause}
+		wrapped := fmt.Errorf("chain resolve failed: %w", err)
+		assert.True(t, errors.Is(wrapped, ErrCatalogUnreachable))
+	})
+
+	t.Run("errors.As extracts typed value through wrapping", func(t *testing.T) {
+		err := &UnreachableError{Catalog: "official", Cause: cause}
+		wrapped := fmt.Errorf("chain resolve failed: %w", err)
+		var target *UnreachableError
+		assert.True(t, errors.As(wrapped, &target))
+		assert.Same(t, err, target)
+	})
+}
+
+func TestIsCatalogUnreachable(t *testing.T) {
+	t.Run("direct", func(t *testing.T) {
+		base := &UnreachableError{Catalog: "official", Cause: errors.New("boom")}
+		got, ok := IsCatalogUnreachable(base)
+		assert.True(t, ok)
+		assert.Same(t, base, got)
+	})
+
+	t.Run("wrapped", func(t *testing.T) {
+		base := &UnreachableError{Catalog: "official", Cause: errors.New("boom")}
+		wrapped := fmt.Errorf("resolving: %w", base)
+		got, ok := IsCatalogUnreachable(wrapped)
+		assert.True(t, ok)
+		assert.Same(t, base, got)
+	})
+
+	t.Run("unrelated error", func(t *testing.T) {
+		got, ok := IsCatalogUnreachable(errors.New("nope"))
+		assert.False(t, ok)
+		assert.Nil(t, got)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		got, ok := IsCatalogUnreachable(nil)
+		assert.False(t, ok)
+		assert.Nil(t, got)
+	})
+
+	t.Run("does not match ArtifactNotFoundError", func(t *testing.T) {
+		got, ok := IsCatalogUnreachable(&ArtifactNotFoundError{Reference: Reference{Name: "test"}})
+		assert.False(t, ok)
+		assert.Nil(t, got)
+	})
+}
+
 func TestIsAuthDegraded(t *testing.T) {
 	t.Run("direct", func(t *testing.T) {
 		base := &AuthDegradedError{Registry: "r"}

--- a/pkg/catalog/remote.go
+++ b/pkg/catalog/remote.go
@@ -8,9 +8,12 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -266,6 +269,66 @@ func isOCIServerError(err error) bool {
 	}
 	s := err.Error()
 	return strings.Contains(s, "status code 500") || strings.Contains(s, "INTERNAL_SERVER_ERROR")
+}
+
+// networkErrorSubstrings is a best-effort fallback for classifying transport
+// failures whose error values do not unwrap cleanly to a structured net.Error
+// (e.g. some ORAS/oras-go transport wrappers flatten errors to plain
+// strings). Structural checks in isNetworkError are preferred; this list only
+// catches what falls through them.
+var networkErrorSubstrings = []string{
+	"dial tcp",
+	"no such host",
+	"connection refused",
+	"i/o timeout",
+	"network is unreachable",
+	"tls handshake timeout",
+	"connection reset by peer",
+}
+
+// isNetworkError returns true if err represents a network/transport-level
+// failure (DNS resolution, dial, timeout, connection reset) reaching a
+// catalog, as opposed to the catalog being reached and reporting that an
+// artifact does not exist. This distinction lets callers surface "catalog
+// unreachable" instead of misleadingly reporting "not found".
+//
+// context.Canceled is intentionally NOT classified as a network error: it
+// indicates the caller gave up (e.g. a CLI-level timeout or explicit
+// cancellation), not that the catalog itself could not be reached.
+// context.DeadlineExceeded, by contrast, commonly originates from a dial or
+// request timeout against an unreachable catalog and is treated as such.
+func isNetworkError(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+	var urlErr *url.Error
+	if errors.As(err, &urlErr) {
+		return true
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	s := strings.ToLower(err.Error())
+	for _, substr := range networkErrorSubstrings {
+		if strings.Contains(s, substr) {
+			return true
+		}
+	}
+	return false
 }
 
 // wrapWithCredentialHint enriches err with a credential diagnostic hint when
@@ -547,6 +610,9 @@ func (c *RemoteCatalog) fetchInternal(ctx context.Context, ref Reference) ([]byt
 	tag := c.tagForRef(ref)
 	manifestDesc, err := repo.Resolve(ctx, tag)
 	if err != nil {
+		if isNetworkError(err) {
+			return nil, ArtifactInfo{}, &UnreachableError{Catalog: c.name, Cause: err}
+		}
 		return nil, ArtifactInfo{}, &ArtifactNotFoundError{Reference: ref, Catalog: c.name}
 	}
 
@@ -628,6 +694,9 @@ func (c *RemoteCatalog) fetchWithBundleInternal(ctx context.Context, ref Referen
 	tag := c.tagForRef(ref)
 	manifestDesc, err := repo.Resolve(ctx, tag)
 	if err != nil {
+		if isNetworkError(err) {
+			return nil, nil, ArtifactInfo{}, &UnreachableError{Catalog: c.name, Cause: err}
+		}
 		return nil, nil, ArtifactInfo{}, &ArtifactNotFoundError{Reference: ref, Catalog: c.name}
 	}
 
@@ -735,7 +804,11 @@ func (c *RemoteCatalog) resolveAcrossKinds(ctx context.Context, ref Reference) (
 			c.logger.V(1).Info("remote catalog kind probe error",
 				"catalog", c.name, "kind", k, "error", err)
 			if firstErr == nil {
-				firstErr = fmt.Errorf("remote catalog %q kind %q: %w", c.name, k, err)
+				if _, ok := IsCatalogUnreachable(err); ok {
+					firstErr = err
+				} else {
+					firstErr = fmt.Errorf("remote catalog %q kind %q: %w", c.name, k, err)
+				}
 			}
 		}
 	}
@@ -764,6 +837,9 @@ func (c *RemoteCatalog) resolveWithKind(ctx context.Context, ref Reference) (Art
 			desc, err = repo.Resolve(ctx, tag)
 		}
 		if err != nil {
+			if isNetworkError(err) {
+				return ArtifactInfo{}, &UnreachableError{Catalog: c.name, Cause: err}
+			}
 			return ArtifactInfo{}, &ArtifactNotFoundError{Reference: ref, Catalog: c.name}
 		}
 
@@ -778,6 +854,8 @@ func (c *RemoteCatalog) resolveWithKind(ctx context.Context, ref Reference) (Art
 	// No version specified - find the latest
 	versions, err := c.listVersions(ctx, ref)
 	if err != nil {
+		// listVersions already classifies network vs. list-tags failures;
+		// propagate as-is rather than re-wrapping as not-found.
 		return ArtifactInfo{}, err
 	}
 
@@ -834,11 +912,17 @@ func (c *RemoteCatalog) listVersions(ctx context.Context, ref Reference) ([]*sem
 		repo.Client = c.client
 		anonVersions, anonErr := c.fetchTags(ctx, repo)
 		if anonErr != nil {
-			return nil, fmt.Errorf("failed to list tags: %w", err)
+			if isNetworkError(anonErr) {
+				return nil, &UnreachableError{Catalog: c.name, Cause: anonErr}
+			}
+			return nil, fmt.Errorf("failed to list tags: %w", anonErr)
 		}
 		return anonVersions, nil
 	}
 	if err != nil {
+		if isNetworkError(err) {
+			return nil, &UnreachableError{Catalog: c.name, Cause: err}
+		}
 		return nil, fmt.Errorf("failed to list tags: %w", err)
 	}
 
@@ -1330,8 +1414,14 @@ func (c *RemoteCatalog) Exists(ctx context.Context, ref Reference) (bool, error)
 		repo.Client = c.client
 		_, err = repo.Resolve(ctx, tag)
 	}
-	//nolint:errcheck // Resolve error means artifact doesn't exist
-	return err == nil, nil
+	if err == nil {
+		return true, nil
+	}
+	if isNetworkError(err) {
+		return false, &UnreachableError{Catalog: c.name, Cause: err}
+	}
+	// Any other resolve error means the artifact doesn't exist.
+	return false, nil
 }
 
 // Delete removes an artifact from the catalog.
@@ -1349,6 +1439,9 @@ func (c *RemoteCatalog) Delete(ctx context.Context, ref Reference) error {
 	tag := c.tagForRef(ref)
 	desc, err := repo.Resolve(ctx, tag)
 	if err != nil {
+		if isNetworkError(err) {
+			return &UnreachableError{Catalog: c.name, Cause: err}
+		}
 		return &ArtifactNotFoundError{Reference: ref, Catalog: c.name}
 	}
 
@@ -1451,6 +1544,9 @@ func (c *RemoteCatalog) Tag(ctx context.Context, ref Reference, alias string) (s
 	tag := c.tagForRef(ref)
 	desc, err := repo.Resolve(ctx, tag)
 	if err != nil {
+		if isNetworkError(err) {
+			return "", &UnreachableError{Catalog: c.name, Cause: err}
+		}
 		return "", &ArtifactNotFoundError{Reference: ref, Catalog: c.name}
 	}
 
@@ -1690,6 +1786,9 @@ func (c *RemoteCatalog) Attach(ctx context.Context, ref Reference, artifactType 
 	tag := c.tagForRef(ref)
 	subjectDesc, err := repo.Resolve(ctx, tag)
 	if err != nil {
+		if isNetworkError(err) {
+			return ocispec.Descriptor{}, &UnreachableError{Catalog: c.name, Cause: err}
+		}
 		return ocispec.Descriptor{}, &ArtifactNotFoundError{Reference: ref, Catalog: c.name}
 	}
 
@@ -1733,6 +1832,9 @@ func (c *RemoteCatalog) Referrers(ctx context.Context, ref Reference, artifactTy
 	tag := c.tagForRef(ref)
 	subjectDesc, err := repo.Resolve(ctx, tag)
 	if err != nil {
+		if isNetworkError(err) {
+			return nil, &UnreachableError{Catalog: c.name, Cause: err}
+		}
 		return nil, &ArtifactNotFoundError{Reference: ref, Catalog: c.name}
 	}
 

--- a/pkg/catalog/remote_test.go
+++ b/pkg/catalog/remote_test.go
@@ -5,7 +5,10 @@ package catalog
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
+	"net/url"
 	"sort"
 	"testing"
 
@@ -1115,3 +1118,96 @@ func TestAuthHandlerFallsBackToCredentialStore(t *testing.T) {
 	assert.Equal(t, "docker-password", cred.Password)
 	assert.Equal(t, "docker config static auth", cat.CredentialSource())
 }
+
+func TestIsNetworkError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "context canceled is not a network error",
+			err:  context.Canceled,
+			want: false,
+		},
+		{
+			name: "wrapped context canceled is not a network error",
+			err:  fmt.Errorf("resolving: %w", context.Canceled),
+			want: false,
+		},
+		{
+			name: "context deadline exceeded is a network error",
+			err:  context.DeadlineExceeded,
+			want: true,
+		},
+		{
+			name: "dns error",
+			err:  &net.DNSError{Err: "no such host", Name: "ghcr.io", IsNotFound: true},
+			want: true,
+		},
+		{
+			name: "wrapped dns error",
+			err:  fmt.Errorf("resolving manifest: %w", &net.DNSError{Err: "no such host", Name: "ghcr.io"}),
+			want: true,
+		},
+		{
+			name: "op error",
+			err:  &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")},
+			want: true,
+		},
+		{
+			name: "url error wrapping op error",
+			err: &url.Error{
+				Op:  "Get",
+				URL: "https://ghcr.io/v2/",
+				Err: &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")},
+			},
+			want: true,
+		},
+		{
+			name: "timeout net.Error",
+			err:  fakeTimeoutError{},
+			want: true,
+		},
+		{
+			name: "opaque dial tcp string",
+			err:  errors.New("Get \"https://ghcr.io/v2/\": dial tcp: lookup ghcr.io: no such host"),
+			want: true,
+		},
+		{
+			name: "opaque connection refused string",
+			err:  errors.New("connection refused"),
+			want: true,
+		},
+		{
+			name: "unrelated error",
+			err:  errors.New("unexpected status code 404"),
+			want: false,
+		},
+		{
+			name: "ArtifactNotFoundError is not a network error",
+			err:  &ArtifactNotFoundError{Reference: Reference{Name: "test"}},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isNetworkError(tt.err))
+		})
+	}
+}
+
+// fakeTimeoutError implements net.Error with Timeout() == true, simulating an
+// opaque transport error that only reveals itself as network-related via the
+// net.Error interface rather than a concrete DNSError/OpError/url.Error type.
+type fakeTimeoutError struct{}
+
+func (fakeTimeoutError) Error() string   { return "fake: i/o timeout" }
+func (fakeTimeoutError) Timeout() bool   { return true }
+func (fakeTimeoutError) Temporary() bool { return true }


### PR DESCRIPTION
## Summary

`ChainCatalog.Fetch/Resolve/FetchWithBundle/FetchByPlatform/ListPlatforms/Exists` previously overwrote a single `lastErr` on each catalog attempt, so a network failure reaching a later catalog (e.g. DNS failure to the official `ghcr.io` catalog) was indistinguishable from a genuine not-found and got reported as "artifact not found in any catalog" -- misleading users into thinking the artifact doesn't exist when the real problem is connectivity.

Fixes #728

## Changes

- Add `ErrCatalogUnreachable` sentinel + `UnreachableError{Catalog, Cause}` type and `IsCatalogUnreachable()` helper in `pkg/catalog/errors.go`.
- Add `isNetworkError()` classifier in `remote.go`: structural checks (`net.DNSError`, `net.OpError`, `url.Error`, `net.Error.Timeout()`, `context.DeadlineExceeded`) with a string-match fallback for opaque transport errors. `context.Canceled` is explicitly NOT classified as unreachable (caller-initiated cancellation, not a connectivity problem).
- Apply the classifier at every `remote.go` call site that previously conflated transport failures with not-found: `Fetch`, `FetchWithBundle`, `resolveWithKind`, `resolveAcrossKinds`, `listVersions`, `Exists`, `Delete`, `Tag`, `Attach`, `Referrers`. Also fixes an independent latent bug in `listVersions`' auth-retry path, which returned the pre-retry error instead of the post-retry error on final failure.
- Rework all six `ChainCatalog` methods to collect per-catalog outcomes and aggregate them via `aggregateChainError`, which separates catalogs that were unreachable (with cause) from catalogs that were checked and returned a genuine not-found, and preserves `errors.Is`/`errors.As` support for the wrapped cause.
- Extensive new unit and chain-level tests covering the classifier, the aggregation helper, and end-to-end chain scenarios including the exact issue repro (official catalog unreachable, others not-found).

## Testing

- `go build ./...`, `go vet ./pkg/catalog/...` clean
- `go test ./pkg/catalog/...` passing (79.1% coverage); `go test -race` unavailable in dev sandbox (no gcc/cgo)
- `task lint:changed`: 0 new issues
- Reviewed via `go-reviewer` (1 HIGH + 1 MEDIUM found and fixed -- `Exists` also silently swallowed network errors; duplicated cause text in aggregated messages) and `artifact-auditor` (confirmed complete: no benchmark needed, no docs/MCP surface changed, no integration test updates needed, no mock.go changes needed)

Note: this PR also fixes the same masking bug in admin operations (`Delete`, `Tag`, `Attach`, `Referrers`) rather than deferring them to a follow-up, per discussion.