### PR TITLE
fix!: make a resolver's declared scalar type authoritative over parameter inference

### DIFF
--- a/docs/design/resolvers.md
+++ b/docs/design/resolvers.md
@@ -194,6 +194,7 @@ When a type is explicitly declared, scafctl will attempt to coerce the resolved 
 - **Array coercion**: Non-array values are wrapped in a single-element array. Already-arrays pass through unchanged. This is useful when a field can accept either a single value or multiple values.
 - **Object coercion**: Accepts any map with string keys. Rejects non-map values (strings, ints, arrays, etc.) with a clear error.
 - **Null coercion**: A null value (whether a Go `nil` or a provider-emitted JSON/CEL null) coerces to the declared type's **zero value** instead of failing -- `""` for `string`, `0` for `int`, `0.0` for `float`, `false` for `bool`, an empty array for `array`, and an empty object for `object`. This lets a typed resolver consume an absent/optional upstream field (e.g. a missing GraphQL or JSON field) and degrade gracefully. A `type: any` (or untyped) resolver leaves null unchanged.
+- **Declared type governs parameter inference**: When a resolver declares a scalar type (`string`, `int`, `float`, `bool`) and reads a `parameter` source under automatic inference, the raw CLI value is coerced **directly** to the declared type rather than being inferred and then re-coerced. The declared type is authoritative (Terraform-style), so `-r version=2.0` for a `type: string` resolver stays `"2.0"` instead of becoming `"2"`. Setting an explicit `type` on the parameter source still overrides this; non-scalar and `any`/untyped resolvers keep normal inference.
 
 ### Type Validation
 

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -2244,10 +2244,10 @@ visible via `scafctl run provider parameter ...` but not in the resolver value.
 
 | Value | Behavior |
 |-------|----------|
-| `auto` | Default. For CLI values, infers booleans, numbers, JSON, and `file://` sources, falling back to the literal string. `http://`/`https://` values are **not** fetched (they stay literal strings -- use `fetch`), and comma-separated values are **not** split into a list (opt in with `csv`). An authored `default` keeps its YAML type under `auto` (a quoted `"false"` stays a string, a bare `false` stays a bool) and is never inferred; use an explicit `type` to coerce a default. |
-| `string` | Coerces the value to a string, stripping surrounding quotes. Use to keep a numeric-looking value (leading zeros, or a value used with CEL `matches()`) as a string. |
+| `auto` | Default. For CLI values, infers booleans, numbers, JSON, and `file://` sources, falling back to the literal string. `http://`/`https://` values are **not** fetched (they stay literal strings -- use `fetch`), and comma-separated values are **not** split into a list (opt in with `csv`). An authored `default` keeps its YAML type under `auto` (a quoted `"false"` stays a string, a bare `false` stays a bool) and is never inferred; use an explicit `type` to coerce a default. When the enclosing resolver declares a scalar output type (`string`/`int`/`float`/`bool`), that declared type is authoritative -- the CLI value is coerced directly to it instead of being inferred and re-coerced (so `-r version=2.0` on a `type: string` resolver stays `"2.0"`). |
+| `string` | Coerces the value to a string, stripping surrounding quotes. Use to keep a numeric-looking value (leading zeros, or a value used with CEL `matches()`) as a string. A resolver that already declares `type: string` gets this automatically under `auto`. |
 | `raw` | Returns the value untouched -- no coercion or quote-stripping. A numeric YAML default stays numeric; a CLI string stays verbatim. The escape hatch to disable inference. |
-| `int` | Forces integer parsing. A non-integer value is an error. |
+| `int` | Forces integer parsing. Whole-number float syntax (e.g. `2.0`) is accepted; a fractional (e.g. `2.5`) or non-numeric value is an error. |
 | `float` | Forces floating-point parsing. A non-numeric value is an error. |
 | `bool` | Forces boolean parsing, accepting only `true`/`false` (case-insensitive). Any other value is an error. |
 | `json` | Parses a string value as JSON. Invalid JSON is an error; non-string values pass through unchanged. |

--- a/docs/tutorials/run-resolver-tutorial.md
+++ b/docs/tutorials/run-resolver-tutorial.md
@@ -1303,14 +1303,24 @@ produces the wrong type -- for example a numeric ID with leading zeros that
 should stay a string, or a value that must be parsed a specific way -- set the
 `type` input to take explicit control.
 
+> [!NOTE]
+> When the **enclosing resolver declares a scalar `type`** (`string`, `int`,
+> `float`, `bool`), that declared type is authoritative under `auto`: the raw
+> CLI value is coerced **directly** to it instead of being inferred and then
+> re-coerced. So a `type: string` resolver keeps `-r version=2.0` as `"2.0"`
+> (not `"2"`) and `-r billingId=00042` as `"00042"` -- you don't need a separate
+> `type: string` on the parameter source. A `type: any` (or untyped) resolver
+> keeps normal inference, and an explicit `type` on the parameter source still
+> wins.
+
 The `type` input accepts these values:
 
 | Type     | Behavior                                                                 |
 | -------- | ------------------------------------------------------------------------ |
-| `auto`   | Default. Infers bool, number, JSON, and `file://` for CLI values; an authored default keeps its YAML type. |
+| `auto`   | Default. Infers bool, number, JSON, and `file://` for CLI values; an authored default keeps its YAML type. When the enclosing resolver declares a scalar type, the CLI value is coerced directly to it. |
 | `string` | Coerces the value to a string (strips surrounding quotes).               |
 | `raw`    | Returns the value exactly as received, with no coercion or quote strip.  |
-| `int`    | Parses the value as an integer; errors if it is not a whole number.      |
+| `int`    | Parses the value as an integer; whole-number float syntax like `2.0` is accepted, but a fractional value like `2.5` errors. |
 | `float`  | Parses the value as a floating-point number; errors on failure.          |
 | `bool`   | Parses `true`/`false` (case-insensitive); errors on any other value.     |
 | `json`   | Parses the value as JSON; errors on invalid JSON.                        |

--- a/examples/resolvers/README.md
+++ b/examples/resolvers/README.md
@@ -31,6 +31,7 @@ This directory contains practical examples demonstrating various resolver patter
 | [validation-conditional-rule.yaml](validation-conditional-rule.yaml) | Rule-level when to skip a validate rule conditionally |
 | [split-resolver-validation.yaml](split-resolver-validation.yaml) | Validate a raw upstream response, then reshape downstream |
 | [null-coercion.yaml](null-coercion.yaml) | Typed resolvers coerce null (absent optional fields) to zero values |
+| [declared-type-coercion.yaml](declared-type-coercion.yaml) | Declared scalar type governs parameter inference (e.g. `type: string` keeps `2.0` verbatim) |
 
 ### CEL Expressions
 

--- a/examples/resolvers/declared-type-coercion.yaml
+++ b/examples/resolvers/declared-type-coercion.yaml
@@ -1,0 +1,87 @@
+# Run: scafctl run resolver -f declared-type-coercion.yaml -r version=2.0 -r build=007 -r replicas=3.0 -o json
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: declared-type-coercion
+  displayName: Declared Type Governs Parameter Coercion
+  category: resolvers
+  tags:
+    - resolver-example
+  description: |
+    A resolver's declared scalar `type` is authoritative over the parameter
+    provider's automatic inference (Terraform-style). Under the default `auto`
+    inference, the raw CLI value is coerced DIRECTLY to the declared type
+    instead of being inferred and then re-coerced -- which is lossy. So a
+    `type: string` resolver keeps `-r version=2.0` as "2.0" instead of the
+    inferred float re-stringified to "2", and a `type: int` resolver accepts
+    whole-number float syntax like "3.0". A `type: any` (or untyped) resolver
+    keeps normal inference, and an explicit `type` on the parameter source
+    still wins.
+
+spec:
+  resolvers:
+    # Declared type:string keeps the raw CLI form verbatim. Without a declared
+    # type, "2.0" would be inferred to the float 2.0 and re-coerced to "2".
+    version:
+      description: Version string that must keep its trailing zero ("2.0")
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: version
+              default: "1.0"
+
+    # Declared type:string preserves leading zeros without a separate
+    # type: string on the parameter source.
+    build:
+      description: Build number that must keep its leading zeros ("007")
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: build
+              default: "001"
+
+    # Declared type:int coerces directly and accepts whole-number float
+    # syntax like "3.0" -> 3 (a fractional value like "3.5" would error).
+    replicas:
+      description: Replica count coerced to an int (whole-number float accepted)
+      type: int
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: replicas
+              default: 1
+
+    # No declared scalar type (any) -> normal auto inference. "2.0" becomes
+    # the float 2.0. Contrast this with the version resolver above.
+    versionInferred:
+      description: Same CLI value, but untyped -- auto inference makes it a float
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: version
+              default: "1.0"
+
+    # Downstream consumer: the declared types above give each field a concrete,
+    # predictable shape, so they compose directly without re-coercion.
+    summary:
+      description: Normalized config assembled from the typed values
+      type: object
+      resolve:
+        with:
+          - provider: cel
+            inputs:
+              expression: |
+                {
+                  "version": _.version,
+                  "build": _.build,
+                  "replicas": _.replicas,
+                  "versionInferred": _.versionInferred,
+                }
+

--- a/pkg/provider/builtin/parameterprovider/parameter.go
+++ b/pkg/provider/builtin/parameterprovider/parameter.go
@@ -39,7 +39,11 @@ const (
 	// is used as-authored under auto (a quoted "false" stays the string "false",
 	// a bare false stays a bool) -- inference and source resolution apply only to
 	// CLI input. http://+https:// values are NOT fetched; use TypeFetch for that.
-	// Comma-separated values are NOT auto-split; use TypeCSV for that.
+	// Comma-separated values are NOT auto-split; use TypeCSV for that. When the
+	// enclosing resolver declares a scalar output type (string/int/float/bool),
+	// a CLI value is coerced directly to that type -- the declared type is
+	// authoritative -- instead of being inferred and then re-coerced (which is
+	// lossy, e.g. "2.0" -> float -> "2" for a string resolver).
 	TypeAuto = "auto"
 	// TypeString forces the value to a string, stripping surrounding quotes and
 	// coercing non-string values to their string representation.
@@ -48,7 +52,9 @@ const (
 	// quote-stripping (a numeric YAML default stays numeric, a CLI string stays
 	// verbatim). This is the "disable inference" escape hatch.
 	TypeRaw = "raw"
-	// TypeInt forces integer parsing; a non-integer value is an error.
+	// TypeInt forces integer parsing. Whole-number float syntax is accepted
+	// (e.g. "2.0" -> 2); a fractional (e.g. "2.5") or non-numeric value is an
+	// error.
 	TypeInt = "int"
 	// TypeFloat forces float parsing; a non-numeric value is an error.
 	TypeFloat = "float"
@@ -205,7 +211,7 @@ func NewParameterProvider(opts ...Option) *ParameterProvider {
 					schemahelper.WithExample(true)),
 				"default": schemahelper.AnyProp("Default value to return when the parameter is not provided via CLI. Only valid in single-key/alias mode; in map mode absent keys are omitted instead, so combining \"default\" with \"all\" or \"as: map\" is an error. Must be a literal value -- ValueRef expressions are resolved by the executor before Execute is called, so a ValueRef default would be evaluated even when the parameter exists. Under \"auto\" the default keeps its authored YAML type (a quoted \"false\" stays the string \"false\", a bare false stays a bool); inference and source resolution (file://) apply only to CLI values. Use an explicit \"type\" to coerce the default.",
 					schemahelper.WithExample("fallback")),
-				"type": schemahelper.StringProp("Controls how the parameter value is coerced. Only valid in single-key/alias mode; in map mode each value is returned with the provider's standard \"auto\" inference. \"auto\" (default) infers booleans, numbers, JSON, and file:// sources for CLI values, falling back to the literal string; an authored default keeps its YAML type under \"auto\" (a quoted \"false\" stays a string) and is never inferred. \"string\" coerces to a string (stripping surrounding quotes). \"raw\" returns the value untouched. \"int\", \"float\", \"bool\", \"json\", and \"csv\" force that specific coercion and error if the value does not match. Comma-separated values are split into a string list only when type is \"csv\". http:// and https:// values are NOT fetched under \"auto\"; use \"fetch\" to perform an SSRF-guarded HTTP GET, or the http provider for anything beyond a plain GET.",
+				"type": schemahelper.StringProp("Controls how the parameter value is coerced. Only valid in single-key/alias mode; in map mode each value is returned with the provider's standard \"auto\" inference. \"auto\" (default) infers booleans, numbers, JSON, and file:// sources for CLI values, falling back to the literal string; an authored default keeps its YAML type under \"auto\" (a quoted \"false\" stays a string) and is never inferred. Under \"auto\", when the enclosing resolver declares a scalar output type (string/int/float/bool), a CLI value is coerced directly to that declared type instead of being inferred (so \"2.0\" stays \"2.0\" for a string resolver); an explicit \"type\" here overrides that. \"string\" coerces to a string (stripping surrounding quotes). \"raw\" returns the value untouched. \"int\" parses an integer and also accepts whole-number float strings (\"2.0\" -> 2), erroring on fractional or non-numeric values. \"float\", \"bool\", \"json\", and \"csv\" force that specific coercion and error if the value does not match. Comma-separated values are split into a string list only when type is \"csv\". http:// and https:// values are NOT fetched under \"auto\"; use \"fetch\" to perform an SSRF-guarded HTTP GET, or the http provider for anything beyond a plain GET.",
 					schemahelper.WithEnum(paramTypeEnum...),
 					schemahelper.WithExample(TypeString)),
 			}),
@@ -445,6 +451,15 @@ func (p *ParameterProvider) resolveValue(ctx context.Context, value any, paramTy
 		}
 		return p.fetchURL(ctx, str)
 	case TypeAuto:
+		// When the enclosing resolver declares a scalar output type, coerce the
+		// raw CLI string directly to that type (Terraform-style: the declared
+		// type is authoritative) instead of inferring and then re-coercing,
+		// which is lossy (e.g. "2.0" -> float -> "2" for a string resolver).
+		if declared, ok := provider.DeclaredScalarTypeFromContext(ctx); ok {
+			if pt, mapped := resolverTypeToParamType(declared); mapped {
+				return p.resolveValue(ctx, value, pt)
+			}
+		}
 		return p.parseValue(ctx, value)
 	default:
 		return nil, fmt.Errorf("%s: unsupported type %q", ProviderName, paramType)
@@ -490,11 +505,19 @@ func coerceString(value any) string {
 func coerceInt(value any) (any, error) {
 	switch v := value.(type) {
 	case string:
-		n, err := strconv.ParseInt(strings.TrimSpace(unquote(v)), 10, 64)
-		if err != nil {
-			return nil, fmt.Errorf("cannot parse %q as int", v)
+		s := strings.TrimSpace(unquote(v))
+		if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return n, nil
 		}
-		return n, nil
+		// Accept whole-number float strings (e.g. "2.0" -> 2), mirroring the
+		// float64 branch below. Reject fractional or out-of-range values.
+		if f, err := strconv.ParseFloat(s, 64); err == nil {
+			if f == math.Trunc(f) && float64(int64(f)) == f {
+				return int64(f), nil
+			}
+			return nil, fmt.Errorf("cannot represent %v as int without loss", v)
+		}
+		return nil, fmt.Errorf("cannot parse %q as int", v)
 	case int:
 		return int64(v), nil
 	case int8:
@@ -765,6 +788,26 @@ func (p *ParameterProvider) executeDryRun(key, paramType string) (*provider.Outp
 	}, nil
 }
 
+// resolverTypeToParamType maps a resolver's declared scalar output type
+// (canonical or aliased) to the parameter provider's coercion type. It returns
+// ("", false) for non-scalar or unknown types, in which case the caller keeps
+// automatic inference. This lets a declared resolver type govern how a raw CLI
+// string is coerced instead of the provider guessing and then re-coercing.
+func resolverTypeToParamType(declared string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(declared)) {
+	case "string":
+		return TypeString, true
+	case "int", "integer":
+		return TypeInt, true
+	case "float", "number":
+		return TypeFloat, true
+	case "bool", "boolean":
+		return TypeBool, true
+	default:
+		return "", false
+	}
+}
+
 // resolveParamType returns the requested parameter value type from the inputs,
 // defaulting to TypeAuto when "type" is absent. The provider schema constrains
 // "type" to the values in paramTypes, so this mirrors that validation for
@@ -907,6 +950,13 @@ func resolveMapMode(inputs map[string]any) (mapMode, allMode bool, err error) {
 // (and, in keys mode, the requested-but-absent list) is reported in metadata;
 // the resolver value is the bare map.
 func (p *ParameterProvider) executeMapGet(ctx context.Context, lgr *logr.Logger, rawKeys any, allMode bool) (*provider.Output, error) {
+	// Map mode returns each value with the provider's standard auto inference
+	// (an explicit "type" input is already rejected upstream). The enclosing
+	// resolver's declared scalar type describes the aggregate output, not each
+	// element, so clear it here to keep per-element inference from being
+	// governed by it.
+	ctx = provider.WithDeclaredScalarType(ctx, "")
+
 	params, ok := provider.ParametersFromContext(ctx)
 	if !ok {
 		params = make(map[string]any)

--- a/pkg/provider/builtin/parameterprovider/parameter.go
+++ b/pkg/provider/builtin/parameterprovider/parameter.go
@@ -510,12 +510,15 @@ func coerceInt(value any) (any, error) {
 			return n, nil
 		}
 		// Accept whole-number float strings (e.g. "2.0" -> 2), mirroring the
-		// float64 branch below. Reject fractional or out-of-range values.
+		// float64 branch below. Reject fractional, non-finite, or out-of-range
+		// values: int64(f) is implementation-defined when f is Inf/NaN or outside
+		// the int64 range, so guard explicitly before converting.
 		if f, err := strconv.ParseFloat(s, 64); err == nil {
-			if f == math.Trunc(f) && float64(int64(f)) == f {
-				return int64(f), nil
+			if math.IsInf(f, 0) || math.IsNaN(f) || f != math.Trunc(f) ||
+				f < float64(math.MinInt64) || f >= float64(math.MaxInt64) {
+				return nil, fmt.Errorf("cannot represent %v as int without loss", v)
 			}
-			return nil, fmt.Errorf("cannot represent %v as int without loss", v)
+			return int64(f), nil
 		}
 		return nil, fmt.Errorf("cannot parse %q as int", v)
 	case int:

--- a/pkg/provider/builtin/parameterprovider/parameter_benchmark_test.go
+++ b/pkg/provider/builtin/parameterprovider/parameter_benchmark_test.go
@@ -116,3 +116,39 @@ func BenchmarkParameterProvider_Execute_TypedCoercion(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkParameterProvider_Execute_DeclaredType measures the auto path when
+// the enclosing resolver declares a scalar output type, which triggers the
+// declared-type context lookup and re-dispatch in resolveValue (and the
+// whole-number-float fallback in coerceInt for the int case).
+func BenchmarkParameterProvider_Execute_DeclaredType(b *testing.B) {
+	p := NewParameterProvider()
+
+	cases := []struct {
+		name     string
+		value    any
+		declared string
+	}{
+		{"declared_string", "2.0", "string"},
+		{"declared_int_whole_float", "2.0", "int"},
+		{"declared_int_fast", "8080", "int"},
+		{"declared_float", "3.14", "float"},
+		{"declared_none_auto", "8080", ""},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			ctx := provider.WithParameters(context.Background(), map[string]any{
+				"val": tc.value,
+			})
+			ctx = provider.WithDeclaredScalarType(ctx, tc.declared)
+			inputs := map[string]any{"key": "val"}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				_, _ = p.Execute(ctx, inputs)
+			}
+		})
+	}
+}

--- a/pkg/provider/builtin/parameterprovider/parameter_test.go
+++ b/pkg/provider/builtin/parameterprovider/parameter_test.go
@@ -1650,6 +1650,11 @@ func TestCoerceInt_WholeFloatString(t *testing.T) {
 		{"plain int string", "5", 5, false},
 		{"fractional string errors", "2.5", 0, true},
 		{"non-numeric errors", "abc", 0, true},
+		{"positive infinity errors", "Inf", 0, true},
+		{"negative infinity errors", "-Inf", 0, true},
+		{"nan errors", "NaN", 0, true},
+		{"whole float above int64 range errors", "1e19", 0, true},
+		{"whole float below int64 range errors", "-1e19", 0, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/provider/builtin/parameterprovider/parameter_test.go
+++ b/pkg/provider/builtin/parameterprovider/parameter_test.go
@@ -1520,3 +1520,146 @@ func TestToStringKeys(t *testing.T) {
 		})
 	}
 }
+
+func TestResolverTypeToParamType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		declared string
+		want     string
+		wantOK   bool
+	}{
+		{"string", "string", TypeString, true},
+		{"int", "int", TypeInt, true},
+		{"integer alias", "integer", TypeInt, true},
+		{"float", "float", TypeFloat, true},
+		{"number alias", "number", TypeFloat, true},
+		{"bool", "bool", TypeBool, true},
+		{"boolean alias", "boolean", TypeBool, true},
+		{"mixed case", "String", TypeString, true},
+		{"whitespace", "  int  ", TypeInt, true},
+		{"array not scalar", "array", "", false},
+		{"object not scalar", "object", "", false},
+		{"any not scalar", "any", "", false},
+		{"time not scalar", "time", "", false},
+		{"empty", "", "", false},
+		{"unknown", "weird", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := resolverTypeToParamType(tt.declared)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParameterProvider_Execute_DeclaredScalarType(t *testing.T) {
+	tests := []struct {
+		name     string
+		declared string
+		raw      any
+		want     any
+		wantErr  bool
+	}{
+		// Declared string keeps the raw CLI string verbatim (no lossy inference).
+		{"string 2.0 stays 2.0", "string", "2.0", "2.0", false},
+		{"string 1.10 stays 1.10", "string", "1.10", "1.10", false},
+		{"string 007 stays 007", "string", "007", "007", false},
+		{"string true stays true", "string", "true", "true", false},
+		// Declared float coerces a bare int string to a float.
+		{"float 2 becomes 2.0", "float", "2", 2.0, false},
+		// Declared bool coerces.
+		{"bool false becomes false", "bool", "false", false, false},
+		// Declared int coerces, including whole-number float strings.
+		{"int 2 becomes 2", "int", "2", int64(2), false},
+		{"int 2.0 becomes 2", "int", "2.0", int64(2), false},
+		{"int 2.5 errors", "int", "2.5", nil, true},
+		// Non-scalar declared types fall back to auto inference.
+		{"array falls back to inference", "array", "2.0", float64(2.0), false},
+		{"object falls back to inference", "object", "2.0", float64(2.0), false},
+		{"any falls back to inference", "any", "2.0", float64(2.0), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewParameterProvider()
+			ctx := provider.WithParameters(context.Background(), map[string]any{
+				"version": tt.raw,
+			})
+			ctx = provider.WithDeclaredScalarType(ctx, tt.declared)
+
+			output, err := p.Execute(ctx, map[string]any{"key": "version"})
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, output)
+			assert.Equal(t, tt.want, output.Data)
+		})
+	}
+}
+
+// TestParameterProvider_Execute_ExplicitTypeWinsOverDeclared verifies that an
+// explicit provider "type:" input takes precedence over the resolver's declared
+// scalar type (the declared type only governs the default auto path).
+func TestParameterProvider_Execute_ExplicitTypeWinsOverDeclared(t *testing.T) {
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{
+		"version": "2.0",
+	})
+	ctx = provider.WithDeclaredScalarType(ctx, "string")
+
+	// type: raw returns the value untouched, ignoring the declared "string".
+	output, err := p.Execute(ctx, map[string]any{"key": "version", "type": TypeRaw})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	assert.Equal(t, "2.0", output.Data)
+}
+
+// TestParameterProvider_Execute_MapModeIgnoresDeclaredType verifies map mode
+// (all: true) uses standard auto inference per element and is not governed by
+// the enclosing resolver's declared scalar type, which describes the aggregate
+// output rather than each element.
+func TestParameterProvider_Execute_MapModeIgnoresDeclaredType(t *testing.T) {
+	p := NewParameterProvider()
+	ctx := provider.WithParameters(context.Background(), map[string]any{
+		"version": "2.0",
+	})
+	// A declared "string" must not force each element to a string.
+	ctx = provider.WithDeclaredScalarType(ctx, "string")
+
+	output, err := p.Execute(ctx, map[string]any{"all": true})
+	require.NoError(t, err)
+	require.NotNil(t, output)
+	m, ok := output.Data.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(2.0), m["version"], "map mode must auto-infer, not honor the declared scalar type")
+}
+
+func TestCoerceInt_WholeFloatString(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   any
+		want    int64
+		wantErr bool
+	}{
+		{"whole float string", "2.0", 2, false},
+		{"whole float string negative", "-3.0", -3, false},
+		{"plain int string", "5", 5, false},
+		{"fractional string errors", "2.5", 0, true},
+		{"non-numeric errors", "abc", 0, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := coerceInt(tt.value)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/provider/context.go
+++ b/pkg/provider/context.go
@@ -177,6 +177,29 @@ func ExecutionSettingsFromContext(ctx context.Context) (map[string]json.RawMessa
 	return settings, ok
 }
 
+// declaredScalarTypeKey is a scafctl-only context key carrying the enclosing
+// resolver's declared scalar output type (string/int/float/bool). The builtin
+// parameter provider consults it so a raw CLI string is coerced directly to the
+// intended type instead of being inferred and then re-coerced (which loses e.g.
+// the trailing ".0" of "2.0" when the declared type is string).
+const declaredScalarTypeKey scafctlContextKey = "scafctl.provider.declaredScalarType"
+
+// WithDeclaredScalarType returns a new context carrying the enclosing resolver's
+// declared scalar output type. An empty string clears/omits it.
+func WithDeclaredScalarType(ctx context.Context, t string) context.Context {
+	return context.WithValue(ctx, declaredScalarTypeKey, t)
+}
+
+// DeclaredScalarTypeFromContext retrieves the declared scalar output type.
+// Returns the type and true when a non-empty one was set, "" and false otherwise.
+func DeclaredScalarTypeFromContext(ctx context.Context) (string, bool) {
+	t, ok := ctx.Value(declaredScalarTypeKey).(string)
+	if !ok || t == "" {
+		return "", false
+	}
+	return t, true
+}
+
 // TemplateFuncBinder supplies solution-author-defined Go template helper
 // functions to the go-template provider. It is implemented by the authorfuncs
 // library compiled from a solution's spec.functions. Keeping the provider layer

--- a/pkg/provider/context_test.go
+++ b/pkg/provider/context_test.go
@@ -388,3 +388,47 @@ func TestWithExecutionSettings_Nil(t *testing.T) {
 	assert.True(t, ok)
 	assert.Nil(t, got)
 }
+
+func TestWithDeclaredScalarType_AndFromContext(t *testing.T) {
+	tests := []struct {
+		name    string
+		set     string
+		wantVal string
+		wantOK  bool
+	}{
+		{"string", "string", "string", true},
+		{"int", "int", "int", true},
+		{"float", "float", "float", true},
+		{"bool", "bool", "bool", true},
+		{"empty clears", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := WithDeclaredScalarType(context.Background(), tt.set)
+			got, ok := DeclaredScalarTypeFromContext(ctx)
+			assert.Equal(t, tt.wantOK, ok)
+			assert.Equal(t, tt.wantVal, got)
+		})
+	}
+}
+
+func TestDeclaredScalarTypeFromContext_NotSet(t *testing.T) {
+	got, ok := DeclaredScalarTypeFromContext(context.Background())
+	assert.False(t, ok)
+	assert.Equal(t, "", got)
+}
+
+func BenchmarkWithDeclaredScalarType(b *testing.B) {
+	ctx := context.Background()
+	for i := 0; i < b.N; i++ {
+		_ = WithDeclaredScalarType(ctx, "string")
+	}
+}
+
+func BenchmarkDeclaredScalarTypeFromContext(b *testing.B) {
+	ctx := WithDeclaredScalarType(context.Background(), "string")
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = DeclaredScalarTypeFromContext(ctx)
+	}
+}

--- a/pkg/resolver/executor.go
+++ b/pkg/resolver/executor.go
@@ -835,12 +835,13 @@ func (e *Executor) executeResolver(ctx context.Context, r *Resolver, phaseNum in
 	// Propagate the resolver's declared scalar output type into the resolve
 	// phase only, so the parameter provider can coerce a raw CLI string
 	// directly to the intended type instead of guessing (avoids lossy
-	// "2.0" -> float -> "2"). Non-scalar and "any"/unset types are left for the
-	// provider's normal auto inference. Scoping this to the resolve phase keeps
-	// it from governing intermediate parameter reads inside a transform, whose
-	// values are not the resolver's output contract.
+	// "2.0" -> float -> "2"). Only scalar types (string/int/float/bool) are
+	// propagated -- composite/temporal/any types keep the provider's normal
+	// auto inference. Scoping this to the resolve phase keeps it from governing
+	// intermediate parameter reads inside a transform, whose values are not the
+	// resolver's output contract.
 	resolveContext := resolverContext
-	if r.Type != "" && r.Type != TypeAny {
+	if r.Type.IsScalar() {
 		resolveContext = provider.WithDeclaredScalarType(resolverContext, string(r.Type))
 	}
 	value, providerCalls, err := e.executeResolvePhase(resolveContext, r.Resolve)

--- a/pkg/resolver/executor.go
+++ b/pkg/resolver/executor.go
@@ -832,7 +832,18 @@ func (e *Executor) executeResolver(ctx context.Context, r *Resolver, phaseNum in
 
 	// Execute resolve phase
 	phaseStart := time.Now()
-	value, providerCalls, err := e.executeResolvePhase(resolverContext, r.Resolve)
+	// Propagate the resolver's declared scalar output type into the resolve
+	// phase only, so the parameter provider can coerce a raw CLI string
+	// directly to the intended type instead of guessing (avoids lossy
+	// "2.0" -> float -> "2"). Non-scalar and "any"/unset types are left for the
+	// provider's normal auto inference. Scoping this to the resolve phase keeps
+	// it from governing intermediate parameter reads inside a transform, whose
+	// values are not the resolver's output contract.
+	resolveContext := resolverContext
+	if r.Type != "" && r.Type != TypeAny {
+		resolveContext = provider.WithDeclaredScalarType(resolverContext, string(r.Type))
+	}
+	value, providerCalls, err := e.executeResolvePhase(resolveContext, r.Resolve)
 	providerCallCount += providerCalls
 	result.PhaseMetrics = append(result.PhaseMetrics, PhaseMetrics{
 		Phase:    "resolve",

--- a/pkg/resolver/executor_test.go
+++ b/pkg/resolver/executor_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/parameterprovider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -2261,4 +2262,118 @@ func TestExecutor_WriteOperationGuard_AllowsReadInResolver(t *testing.T) {
 	results, err := executor.Execute(ctx, resolvers, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, results)
+}
+
+// TestExecutor_Execute_DeclaredTypeGovernsParameterCoercion verifies the
+// declared scalar output type is authoritative over the parameter provider's
+// auto inference: a CLI value "2.0" resolved by a type:string resolver stays
+// "2.0" (no lossy float round-trip), while a type:any resolver still infers a
+// float.
+func TestExecutor_Execute_DeclaredTypeGovernsParameterCoercion(t *testing.T) {
+	tests := []struct {
+		name         string
+		resolverType Type
+		want         any
+	}{
+		{"string keeps 2.0 verbatim", TypeString, "2.0"},
+		{"any infers float", TypeAny, float64(2.0)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := newMockRegistry()
+			require.NoError(t, registry.Register(parameterprovider.NewParameterProvider()))
+
+			executor := NewExecutor(registry)
+			resolvers := []*Resolver{
+				{
+					Name: "version",
+					Type: tt.resolverType,
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{
+							{
+								Provider: "parameter",
+								Inputs: map[string]*ValueRef{
+									"key": {Literal: "version"},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			ctx := context.Background()
+			ctx, err := executor.Execute(ctx, resolvers, map[string]any{
+				"version": "2.0",
+			})
+			require.NoError(t, err)
+
+			result, _ := FromContext(ctx)
+			require.NotNil(t, result)
+			value, ok := result.Get("version")
+			require.True(t, ok)
+			assert.Equal(t, tt.want, value)
+		})
+	}
+}
+
+// TestExecutor_Execute_DeclaredTypeScopedToResolvePhase verifies the declared
+// scalar type is propagated into the resolve phase only, not the transform
+// phase. A parameter read inside a transform must use the provider's normal
+// auto inference, because a mid-chain value is not the resolver's output
+// contract.
+func TestExecutor_Execute_DeclaredTypeScopedToResolvePhase(t *testing.T) {
+	registry := newMockRegistry()
+
+	var resolveDeclared, transformDeclared string
+	var resolveOK, transformOK bool
+
+	// A capturing provider records the declared scalar type visible in whichever
+	// phase invokes it.
+	capture := &mockProvider{
+		name: "capture",
+		executeFunc: func(ctx context.Context, inputs map[string]any) (*provider.Output, error) {
+			phase, _ := inputs["phase"].(string)
+			declared, ok := provider.DeclaredScalarTypeFromContext(ctx)
+			switch phase {
+			case "resolve":
+				resolveDeclared, resolveOK = declared, ok
+			case "transform":
+				transformDeclared, transformOK = declared, ok
+			}
+			return &provider.Output{Data: "x"}, nil
+		},
+	}
+	require.NoError(t, registry.Register(capture))
+
+	executor := NewExecutor(registry)
+	resolvers := []*Resolver{
+		{
+			Name: "value",
+			Type: TypeString,
+			Resolve: &ResolvePhase{
+				With: []ProviderSource{
+					{
+						Provider: "capture",
+						Inputs:   map[string]*ValueRef{"phase": {Literal: "resolve"}},
+					},
+				},
+			},
+			Transform: &TransformPhase{
+				With: []ProviderTransform{
+					{
+						Provider: "capture",
+						Inputs:   map[string]*ValueRef{"phase": {Literal: "transform"}},
+					},
+				},
+			},
+		},
+	}
+
+	_, err := executor.Execute(context.Background(), resolvers, nil)
+	require.NoError(t, err)
+
+	assert.True(t, resolveOK, "declared scalar type must be visible in the resolve phase")
+	assert.Equal(t, string(TypeString), resolveDeclared)
+	assert.False(t, transformOK, "declared scalar type must NOT leak into the transform phase")
+	assert.Empty(t, transformDeclared)
 }

--- a/pkg/resolver/executor_test.go
+++ b/pkg/resolver/executor_test.go
@@ -2377,3 +2377,65 @@ func TestExecutor_Execute_DeclaredTypeScopedToResolvePhase(t *testing.T) {
 	assert.False(t, transformOK, "declared scalar type must NOT leak into the transform phase")
 	assert.Empty(t, transformDeclared)
 }
+
+// TestExecutor_Execute_DeclaredTypeOnlyForScalarTypes verifies the declared
+// type is propagated into the resolve phase only for scalar types
+// (string/int/float/bool). Composite, temporal, and any/untyped resolvers must
+// not carry a declared scalar type, keeping the parameter provider on its
+// normal auto inference.
+func TestExecutor_Execute_DeclaredTypeOnlyForScalarTypes(t *testing.T) {
+	tests := []struct {
+		name         string
+		resolverType Type
+		wantOK       bool
+		wantDeclared string
+	}{
+		{"string is scalar", TypeString, true, string(TypeString)},
+		{"int is scalar", TypeInt, true, string(TypeInt)},
+		{"float is scalar", TypeFloat, true, string(TypeFloat)},
+		{"bool is scalar", TypeBool, true, string(TypeBool)},
+		{"array is not scalar", TypeArray, false, ""},
+		{"object is not scalar", TypeObject, false, ""},
+		{"time is not scalar", TypeTime, false, ""},
+		{"duration is not scalar", TypeDuration, false, ""},
+		{"any is not scalar", TypeAny, false, ""},
+		{"unset is not scalar", Type(""), false, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := newMockRegistry()
+
+			var gotDeclared string
+			var gotOK bool
+			capture := &mockProvider{
+				name: "capture",
+				executeFunc: func(ctx context.Context, _ map[string]any) (*provider.Output, error) {
+					gotDeclared, gotOK = provider.DeclaredScalarTypeFromContext(ctx)
+					// Return a value compatible with every declared type so
+					// coercion never fails and masks the assertion.
+					return &provider.Output{Data: nil}, nil
+				},
+			}
+			require.NoError(t, registry.Register(capture))
+
+			executor := NewExecutor(registry)
+			resolvers := []*Resolver{
+				{
+					Name: "value",
+					Type: tt.resolverType,
+					Resolve: &ResolvePhase{
+						With: []ProviderSource{
+							{Provider: "capture"},
+						},
+					},
+				},
+			}
+
+			_, err := executor.Execute(context.Background(), resolvers, nil)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantOK, gotOK)
+			assert.Equal(t, tt.wantDeclared, gotDeclared)
+		})
+	}
+}

--- a/pkg/resolver/resolver.go
+++ b/pkg/resolver/resolver.go
@@ -23,6 +23,7 @@ const (
 	TypeFloat    = spec.TypeFloat
 	TypeBool     = spec.TypeBool
 	TypeArray    = spec.TypeArray
+	TypeObject   = spec.TypeObject
 	TypeTime     = spec.TypeTime
 	TypeDuration = spec.TypeDuration
 	TypeAny      = spec.TypeAny

--- a/pkg/spec/types.go
+++ b/pkg/spec/types.go
@@ -29,6 +29,22 @@ const (
 	TypeAny      Type = "any"
 )
 
+// IsScalar reports whether t is one of the scalar value types
+// (string, int, float, bool). Composite types (array, object), the temporal
+// types (time, duration), and TypeAny are not scalar. Callers use this to
+// gate scalar-only behavior such as the parameter provider's declared-type
+// coercion.
+func (t Type) IsScalar() bool {
+	switch t {
+	case TypeString, TypeInt, TypeFloat, TypeBool:
+		return true
+	case TypeArray, TypeObject, TypeTime, TypeDuration, TypeAny:
+		return false
+	default:
+		return false
+	}
+}
+
 // CoerceType attempts to coerce a value to the specified type.
 // Returns the coerced value or an error if coercion is not possible.
 func CoerceType(value any, targetType Type) (any, error) {

--- a/pkg/spec/types_test.go
+++ b/pkg/spec/types_test.go
@@ -530,3 +530,28 @@ func TestCoerceType_Bool_EdgeCases(t *testing.T) {
 	_, err = CoerceType(map[string]any{"k": "v"}, TypeBool)
 	assert.Error(t, err)
 }
+
+// TestType_IsScalar verifies only the scalar value types report true.
+func TestType_IsScalar(t *testing.T) {
+	tests := []struct {
+		typ  Type
+		want bool
+	}{
+		{TypeString, true},
+		{TypeInt, true},
+		{TypeFloat, true},
+		{TypeBool, true},
+		{TypeArray, false},
+		{TypeObject, false},
+		{TypeTime, false},
+		{TypeDuration, false},
+		{TypeAny, false},
+		{Type(""), false},
+		{Type("bogus"), false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.typ), func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.typ.IsScalar())
+		})
+	}
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -6846,6 +6846,27 @@ func TestIntegration_SolutionResolver_AuthProviderUnavailable(t *testing.T) {
 	assert.Contains(t, stderr, "nonexistent-handler-xyz", "error should reference the missing handler name")
 }
 
+// TestIntegration_SolutionResolver_DeclaredTypeGovernsParameterCoercion is the
+// regression test for issue-17: a type:string resolver reading a parameter
+// source must keep the raw CLI value "2.0" verbatim instead of inferring a
+// float and re-coercing it to "2".
+func TestIntegration_SolutionResolver_DeclaredTypeGovernsParameterCoercion(t *testing.T) {
+	t.Parallel()
+	stdout, stderr, exitCode := runScafctl(t,
+		"run", "resolver",
+		"-f", "tests/integration/solutions/resolvers/declared-type-coercion/solution.yaml",
+		"-r", "version=2.0",
+		"-o", "json",
+	)
+	t.Logf("stdout: %s", stdout)
+	t.Logf("stderr: %s", stderr)
+	require.Equal(t, 0, exitCode, "expected exit code 0, got %d", exitCode)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &decoded), "stdout must be valid JSON")
+	assert.Equal(t, "2.0", decoded["version"], "declared type:string must keep the raw CLI value verbatim")
+}
+
 // ============================================================================
 // Bundle Command Tests
 // ============================================================================

--- a/tests/integration/solutions/resolvers/declared-type-coercion/solution.yaml
+++ b/tests/integration/solutions/resolvers/declared-type-coercion/solution.yaml
@@ -1,0 +1,22 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: test-resolver-declared-type-coercion
+  version: 1.0.0
+  description: |
+    Regression fixture for issue-17: a resolver's declared scalar type is
+    authoritative over the parameter provider's auto inference. A CLI value
+    like "2.0" resolved by a type:string resolver must stay "2.0" instead of
+    being inferred to a float and re-coerced to "2".
+
+spec:
+  resolvers:
+    version:
+      description: String parameter that must keep its raw CLI form verbatim
+      type: string
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: version


### PR DESCRIPTION
A `type: string` resolver reading a `parameter` source under automatic
inference lost precision: the raw CLI string was inferred to a typed value and
then re-coerced, so `-r version=2.0` became `"2"` (and `"1.10"` -> `"1.1"`,
`"007"` -> `"7"`). The loss happens at the inference step, so it cannot be fixed
at stringification.

Adopt the Terraform model: when a resolver declares a scalar output type
(`string`/`int`/`float`/`bool`), the declared type is authoritative under
`auto` and the raw CLI value is coerced DIRECTLY to it instead of being
inferred and re-coerced. The executor propagates the declared type into the
resolve phase only (not transform/validate, whose intermediate values are not
the resolver's output contract), via a scafctl-only context value the builtin
parameter provider consults. `type: any`/untyped resolvers keep normal
inference, an explicit `type` on the parameter source still wins, and map mode
(`all: true` / `keys` + `as: map`) is unaffected (the declared type describes
the aggregate, not each element).

Also enhance `int` coercion to accept whole-number float syntax (`"2.0"` -> 2),
rejecting fractional values (`"2.5"`), mirroring the existing float branch.

BREAKING CHANGE: parameter values feeding a typed resolver now coerce to the
declared type instead of being inferred first. A `type: string` resolver keeps
the raw CLI form verbatim (`-r version=2.0` stays `"2.0"`, not `"2"`;
`-r id=007` stays `"007"`), and a `type: int` resolver accepts whole-number
float strings (`"2.0"` -> 2). Solutions that relied on the old lossy inference
will see different (correct) values.

Fixes #17
