### PR TITLE
fix(celexp): preserve CEL null instead of coercing to 0

### DIFF
--- a/docs/tutorials/cel-tutorial.md
+++ b/docs/tutorials/cel-tutorial.md
@@ -738,6 +738,14 @@ apiData:
           expression: "json.unmarshal(_.rawResponse.body)"
 ```
 
+> **Null preservation:** An explicit `null` in the source is preserved as null,
+> not coerced to `0` or `""`. For example
+> `json.unmarshal('{"present": 1, "absent": null}')` yields
+> `{"present": 1, "absent": null}`, so `has(x.absent)` is `true` and
+> `x.absent == null` is `true`. This is distinct from assigning null to a
+> resolver with a declared `type` (e.g. `type: int`), where the null coerces to
+> that type's zero value.
+
 ### Debug
 
 Functions for debugging expressions during development.

--- a/examples/resolvers/cel-extensions.yaml
+++ b/examples/resolvers/cel-extensions.yaml
@@ -351,6 +351,17 @@ spec:
             inputs:
               expression: 'json.unmarshal("{\"user\": {\"name\": \"Alice\"}}").user.name'
 
+    json_null_preserved:
+      description: "json.unmarshal preserves null (not coerced to 0)"
+      # No `type` is declared so the decoded object passes through unchanged and
+      # the explicit null is preserved as a real null instead of being coerced
+      # to a numeric 0. has()/presence checks stay faithful downstream.
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'json.unmarshal("{\"present\": 1, \"absent\": null}")'
+
     yaml_marshal:
       description: "yaml.marshal - Serialize to YAML"
       type: string

--- a/pkg/celexp/celexp.go
+++ b/pkg/celexp/celexp.go
@@ -577,7 +577,10 @@ func (r *CompileResult) EvalWithContext(ctx context.Context, vars map[string]any
 		}
 	}
 
-	return out.Value(), nil
+	// Normalize a CEL null result to Go nil. Without this, cel-go's
+	// Null.Value() returns structpb.NullValue_NULL_VALUE (integer 0), silently
+	// coercing an explicit null into 0 for direct callers of Eval/EvalWithContext.
+	return conversion.NullSafeValue(out), nil
 }
 
 // isCostLimitError checks if an evaluation error is a cost limit exceeded error.
@@ -698,7 +701,7 @@ func EvalAsWithContext[T any](ctx context.Context, r *CompileResult, vars map[st
 			return zero, fmt.Errorf("expression result is %T, not a list", celList)
 		}
 	default:
-		result = out.Value()
+		result = conversion.NullSafeValue(out)
 	}
 
 	// Type assertion to convert to T

--- a/pkg/celexp/celexp_test.go
+++ b/pkg/celexp/celexp_test.go
@@ -285,6 +285,36 @@ func TestEval_NilResult(t *testing.T) {
 	assert.Contains(t, err.Error(), "compile result or program is nil")
 }
 
+func TestEval_NullResultNormalizedToNil(t *testing.T) {
+	// A CEL expression evaluating to null must return Go nil from the low-level
+	// Eval path, not cel-go's structpb.NullValue enum (whose underlying value is
+	// the integer 0). Guards against silent null -> 0 coercion for direct callers.
+	expr := Expression("null")
+	compiled, err := expr.Compile([]cel.EnvOption{})
+	require.NoError(t, err)
+
+	t.Run("Eval", func(t *testing.T) {
+		value, err := compiled.Eval(nil)
+		require.NoError(t, err)
+		assert.Nil(t, value)
+	})
+
+	t.Run("EvalWithContext", func(t *testing.T) {
+		value, err := compiled.EvalWithContext(context.Background(), nil)
+		require.NoError(t, err)
+		assert.Nil(t, value)
+	})
+
+	t.Run("EvalAs rejects null for a concrete type", func(t *testing.T) {
+		// A typed EvalAs must not silently yield the zero value for a null
+		// result; it reports the mismatch instead. The default branch now
+		// surfaces the value as <nil> rather than cel-go's internal null type.
+		_, err := EvalAs[string](compiled, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "<nil>")
+	})
+}
+
 func BenchmarkCompile(b *testing.B) {
 	expr := Expression("x * 2 + y * 3")
 	opts := []cel.EnvOption{

--- a/pkg/celexp/conversion/conversion.go
+++ b/pkg/celexp/conversion/conversion.go
@@ -37,6 +37,11 @@ func ListToStringSlice(listVal ref.Val) ([]string, error) {
 
 // ToObject converts a CEL map to a Go map[string]any.
 // Returns an error if the input is not a map or if any key is not a string.
+//
+// Values are converted one level deep: each value is normalized via
+// NullSafeValue (so a null value becomes Go nil, never a numeric 0), but nested
+// maps/lists are returned in their immediate CEL representation. Use
+// CelValueToGo when a fully-recursive conversion is required.
 func ToObject(mapVal ref.Val) (map[string]any, error) {
 	// Type check the map
 	mapper, ok := mapVal.(traits.Mapper)
@@ -54,7 +59,7 @@ func ToObject(mapVal ref.Val) (map[string]any, error) {
 			return nil, fmt.Errorf("map contains non-string key of type %s", key.Type())
 		}
 		value := mapper.Get(key)
-		result[keyStr] = value.Value()
+		result[keyStr] = NullSafeValue(value)
 	}
 
 	return result, nil
@@ -84,12 +89,32 @@ func ListToObjectSlice(listVal ref.Val) ([]map[string]any, error) {
 	return result, nil
 }
 
+// NullSafeValue returns the native Go value of a CEL ref.Val, mapping CEL null
+// to Go nil.
+//
+// It behaves like ref.Val.Value() for every type except null. This is required
+// because cel-go's Null.Value() returns structpb.NullValue_NULL_VALUE, whose
+// underlying value is the integer 0. Returning that raw value would silently
+// corrupt an explicit null into a numeric 0 (for example when round-tripping
+// through json.unmarshal or when serializing an evaluation result), so null is
+// normalized to Go nil here. A nil ref.Val is likewise treated as nil.
+//
+// Note that for container values (maps, lists) this returns the value's
+// immediate representation without recursing; use CelValueToGo for a deep
+// conversion that normalizes nested nulls.
+func NullSafeValue(val ref.Val) any {
+	if val == nil {
+		return nil
+	}
+	if _, ok := val.(types.Null); ok {
+		return nil
+	}
+	return val.Value()
+}
+
 // CelValueToGo recursively converts a CEL ref.Val to a native Go value.
 // This handles maps, lists, and primitive types.
 func CelValueToGo(val ref.Val) any {
-	// Get the underlying Go value
-	goVal := val.Value()
-
 	// Handle maps
 	if mapper, ok := val.(traits.Mapper); ok {
 		result := make(map[string]any)
@@ -118,8 +143,8 @@ func CelValueToGo(val ref.Val) any {
 		return result
 	}
 
-	// Return the primitive value as-is
-	return goVal
+	// Return the primitive value as-is (null is normalized to Go nil).
+	return NullSafeValue(val)
 }
 
 // GoToCelValue converts a native Go value to a CEL ref.Val.

--- a/pkg/celexp/conversion/conversion_test.go
+++ b/pkg/celexp/conversion/conversion_test.go
@@ -227,7 +227,7 @@ func TestToObject(t *testing.T) {
 			name:  "map with null value",
 			input: "{'value': null}",
 			expected: map[string]any{
-				"value": struct{}{}, // Special marker for null - we'll verify it exists but not the exact value
+				"value": nil, // CEL null is normalized to Go nil, not coerced to 0
 			},
 		},
 		{
@@ -291,9 +291,9 @@ func TestToObject(t *testing.T) {
 				for key, expectedVal := range tt.expected {
 					actualVal, exists := result[key]
 					assert.True(t, exists, "key %s should exist", key)
-					// For complex types (nested maps, lists, null), just verify they exist
+					// For complex types (nested maps, lists), just verify they exist
 					switch expectedVal.(type) {
-					case map[ref.Val]ref.Val, []ref.Val, struct{}:
+					case map[ref.Val]ref.Val, []ref.Val:
 						assert.NotNil(t, actualVal)
 					default:
 						assert.Equal(t, expectedVal, actualVal, "value for key %s", key)
@@ -374,9 +374,11 @@ func TestListToObjectSlice(t *testing.T) {
 			input:       "[{'value': null}, {'value': 'test'}]",
 			expectedLen: 2,
 			validateFunc: func(t *testing.T, result []map[string]any) {
-				// Just verify the key exists - CEL represents null differently than Go nil
-				_, exists := result[0]["value"]
+				// CEL null is normalized to Go nil (not coerced to 0), while the
+				// key remains present so has()-style presence checks stay faithful.
+				actual, exists := result[0]["value"]
 				assert.True(t, exists, "key 'value' should exist in first map")
+				assert.Nil(t, actual, "null value should convert to Go nil")
 				assert.Equal(t, "test", result[1]["value"])
 			},
 		},
@@ -538,4 +540,87 @@ func TestGoToCelValue_Bool(t *testing.T) {
 func TestGoToCelValue_Nil(t *testing.T) {
 	val := GoToCelValue(nil)
 	assert.NotNil(t, val)
+}
+
+func TestNullSafeValue(t *testing.T) {
+	t.Run("null converts to nil", func(t *testing.T) {
+		assert.Nil(t, NullSafeValue(types.NullValue))
+	})
+
+	t.Run("nil ref.Val converts to nil", func(t *testing.T) {
+		assert.Nil(t, NullSafeValue(nil))
+	})
+
+	t.Run("string passes through", func(t *testing.T) {
+		assert.Equal(t, "hello", NullSafeValue(types.String("hello")))
+	})
+
+	t.Run("int passes through", func(t *testing.T) {
+		assert.Equal(t, int64(42), NullSafeValue(types.Int(42)))
+	})
+
+	t.Run("bool passes through", func(t *testing.T) {
+		assert.Equal(t, true, NullSafeValue(types.Bool(true)))
+	})
+
+	t.Run("double passes through", func(t *testing.T) {
+		assert.InEpsilon(t, 3.14, NullSafeValue(types.Double(3.14)), 1e-9)
+	})
+}
+
+func TestCelValueToGo_Null(t *testing.T) {
+	out := evalCEL(t, "null")
+	assert.Nil(t, CelValueToGo(out), "top-level null should convert to Go nil")
+}
+
+func TestCelValueToGo_MapWithNull(t *testing.T) {
+	out := evalCEL(t, "{'a': null, 'b': 1}")
+	result := CelValueToGo(out)
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+
+	actual, exists := m["a"]
+	assert.True(t, exists, "key 'a' should remain present")
+	assert.Nil(t, actual, "null value must not be coerced to 0")
+	assert.Equal(t, int64(1), m["b"])
+}
+
+func TestCelValueToGo_ListWithNull(t *testing.T) {
+	out := evalCEL(t, "[1, null, 2]")
+	result := CelValueToGo(out)
+	lst, ok := result.([]any)
+	require.True(t, ok)
+	require.Len(t, lst, 3)
+	assert.Equal(t, int64(1), lst[0])
+	assert.Nil(t, lst[1], "null element must not be coerced to 0")
+	assert.Equal(t, int64(2), lst[2])
+}
+
+func TestCelValueToGo_NestedNull(t *testing.T) {
+	out := evalCEL(t, "{'outer': {'inner': null}}")
+	result := CelValueToGo(out)
+	m, ok := result.(map[string]any)
+	require.True(t, ok)
+	inner, ok := m["outer"].(map[string]any)
+	require.True(t, ok)
+
+	actual, exists := inner["inner"]
+	assert.True(t, exists, "nested key should remain present")
+	assert.Nil(t, actual, "nested null must not be coerced to 0")
+}
+
+func BenchmarkCelValueToGo_NullMap(b *testing.B) {
+	env, err := cel.NewEnv()
+	require.NoError(b, err)
+	ast, issues := env.Compile("{'a': null, 'b': 1, 'c': 'x', 'd': null, 'e': true}")
+	require.NoError(b, issues.Err())
+	prg, err := env.Program(ast)
+	require.NoError(b, err)
+	out, _, err := prg.Eval(map[string]interface{}{})
+	require.NoError(b, err)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = CelValueToGo(out)
+	}
 }

--- a/pkg/celexp/ext/marshalling/marshalling_test.go
+++ b/pkg/celexp/ext/marshalling/marshalling_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/cel-go/cel"
+	"github.com/oakwood-commons/scafctl/pkg/celexp/conversion"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -292,6 +293,102 @@ func TestJsonRoundTrip(t *testing.T) {
 
 	expected := map[string]any{"name": "John", "age": float64(30)}
 	assert.Equal(t, expected, result.Value())
+}
+
+// TestUnmarshalNullPreservation guards against a regression where an explicit
+// JSON/YAML null was coerced to the integer 0 while converting the CEL result
+// back to a native Go value (cel-go's Null.Value() returns
+// structpb.NullValue_NULL_VALUE, whose underlying value is 0).
+func TestUnmarshalNullPreservation(t *testing.T) {
+	jsonFn := JSONUnmarshalFunc()
+	yamlFn := YamlUnmarshalFunc()
+	env, err := cel.NewEnv(jsonFn.EnvOptions[0], yamlFn.EnvOptions[0])
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		expr      string
+		expectedB any
+	}{
+		{name: "json unmarshal null field", expr: `json.unmarshal('{"a": null, "b": 1}')`, expectedB: float64(1)},
+		{name: "yaml unmarshal null field", expr: `yaml.unmarshal('{"a": null, "b": 1}')`, expectedB: int64(1)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expr)
+			require.NoError(t, issues.Err())
+
+			prog, err := env.Program(ast)
+			require.NoError(t, err)
+
+			result, _, err := prog.Eval(map[string]any{})
+			require.NoError(t, err)
+
+			// The output path converts the CEL value back to native Go.
+			goVal := conversion.CelValueToGo(result)
+			m, ok := goVal.(map[string]any)
+			require.True(t, ok, "expected map result, got %T", goVal)
+
+			actual, exists := m["a"]
+			assert.True(t, exists, "null key must remain present")
+			assert.Nil(t, actual, "null must not be coerced to 0")
+			assert.Equal(t, tt.expectedB, m["b"])
+		})
+	}
+}
+
+// TestMarshalUnmarshalNullRoundTrip verifies that a document containing null
+// survives an unmarshal -> marshal round-trip without the null becoming 0.
+func TestMarshalUnmarshalNullRoundTrip(t *testing.T) {
+	marshalFn := JSONMarshalFunc()
+	unmarshalFn := JSONUnmarshalFunc()
+	env, err := cel.NewEnv(marshalFn.EnvOptions[0], unmarshalFn.EnvOptions[0])
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`json.marshal(json.unmarshal('{"a":null,"b":1}'))`)
+	require.NoError(t, issues.Err())
+
+	prog, err := env.Program(ast)
+	require.NoError(t, err)
+
+	result, _, err := prog.Eval(map[string]any{})
+	require.NoError(t, err)
+
+	assert.Equal(t, `{"a":null,"b":1}`, result.Value())
+}
+
+// TestUnmarshalNullPresenceAndEquality verifies that a null value keeps has()
+// faithful (the key is present) and is comparable to null.
+func TestUnmarshalNullPresenceAndEquality(t *testing.T) {
+	fn := JSONUnmarshalFunc()
+	env, err := cel.NewEnv(fn.EnvOptions[0])
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		expr     string
+		expected bool
+	}{
+		{name: "has() true for present null key", expr: `has(json.unmarshal('{"a": null}').a)`, expected: true},
+		{name: "null equals null", expr: `json.unmarshal('{"a": null}').a == null`, expected: true},
+		{name: "null not equal to zero", expr: `json.unmarshal('{"a": null}').a == 0`, expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ast, issues := env.Compile(tt.expr)
+			require.NoError(t, issues.Err())
+
+			prog, err := env.Program(ast)
+			require.NoError(t, err)
+
+			result, _, err := prog.Eval(map[string]any{})
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.expected, result.Value())
+		})
+	}
 }
 
 func TestYamlMarshalFunc_Metadata(t *testing.T) {

--- a/pkg/mcp/main_test.go
+++ b/pkg/mcp/main_test.go
@@ -1,0 +1,22 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"os"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/celexp/env"
+)
+
+// TestMain wires the standard CEL environment and cache factories that
+// production installs via RegisterDefaults(). Without this, custom CEL
+// functions (e.g. json.unmarshal) are undeclared, so any test exercising the
+// evaluate_cel path with extension functions would fail.
+func TestMain(m *testing.M) {
+	celexp.SetEnvFactory(env.New)
+	celexp.SetCacheFactory(env.GlobalCache)
+	os.Exit(m.Run())
+}

--- a/pkg/mcp/tools_cel_test.go
+++ b/pkg/mcp/tools_cel_test.go
@@ -178,6 +178,34 @@ func TestHandleEvaluateCEL(t *testing.T) {
 		assert.Equal(t, float64(3), parsed["result"])
 	})
 
+	t.Run("unmarshal preserves null", func(t *testing.T) {
+		// Custom CEL functions (json.unmarshal) require the standard env factory,
+		// which TestMain wires via SetEnvFactory(env.New).
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "evaluate_cel"
+		request.Params.Arguments = map[string]any{
+			"expression": `json.unmarshal('{"a": null, "b": 1}')`,
+		}
+
+		result, err := srv.handleEvaluateCEL(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+
+		resultMap, ok := parsed["result"].(map[string]any)
+		require.True(t, ok, "result should be a map, got %T", parsed["result"])
+		actual, exists := resultMap["a"]
+		assert.True(t, exists, "null key must remain present")
+		assert.Nil(t, actual, "null must not be coerced to 0")
+		assert.Equal(t, float64(1), resultMap["b"])
+	})
+
 	t.Run("with inline data", func(t *testing.T) {
 		srv, err := NewServer(WithServerVersion("test"))
 		require.NoError(t, err)

--- a/tests/integration/solutions/edge-cases/null-coercion/solution.yaml
+++ b/tests/integration/solutions/edge-cases/null-coercion/solution.yaml
@@ -12,6 +12,10 @@ metadata:
     type's zero value. Each resolver transforms to CEL null, then relies on the
     declared type to coerce the null to its zero value.
 
+    The nullPreserved resolver covers the complementary case: an UNTYPED
+    resolver must preserve an explicit null inside a decoded object as JSON
+    null (not silently coerce it to the integer 0).
+
 spec:
   resolvers:
     nullToString:
@@ -85,6 +89,14 @@ spec:
             inputs:
               expression: "null"
 
+    nullPreserved:
+      description: An untyped object preserves an explicit null field as null
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: 'json.unmarshal("{\"present\": 1, \"absent\": null}")'
+
   testing:
     cases:
       null-to-string:
@@ -136,3 +148,17 @@ spec:
           - expression: __exitCode == 0
           - expression: "__output.nullToObject.size() == 0"
             message: "Null must coerce to an empty object"
+
+      null-preserved:
+        description: An untyped object preserves an explicit null field as null
+        command: [run, resolver]
+        args: ["nullPreserved", "-o", "json"]
+        tags: [edge-case, coercion]
+        assertions:
+          - expression: __exitCode == 0
+          - expression: "has(__output.nullPreserved.present) && __output.nullPreserved.present == 1"
+            message: "Present field must decode to its value"
+          - expression: "has(__output.nullPreserved.absent)"
+            message: "An explicit null field must remain present, not be dropped"
+          - expression: "__output.nullPreserved.absent == null"
+            message: "An explicit null must be preserved as null, not coerced to 0"


### PR DESCRIPTION
## Summary

CEL `json.unmarshal` / `yaml.unmarshal` (and the general CEL→Go conversion and
low-level `Eval` paths) silently coerced an explicit JSON/YAML `null` into the
integer `0`. A field like `{"present": 1, "absent": null}` decoded to
`{"present": 1, "absent": 0}`, so `absent == null` was `false` and
`absent == 0` was `true` — silent data corruption.

Root cause: cel-go's `types.Null.Value()` returns
`structpb.NullValue_NULL_VALUE`, whose underlying value is the integer `0`. Every
site that read `ref.Val.Value()` at a conversion leaf therefore turned CEL null
into `0`.

## Fix

Introduce a single choke-point helper and route all leaf conversions and
low-level `Eval` return sites through it:

- `conversion.NullSafeValue(ref.Val) any` maps CEL null (and a nil `ref.Val`) to
  Go `nil`, otherwise returns `val.Value()`. It intentionally does not recurse —
  `CelValueToGo` still handles deep maps/lists and calls `NullSafeValue` at each
  leaf.
- `CelValueToGo`, `ToObject`, and `ListToObjectSlice` now normalize leaves via
  `NullSafeValue`.
- `CompileResult.EvalWithContext` and the `EvalAsWithContext` default branch
  return `NullSafeValue(out)` so direct callers get `nil`, not the null enum.

An explicit `null` is now preserved as null: `has(x.absent)` is `true` and
`x.absent == null` is `true`. This is deliberately distinct from assigning null
to a resolver with a declared `type` (e.g. `type: int`), where the null still
coerces to that type's zero value.

## Tests / examples / docs

- Unit tests for `NullSafeValue`, `CelValueToGo` (null leaf, map/list/nested
  null), `ToObject`, `ListToObjectSlice`, and the low-level `Eval` /
  `EvalWithContext` / `EvalAs` null paths.
- Marshalling extension tests: null preservation, marshal↔unmarshal round-trip,
  and presence/equality (`has()` true, `== null` true, `== 0` false).
- MCP `evaluate_cel` "unmarshal preserves null" subtest, plus a package
  `TestMain` wiring the standard env/cache factories.
- End-to-end functional case `null-preserved` in the `null-coercion` edge-case
  solution, asserting an untyped decoded object keeps its null field.
- Docs note in the CEL tutorial and a `json_null_preserved` example resolver.

## Validation

- `pkg/celexp/...`, `pkg/mcp/...`, and downstream consumers pass.
- Functional `null-coercion` suite: 9 passed, 0 failed.
- `task lint:changed`: 0 issues.
