### PR TITLE
feat(run)!: unify resolver validation policy behind --on-validation-error

### DIFF
--- a/docs/design/resolvers.md
+++ b/docs/design/resolvers.md
@@ -42,7 +42,7 @@ Resolvers do not cause side effects. They only compute values.
 | forEach nil filtering (default behavior) | ✅ Implemented | `pkg/resolver/executor.go`, `pkg/spec/foreach.go` (`KeepSkipped`) |
 | `onError` behavior | ✅ Implemented | `ErrorBehavior` type |
 | ValidateAll mode (`--validate-all`) | ✅ Implemented | `WithValidateAll()` |
-| SkipValidation mode (`--skip-validation`) | ✅ Implemented | `WithSkipValidation()` |
+| SkipValidation mode (`--on-validation-error ignore`) | ✅ Implemented | `WithSkipValidation()` |
 | Value size limits | ✅ Implemented | `WarnValueSize`, `MaxValueSize` |
 | Run resolver command | ✅ Implemented | `pkg/cmd/scafctl/run/resolver.go` |
 
@@ -1999,12 +1999,12 @@ This mode is useful for:
 
 ### Skip Validation Mode
 
-> **Status**: ✅ Implemented via `--skip-validation` flag
+> **Status**: ✅ Implemented via `--on-validation-error ignore` flag
 
 Skip the validation phase for all resolvers:
 
 ~~~bash
-scafctl run solution myapp --skip-validation
+scafctl run solution myapp --on-validation-error ignore
 ~~~
 
 This is useful during development when validation rules are being refined.

--- a/docs/design/two-phase-validation.md
+++ b/docs/design/two-phase-validation.md
@@ -113,7 +113,7 @@ The behavior on a deferred validation failure depends on the execution mode:
 
 | Mode | Flag | Behavior |
 | --- | --- | --- |
-| Default (fatal) | `--on-validation-error error` | Execution stops; an `AggregatedDeferredValidationError` is returned before actions run. |
+| Fatal | `--on-validation-error error` (default for `run solution` / `run action` / `validate resolver`) | Execution stops; an `AggregatedDeferredValidationError` is returned before actions run. |
 | Non-fatal | `--on-validation-error warn` (default for `run resolver`) | Values are still emitted; failures are reported as validation diagnostics on stderr; state persistence is skipped; the process exits `0`. |
 | Validate-all | `--validate-all` | Failures are folded into the aggregated execution error alongside inline failures. |
 | Skip validation | `--on-validation-error ignore` | Both phases are skipped entirely. |

--- a/docs/design/two-phase-validation.md
+++ b/docs/design/two-phase-validation.md
@@ -113,10 +113,10 @@ The behavior on a deferred validation failure depends on the execution mode:
 
 | Mode | Flag | Behavior |
 | --- | --- | --- |
-| Default (fatal) | none | Execution stops; an `AggregatedDeferredValidationError` is returned before actions run. |
-| Non-fatal | (default for `run resolver`) | Values are still emitted; failures are reported as validation diagnostics on stderr; state persistence is skipped; `--fail-on-validation` makes the process exit non-zero. |
+| Default (fatal) | `--on-validation-error error` | Execution stops; an `AggregatedDeferredValidationError` is returned before actions run. |
+| Non-fatal | `--on-validation-error warn` (default for `run resolver`) | Values are still emitted; failures are reported as validation diagnostics on stderr; state persistence is skipped; the process exits `0`. |
 | Validate-all | `--validate-all` | Failures are folded into the aggregated execution error alongside inline failures. |
-| Skip validation | `--skip-validation` | Both phases are skipped entirely. |
+| Skip validation | `--on-validation-error ignore` | Both phases are skipped entirely. |
 
 ## Linting
 

--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -458,11 +458,11 @@ Output:
 
 Resolvers execute through three ordered phases: **resolve -> transform -> validate**. You can skip phases to inspect intermediate values, or rely on the non-fatal validation behavior described below to see resolved values even when validation fails.
 
-> **Validation is non-fatal in `run resolver`.** Because `run resolver` is an inspection and troubleshooting command, validation failures never withhold the produced values. The resolved values are still printed, validation diagnostics are written to stderr, and the command exits `0`. To make validation failures exit non-zero (for example, in CI), pass `--fail-on-validation`. To gate on validation as the primary intent, use the dedicated [`scafctl validate resolver`](#validate-resolver) command, which presets fatal validation.
+> **Validation is non-fatal in `run resolver`.** Because `run resolver` is an inspection and troubleshooting command, validation failures never withhold the produced values. The resolved values are still printed, validation diagnostics are written to stderr, and the command exits `0`. To make validation failures exit non-zero (for example, in CI), pass `--on-validation-error error`. To gate on validation as the primary intent, use the dedicated [`scafctl validate resolver`](#validate-resolver) command, which presets fatal validation.
 >
 > **Dependents keep running too.** Because a resolver that fails only a validation rule still produces a usable value, its dependent resolvers continue to execute and read that value -- they are not skipped. (Resolve and transform failures still exit non-zero and their dependents are skipped because no value was produced.)
 >
-> **Partial values survive a resolve/transform failure.** When a resolver hard-fails in the resolve or transform phase, `run resolver` still emits the values of every resolver that *did* resolve successfully on stdout, plus a failure summary on stderr. In structured output (`-o json`/`-o yaml`) the stdout document additionally carries a `__status: failed` / `__diagnostics` envelope naming the failed resolver(s); table output shows only the successful values on stdout (the failure detail stays on stderr). Unlike a validation-only failure, a resolve/transform failure always exits non-zero (exit `1`) regardless of `--fail-on-validation` -- but the successful values are no longer discarded.
+> **Partial values survive a resolve/transform failure.** When a resolver hard-fails in the resolve or transform phase, `run resolver` still emits the values of every resolver that *did* resolve successfully on stdout, plus a failure summary on stderr. In structured output (`-o json`/`-o yaml`) the stdout document additionally carries a `__status: failed` / `__diagnostics` envelope naming the failed resolver(s); table output shows only the successful values on stdout (the failure detail stays on stderr). Unlike a validation-only failure, a resolve/transform failure always exits non-zero (exit `1`) regardless of `--on-validation-error` -- but the successful values are no longer discarded.
 
 Create a file called `phases-demo.yaml`. This example resolves a port number, transforms it by adding `8000`, then validates the result is within the valid port range. The input value of `60000` is intentionally too high -- after the transform, the result (`68000`) exceeds the valid range:
 
@@ -522,22 +522,22 @@ Diagnostics on stderr:
 ```
 Warning: 1 resolver(s) failed validation:
   - port: Port must be between 1024 and 65535
-(resolved values are still emitted on stdout; pass --fail-on-validation to exit non-zero)
+(resolved values are still emitted on stdout; pass --on-validation-error error to exit non-zero)
 ```
 
 You can see the resolved value (`68000`) directly, and the diagnostic explains why it is invalid -- no flags required.
 
-To make validation failures exit non-zero, add `--fail-on-validation`:
+To make validation failures exit non-zero, add `--on-validation-error error`:
 
 {{< tabs "run-resolver-tutorial-cmd-9b" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver -f phases-demo.yaml -o json --fail-on-validation
+scafctl run resolver -f phases-demo.yaml -o json --on-validation-error error
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver -f phases-demo.yaml -o json --fail-on-validation
+scafctl run resolver -f phases-demo.yaml -o json --on-validation-error error
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -546,17 +546,17 @@ The values are still printed, the diagnostics still appear on stderr, but the co
 
 ### Skip Validation
 
-Use `--skip-validation` to bypass the validation phase entirely (no diagnostics, no validation work):
+Use `--on-validation-error ignore` to bypass the validation phase entirely (no diagnostics, no validation work):
 
 {{< tabs "run-resolver-tutorial-cmd-10" >}}
 {{% tab "Bash" %}}
 ```bash
-scafctl run resolver --skip-validation -f phases-demo.yaml -o json
+scafctl run resolver --on-validation-error ignore -f phases-demo.yaml -o json
 ```
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-scafctl run resolver --skip-validation -f phases-demo.yaml -o json
+scafctl run resolver --on-validation-error ignore -f phases-demo.yaml -o json
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -569,7 +569,7 @@ Output:
 }
 ```
 
-Now you can see the problem: the transform added `8000` to `60000`, producing `68000` which exceeds the valid port range. Unlike the default non-fatal behavior, `--skip-validation` produces no validation diagnostics at all.
+Now you can see the problem: the transform added `8000` to `60000`, producing `68000` which exceeds the valid port range. Unlike the default non-fatal behavior, `--on-validation-error ignore` produces no validation diagnostics at all.
 
 ### Skip Transform (and Validation)
 
@@ -599,7 +599,7 @@ Output:
 This reveals the provider returned `60000` — confirming the root cause is the input value, not the transform logic.
 
 > [!WARNING]
-> **Note**: `--skip-transform` implies `--skip-validation` because validating a pre-transform value is misleading — validation rules are written against the expected final shape.
+> **Note**: `--skip-transform` implies skipping validation because validating a pre-transform value is misleading — validation rules are written against the expected final shape.
 
 ---
 

--- a/docs/tutorials/validation-patterns-tutorial.md
+++ b/docs/tutorials/validation-patterns-tutorial.md
@@ -795,7 +795,7 @@ scafctl run resolver -f my-solution.yaml -r region=us-east1 -r backupRegion=us-w
 
 In `run resolver` (non-fatal) mode, a failing deferred rule still shows the
 resolved values, reports the failure on stderr, and skips state persistence. Add
-`--fail-on-validation` to exit non-zero. See the
+`--on-validation-error error` to exit non-zero. See the
 [Two-Phase Validation design doc](../design/two-phase-validation.md) for the full
 execution order and skipped/errored semantics.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -239,7 +239,7 @@ Standalone demo files in the root examples directory:
 |------|-------------|
 | [resolver-demo.yaml](resolver-demo.yaml) | Interactive resolver demonstration |
 | [resolver-stress-demo.yaml](resolver-stress-demo.yaml) | Performance testing with many resolvers |
-| [resolver-validation-failures-demo.yaml](resolver-validation-failures-demo.yaml) | Validation error handling; non-fatal by default (`--fail-on-validation` or `validate resolver` to exit non-zero) |
+| [resolver-validation-failures-demo.yaml](resolver-validation-failures-demo.yaml) | Validation error handling; non-fatal by default (`--on-validation-error error` or `validate resolver` to exit non-zero) |
 
 ---
 

--- a/examples/config/full-config.yaml
+++ b/examples/config/full-config.yaml
@@ -277,6 +277,14 @@ resolver:
   # Default: "error"
   # onUnknownResolver: "warn"
 
+  # Default policy for resolver validation failures: "error" aborts and exits
+  # non-zero, "warn" reports failures as non-fatal diagnostics and keeps going,
+  # "ignore" skips the validation phase entirely. Overridden by the
+  # --on-validation-error CLI flag. Note that `run resolver` defaults to "warn"
+  # while `run solution` / `run action` default to "error".
+  # Default: "error"
+  # onValidationError: "warn"
+
 # =============================================================================
 # Action - Configuration for action execution
 # =============================================================================

--- a/examples/resolver-validation-failures-demo.yaml
+++ b/examples/resolver-validation-failures-demo.yaml
@@ -3,7 +3,7 @@
 # Validation is non-fatal in `run resolver`: the resolved values are still
 # printed on stdout, validation diagnostics are written to stderr, and the
 # command exits 0. To make validation failures exit non-zero (e.g. in CI):
-#   scafctl run resolver -f resolver-validation-failures-demo.yaml --fail-on-validation
+#   scafctl run resolver -f resolver-validation-failures-demo.yaml --on-validation-error error
 # Or use the dedicated validation gate, which presets fatal validation (exit 2):
 #   scafctl validate resolver -f resolver-validation-failures-demo.yaml
 
@@ -22,7 +22,7 @@ metadata:
     Shows how scafctl reports different types of validation failures.
 
     Validation is non-fatal in `run resolver`: resolved values are still shown,
-    diagnostics go to stderr, and the command exits 0. Pass --fail-on-validation
+    diagnostics go to stderr, and the command exits 0. Pass --on-validation-error error
     (or use `scafctl validate resolver`) to exit non-zero on validation failure.
 
 spec:

--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -59,6 +59,12 @@ type ActionOptions struct {
 
 	// DynamicArgs are resolver parameters from positional key=value syntax.
 	DynamicArgs []string
+
+	// validationWarn / validationWarnResolvers carry a non-fatal validation-only
+	// failure captured under the "warn" policy so the delegate SolutionOptions
+	// can embed its diagnostics and resolved values in the success envelope.
+	validationWarn          error
+	validationWarnResolvers map[string]any
 }
 
 // CommandAction creates the 'run action' subcommand.
@@ -367,6 +373,15 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 		return o.exitWithCode(ctx, err, exitcode.InvalidInput)
 	}
 
+	// Resolve the validation-failure policy up front so it governs both the
+	// state two-phase pre-load and the main resolver execution below. run
+	// action defaults to "error" (validation failures abort the workflow);
+	// "warn" continues with diagnostics, "ignore" skips validation.
+	validationPolicy, err := o.resolveValidationPolicy(ctx)
+	if err != nil {
+		return o.exitWithCode(ctx, err, exitcode.InvalidInput)
+	}
+
 	// Inject CLI overrides into context
 	actionCtx := ctx
 	if absOutputDir != "" {
@@ -416,7 +431,26 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 	start := time.Now()
 	resolverData, resolverCtx, err := o.executeResolvers(ctx, sol, resolvers, params, reg, withSeededResults(stateSeed))
 	if err != nil {
-		return o.failStructured(ctx, err, exitcode.GeneralError)
+		validationOnly := execute.IsValidationOnlyFailure(err)
+		if validationPolicy == settings.ValidationWarn && validationOnly {
+			// warn: surface diagnostics on stderr and continue to the workflow
+			// with the partially-resolved values. The failure is embedded in
+			// the final success envelope (via o.validationWarn*), not treated
+			// as fatal.
+			o.renderResolverDiagnostics(ctx, err)
+			o.validationWarn = err
+			o.validationWarnResolvers = o.buildResolverOutputMap(resolverData, sol)
+		} else {
+			// Fatal: resolve/transform failures under any policy, and
+			// validation failures under the "error" policy. Preserve the
+			// resolved values in the failure envelope. Validation-only failures
+			// use the dedicated ValidationFailed code.
+			code := exitcode.GeneralError
+			if validationOnly {
+				code = exitcode.ValidationFailed
+			}
+			return o.failStructured(ctx, o.buildResolverOutputMap(resolverData, sol), err, code)
+		}
 	}
 	resolverElapsed := time.Since(start)
 
@@ -522,15 +556,16 @@ func (o *ActionOptions) exitWithCode(ctx context.Context, err error, code int) e
 }
 
 // failStructured delegates to SolutionOptions.failStructured so setup and
-// resolver-phase failures emit a parseable {status, diagnostics} document in
-// json/yaml instead of an empty stdout.
-func (o *ActionOptions) failStructured(ctx context.Context, err error, code int) error {
+// resolver-phase failures emit a parseable {status, diagnostics, resolvers}
+// document in json/yaml instead of an empty stdout. resolverOut is an
+// already-redacted resolver output map embedded under "resolvers".
+func (o *ActionOptions) failStructured(ctx context.Context, resolverOut map[string]any, err error, code int) error {
 	s := &SolutionOptions{
 		sharedResolverOptions: o.sharedResolverOptions,
 		Verbose:               o.Verbose,
 		ShowExecution:         o.ShowExecution,
 	}
-	return s.failStructured(ctx, err, code)
+	return s.failStructured(ctx, resolverOut, err, code)
 }
 
 // executeDryRun delegates to SolutionOptions.executeDryRun which runs
@@ -554,9 +589,11 @@ func (o *ActionOptions) resolveOutputDir(ctx context.Context, dryRun bool) (stri
 // writeActionOutput writes the action execution results using the shared implementation.
 func (o *ActionOptions) writeActionOutput(ctx context.Context, result *action.ExecutionResult, executionData map[string]any) error {
 	s := &SolutionOptions{
-		sharedResolverOptions: o.sharedResolverOptions,
-		Verbose:               o.Verbose,
-		ShowExecution:         o.ShowExecution,
+		sharedResolverOptions:   o.sharedResolverOptions,
+		Verbose:                 o.Verbose,
+		ShowExecution:           o.ShowExecution,
+		validationWarn:          o.validationWarn,
+		validationWarnResolvers: o.validationWarnResolvers,
 	}
 	return s.writeActionOutput(ctx, result, executionData)
 }

--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -245,6 +245,12 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 		o.BinaryName = settings.CliBinaryName
 	}
 
+	// Reset per-run warn state so a previous non-fatal validation run cannot
+	// leak diagnostics/resolvers into a later successful run when the same
+	// options instance is reused in-process (e.g. an embedder re-executing).
+	o.validationWarn = nil
+	o.validationWarnResolvers = nil
+
 	lgr := logger.FromContext(ctx)
 
 	// Apply config default for output-dir

--- a/pkg/cmd/scafctl/run/common.go
+++ b/pkg/cmd/scafctl/run/common.go
@@ -167,7 +167,6 @@ type sharedResolverOptions struct {
 	ResolveAll      bool
 	Progress        bool
 	ValidateAll     bool
-	SkipValidation  bool
 	SkipTransform   bool
 	ShowMetrics     bool
 	ShowSensitive   bool
@@ -215,13 +214,26 @@ type sharedResolverOptions struct {
 	// strict default. Set via the --on-unknown-resolver flag.
 	OnUnknownResolver string
 
-	// nonFatalValidation, when true, makes executeResolvers treat resolver
-	// validation-only failures as non-fatal: it returns the populated values
-	// and resolver context alongside the error instead of discarding them.
-	// Resolve- and transform-phase failures remain fatal. Set only by
-	// inspection commands (run resolver, validate resolver), never by run
-	// solution / run action which keep validation as a hard gate.
-	nonFatalValidation bool
+	// OnValidationError is the raw --on-validation-error flag value controlling
+	// how resolver validation failures are handled: "error" aborts the run,
+	// "warn" reports non-fatal diagnostics and continues, "ignore" skips
+	// validation entirely. Empty resolves via resolveValidationPolicy to the
+	// config default, then ValidationPolicyDefault. Prefer reading the resolved
+	// value from the validationPolicy field after Run() has set it.
+	OnValidationError string
+
+	// ValidationPolicyDefault is the per-command fallback policy used when
+	// neither the --on-validation-error flag nor the config default is set.
+	// Execution commands (run solution, run action) and the validate gate leave
+	// it empty (resolving to settings.ValidationError); run resolver seeds it
+	// with settings.ValidationWarn so validation is non-fatal by default there.
+	ValidationPolicyDefault settings.ValidationErrorPolicy
+
+	// validationPolicy is the resolved validation-failure policy. It is
+	// populated by resolveValidationPolicy in each command's Run() before
+	// resolvers execute, and read by executeResolvers (to configure the
+	// executor) and by the callers (to decide fatal vs. continue).
+	validationPolicy settings.ValidationErrorPolicy
 
 	// kvx output integration (shared flags)
 	flags.KvxOutputFlags
@@ -558,14 +570,25 @@ func (o *sharedResolverOptions) executeResolvers(
 	if resolverCfg.ValidateAll {
 		executorOpts = append(executorOpts, resolver.WithValidateAll(true))
 	}
-	// Non-fatal validation (used by `run resolver`) continues execution and
-	// collects all errors like validate-all, but keeps dependents of a
-	// validation-only failure running so the data layer stays fully inspectable.
-	if o.nonFatalValidation {
-		executorOpts = append(executorOpts, resolver.WithNonFatalValidation(true))
+	// Resolve the validation-failure policy. It is normally set on
+	// o.validationPolicy by the command's Run() via resolveValidationPolicy; a
+	// zero value (e.g. direct executeResolvers calls in tests, or the state
+	// two-phase pre-load closure) falls back to the safe built-in default.
+	policy := o.validationPolicy
+	if policy == "" {
+		policy = settings.DefaultValidationErrorPolicy
 	}
-	if o.SkipValidation {
+	switch policy {
+	case settings.ValidationWarn:
+		// warn: continue execution and collect all errors like validate-all,
+		// but keep dependents of a validation-only failure running so the data
+		// layer stays fully inspectable. The caller decides fatal vs. continue.
+		executorOpts = append(executorOpts, resolver.WithNonFatalValidation(true))
+	case settings.ValidationIgnore:
+		// ignore: skip the validation phase of all resolvers entirely.
 		executorOpts = append(executorOpts, resolver.WithSkipValidation(true))
+	case settings.ValidationError:
+		// error: default hard gate — no extra executor option.
 	}
 	if o.SkipTransform {
 		executorOpts = append(executorOpts, resolver.WithSkipTransform(true))
@@ -640,8 +663,9 @@ func (o *sharedResolverOptions) executeResolvers(
 		return nil, nil, fmt.Errorf("failed to retrieve resolver results")
 	}
 
-	// Build resolver data map. In non-fatal mode, also include partial values
-	// captured by resolvers that failed validation so they remain inspectable.
+	// Build resolver data map. Partial values captured by resolvers that failed
+	// (e.g. validation) are always included so they remain inspectable in the
+	// structured output regardless of the validation policy.
 	for name := range sol.Spec.Resolvers {
 		result, ok := resolverCtx.GetResult(name)
 		if !ok {
@@ -649,7 +673,7 @@ func (o *sharedResolverOptions) executeResolvers(
 		}
 		if result.Status == resolver.ExecutionStatusSuccess {
 			resolverData[name] = result.Value
-		} else if o.nonFatalValidation && result.Value != nil {
+		} else if result.Value != nil {
 			resolverData[name] = result.Value
 		}
 	}
@@ -660,20 +684,15 @@ func (o *sharedResolverOptions) executeResolvers(
 	}
 
 	if err != nil {
-		// In non-fatal mode (run resolver / validate resolver), return the
-		// populated values and context alongside the error for ALL failure
-		// kinds so the caller can render the successfully-resolved values plus
-		// diagnostics instead of dropping them. The caller classifies the error
-		// with execute.IsValidationOnlyFailure to choose the exit code:
-		// validation-only failures are a soft gate (exit 0 unless
-		// --fail-on-validation), while resolve- and transform-phase failures
-		// remain a hard failure (non-zero exit) -- but the partial values stay
-		// inspectable in the structured output either way. In fatal mode (run
-		// solution / run action), all errors discard partial results.
-		if o.nonFatalValidation {
-			return resolverData, resolverCtx, fmt.Errorf("resolver execution failed: %w", err)
-		}
-		return nil, nil, fmt.Errorf("resolver execution failed: %w", err)
+		// Always return the populated values and resolver context alongside the
+		// error so callers can render the successfully-resolved values plus
+		// diagnostics instead of dropping them. Callers classify the error with
+		// execute.IsValidationOnlyFailure and consult the resolved validation
+		// policy to decide the outcome: under "warn" a validation-only failure
+		// is a soft gate (continue / exit 0), under "error" it aborts, and
+		// resolve- and transform-phase failures remain fatal under every policy
+		// -- but the partial values stay inspectable in the structured output.
+		return resolverData, resolverCtx, fmt.Errorf("resolver execution failed: %w", err)
 	}
 
 	lgr.V(1).Info("resolver execution complete", "resolvedCount", len(resolverData))
@@ -968,7 +987,7 @@ func addSharedResolverFlags(cCmd *cobra.Command, o *sharedResolverOptions) {
 	cCmd.Flags().BoolVar(&o.ResolveAll, "resolve-all", false, "Execute all resolvers regardless of action requirements")
 	cCmd.Flags().BoolVar(&o.Progress, "progress", false, "Show resolver phase progress bars (requires TTY)")
 	cCmd.Flags().BoolVar(&o.ValidateAll, "validate-all", false, "Continue execution and show all validation/resolver errors")
-	cCmd.Flags().BoolVar(&o.SkipValidation, "skip-validation", false, "Skip the validation phase of all resolvers")
+	cCmd.Flags().StringVar(&o.OnValidationError, "on-validation-error", "", "Policy for resolver validation failures: error (abort and exit non-zero), warn (report as non-fatal diagnostics and continue, preserving resolved values), or ignore (skip validation entirely). Defaults to warn for 'run resolver' and error for 'run solution' / 'run action'; overrides resolver.onValidationError config")
 	cCmd.Flags().BoolVar(&o.ShowMetrics, "show-metrics", false, "Show provider execution metrics after completion (output to stderr)")
 	cCmd.Flags().BoolVar(&o.ShowSensitive, "show-sensitive", false, "Reveal sensitive values in all output formats (by default, sensitive values are redacted in table output but shown in json/yaml)")
 	cCmd.Flags().BoolVar(&o.NoCache, "no-cache", false, "Bypass the artifact cache and fetch directly from the catalog")
@@ -1171,6 +1190,39 @@ func (o *sharedResolverOptions) effectiveUnknownResolverPolicy(ctx context.Conte
 		}
 	}
 	return settings.ParseUnknownResolverPolicy(raw)
+}
+
+// resolveValidationPolicy resolves the validation-failure policy honoring
+// precedence: the --on-validation-error flag overrides the resolver config
+// default (resolver.onValidationError), which overrides the per-command
+// ValidationPolicyDefault (which itself falls back to the built-in
+// settings.DefaultValidationErrorPolicy for an empty value). It returns an error
+// if the resolved value is not a recognized policy. The resolved value is also
+// stored on o.validationPolicy so executeResolvers and callers can read it.
+func (o *sharedResolverOptions) resolveValidationPolicy(ctx context.Context) (settings.ValidationErrorPolicy, error) {
+	raw := o.OnValidationError
+	// When the flag was not explicitly set, defer to config, then to the
+	// per-command default. flagsChanged is nil outside the command-execution
+	// flow (e.g. unit tests), in which case the value on the options struct is
+	// authoritative.
+	if o.flagsChanged == nil || !o.flagsChanged["on-validation-error"] {
+		switch {
+		case raw != "":
+			// Explicitly set on the struct (tests) — honor it.
+		default:
+			if cfg := config.FromContext(ctx); cfg != nil && cfg.Resolver.OnValidationError != "" {
+				raw = cfg.Resolver.OnValidationError
+			} else if o.ValidationPolicyDefault != "" {
+				raw = string(o.ValidationPolicyDefault)
+			}
+		}
+	}
+	policy, err := settings.ParseValidationErrorPolicy(raw)
+	if err != nil {
+		return "", err
+	}
+	o.validationPolicy = policy
+	return policy, nil
 }
 
 // extractParameterKeys collects the CLI parameter keys accepted by a set of resolvers.

--- a/pkg/cmd/scafctl/run/common_coverage_test.go
+++ b/pkg/cmd/scafctl/run/common_coverage_test.go
@@ -120,7 +120,7 @@ func TestAddSharedResolverFlags(t *testing.T) {
 		"resolve-all",
 		"progress",
 		"validate-all",
-		"skip-validation",
+		"on-validation-error",
 		"show-metrics",
 		"show-sensitive",
 		"no-cache",

--- a/pkg/cmd/scafctl/run/common_test.go
+++ b/pkg/cmd/scafctl/run/common_test.go
@@ -534,3 +534,62 @@ func TestEffectiveUnknownResolverPolicy(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+func TestResolveValidationPolicy(t *testing.T) {
+	t.Run("empty resolves to safe default (error)", func(t *testing.T) {
+		opts := &sharedResolverOptions{}
+		got, err := opts.resolveValidationPolicy(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, settings.ValidationError, got)
+		assert.Equal(t, settings.ValidationError, opts.validationPolicy,
+			"resolved policy must be stored on the options")
+	})
+
+	t.Run("per-command default is honored when flag and config unset", func(t *testing.T) {
+		opts := &sharedResolverOptions{ValidationPolicyDefault: settings.ValidationWarn}
+		got, err := opts.resolveValidationPolicy(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, settings.ValidationWarn, got)
+	})
+
+	t.Run("explicit struct value is honored when flagsChanged nil", func(t *testing.T) {
+		opts := &sharedResolverOptions{
+			OnValidationError:       "ignore",
+			ValidationPolicyDefault: settings.ValidationWarn,
+		}
+		got, err := opts.resolveValidationPolicy(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, settings.ValidationIgnore, got)
+	})
+
+	t.Run("flag not set falls back to config over per-command default", func(t *testing.T) {
+		cfg := &config.Config{Resolver: config.ResolverConfig{OnValidationError: "ignore"}}
+		ctx := config.WithConfig(context.Background(), cfg)
+		opts := &sharedResolverOptions{
+			ValidationPolicyDefault: settings.ValidationWarn,
+			flagsChanged:            map[string]bool{},
+		}
+		got, err := opts.resolveValidationPolicy(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, settings.ValidationIgnore, got)
+	})
+
+	t.Run("explicit flag overrides config", func(t *testing.T) {
+		cfg := &config.Config{Resolver: config.ResolverConfig{OnValidationError: "ignore"}}
+		ctx := config.WithConfig(context.Background(), cfg)
+		opts := &sharedResolverOptions{
+			OnValidationError: "error",
+			flagsChanged:      map[string]bool{"on-validation-error": true},
+		}
+		got, err := opts.resolveValidationPolicy(ctx)
+		require.NoError(t, err)
+		assert.Equal(t, settings.ValidationError, got)
+	})
+
+	t.Run("invalid flag value errors", func(t *testing.T) {
+		opts := &sharedResolverOptions{OnValidationError: "loud"}
+		_, err := opts.resolveValidationPolicy(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "valid: error, warn, ignore")
+	})
+}

--- a/pkg/cmd/scafctl/run/failure_envelope_cli_test.go
+++ b/pkg/cmd/scafctl/run/failure_envelope_cli_test.go
@@ -130,8 +130,8 @@ func TestResolverOptions_Run_ValidationFailure_TableUnchanged(t *testing.T) {
 }
 
 // TestValidateResolver_Run_ValidationFailure_ExitNonZeroWithEnvelope verifies
-// that the gate mode (FailOnValidation) exits non-zero AND still emits the
-// structured failure envelope on stdout.
+// that the gate mode (--on-validation-error error) exits non-zero AND still
+// emits the structured failure envelope on stdout.
 func TestValidateResolver_Run_ValidationFailure_ExitNonZeroWithEnvelope(t *testing.T) {
 	t.Parallel()
 
@@ -140,7 +140,7 @@ func TestValidateResolver_Run_ValidationFailure_ExitNonZeroWithEnvelope(t *testi
 
 	var stdout, stderr bytes.Buffer
 	opts := newResolverOptions(t, solutionPath, &stdout, &stderr)
-	opts.FailOnValidation = true
+	opts.OnValidationError = "error"
 
 	ctx := logger.WithLogger(context.Background(), logger.Get(0))
 	err := opts.Run(ctx)
@@ -412,13 +412,14 @@ func newResolverOptionsForResolveFailure(t *testing.T, solutionPath string, stdo
 
 	return &ResolverOptions{
 		sharedResolverOptions: sharedResolverOptions{
-			IOStreams:       streams,
-			CliParams:       cliParams,
-			File:            solutionPath,
-			KvxOutputFlags:  flags.KvxOutputFlags{Output: format},
-			ResolverTimeout: 30 * time.Second,
-			PhaseTimeout:    5 * time.Minute,
-			registry:        testRegistryWithGoTemplate(t),
+			IOStreams:               streams,
+			CliParams:               cliParams,
+			File:                    solutionPath,
+			KvxOutputFlags:          flags.KvxOutputFlags{Output: format},
+			ResolverTimeout:         30 * time.Second,
+			PhaseTimeout:            5 * time.Minute,
+			registry:                testRegistryWithGoTemplate(t),
+			ValidationPolicyDefault: settings.ValidationWarn,
 		},
 	}
 }
@@ -448,7 +449,7 @@ func TestResolverOptions_Run_ResolvePhaseFailure_PreservesValues(t *testing.T) {
 			err := opts.Run(ctx)
 
 			// A resolve/transform failure is a HARD failure: it exits non-zero
-			// even without --fail-on-validation, unlike a validation-only failure.
+			// under every validation policy, unlike a validation-only failure.
 			require.Error(t, err, "a resolve/transform failure must exit non-zero")
 			assert.Equal(t, exitcode.GeneralError, exitcode.GetCode(err),
 				"a resolve/transform failure must use the general-error exit code")

--- a/pkg/cmd/scafctl/run/resolver.go
+++ b/pkg/cmd/scafctl/run/resolver.go
@@ -76,11 +76,6 @@ type ResolverOptions struct {
 	// ShowExecution includes the __execution metadata in output.
 	ShowExecution bool
 
-	// FailOnValidation makes the command exit with a non-zero status when any
-	// resolver fails validation. By default, validation failures are reported as
-	// non-fatal diagnostics (values are still shown) and the command exits 0.
-	FailOnValidation bool
-
 	// LintAfterValidate, when true, runs lint on the solution after resolver
 	// validation passes. It is set by 'validate resolver' so that command acts
 	// as a full gate (resolver validation + lint). 'run resolver' leaves it
@@ -94,7 +89,12 @@ type ResolverOptions struct {
 
 // CommandResolver creates the 'run resolver' subcommand
 func CommandResolver(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	options := &ResolverOptions{}
+	// run resolver is an inspection command: validation failures default to the
+	// non-fatal "warn" policy so produced values are never withheld. Users can
+	// still opt into "error" (abort) or "ignore" via --on-validation-error.
+	options := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{ValidationPolicyDefault: settings.ValidationWarn},
+	}
 
 	cfg := runCommandConfig{
 		cliParams: cliParams,
@@ -143,7 +143,7 @@ RESOLVER SELECTION:
     scafctl run resolver db config -f my-app       Execute from catalog, filter to db + config
 
 SKIPPING PHASES:
-  Use --skip-validation to skip the validation phase of all resolvers.
+  Use --on-validation-error ignore to skip the validation phase of all resolvers.
   Use --skip-transform to skip both the transform and validation phases,
   returning only the raw resolved values. This is useful for inspecting
   what providers return before any transformation.
@@ -163,6 +163,16 @@ SNAPSHOT MODE:
   Use --snapshot to save a full execution snapshot to a file. Snapshots
   capture resolver values, timing, phases, parameters, and metadata for
   debugging, testing, comparison, and audit trails.
+
+VALIDATION POLICY:
+  Use --on-validation-error to control how resolver validation failures are
+  handled:
+    warn    (default) report failures as non-fatal diagnostics on stderr,
+            still emit the resolved values, and exit 0
+    error   abort and exit non-zero (exit 2) when any resolver fails validation
+    ignore  skip the validation phase entirely
+  To gate on validation as the primary intent, use the dedicated
+  'scafctl validate resolver' command, which defaults to error.
 
 `+ResolverParametersHelp+`
 
@@ -290,7 +300,6 @@ Examples:
 	cCmd.Flags().StringVar(&options.SnapshotFile, "snapshot-file", "", "Snapshot output file (required with --snapshot)")
 	cCmd.Flags().BoolVar(&options.Redact, "redact", false, "Redact sensitive values in snapshot")
 	cCmd.Flags().BoolVar(&options.ShowExecution, "show-execution", false, "Include __execution metadata (phases, timing, dependencies, providers) in output")
-	cCmd.Flags().BoolVar(&options.FailOnValidation, "fail-on-validation", false, "Exit non-zero when any resolver fails validation (by default validation failures are non-fatal diagnostics)")
 	cCmd.Flags().StringArrayVar(&options.Actions, "action", nil, "Scope resolver output to the resolvers consumed by this action (repeatable)")
 
 	setResolverHelpFunc(cCmd)
@@ -304,7 +313,10 @@ Examples:
 // 'run resolver', it does not expose graph/snapshot modes — its sole purpose is
 // to validate resolver outputs and report failures.
 func CommandValidateResolver(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
-	options := &ResolverOptions{FailOnValidation: true, LintAfterValidate: true}
+	options := &ResolverOptions{
+		sharedResolverOptions: sharedResolverOptions{ValidationPolicyDefault: settings.ValidationError},
+		LintAfterValidate:     true,
+	}
 
 	cfg := runCommandConfig{
 		cliParams: cliParams,
@@ -646,10 +658,13 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 		o.sharedResolverOptions.SkipTransform = true
 	}
 
-	// run resolver is an inspection command: validation failures must never
-	// withhold the produced values. Enable non-fatal mode so executeResolvers
-	// returns partial values plus diagnostics instead of aborting.
-	o.nonFatalValidation = true
+	// Resolve the validation-failure policy (default "warn" for run resolver /
+	// "error" for validate resolver). This configures executeResolvers and
+	// drives the exit-code decision below.
+	policy, err := o.resolveValidationPolicy(ctx)
+	if err != nil {
+		return o.exitWithCode(ctx, err, exitcode.InvalidInput)
+	}
 
 	// Track timing
 	start := time.Now()
@@ -740,14 +755,16 @@ func (o *ResolverOptions) Run(ctx context.Context) error {
 	// written to stdout above (with the failure envelope in structured mode),
 	// so returning a coded error here only sets the process exit status.
 	//   - Resolve/transform failures are a HARD failure: a resolver could not
-	//     produce a value, so exit non-zero regardless of --fail-on-validation.
-	//   - Validation-only failures are a SOFT gate in this inspection command:
-	//     exit 0 by default, and non-zero only when --fail-on-validation is set.
+	//     produce a value, so exit non-zero under every validation policy.
+	//   - Validation-only failures follow the resolved policy: under "warn"
+	//     (the run resolver default) they are a soft gate (exit 0); under
+	//     "error" (the validate resolver default) they exit with
+	//     ValidationFailed. ("ignore" skips validation, so none surface here.)
 	if execErr != nil {
 		if !execute.IsValidationOnlyFailure(execErr) {
 			return exitcode.WithCode(execErr, exitcode.GeneralError)
 		}
-		if o.FailOnValidation {
+		if policy == settings.ValidationError {
 			return exitcode.WithCode(execErr, exitcode.ValidationFailed)
 		}
 	}
@@ -858,9 +875,9 @@ func (o *ResolverOptions) failStructured(ctx context.Context, results map[string
 // failures to stderr. It is used by the non-fatal inspection path so the
 // resolved values on stdout are not polluted. It handles both validation-only
 // failures (a soft gate) and resolve/transform failures (a hard failure): the
-// heading and the --fail-on-validation hint adapt to the failure kind so the
+// heading and the --on-validation-error hint adapt to the failure kind so the
 // message never claims a hard failure is merely a validation issue.
-func (o *ResolverOptions) renderResolverDiagnostics(ctx context.Context, execErr error) {
+func (o *sharedResolverOptions) renderResolverDiagnostics(ctx context.Context, execErr error) {
 	w := writer.FromContext(ctx)
 	if w == nil {
 		// Fall back to a writer built from the command's IO streams so
@@ -902,11 +919,12 @@ func (o *ResolverOptions) renderResolverDiagnostics(ctx context.Context, execErr
 			w.PlainStderrf("  - %s", d.Message)
 		}
 	}
-	// The --fail-on-validation hint only applies to validation-only failures,
-	// which exit 0 by default. Resolve/transform failures always exit non-zero,
-	// so suppress the hint to avoid implying the exit code is opt-in.
-	if validationOnly && !o.FailOnValidation {
-		w.PlainStderrf("(resolved values are still emitted on stdout; pass --fail-on-validation to exit non-zero)")
+	// The hint only applies to validation-only failures, which exit 0 under the
+	// "warn" policy. Resolve/transform failures always exit non-zero, and under
+	// the "error" policy validation failures already exit non-zero, so suppress
+	// the hint in those cases to avoid implying the exit code is opt-in.
+	if validationOnly && o.validationPolicy != settings.ValidationError {
+		w.PlainStderrf("(resolved values are still emitted on stdout; pass --on-validation-error error to exit non-zero)")
 	}
 }
 
@@ -944,9 +962,10 @@ func (o *ResolverOptions) showResolverSnapshot(
 		o.sharedResolverOptions.SkipTransform = true
 	}
 
-	// Capture the snapshot even when validation fails: non-fatal mode keeps the
-	// populated resolver context so the snapshot reflects partial values.
-	o.nonFatalValidation = true
+	// Capture the snapshot even when validation fails: use the non-fatal "warn"
+	// policy so executeResolvers keeps the populated resolver context and the
+	// snapshot reflects partial values.
+	o.validationPolicy = settings.ValidationWarn
 
 	start := time.Now()
 

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -83,6 +83,13 @@ type SolutionOptions struct {
 	// positionalPathErr is set in PreRun when the user passes a local file
 	// path as a positional argument instead of using -f/--file.
 	positionalPathErr error
+
+	// validationWarn holds a non-fatal validation-only failure captured under
+	// the "warn" policy. When set, its diagnostics and the resolved values
+	// (validationWarnResolvers) are injected into the successful action output
+	// envelope so the warning is visible in structured output. Reset per run.
+	validationWarn          error
+	validationWarnResolvers map[string]any
 }
 
 // CommandSolution creates the 'run solution' subcommand
@@ -471,6 +478,15 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 		return o.exitWithCode(ctx, err, exitcode.InvalidInput)
 	}
 
+	// Resolve the validation-failure policy up front so it governs both the
+	// state two-phase pre-load and the main resolver execution below. run
+	// solution defaults to "error" (validation failures abort the workflow);
+	// "warn" continues with diagnostics, "ignore" skips validation.
+	validationPolicy, err := o.resolveValidationPolicy(ctx)
+	if err != nil {
+		return o.exitWithCode(ctx, err, exitcode.InvalidInput)
+	}
+
 	// Inject CLI overrides into context before dry-run or live execution,
 	// so both paths honour --output-dir, --on-conflict, and --backup.
 	actionCtx := ctx
@@ -533,7 +549,26 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 
 	resolverData, resolverCtx, err := o.executeResolvers(ctx, sol, resolvers, params, reg, withSeededResults(stateSeed))
 	if err != nil {
-		return o.failStructured(ctx, err, exitcode.GeneralError)
+		validationOnly := execute.IsValidationOnlyFailure(err)
+		if validationPolicy == settings.ValidationWarn && validationOnly {
+			// warn: surface diagnostics on stderr and continue to the workflow
+			// with the partially-resolved values. The failure is embedded in
+			// the final success envelope (via o.validationWarn*), not treated
+			// as fatal.
+			o.renderResolverDiagnostics(ctx, err)
+			o.validationWarn = err
+			o.validationWarnResolvers = o.buildResolverOutputMap(resolverData, sol)
+		} else {
+			// Fatal: resolve/transform failures under any policy, and
+			// validation failures under the "error" policy. Preserve the
+			// resolved values in the failure envelope instead of dropping them.
+			// Validation-only failures use the dedicated ValidationFailed code.
+			code := exitcode.GeneralError
+			if validationOnly {
+				code = exitcode.ValidationFailed
+			}
+			return o.failStructured(ctx, o.buildResolverOutputMap(resolverData, sol), err, code)
+		}
 	}
 
 	resolverElapsed := time.Since(start)
@@ -913,6 +948,12 @@ func (o *SolutionOptions) writeVerboseActionStatus(w *writer.Writer, name string
 // writeActionOutputStructured writes action results as JSON or YAML (the full execution envelope).
 func (o *SolutionOptions) writeActionOutputStructured(ctx context.Context, result *action.ExecutionResult, executionData map[string]any, format string) error {
 	outputData := action.BuildOutputData(result, executionData)
+	// Under the "warn" validation policy a validation-only failure did not abort
+	// the run: embed its diagnostics and the resolved values so the warning is
+	// visible in structured output alongside the successful action results.
+	if o.validationWarn != nil {
+		outputData = execute.InjectSolutionDiagnostics(outputData, o.validationWarn, o.validationWarnResolvers)
+	}
 	return o.writeStructuredData(ctx, outputData, format)
 }
 
@@ -945,17 +986,19 @@ func (o *SolutionOptions) writeStructuredData(ctx context.Context, outputData ma
 }
 
 // failStructured renders a solution/action failure so that machine-readable
-// output formats (json/yaml) still emit a parseable {status, diagnostics}
-// document on stdout instead of an empty stdout with a stderr-only error. It is
-// used for setup and resolver-phase failures that occur before an action
-// ExecutionResult exists; action-execution failures instead emit the full
-// action envelope via writeActionOutput. For human formats (table/quiet) it
-// falls back to the stderr-only exitWithCode behavior.
-func (o *SolutionOptions) failStructured(ctx context.Context, err error, code int) error {
+// output formats (json/yaml) still emit a parseable {status, diagnostics,
+// resolvers} document on stdout instead of an empty stdout with a stderr-only
+// error. It is used for setup and resolver-phase failures that occur before an
+// action ExecutionResult exists; action-execution failures instead emit the
+// full action envelope via writeActionOutput. When resolverOut (an
+// already-redacted resolver output map) is non-empty its values are embedded
+// under "resolvers" so successfully-resolved values are never dropped. For human
+// formats (table/quiet) it falls back to the stderr-only exitWithCode behavior.
+func (o *SolutionOptions) failStructured(ctx context.Context, resolverOut map[string]any, err error, code int) error {
 	if !o.isStructuredOutput() {
 		return o.exitWithCode(ctx, err, code)
 	}
-	envelope := execute.BuildFailureEnvelope(err)
+	envelope := execute.BuildFailureEnvelope(err, resolverOut)
 	if writeErr := o.writeStructuredData(ctx, envelope, o.Output); writeErr != nil {
 		return o.exitWithCode(ctx, err, code)
 	}

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -317,6 +317,12 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 		o.BinaryName = settings.CliBinaryName
 	}
 
+	// Reset per-run warn state so a previous non-fatal validation run cannot
+	// leak diagnostics/resolvers into a later successful run when the same
+	// options instance is reused in-process (e.g. an embedder re-executing).
+	o.validationWarn = nil
+	o.validationWarnResolvers = nil
+
 	// Fail early if PreRun detected a local file path as positional arg
 	if o.positionalPathErr != nil {
 		return o.exitWithCode(ctx, o.positionalPathErr, exitcode.InvalidInput)

--- a/pkg/cmd/scafctl/run/validate_resolver_test.go
+++ b/pkg/cmd/scafctl/run/validate_resolver_test.go
@@ -95,13 +95,14 @@ func newResolverOptions(t *testing.T, solutionPath string, stdout, stderr *bytes
 
 	return &ResolverOptions{
 		sharedResolverOptions: sharedResolverOptions{
-			IOStreams:       streams,
-			CliParams:       cliParams,
-			File:            solutionPath,
-			KvxOutputFlags:  flags.KvxOutputFlags{Output: "json"},
-			ResolverTimeout: 30 * time.Second,
-			PhaseTimeout:    5 * time.Minute,
-			registry:        testRegistryWithValidation(t),
+			IOStreams:               streams,
+			CliParams:               cliParams,
+			File:                    solutionPath,
+			KvxOutputFlags:          flags.KvxOutputFlags{Output: "json"},
+			ResolverTimeout:         30 * time.Second,
+			PhaseTimeout:            5 * time.Minute,
+			registry:                testRegistryWithValidation(t),
+			ValidationPolicyDefault: settings.ValidationWarn,
 		},
 	}
 }
@@ -142,7 +143,7 @@ func TestResolverOptions_Run_ValidationFailureDoesNotSkipDependents(t *testing.T
 	assert.Contains(t, stderr.String(), "failed validation", "diagnostics must be rendered to stderr")
 }
 
-func TestResolverOptions_Run_FailOnValidationExitsNonZero(t *testing.T) {
+func TestResolverOptions_Run_OnValidationErrorExitsNonZero(t *testing.T) {
 	t.Parallel()
 
 	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
@@ -150,12 +151,12 @@ func TestResolverOptions_Run_FailOnValidationExitsNonZero(t *testing.T) {
 
 	var stdout, stderr bytes.Buffer
 	opts := newResolverOptions(t, solutionPath, &stdout, &stderr)
-	opts.FailOnValidation = true
+	opts.OnValidationError = "error"
 
 	ctx := logger.WithLogger(context.Background(), logger.Get(0))
 	err := opts.Run(ctx)
 
-	require.Error(t, err, "--fail-on-validation must produce an error on validation failure")
+	require.Error(t, err, "--on-validation-error error must produce an error on validation failure")
 	assert.Equal(t, exitcode.ValidationFailed, exitcode.GetCode(err))
 	assert.Contains(t, stdout.String(), "Bob", "resolved value must still be shown even when failing")
 }
@@ -170,9 +171,10 @@ func TestCommandValidateResolver(t *testing.T) {
 
 	assert.Equal(t, "resolver [resolver-name...] [key=value...]", cmd.Use)
 	assert.NotEmpty(t, cmd.Short)
-	// The validate command does not expose the fail-on-validation toggle —
-	// it is always fatal.
+	// The validate command exposes the shared --on-validation-error flag but
+	// defaults to the fatal "error" policy (via ValidationPolicyDefault).
 	assert.Nil(t, cmd.Flags().Lookup("fail-on-validation"))
+	assert.NotNil(t, cmd.Flags().Lookup("on-validation-error"))
 	assert.NotNil(t, cmd.Flags().Lookup("file"))
 	assert.NotNil(t, cmd.Flags().Lookup("resolver"))
 }

--- a/pkg/cmd/scafctl/run/validation_policy_cli_test.go
+++ b/pkg/cmd/scafctl/run/validation_policy_cli_test.go
@@ -250,3 +250,65 @@ func TestResolverOptions_Run_ValidationPolicy_IgnoreSkipsPhase(t *testing.T) {
 	assert.NotContains(t, stderr.String(), "name must be Alice",
 		"ignore must not emit validation diagnostics")
 }
+
+// solutionCleanWithWorkflow resolves cleanly (no validation rule) and has a
+// workflow action, used to prove that a prior warn run does not leak diagnostics
+// into a later successful run on a reused options instance.
+const solutionCleanWithWorkflow = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: validation-policy-clean
+  version: 1.0.0
+spec:
+  resolvers:
+    good:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "i-resolved"
+  workflow:
+    actions:
+      echo:
+        provider: static
+        inputs:
+          value:
+            expr: '_.good'
+`
+
+// TestSolutionOptions_Run_ValidationPolicy_WarnStateResetBetweenRuns verifies
+// that reusing a SolutionOptions instance does not leak warn diagnostics from an
+// earlier non-fatal validation run into a later clean run's output envelope.
+func TestSolutionOptions_Run_ValidationPolicy_WarnStateResetBetweenRuns(t *testing.T) {
+	t.Parallel()
+
+	warnPath := filepath.Join(t.TempDir(), "warn.yaml")
+	require.NoError(t, os.WriteFile(warnPath, []byte(solutionValidationFailWithWorkflow), 0o600))
+	cleanPath := filepath.Join(t.TempDir(), "clean.yaml")
+	require.NoError(t, os.WriteFile(cleanPath, []byte(solutionCleanWithWorkflow), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	opts := newSolutionOptionsForPolicy(t, warnPath, &stdout, &stderr, "json")
+	opts.OnValidationError = "warn"
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = writer.WithWriter(ctx, writer.New(opts.IOStreams, opts.CliParams))
+
+	// First run: validation-only failure captured as a warning.
+	require.NoError(t, opts.Run(ctx))
+	require.NotEmpty(t, decodeStructured(t, "json", stdout.Bytes())[execute.DiagnosticsFieldKey],
+		"first (warn) run must carry diagnostics")
+
+	// Second run on the SAME instance against a clean solution.
+	stdout.Reset()
+	stderr.Reset()
+	opts.File = cleanPath
+	require.NoError(t, opts.Run(ctx))
+
+	decoded := decodeStructured(t, "json", stdout.Bytes())
+	assert.NotContains(t, decoded, execute.DiagnosticsFieldKey,
+		"clean re-run must not leak diagnostics from the prior warn run")
+	assert.NotContains(t, decoded, execute.ResolversFieldKey,
+		"clean re-run must not leak the prior run's resolvers map")
+}

--- a/pkg/cmd/scafctl/run/validation_policy_cli_test.go
+++ b/pkg/cmd/scafctl/run/validation_policy_cli_test.go
@@ -1,0 +1,252 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution/execute"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// solutionValidationFailWithWorkflow has a resolver that produces a usable value
+// but fails a validation rule, plus a workflow action that echoes a produced
+// value. It exercises the warn-vs-fatal branch in `run solution` / `run action`:
+// under a fatal policy the workflow never runs; under warn it does.
+const solutionValidationFailWithWorkflow = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: validation-policy-workflow
+  version: 1.0.0
+spec:
+  resolvers:
+    good:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "i-resolved"
+    bad:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: "x"
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              match: "^longer-than-one$"
+              message: "bad must be longer"
+  workflow:
+    actions:
+      echo:
+        provider: static
+        inputs:
+          value:
+            expr: '_.good'
+`
+
+func testRegistryWithValidationAndWorkflow(t *testing.T) *provider.Registry {
+	t.Helper()
+	// The static + validation providers are sufficient for this fixture; reuse
+	// the shared helper to avoid drift.
+	return testRegistryWithValidation(t)
+}
+
+func newSolutionOptionsForPolicy(t *testing.T, solutionPath string, stdout, stderr *bytes.Buffer, format string) *SolutionOptions {
+	t.Helper()
+	streams := &terminal.IOStreams{In: nil, Out: stdout, ErrOut: stderr}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	return &SolutionOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:               streams,
+			CliParams:               cliParams,
+			File:                    solutionPath,
+			KvxOutputFlags:          flags.KvxOutputFlags{Output: format},
+			ResolverTimeout:         30 * time.Second,
+			PhaseTimeout:            5 * time.Minute,
+			registry:                testRegistryWithValidationAndWorkflow(t),
+			ValidationPolicyDefault: settings.ValidationError,
+		},
+		ActionTimeout: 30 * time.Second,
+	}
+}
+
+// TestSolutionOptions_Run_ValidationPolicy_ErrorIsFatal verifies that the
+// default fatal policy for `run solution` aborts before the workflow runs and
+// emits a structured failure envelope that still carries the resolved values.
+func TestSolutionOptions_Run_ValidationPolicy_ErrorIsFatal(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(solutionValidationFailWithWorkflow), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	opts := newSolutionOptionsForPolicy(t, solutionPath, &stdout, &stderr, "json")
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = writer.WithWriter(ctx, writer.New(opts.IOStreams, opts.CliParams))
+	err := opts.Run(ctx)
+
+	require.Error(t, err, "fatal policy must exit non-zero on validation failure")
+
+	decoded := decodeStructured(t, "json", stdout.Bytes())
+	assert.Equal(t, execute.StatusFailed, decoded[execute.StatusFieldKey],
+		"fatal envelope must carry the failed status")
+	assert.NotEmpty(t, decoded[execute.DiagnosticsFieldKey],
+		"fatal envelope must carry diagnostics")
+
+	resolvers, ok := decoded[execute.ResolversFieldKey].(map[string]any)
+	require.True(t, ok, "fatal envelope must embed the partial resolvers map")
+	assert.Equal(t, "i-resolved", resolvers["good"],
+		"successfully resolved values must be preserved in the failure envelope")
+}
+
+// TestSolutionOptions_Run_ValidationPolicy_WarnContinuesToWorkflow verifies that
+// the warn policy softens a validation-only failure: the workflow still runs,
+// the command exits zero, and the output carries diagnostics + resolvers.
+func TestSolutionOptions_Run_ValidationPolicy_WarnContinuesToWorkflow(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(solutionValidationFailWithWorkflow), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	opts := newSolutionOptionsForPolicy(t, solutionPath, &stdout, &stderr, "json")
+	opts.OnValidationError = "warn"
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = writer.WithWriter(ctx, writer.New(opts.IOStreams, opts.CliParams))
+	err := opts.Run(ctx)
+
+	require.NoError(t, err, "warn policy must not abort on a validation-only failure")
+
+	decoded := decodeStructured(t, "json", stdout.Bytes())
+	assert.NotEmpty(t, decoded[execute.DiagnosticsFieldKey],
+		"warn output must surface the validation diagnostics")
+	resolvers, ok := decoded[execute.ResolversFieldKey].(map[string]any)
+	require.True(t, ok, "warn output must embed the resolvers map")
+	assert.Equal(t, "i-resolved", resolvers["good"])
+	assert.Contains(t, stderr.String(), "bad must be longer",
+		"the validation diagnostic must still be reported on stderr")
+}
+
+func newActionOptionsForPolicy(t *testing.T, solutionPath string, stdout, stderr *bytes.Buffer, format string) *ActionOptions {
+	t.Helper()
+	streams := &terminal.IOStreams{In: nil, Out: stdout, ErrOut: stderr}
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+
+	return &ActionOptions{
+		sharedResolverOptions: sharedResolverOptions{
+			IOStreams:               streams,
+			CliParams:               cliParams,
+			File:                    solutionPath,
+			KvxOutputFlags:          flags.KvxOutputFlags{Output: format},
+			ResolverTimeout:         30 * time.Second,
+			PhaseTimeout:            5 * time.Minute,
+			registry:                testRegistryWithValidationAndWorkflow(t),
+			ValidationPolicyDefault: settings.ValidationError,
+		},
+		ActionTimeout: 30 * time.Second,
+	}
+}
+
+// TestActionOptions_Run_ValidationPolicy_ErrorIsFatal verifies that `run action`
+// defaults to a fatal validation policy: a validation-only failure aborts before
+// any action runs and emits a structured failure envelope carrying the partial
+// resolved values.
+func TestActionOptions_Run_ValidationPolicy_ErrorIsFatal(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(solutionValidationFailWithWorkflow), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	opts := newActionOptionsForPolicy(t, solutionPath, &stdout, &stderr, "json")
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = writer.WithWriter(ctx, writer.New(opts.IOStreams, opts.CliParams))
+	err := opts.Run(ctx)
+
+	require.Error(t, err, "run action must default to a fatal validation policy")
+
+	decoded := decodeStructured(t, "json", stdout.Bytes())
+	assert.Equal(t, execute.StatusFailed, decoded[execute.StatusFieldKey])
+	resolvers, ok := decoded[execute.ResolversFieldKey].(map[string]any)
+	require.True(t, ok, "fatal envelope must embed the partial resolvers map")
+	assert.Equal(t, "i-resolved", resolvers["good"])
+}
+
+// TestActionOptions_Run_ValidationPolicy_WarnContinuesToWorkflow verifies parity
+// with `run solution`: under warn, a validation-only failure is non-fatal, the
+// action still runs, the command exits zero, and the output carries diagnostics
+// plus the resolved values.
+func TestActionOptions_Run_ValidationPolicy_WarnContinuesToWorkflow(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(solutionValidationFailWithWorkflow), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	opts := newActionOptionsForPolicy(t, solutionPath, &stdout, &stderr, "json")
+	opts.OnValidationError = "warn"
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	ctx = writer.WithWriter(ctx, writer.New(opts.IOStreams, opts.CliParams))
+	err := opts.Run(ctx)
+
+	require.NoError(t, err, "warn policy must not abort run action on a validation-only failure")
+
+	decoded := decodeStructured(t, "json", stdout.Bytes())
+	assert.NotEmpty(t, decoded[execute.DiagnosticsFieldKey],
+		"warn output must surface the validation diagnostics")
+	resolvers, ok := decoded[execute.ResolversFieldKey].(map[string]any)
+	require.True(t, ok, "warn output must embed the resolvers map")
+	assert.Equal(t, "i-resolved", resolvers["good"])
+	assert.Contains(t, stderr.String(), "bad must be longer",
+		"the validation diagnostic must still be reported on stderr")
+}
+
+// TestResolverOptions_Run_ValidationPolicy_IgnoreSkipsPhase verifies that
+// `--on-validation-error ignore` skips the validation phase entirely for
+// `run resolver`: values are emitted, the command exits zero, and NO validation
+// diagnostics are produced (unlike warn, which reports them).
+func TestResolverOptions_Run_ValidationPolicy_IgnoreSkipsPhase(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(failingValidationSolution), 0o600))
+
+	var stdout, stderr bytes.Buffer
+	opts := newResolverOptions(t, solutionPath, &stdout, &stderr)
+	opts.OnValidationError = "ignore"
+
+	ctx := logger.WithLogger(context.Background(), logger.Get(0))
+	require.NoError(t, opts.Run(ctx), "ignore policy must not fail on a validation rule")
+
+	decoded := decodeStructured(t, "json", stdout.Bytes())
+	assert.Equal(t, "Bob", decoded["name"], "the resolved value must still be emitted")
+	assert.NotContains(t, decoded, execute.StatusKey,
+		"ignore must skip validation so no failure envelope is attached")
+	assert.NotContains(t, stderr.String(), "name must be Alice",
+		"ignore must not emit validation diagnostics")
+}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -400,6 +400,14 @@ type ResolverConfig struct {
 	// (default) rejects them, "warn" proceeds with a warning, "ignore" accepts
 	// them silently. Overridden by the --on-unknown-resolver CLI flag.
 	OnUnknownResolver string `json:"onUnknownResolver,omitempty" yaml:"onUnknownResolver,omitempty" mapstructure:"onUnknownResolver" doc:"Default policy for unknown -r keys (error|warn|ignore)" enum:"error,warn,ignore" example:"error"`
+
+	// OnValidationError sets the default policy for resolver validation
+	// failures: "error" aborts the run and exits non-zero (the safe default for
+	// execution commands), "warn" reports failures as non-fatal diagnostics and
+	// continues (resolved values are preserved), "ignore" skips validation
+	// entirely. Overridden by the --on-validation-error CLI flag. Note that
+	// run resolver defaults to "warn" regardless of this setting when unset.
+	OnValidationError string `json:"onValidationError,omitempty" yaml:"onValidationError,omitempty" mapstructure:"onValidationError" doc:"Default policy for resolver validation failures (error|warn|ignore)" enum:"error,warn,ignore" example:"error"`
 }
 
 // ActionConfig holds action executor configuration.

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -188,6 +188,58 @@ func ParseUnknownResolverPolicy(s string) (UnknownResolverPolicy, error) {
 	}
 }
 
+// ValidationErrorPolicy controls how the run commands react when a resolver
+// fails its validation phase. It unifies what used to be two separate booleans
+// (--skip-validation and --fail-on-validation) into a single tri-state control,
+// mirroring the sibling --on-unknown-resolver flag and kubectl's
+// --validate=strict|warn|ignore semantics.
+//
+// The policy governs only validation-phase failures. Resolve- and
+// transform-phase failures (where a resolver produces no value) remain fatal
+// under every policy, because downstream actions cannot run without a value.
+type ValidationErrorPolicy string
+
+const (
+	// ValidationError treats a validation failure as fatal: the run aborts (for
+	// execution commands, before any workflow action runs) and exits non-zero.
+	// Partial resolved values are still emitted in the failure envelope.
+	ValidationError ValidationErrorPolicy = "error"
+
+	// ValidationWarn runs validation but treats failures as non-fatal
+	// diagnostics: the resolved values are preserved, the failures are reported
+	// on stderr (and in the structured envelope), and execution continues
+	// (for execution commands, the workflow still runs). Only validation-only
+	// failures are softened; resolve/transform failures remain fatal.
+	ValidationWarn ValidationErrorPolicy = "warn"
+
+	// ValidationIgnore skips the validation phase entirely: no validation rules
+	// run, so no validation diagnostics are produced.
+	ValidationIgnore ValidationErrorPolicy = "ignore"
+
+	// DefaultValidationErrorPolicy is the safe default for execution commands
+	// (run solution, run action) and the validate gate: validation failures are
+	// fatal. Inspection commands (run resolver) override this to ValidationWarn.
+	DefaultValidationErrorPolicy = ValidationError
+)
+
+// ParseValidationErrorPolicy validates and normalizes a policy string. An empty
+// string resolves to DefaultValidationErrorPolicy. Unrecognized values return
+// an error naming the valid choices.
+func ParseValidationErrorPolicy(s string) (ValidationErrorPolicy, error) {
+	switch ValidationErrorPolicy(strings.ToLower(strings.TrimSpace(s))) {
+	case "":
+		return DefaultValidationErrorPolicy, nil
+	case ValidationError:
+		return ValidationError, nil
+	case ValidationWarn:
+		return ValidationWarn, nil
+	case ValidationIgnore:
+		return ValidationIgnore, nil
+	default:
+		return "", fmt.Errorf("invalid on-validation-error policy %q (valid: error, warn, ignore)", s)
+	}
+}
+
 // OTel / telemetry defaults
 const (
 	// DefaultOTelSamplerType is the default trace sampler. always_on means every

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -415,3 +415,39 @@ func TestDefaultUnknownResolverPolicy_IsStrict(t *testing.T) {
 	t.Parallel()
 	assert.Equal(t, UnknownResolverError, DefaultUnknownResolverPolicy)
 }
+
+func TestParseValidationErrorPolicy(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		input   string
+		want    ValidationErrorPolicy
+		wantErr bool
+	}{
+		{name: "empty resolves to default", input: "", want: DefaultValidationErrorPolicy},
+		{name: "error", input: "error", want: ValidationError},
+		{name: "warn", input: "warn", want: ValidationWarn},
+		{name: "ignore", input: "ignore", want: ValidationIgnore},
+		{name: "uppercase normalized", input: "WARN", want: ValidationWarn},
+		{name: "whitespace trimmed", input: "  ignore  ", want: ValidationIgnore},
+		{name: "invalid value", input: "loud", wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseValidationErrorPolicy(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "valid: error, warn, ignore")
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestDefaultValidationErrorPolicy_IsError(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, ValidationError, DefaultValidationErrorPolicy)
+}

--- a/pkg/solution/execute/execute.go
+++ b/pkg/solution/execute/execute.go
@@ -202,6 +202,12 @@ const (
 	// ("failedActions", "skippedActions").
 	DiagnosticsFieldKey = "diagnostics"
 
+	// ResolversFieldKey is the plain (non-underscore) key under which the
+	// resolved (and partially-resolved) resolver values are attached to the
+	// action/solution failure envelope so successfully-resolved values are
+	// never dropped when a run aborts.
+	ResolversFieldKey = "resolvers"
+
 	// StatusFailed is the status value written when a run fails.
 	StatusFailed = "failed"
 )
@@ -227,15 +233,40 @@ func InjectResolverFailureEnvelope(results map[string]any, err error) map[string
 // BuildFailureEnvelope builds a standalone structured failure envelope for
 // commands whose output is a fixed-schema map (run solution / run action) rather
 // than a bare resolver map. It returns {status: "failed", diagnostics: [...]}
-// keyed to match action.BuildOutputData. Returns nil when err is nil.
-func BuildFailureEnvelope(err error) map[string]any {
+// keyed to match action.BuildOutputData. When resolverData is non-empty, a
+// "resolvers" key carrying the resolved (and partially-resolved) values is
+// added so successfully-resolved values are never dropped when the run aborts.
+// Returns nil when err is nil.
+func BuildFailureEnvelope(err error, resolverData map[string]any) map[string]any {
 	if err == nil {
 		return nil
 	}
-	return map[string]any{
+	envelope := map[string]any{
 		StatusFieldKey:      StatusFailed,
 		DiagnosticsFieldKey: DiagnosticsFromError(err),
 	}
+	if len(resolverData) > 0 {
+		envelope[ResolversFieldKey] = resolverData
+	}
+	return envelope
+}
+
+// InjectSolutionDiagnostics attaches non-fatal validation diagnostics (and the
+// resolved values) to an otherwise-successful action/solution output envelope.
+// It is used under the "warn" validation policy, where a validation-only
+// failure does not abort the run: the workflow still executes, but the
+// diagnostics and resolved values are surfaced in the structured output so the
+// warning is visible to machine consumers. A nil err or nil envelope is a
+// no-op. Existing keys in the envelope are preserved.
+func InjectSolutionDiagnostics(envelope map[string]any, err error, resolverData map[string]any) map[string]any {
+	if envelope == nil || err == nil {
+		return envelope
+	}
+	envelope[DiagnosticsFieldKey] = DiagnosticsFromError(err)
+	if len(resolverData) > 0 {
+		envelope[ResolversFieldKey] = resolverData
+	}
+	return envelope
 }
 
 // isValidationFailure reports whether a single resolver failure originated from

--- a/pkg/solution/execute/failure_envelope_test.go
+++ b/pkg/solution/execute/failure_envelope_test.go
@@ -42,16 +42,53 @@ func TestInjectResolverFailureEnvelope(t *testing.T) {
 
 func TestBuildFailureEnvelope(t *testing.T) {
 	t.Run("nil error returns nil", func(t *testing.T) {
-		assert.Nil(t, BuildFailureEnvelope(nil))
+		assert.Nil(t, BuildFailureEnvelope(nil, nil))
 	})
 
 	t.Run("builds status and diagnostics", func(t *testing.T) {
-		got := BuildFailureEnvelope(errors.New("kaboom"))
+		got := BuildFailureEnvelope(errors.New("kaboom"), nil)
 		require.NotNil(t, got)
 		assert.Equal(t, StatusFailed, got[StatusFieldKey])
 		diags, ok := got[DiagnosticsFieldKey].([]ResolverDiagnostic)
 		require.True(t, ok)
 		require.Len(t, diags, 1)
 		assert.Equal(t, "kaboom", diags[0].Message)
+		assert.NotContains(t, got, ResolversFieldKey,
+			"resolvers key must be omitted when no resolver data is supplied")
+	})
+
+	t.Run("embeds resolvers when data supplied", func(t *testing.T) {
+		got := BuildFailureEnvelope(errors.New("kaboom"), map[string]any{"good": "i-resolved"})
+		require.NotNil(t, got)
+		assert.Equal(t, StatusFailed, got[StatusFieldKey])
+		resolvers, ok := got[ResolversFieldKey].(map[string]any)
+		require.True(t, ok, "resolvers key must carry the resolved values")
+		assert.Equal(t, "i-resolved", resolvers["good"])
+	})
+}
+
+func TestInjectSolutionDiagnostics(t *testing.T) {
+	t.Run("nil error is a no-op", func(t *testing.T) {
+		envelope := map[string]any{"status": "succeeded"}
+		got := InjectSolutionDiagnostics(envelope, nil, map[string]any{"good": "x"})
+		assert.NotContains(t, got, DiagnosticsFieldKey)
+		assert.NotContains(t, got, ResolversFieldKey)
+	})
+
+	t.Run("nil envelope is a no-op", func(t *testing.T) {
+		assert.Nil(t, InjectSolutionDiagnostics(nil, errors.New("kaboom"), nil))
+	})
+
+	t.Run("injects diagnostics and resolvers into success envelope", func(t *testing.T) {
+		envelope := map[string]any{"status": "succeeded"}
+		got := InjectSolutionDiagnostics(envelope, errors.New("kaboom"), map[string]any{"good": "i-resolved"})
+		assert.Equal(t, "succeeded", got["status"], "existing keys must be preserved")
+		diags, ok := got[DiagnosticsFieldKey].([]ResolverDiagnostic)
+		require.True(t, ok)
+		require.Len(t, diags, 1)
+		assert.Equal(t, "kaboom", diags[0].Message)
+		resolvers, ok := got[ResolversFieldKey].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "i-resolved", resolvers["good"])
 	})
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -7866,7 +7866,7 @@ func TestIntegration_Test_Functional_Calls(t *testing.T) {
 // (deferred cross-resolver) validation feature end-to-end by running the
 // functional test cases bundled with the cross-validation fixture solution.
 // The fixture covers the load-without-cycle guarantee, deferred rules passing
-// when the cross-resolver assertion holds, and both fatal (--fail-on-validation)
+// when the cross-resolver assertion holds, and both fatal (--on-validation-error error)
 // and non-fatal failure modes when the assertion is violated.
 func TestIntegration_Test_Functional_CrossValidation(t *testing.T) {
 	t.Parallel()

--- a/tests/integration/solutions/edge-cases/validation-failures/solution.yaml
+++ b/tests/integration/solutions/edge-cases/validation-failures/solution.yaml
@@ -98,9 +98,9 @@ spec:
           - expression: '__output.validValue == "good"'
 
       regex-failure:
-        description: Verify regex validation failure exits non-zero with --fail-on-validation
+        description: Verify regex validation failure exits non-zero with --on-validation-error error
         command: [run, resolver]
-        args: ["invalidRegex", "--fail-on-validation"]
+        args: ["invalidRegex", "--on-validation-error", "error"]
         tags: [edge-case, validation, negative]
         expectFailure: true
         assertions:
@@ -134,9 +134,9 @@ spec:
             message: "Dependent of a validation-only failure must still resolve using the upstream value"
 
       expression-failure:
-        description: Verify CEL expression validation failure exits non-zero with --fail-on-validation
+        description: Verify CEL expression validation failure exits non-zero with --on-validation-error error
         command: [run, resolver]
-        args: ["invalidExpression", "--fail-on-validation"]
+        args: ["invalidExpression", "--on-validation-error", "error"]
         tags: [edge-case, validation, negative]
         expectFailure: true
         assertions:
@@ -144,9 +144,9 @@ spec:
             message: "Should fail validation"
 
       not-match-failure:
-        description: Verify notMatch validation failure exits non-zero with --fail-on-validation
+        description: Verify notMatch validation failure exits non-zero with --on-validation-error error
         command: [run, resolver]
-        args: ["invalidNotMatch", "--fail-on-validation"]
+        args: ["invalidNotMatch", "--on-validation-error", "error"]
         tags: [edge-case, validation, negative]
         expectFailure: true
         assertions:

--- a/tests/integration/solutions/resolvers/cross-validation/solution.yaml
+++ b/tests/integration/solutions/resolvers/cross-validation/solution.yaml
@@ -82,7 +82,7 @@ spec:
       equal-regions-fail:
         description: Deferred validation fails (non-zero) when regions are equal
         extends: [_base]
-        args: ["-r", "region=us-east1", "-r", "backupRegion=us-east1", "--fail-on-validation"]
+        args: ["-r", "region=us-east1", "-r", "backupRegion=us-east1", "--on-validation-error", "error"]
         tags: [negative]
         expectFailure: true
         assertions:
@@ -93,7 +93,7 @@ spec:
             message: "Failure should surface the rendered deferred validation message"
 
       equal-regions-nonfatal-shows-values:
-        description: Without --fail-on-validation, values still emit but the failure is reported
+        description: Without --on-validation-error error, values still emit but the failure is reported
         extends: [_base]
         args: ["-r", "region=us-east1", "-r", "backupRegion=us-east1"]
         assertions:

--- a/tests/integration/solutions/resolvers/messages/solution.yaml
+++ b/tests/integration/solutions/resolvers/messages/solution.yaml
@@ -77,7 +77,7 @@ spec:
       static-custom-error:
         description: Verify static custom error message overrides default
         command: [run, resolver, invalidPortStatic]
-        args: ["-o", "json", "--fail-on-validation"]
+        args: ["-o", "json", "--on-validation-error", "error"]
         tags: [resolver, messages, negative]
         expectFailure: true
         assertions:
@@ -88,7 +88,7 @@ spec:
       cel-custom-error:
         description: Verify CEL-based custom error message includes dynamic content
         command: [run, resolver, invalidPortCel]
-        args: ["-o", "json", "--fail-on-validation"]
+        args: ["-o", "json", "--on-validation-error", "error"]
         tags: [resolver, messages, negative]
         expectFailure: true
         assertions:

--- a/tests/integration/solutions/resolvers/split-resolver-validation/solution.yaml
+++ b/tests/integration/solutions/resolvers/split-resolver-validation/solution.yaml
@@ -129,7 +129,7 @@ spec:
       non-200-fails-with-message:
         description: Raw resolver validation fails on a non-200 upstream response
         extends: [_base]
-        args: ["userMissingRaw", "--fail-on-validation"]
+        args: ["userMissingRaw", "--on-validation-error", "error"]
         tags: [negative]
         expectFailure: true
         assertions:


### PR DESCRIPTION
Replace the removed `--skip-validation` and `--fail-on-validation` boolean
flags with a single tri-state flag `--on-validation-error <error|warn|ignore>`,
shared across `run resolver`, `run solution`, `run action`, and
`validate resolver`. The design mirrors the existing `--on-unknown-resolver`
flag, its `settings.UnknownResolverPolicy` type, and the
`resolver.onUnknownResolver` config field.

## Motivation

`run solution` / `run action` treated any resolver validation failure as fatal
and discarded the partial resolved values, while `run resolver` was non-fatal
and preserved them. The two boolean flags (`--skip-validation`,
`--fail-on-validation`) were an all-or-nothing pair that could not express the
desired middle ground and behaved inconsistently across commands.

## Behavior

- **Per-command defaults**: `run resolver` = `warn` (non-fatal);
  `run solution` / `run action` / `validate resolver` = `error` (fatal).
- **Precedence**: explicit `--on-validation-error` flag >
  `resolver.onValidationError` config > per-command default > built-in `error`.
- **`warn`** softens only validation-only failures (resolve/transform failures
  stay fatal under every policy). The workflow still runs, the command exits `0`,
  and the output embeds the validation `diagnostics` plus the resolved values.
- **`ignore`** skips the validation phase entirely (no diagnostics, no work).
- **Partial resolved values are now always preserved** in the failure envelope
  via a new `resolvers` key, for every fatal path.
- **Exit codes**: validation-only failure under `error` -> `2`
  (`exitcode.ValidationFailed`); resolve/transform failure under any policy ->
  `1` (`exitcode.GeneralError`); `warn` success -> `0`.

Internal executor plumbing (`WithNonFatalValidation`, `WithSkipValidation`,
`execute.ResolverExecutionConfig`, MCP `NonFatalValidation`) is intentionally
retained; only the user-facing CLI flags changed.

## Changes

- `settings.ValidationErrorPolicy` type + constants + `ParseValidationErrorPolicy`.
- `config.ResolverConfig.OnValidationError` field (documented, `enum`/`example` tags).
- Shared `sharedResolverOptions.resolveValidationPolicy` precedence resolver and
  `ValidationPolicyDefault` per-command seed; `renderResolverDiagnostics` shared
  across resolver/solution/action.
- `execute.BuildFailureEnvelope(err, resolverData)` now embeds the `resolvers`
  key; new `execute.InjectSolutionDiagnostics` and `execute.ResolversFieldKey`.
- Migrated docs, tutorials, examples, and integration test fixtures off the
  removed flags.

## Tests

- Unit: `ParseValidationErrorPolicy`, `resolveValidationPolicy` precedence
  matrix, `BuildFailureEnvelope` + `InjectSolutionDiagnostics`.
- Command-level: `run solution` and `run action` fatal-vs-warn parity
  (workflow-continues, embedded diagnostics + resolvers), and
  `run resolver --on-validation-error ignore` skips the validation phase.
- `task test:e2e` green (917 passed); `task lint:changed` clean.

BREAKING CHANGE: the `--skip-validation` and `--fail-on-validation` flags are
removed. Use `--on-validation-error ignore` in place of `--skip-validation`,
and `--on-validation-error error` in place of `--fail-on-validation`.
