### PR TITLE
fix(plugin): wire AuthGroupsFunc so plugins can fetch group membership

### DIFF
--- a/docs/design/auth.md
+++ b/docs/design/auth.md
@@ -150,6 +150,22 @@ This design makes plugin-loaded auth handlers work without CLI code changes -- a
 **Example**: Running `scafctl auth token github --scope repo` returns an error:
 > the "github" auth handler does not support per-request scopes; scopes are fixed at login time. Use 'scafctl auth login github --scope <scope>' to change scopes
 
+### Group Membership (GroupsProvider)
+
+Group membership is served separately from identity claims. A handler may
+optionally implement the `auth.GroupsProvider` interface
+(`GetGroups(ctx) ([]string, error)`) to return the authenticated user's group
+memberships as ObjectIDs. This is intentionally **not** part of `auth.Claims`:
+Microsoft Entra caps the `groups` claim and instead emits a
+`_claim_names.groups` overage once a user belongs to more than 200 groups, so
+the full list must be fetched out of band (e.g. via Microsoft Graph) with
+transparent pagination.
+
+Callers -- including the `auth token` command and plugins via the
+`GetAuthGroups` host RPC (see the plugins design doc) -- type-assert the
+resolved handler to `GroupsProvider` before querying it. Handlers that do not
+implement the interface return an actionable error rather than an empty list.
+
 ### Handler Registry
 
 Auth handlers are managed via a thread-safe registry (`auth.Registry`). CLI commands look up handlers by name from the registry in context, rather than using hardcoded switch statements. This supports:

--- a/docs/design/plugins.md
+++ b/docs/design/plugins.md
@@ -209,6 +209,7 @@ service HostService {
   rpc GetAuthIdentity(GetAuthIdentityRequest) returns (GetAuthIdentityResponse);
   rpc ListAuthHandlers(ListAuthHandlersRequest) returns (ListAuthHandlersResponse);
   rpc GetAuthToken(GetAuthTokenRequest) returns (GetAuthTokenResponse);
+  rpc GetAuthGroups(GetAuthGroupsRequest) returns (GetAuthGroupsResponse);
 }
 ```
 
@@ -278,8 +279,20 @@ Plugins that need host-side resources (secrets, auth tokens) use the `HostServic
 | `GetAuthIdentity` | Retrieve identity claims from the host's auth registry |
 | `ListAuthHandlers` | List available auth handlers (filtered by AllowedAuthHandlers) |
 | `GetAuthToken` | Retrieve a valid access token from the host's auth registry |
+| `GetAuthGroups` | Retrieve the authenticated user's group memberships |
 
 Plugins access HostService via a client injected during `ConfigureProvider`.
+
+`GetAuthGroups` returns the authenticated user's group memberships (as
+ObjectIDs) for the named handler, resolving an empty name to the default
+handler. Group membership is served by a separate paginated callback rather
+than being folded into `GetAuthIdentity`'s `Claims`: Microsoft Entra emits a
+`_claim_names.groups` overage (instead of a `groups` claim) once a user belongs
+to more than 200 groups, so the full list must be fetched out of band. The
+callback requires the resolved handler to implement the `auth.GroupsProvider`
+interface; handlers that do not implement it return an actionable error rather
+than an empty list. As with the other auth callbacks, the request is gated by
+`AllowedAuthHandlers`.
 
 ### Diagnostics and Exit Codes
 

--- a/docs/tutorials/auth-handler-development.md
+++ b/docs/tutorials/auth-handler-development.md
@@ -61,7 +61,7 @@ type Handler interface {
 
 ### Optional Interfaces
 
-Auth handlers can optionally implement these interfaces for token management:
+Auth handlers can optionally implement these interfaces:
 
 ```go
 // TokenLister enumerates all cached tokens (refresh + access).
@@ -72,6 +72,15 @@ type TokenLister interface {
 // TokenPurger removes expired access tokens from the cache.
 type TokenPurger interface {
     PurgeExpiredTokens(ctx context.Context) (int, error)
+}
+
+// GroupsProvider returns the authenticated user's group memberships as
+// ObjectIDs. Implementing it enables the host's GetAuthGroups callback and
+// the identity provider's `operation: groups`. Implementations must handle
+// pagination transparently so all memberships are returned even beyond a
+// per-token cap (e.g. Entra's 200-group JWT overage).
+type GroupsProvider interface {
+    GetGroups(ctx context.Context) ([]string, error)
 }
 ```
 

--- a/docs/tutorials/provider-development.md
+++ b/docs/tutorials/provider-development.md
@@ -1014,6 +1014,7 @@ Plugins that need host-side resources can access the **HostService** callback se
 - **GetAuthIdentity** -- retrieve identity claims from the host's auth registry
 - **ListAuthHandlers** -- list available auth handlers (filtered by AllowedAuthHandlers)
 - **GetAuthToken** -- retrieve a valid access token from the host's auth registry
+- **GetAuthGroups** -- retrieve the authenticated user's group memberships (requires the handler to implement `GroupsProvider`; served separately from claims because Entra emits a `_claim_names.groups` overage past 200 groups)
 
 The host registers HostService via the go-plugin GRPCBroker during plugin startup. Plugins receive the broker service ID in `ProviderConfig.HostServiceID` from the `ConfigureProvider` call. Use this ID to dial the HostService via the broker.
 

--- a/pkg/plugin/grpc_host.go
+++ b/pkg/plugin/grpc_host.go
@@ -67,10 +67,9 @@ type HostServiceDeps struct {
 	// May be nil if auth is unavailable.
 	AuthTokenFunc func(ctx context.Context, handler, scope string, minValidFor int64, forceRefresh bool) (*proto.GetAuthTokenResponse, error) `json:"-" yaml:"-" doc:"Auth token callback (not serialized)."`
 	// AuthGroupsFunc retrieves group memberships for the authenticated user.
-	// Only handlers that implement group queries (e.g. Entra) will return results.
-	// May be nil if group queries are unavailable.
-	// TODO: Wire this callback in production code (e.g. via RootOptions or plugin SDK)
-	// once an auth handler with group query support is available.
+	// Only handlers that implement auth.GroupsProvider (e.g. Entra) return
+	// results; others yield an actionable error. Wired in production by
+	// HostDepsFromAuthRegistry. May be nil if group queries are unavailable.
 	AuthGroupsFunc func(ctx context.Context, handler string) ([]string, error) `json:"-" yaml:"-" doc:"Auth groups callback (not serialized)."`
 	// ProfileResolverFunc resolves the active auth profile for a handler when
 	// the plugin request does not specify one explicitly. This bridges the gap
@@ -620,6 +619,33 @@ func HostDepsFromAuthRegistry(authReg *auth.Registry) *HostServiceDeps {
 						"scoped token can be minted to derive identity claims", handler)
 			}
 			return claimsToProto(st.Claims), nil
+		},
+		AuthGroupsFunc: func(ctx context.Context, handler string) ([]string, error) {
+			// Resolve empty handler name to the default handler (the first in
+			// authReg.List(), which is sorted, i.e. first alphabetically).
+			if handler == "" {
+				handlers := authReg.List()
+				if len(handlers) == 0 {
+					return nil, fmt.Errorf("no auth handlers registered")
+				}
+				handler = handlers[0]
+			}
+			h, err := authReg.Get(handler)
+			if err != nil {
+				return nil, fmt.Errorf("auth handler %q: %w", handler, err)
+			}
+			// Group membership is served via the optional GroupsProvider
+			// interface (a separate paginated callback), not the claim set,
+			// because Entra emits a _claim_names.groups overage past 200 groups.
+			gp, ok := h.(auth.GroupsProvider)
+			if !ok {
+				return nil, fmt.Errorf("auth handler %q does not support group membership queries (GroupsProvider not implemented)", handler)
+			}
+			groups, err := gp.GetGroups(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("get groups from %q: %w", handler, err)
+			}
+			return groups, nil
 		},
 	}
 }

--- a/pkg/plugin/grpc_host_deps_test.go
+++ b/pkg/plugin/grpc_host_deps_test.go
@@ -300,6 +300,120 @@ func TestHostDepsFromAuthRegistry_IdentityFunc_EmptyHandlerResolvesToDefault(t *
 	assert.Equal(t, "alpha-sub", claims.Subject)
 }
 
+// mockGroupsHandler embeds *auth.MockHandler and additionally implements
+// auth.GroupsProvider so the AuthGroupsFunc closure can type-assert to it.
+type mockGroupsHandler struct {
+	*auth.MockHandler
+	groups   []string
+	groupErr error
+}
+
+func (m *mockGroupsHandler) GetGroups(_ context.Context) ([]string, error) {
+	return m.groups, m.groupErr
+}
+
+// Compile-time assertion that mockGroupsHandler satisfies GroupsProvider.
+var _ auth.GroupsProvider = (*mockGroupsHandler)(nil)
+
+func TestHostDepsFromAuthRegistry_GroupsFunc(t *testing.T) {
+	tests := []struct {
+		name       string
+		register   func(reg *auth.Registry)
+		handler    string
+		wantGroups []string
+		wantErr    string
+	}{
+		{
+			name: "success returns groups",
+			register: func(reg *auth.Registry) {
+				require.NoError(t, reg.Register(&mockGroupsHandler{
+					MockHandler: auth.NewMockHandler("entra"),
+					groups:      []string{"group-a", "group-b"},
+				}))
+			},
+			handler:    "entra",
+			wantGroups: []string{"group-a", "group-b"},
+		},
+		{
+			name: "success returns empty membership",
+			register: func(reg *auth.Registry) {
+				require.NoError(t, reg.Register(&mockGroupsHandler{
+					MockHandler: auth.NewMockHandler("entra"),
+					groups:      []string{},
+				}))
+			},
+			handler:    "entra",
+			wantGroups: []string{},
+		},
+		{
+			name: "empty handler resolves to default",
+			register: func(reg *auth.Registry) {
+				require.NoError(t, reg.Register(&mockGroupsHandler{
+					MockHandler: auth.NewMockHandler("alpha"),
+					groups:      []string{"alpha-group"},
+				}))
+				require.NoError(t, reg.Register(&mockGroupsHandler{
+					MockHandler: auth.NewMockHandler("beta"),
+					groups:      []string{"beta-group"},
+				}))
+			},
+			handler:    "",
+			wantGroups: []string{"alpha-group"},
+		},
+		{
+			name:     "no handlers registered",
+			register: func(_ *auth.Registry) {},
+			handler:  "",
+			wantErr:  "no auth handlers registered",
+		},
+		{
+			name:     "unknown handler",
+			register: func(_ *auth.Registry) {},
+			handler:  "missing",
+			wantErr:  `auth handler "missing"`,
+		},
+		{
+			name: "handler does not implement GroupsProvider",
+			register: func(reg *auth.Registry) {
+				require.NoError(t, reg.Register(auth.NewMockHandler("plain")))
+			},
+			handler: "plain",
+			wantErr: "does not support group membership queries (GroupsProvider not implemented)",
+		},
+		{
+			name: "GetGroups returns an error",
+			register: func(reg *auth.Registry) {
+				require.NoError(t, reg.Register(&mockGroupsHandler{
+					MockHandler: auth.NewMockHandler("entra"),
+					groupErr:    fmt.Errorf("graph API unavailable"),
+				}))
+			},
+			handler: "entra",
+			wantErr: `get groups from "entra": graph API unavailable`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reg := auth.NewRegistry()
+			tt.register(reg)
+
+			deps := HostDepsFromAuthRegistry(reg)
+			require.NotNil(t, deps.AuthGroupsFunc)
+
+			groups, err := deps.AuthGroupsFunc(context.Background(), tt.handler)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Nil(t, groups)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantGroups, groups)
+		})
+	}
+}
+
 func BenchmarkHostDepsFromAuthRegistry(b *testing.B) {
 	reg := auth.NewRegistry()
 	mock := auth.NewMockHandler("bench")

--- a/pkg/plugin/grpc_host_deps_test.go
+++ b/pkg/plugin/grpc_host_deps_test.go
@@ -318,14 +318,14 @@ var _ auth.GroupsProvider = (*mockGroupsHandler)(nil)
 func TestHostDepsFromAuthRegistry_GroupsFunc(t *testing.T) {
 	tests := []struct {
 		name       string
-		register   func(reg *auth.Registry)
+		register   func(t *testing.T, reg *auth.Registry)
 		handler    string
 		wantGroups []string
 		wantErr    string
 	}{
 		{
 			name: "success returns groups",
-			register: func(reg *auth.Registry) {
+			register: func(t *testing.T, reg *auth.Registry) {
 				require.NoError(t, reg.Register(&mockGroupsHandler{
 					MockHandler: auth.NewMockHandler("entra"),
 					groups:      []string{"group-a", "group-b"},
@@ -336,7 +336,7 @@ func TestHostDepsFromAuthRegistry_GroupsFunc(t *testing.T) {
 		},
 		{
 			name: "success returns empty membership",
-			register: func(reg *auth.Registry) {
+			register: func(t *testing.T, reg *auth.Registry) {
 				require.NoError(t, reg.Register(&mockGroupsHandler{
 					MockHandler: auth.NewMockHandler("entra"),
 					groups:      []string{},
@@ -347,7 +347,7 @@ func TestHostDepsFromAuthRegistry_GroupsFunc(t *testing.T) {
 		},
 		{
 			name: "empty handler resolves to default",
-			register: func(reg *auth.Registry) {
+			register: func(t *testing.T, reg *auth.Registry) {
 				require.NoError(t, reg.Register(&mockGroupsHandler{
 					MockHandler: auth.NewMockHandler("alpha"),
 					groups:      []string{"alpha-group"},
@@ -362,19 +362,19 @@ func TestHostDepsFromAuthRegistry_GroupsFunc(t *testing.T) {
 		},
 		{
 			name:     "no handlers registered",
-			register: func(_ *auth.Registry) {},
+			register: func(_ *testing.T, _ *auth.Registry) {},
 			handler:  "",
 			wantErr:  "no auth handlers registered",
 		},
 		{
 			name:     "unknown handler",
-			register: func(_ *auth.Registry) {},
+			register: func(_ *testing.T, _ *auth.Registry) {},
 			handler:  "missing",
 			wantErr:  `auth handler "missing"`,
 		},
 		{
 			name: "handler does not implement GroupsProvider",
-			register: func(reg *auth.Registry) {
+			register: func(t *testing.T, reg *auth.Registry) {
 				require.NoError(t, reg.Register(auth.NewMockHandler("plain")))
 			},
 			handler: "plain",
@@ -382,7 +382,7 @@ func TestHostDepsFromAuthRegistry_GroupsFunc(t *testing.T) {
 		},
 		{
 			name: "GetGroups returns an error",
-			register: func(reg *auth.Registry) {
+			register: func(t *testing.T, reg *auth.Registry) {
 				require.NoError(t, reg.Register(&mockGroupsHandler{
 					MockHandler: auth.NewMockHandler("entra"),
 					groupErr:    fmt.Errorf("graph API unavailable"),
@@ -396,7 +396,7 @@ func TestHostDepsFromAuthRegistry_GroupsFunc(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reg := auth.NewRegistry()
-			tt.register(reg)
+			tt.register(t, reg)
 
 			deps := HostDepsFromAuthRegistry(reg)
 			require.NotNil(t, deps.AuthGroupsFunc)

--- a/pkg/plugin/grpc_host_groups_test.go
+++ b/pkg/plugin/grpc_host_groups_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/oakwood-commons/scafctl-plugin-sdk/plugin/proto"
+	"github.com/oakwood-commons/scafctl/pkg/auth"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,6 +72,51 @@ func TestHostServiceServer_GetAuthGroups_FuncError(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Contains(t, resp.Error, "graph API unavailable")
+}
+
+// TestHostServiceServer_GetAuthGroups_WiredFromRegistry exercises the full path:
+// deps produced by HostDepsFromAuthRegistry driving the RPC server against a
+// real auth.Registry whose handler implements GroupsProvider.
+func TestHostServiceServer_GetAuthGroups_WiredFromRegistry(t *testing.T) {
+	reg := auth.NewRegistry()
+	require.NoError(t, reg.Register(&mockGroupsHandler{
+		MockHandler: auth.NewMockHandler("entra"),
+		groups:      []string{"g1", "g2", "g3"},
+	}))
+
+	deps := HostDepsFromAuthRegistry(reg)
+	require.NotNil(t, deps)
+	server := &HostServiceServer{Deps: *deps}
+
+	resp, err := server.GetAuthGroups(context.Background(), &proto.GetAuthGroupsRequest{
+		HandlerName: "entra",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Error)
+	assert.Equal(t, []string{"g1", "g2", "g3"}, resp.Groups)
+}
+
+// TestHostServiceServer_GetAuthGroups_WiredFromRegistry_Denied verifies the
+// allowlist gate still blocks a disallowed handler even when the callback is
+// wired from a real registry.
+func TestHostServiceServer_GetAuthGroups_WiredFromRegistry_Denied(t *testing.T) {
+	reg := auth.NewRegistry()
+	require.NoError(t, reg.Register(&mockGroupsHandler{
+		MockHandler: auth.NewMockHandler("entra"),
+		groups:      []string{"g1"},
+	}))
+
+	deps := HostDepsFromAuthRegistry(reg)
+	require.NotNil(t, deps)
+	deps.AllowedAuthHandlers = []string{"github"}
+	server := &HostServiceServer{Deps: *deps}
+
+	resp, err := server.GetAuthGroups(context.Background(), &proto.GetAuthGroupsRequest{
+		HandlerName: "entra",
+	})
+	require.NoError(t, err)
+	assert.Contains(t, resp.Error, "access denied")
+	assert.Nil(t, resp.Groups)
 }
 
 // --- GetAuthGroups client tests ---


### PR DESCRIPTION
## Summary

`HostDepsFromAuthRegistry` never populated `AuthGroupsFunc`, so the `GetAuthGroups` host RPC always returned `"auth groups not available"` for real plugins (the field was set only in tests). This meant the `identity` provider's `operation: groups` — already implemented in the plugin, which calls `GetAuthGroups` — silently failed on the live path.

This wires `AuthGroupsFunc` to resolve the handler (defaulting to the first registered), type-assert it to `auth.GroupsProvider`, and return its paginated `GetGroups` result.

## Why groups stay separate from claims

Group membership is intentionally **not** folded into `Claims`. Microsoft Entra emits a `_claim_names.groups` overage (instead of a `groups` claim) once a user belongs to more than 200 groups, so the full list must be fetched out of band with transparent pagination via the `GroupsProvider` interface. `oid` is unchanged — it is already carried end-to-end as `proto.Claims.ObjectId` and surfaced by the identity plugin as the `objectId` claim.

## Changes

- `pkg/plugin/grpc_host.go`: wire `AuthGroupsFunc` in `HostDepsFromAuthRegistry` (mirrors `AuthIdentityFunc`: empty-handler default resolution, `%w` error wrapping, actionable "GroupsProvider not implemented" error); remove the stale TODO on the field.
- Tests: table-driven closure tests (success, empty membership, empty→default, no handlers, unknown handler, no `GroupsProvider`, `GetGroups` error) and RPC-level wired happy-path + allowlist-denied tests.
- Docs: `docs/design/auth.md`, `docs/design/plugins.md`, and the `provider-development` / `auth-handler-development` tutorials document `GetAuthGroups`, the `GroupsProvider` requirement, and the overage rationale.

## Scope note

This is the complete fix for the `groups` gap: the external `identity` plugin already calls `GetAuthGroups` for `operation: groups` and already surfaces `oid` as the `objectId` claim, so no companion plugin change is required — the only missing piece was this host-side wiring.