### PR TITLE
feat: add render solution --effective for composed solution fidelity

### DIFF
--- a/docs/design/_index.md
+++ b/docs/design/_index.md
@@ -15,6 +15,7 @@ Architecture and design documentation for scafctl.
 - [Providers](providers.md) — Provider framework design
 - [Parameterized Provider Calls](parameterized-calls.md) — Reusable, argument-driven call definitions (`spec.calls`)
 - [Actions](actions.md) — Actions system design
+- [Effective Solution Rendering](effective-solution-render.md) — Deterministic post-compose document rendering for fidelity diffing
 - [Authentication](auth.md) — Authentication architecture
 - [CEL Integration](cel.md) — CEL expression language integration
 - [Go-Template Embedder Functions](gotmpl-embedder-funcs.md) -- Registering custom Go-template functions from an embedder

--- a/docs/design/effective-solution-render.md
+++ b/docs/design/effective-solution-render.md
@@ -1,0 +1,135 @@
+---
+title: "Effective Solution Rendering"
+weight: 19
+---
+
+# Effective Solution Rendering
+
+## Overview
+
+`scafctl render solution --effective` emits the **effective** solution document:
+the fully-composed, canonicalized solution as it exists after `compose:` partials
+are merged, serialized deterministically to YAML or JSON. It performs **no
+resolver execution and no provider calls** -- it is a pure document transform.
+
+This gives users a stable, diffable view of "what solution am I actually running"
+when a solution is split across multiple files via the `compose:` field. It is the
+scafctl analogue of `docker compose config`, `helm template`, and
+`kustomize build`: tools that render the merged/effective configuration document
+without applying it.
+
+## Problem Statement
+
+The `compose:` feature (see [Solutions](solutions.md)) lets authors split a
+solution across multiple partial YAML files that are merged at load time. This is
+good for organization but creates a visibility and fidelity gap:
+
+1. **No canonical view of the merged result.** Nothing prints the post-compose
+   document. `inspect solution` is a lossy projection (metadata summary),
+   `render solution` (default/`--action-graph`/`--snapshot`) all **execute
+   resolvers** and emit an execution plan -- not the source document.
+2. **No fidelity check for composition.** When a solution is refactored (e.g.
+   inlining a partial, or reorganizing which file a resolver lives in), there is
+   no cheap, deterministic way to prove the *effective* solution did not change.
+   `diff solution` compares actions shallowly (name + provider + description) and
+   still requires two solution files rather than a golden artifact.
+3. **Hard to review composition in CI.** Reviewers cannot see the net effect of a
+   compose change without mentally merging the partials.
+
+## Design
+
+### Command surface
+
+```
+scafctl render solution --effective [--section all|workflow|resolvers] [-o yaml|json] [--compact]
+```
+
+- `--effective` -- select effective-document mode. Mutually exclusive with
+  `--action-graph` and `--snapshot`.
+- `--section` -- scope the output (only valid with `--effective`):
+  - `all` (default) -- the whole composed solution document.
+  - `workflow` -- only `spec.workflow`.
+  - `resolvers` -- only `spec.resolvers`.
+- `-o yaml` (default) or `-o json`. `-o test` is rejected in this mode.
+- `--compact` -- single-line JSON (JSON only).
+
+### Domain package
+
+Business logic lives in the domain package `pkg/solution/effective`, not in the
+CLI command (per the repository's layering rules). The CLI handler and the MCP
+tool are both thin wrappers over it.
+
+```go
+// pkg/solution/effective
+func Render(sol *solution.Solution, opts Options) ([]byte, error)
+
+type Options struct {
+    Section Section // all | workflow | resolvers
+    Format  Format  // yaml | json
+    Compact bool
+}
+```
+
+`Render` projects the requested section out of the already-loaded (already
+composed) `*solution.Solution` and marshals it. It never resolves, never dials a
+provider, and never touches the filesystem beyond the initial load performed by
+the caller.
+
+### Why no execution
+
+The value of this feature is fidelity, and fidelity requires determinism.
+Executing resolvers would make output depend on environment, time, network, and
+provider state -- defeating golden-file comparison. Compose merging is a pure,
+deterministic transform, so the effective document is a pure function of the
+input files.
+
+### Determinism guarantee
+
+Both `gopkg.in/yaml.v3` and `encoding/json` marshal Go maps in sorted-key order
+and structs in field-declaration order, so the serialized output is byte-stable
+for a given input. `compose:` merges resolvers and actions **by name** (rejecting
+duplicates) into maps, and the merged result clears its own `compose:` field
+(the document is self-contained). The `Deterministic` test asserts repeated
+renders of every section/format combination are byte-identical.
+
+## Fidelity workflow
+
+The intended use is golden-file diffing in CI:
+
+```bash
+# Capture the effective document as a golden artifact (once, reviewed).
+scafctl render solution -f ./solution.yaml --effective -o yaml > golden.effective.yaml
+
+# In CI, regenerate and diff. A non-empty diff means composition changed.
+scafctl render solution -f ./solution.yaml --effective -o yaml \
+  | diff -u golden.effective.yaml -
+```
+
+Because the output is deterministic, any change to the merged solution --
+including one introduced by editing a `compose:` partial -- shows up as a diff,
+while pure reorganizations that do not change the effective document produce no
+diff.
+
+## MCP tool
+
+The `render_effective_solution` MCP tool exposes the same capability to agents:
+inputs `path`, `section` (`all|workflow|resolvers`), `format` (`yaml|json`), and
+`cwd`; it returns the rendered document as text. It is marked read-only and
+non-open-world (no network, no execution).
+
+## Alternatives considered
+
+- **Deepen `diff solution` instead.** Making `diff solution` compare full action
+  bodies would help two-file comparisons but still would not produce a stable
+  golden artifact, and it conflates "compare two solutions" with "snapshot one
+  solution." Deepening the diff is a worthwhile but **separate** change.
+- **Add a `mode: effective` to the existing action-graph renderer.** Rejected:
+  the action-graph renderer executes resolvers by construction; bolting a
+  no-execution path onto it would blur its contract. A dedicated flag and domain
+  package keep the two behaviors clearly separated.
+
+## Out of scope
+
+- Deepening `diff solution` field-level comparison.
+- Resolving/normalizing expression values (the effective document keeps
+  expressions verbatim; it is a source-fidelity view, not an evaluated one).

--- a/examples/README.md
+++ b/examples/README.md
@@ -165,6 +165,7 @@ Complete solutions demonstrating real-world use cases.
 |---------|-------------|
 | [comprehensive/](solutions/comprehensive/) | Full-featured solution with all capabilities |
 | [composition/](solutions/composition/) | Parent solution composes a child via the `solution` provider, including the child-opt-in value override contract |
+| [compose-fidelity/](solutions/compose-fidelity/) | Golden-file fidelity checking of a `compose:`-split solution via `render solution --effective` |
 | [terraform/](solutions/terraform/) | Terraform project scaffolding |
 | [taskfile/](solutions/taskfile/) | Taskfile.yaml generation |
 | [email-notifier/](solutions/email-notifier/) | Email notification workflow |

--- a/examples/solutions/compose-fidelity/README.md
+++ b/examples/solutions/compose-fidelity/README.md
@@ -1,0 +1,64 @@
+# Compose Fidelity Demo
+
+Demonstrates golden-file fidelity checking of a **composed** solution using
+`scafctl render solution --effective`.
+
+This solution is deliberately split across `compose:` partials:
+
+- `solution.yaml` -- metadata plus the `compose:` list
+- `resolvers.yaml` -- `spec.resolvers`
+- `workflow.yaml` -- `spec.workflow`
+
+At load time scafctl merges the partials into one effective document. The
+`--effective` renderer prints that merged document **deterministically** and
+**without executing any resolvers or providers** -- the scafctl analogue of
+`docker compose config`, `helm template`, or `kustomize build`.
+
+## Render the effective document
+
+~~~bash
+# Whole composed document (YAML, default)
+scafctl render solution -f examples/solutions/compose-fidelity/solution.yaml --effective
+
+# JSON
+scafctl render solution -f examples/solutions/compose-fidelity/solution.yaml --effective -o json
+
+# Only the effective workflow
+scafctl render solution -f examples/solutions/compose-fidelity/solution.yaml \
+  --effective --section workflow
+
+# Only the effective resolvers
+scafctl render solution -f examples/solutions/compose-fidelity/solution.yaml \
+  --effective --section resolvers
+~~~
+
+## Golden-file workflow (CI fidelity check)
+
+`golden.effective.yaml` in this directory is a committed golden artifact captured
+with:
+
+~~~bash
+scafctl render solution -f examples/solutions/compose-fidelity/solution.yaml \
+  --effective -o yaml > examples/solutions/compose-fidelity/golden.effective.yaml
+~~~
+
+Because the output is byte-stable for a given input, CI can regenerate it and
+fail on any difference -- catching unintended changes introduced while editing a
+`compose:` partial:
+
+~~~bash
+scafctl render solution -f examples/solutions/compose-fidelity/solution.yaml \
+  --effective -o yaml \
+  | diff -u examples/solutions/compose-fidelity/golden.effective.yaml -
+~~~
+
+An empty diff means the effective solution is unchanged. A non-empty diff means
+composition changed and should be reviewed (and the golden file updated
+intentionally).
+
+## Notes
+
+- `--effective` never runs resolvers or providers; expressions are kept verbatim,
+  so the view is a source-fidelity snapshot, not an evaluated one.
+- `--section` scopes the output to `all` (default), `workflow`, or `resolvers`.
+- `-o test` is not valid with `--effective`; use `yaml` or `json`.

--- a/examples/solutions/compose-fidelity/golden.effective.yaml
+++ b/examples/solutions/compose-fidelity/golden.effective.yaml
@@ -41,4 +41,3 @@ spec:
                     message:
                         expr: '''Deploying '' + _.app_name + '' to '' + _.environment'
                     type: success
-

--- a/examples/solutions/compose-fidelity/golden.effective.yaml
+++ b/examples/solutions/compose-fidelity/golden.effective.yaml
@@ -1,0 +1,44 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+    name: compose-fidelity
+    version: 1.0.0
+    displayName: Compose Fidelity Demo
+    description: Golden-file fidelity checking of a composed solution
+    category: solutions
+    tags:
+        - composition
+        - fidelity
+        - golden-file
+catalog:
+    visibility: private
+spec:
+    resolvers:
+        app_name:
+            name: ""
+            description: Application name
+            type: string
+            resolve:
+                with:
+                    - provider: static
+                      inputs:
+                        value: billing-api
+        environment:
+            name: ""
+            description: Target environment
+            type: string
+            resolve:
+                with:
+                    - provider: static
+                      inputs:
+                        value: staging
+    workflow:
+        actions:
+            deploy:
+                name: ""
+                provider: message
+                inputs:
+                    message:
+                        expr: '''Deploying '' + _.app_name + '' to '' + _.environment'
+                    type: success
+

--- a/examples/solutions/compose-fidelity/resolvers.yaml
+++ b/examples/solutions/compose-fidelity/resolvers.yaml
@@ -1,0 +1,19 @@
+spec:
+  resolvers:
+    environment:
+      type: string
+      description: Target environment
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: staging
+
+    app_name:
+      type: string
+      description: Application name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: billing-api

--- a/examples/solutions/compose-fidelity/solution.yaml
+++ b/examples/solutions/compose-fidelity/solution.yaml
@@ -1,0 +1,27 @@
+# Effective-solution fidelity demo.
+#
+# This solution is split across compose partials. Use the effective renderer to
+# capture a deterministic golden artifact of the fully-merged document and diff
+# against it in CI to detect unintended composition changes:
+#
+#   scafctl render solution -f examples/solutions/compose-fidelity/solution.yaml \
+#     --effective -o yaml > golden.effective.yaml
+#
+# See README.md for the full workflow.
+
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: compose-fidelity
+  version: 1.0.0
+  displayName: Compose Fidelity Demo
+  category: solutions
+  tags:
+    - composition
+    - fidelity
+    - golden-file
+  description: Golden-file fidelity checking of a composed solution
+
+compose:
+  - resolvers.yaml
+  - workflow.yaml

--- a/examples/solutions/compose-fidelity/workflow.yaml
+++ b/examples/solutions/compose-fidelity/workflow.yaml
@@ -1,0 +1,9 @@
+spec:
+  workflow:
+    actions:
+      deploy:
+        provider: message
+        inputs:
+          message:
+            expr: "'Deploying ' + _.app_name + ' to ' + _.environment"
+          type: success

--- a/pkg/cmd/scafctl/render/effective_test.go
+++ b/pkg/cmd/scafctl/render/effective_test.go
@@ -7,12 +7,15 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/effective"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/stretchr/testify/assert"
@@ -115,6 +118,53 @@ func TestSolutionOptions_Run_EffectiveRoute_JSON(t *testing.T) {
 	require.NoError(t, opts.Run(ctx))
 
 	assert.Contains(t, buf.String(), `"name": "effective-cli"`)
+}
+
+// TestSolutionOptions_Run_EffectiveRoute_VerbatimStdout asserts that effective
+// mode emits bytes to stdout byte-identical to effective.Render (no extra
+// trailing newline). This keeps stdout, --output-file, and effective.Render in
+// agreement so golden-file diffing is exact.
+func TestSolutionOptions_Run_EffectiveRoute_VerbatimStdout(t *testing.T) {
+	t.Parallel()
+
+	sol := effectiveTestSolution(t)
+	opts, buf, ctx := newEffectiveOptions(sol, nil, "yaml", "all")
+	require.NoError(t, opts.Run(ctx))
+
+	want, err := effective.Render(sol, effective.Options{
+		Section: effective.SectionAll,
+		Format:  effective.FormatYAML,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, string(want), buf.String())
+	assert.True(t, bytes.HasSuffix(buf.Bytes(), []byte("\n")))
+	assert.False(t, bytes.HasSuffix(buf.Bytes(), []byte("\n\n")),
+		"stdout must not carry a doubled trailing newline")
+}
+
+// TestSolutionOptions_Run_EffectiveRoute_OutputFileVerbatim asserts that
+// --output-file receives the exact bytes of effective.Render (no extension
+// munging, no trailing-newline drift) so a file written this way is identical
+// to stdout.
+func TestSolutionOptions_Run_EffectiveRoute_OutputFileVerbatim(t *testing.T) {
+	t.Parallel()
+
+	sol := effectiveTestSolution(t)
+	opts, _, ctx := newEffectiveOptions(sol, nil, "yaml", "all")
+	outFile := filepath.Join(t.TempDir(), "golden.effective.yaml")
+	opts.OutputFile = outFile
+	require.NoError(t, opts.Run(ctx))
+
+	want, err := effective.Render(sol, effective.Options{
+		Section: effective.SectionAll,
+		Format:  effective.FormatYAML,
+	})
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	assert.Equal(t, string(want), string(got))
 }
 
 func TestSolutionOptions_Run_EffectiveRoute_SectionWorkflow(t *testing.T) {

--- a/pkg/cmd/scafctl/render/effective_test.go
+++ b/pkg/cmd/scafctl/render/effective_test.go
@@ -1,0 +1,163 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package render
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// effectiveTestSolution builds a solution with resolvers and a workflow that a
+// mockGetter can return (compose is assumed already applied on load).
+func effectiveTestSolution(t *testing.T) *solution.Solution {
+	t.Helper()
+	sol := &solution.Solution{}
+	require.NoError(t, sol.UnmarshalFromBytes([]byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: effective-cli
+  version: 1.0.0
+spec:
+  resolvers:
+    env:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: env
+  workflow:
+    actions:
+      deploy:
+        provider: shell
+        inputs:
+          command: "echo deploy"
+`)))
+	return sol
+}
+
+// newEffectiveOptions wires a SolutionOptions with a capturing writer context.
+// output simulates an explicit -o value (flagsChanged["output"] is set so the
+// effective-mode format selection mirrors a user-provided flag).
+func newEffectiveOptions(sol *solution.Solution, err error, output, section string) (*SolutionOptions, *bytes.Buffer, context.Context) {
+	opts, buf, ctx := newEffectiveOptionsRaw(sol, err, output, section)
+	opts.flagsChanged = map[string]bool{"output": true}
+	return opts, buf, ctx
+}
+
+// newEffectiveOptionsRaw is like newEffectiveOptions but leaves flagsChanged
+// unset, simulating the bare default (no -o provided).
+func newEffectiveOptionsRaw(sol *solution.Solution, err error, output, section string) (*SolutionOptions, *bytes.Buffer, context.Context) {
+	buf := &bytes.Buffer{}
+	ioStreams := terminal.NewIOStreams(nil, buf, buf, false)
+	opts := &SolutionOptions{
+		Effective: true,
+		Output:    output,
+		Section:   section,
+		IOStreams: ioStreams,
+		CliParams: &settings.Run{},
+		getter:    &mockGetter{sol: sol, err: err},
+	}
+	w := writer.New(ioStreams, opts.CliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+	l := logr.Discard()
+	ctx = logger.WithLogger(ctx, &l)
+	return opts, buf, ctx
+}
+
+func TestSolutionOptions_Run_EffectiveRoute_YAML(t *testing.T) {
+	t.Parallel()
+
+	opts, buf, ctx := newEffectiveOptions(effectiveTestSolution(t), nil, "yaml", "all")
+	require.NoError(t, opts.Run(ctx))
+
+	out := buf.String()
+	assert.Contains(t, out, "name: effective-cli")
+	assert.Contains(t, out, "deploy:")
+	assert.Contains(t, out, "env:")
+	// Effective mode must NOT execute resolvers: the raw command is emitted
+	// unresolved (no materialized ActionGraph envelope).
+	assert.NotContains(t, out, "kind: ActionGraph")
+}
+
+// TestSolutionOptions_Run_EffectiveRoute_DefaultsToYAML verifies that with no
+// explicit -o (flagsChanged unset), effective mode emits YAML even though the
+// shared -o flag defaults to "json".
+func TestSolutionOptions_Run_EffectiveRoute_DefaultsToYAML(t *testing.T) {
+	t.Parallel()
+
+	// Output is "json" (the shared flag default) but the user did not set -o.
+	opts, buf, ctx := newEffectiveOptionsRaw(effectiveTestSolution(t), nil, "json", "all")
+	require.NoError(t, opts.Run(ctx))
+
+	out := buf.String()
+	// YAML markers, not JSON.
+	assert.Contains(t, out, "name: effective-cli")
+	assert.NotContains(t, out, `"name": "effective-cli"`)
+}
+
+func TestSolutionOptions_Run_EffectiveRoute_JSON(t *testing.T) {
+	t.Parallel()
+
+	opts, buf, ctx := newEffectiveOptions(effectiveTestSolution(t), nil, "json", "all")
+	require.NoError(t, opts.Run(ctx))
+
+	assert.Contains(t, buf.String(), `"name": "effective-cli"`)
+}
+
+func TestSolutionOptions_Run_EffectiveRoute_SectionWorkflow(t *testing.T) {
+	t.Parallel()
+
+	opts, buf, ctx := newEffectiveOptions(effectiveTestSolution(t), nil, "yaml", "workflow")
+	require.NoError(t, opts.Run(ctx))
+
+	out := buf.String()
+	assert.Contains(t, out, "deploy:")
+	assert.NotContains(t, out, "env:")
+}
+
+func TestSolutionOptions_Run_EffectiveRoute_LoadError(t *testing.T) {
+	t.Parallel()
+
+	opts, _, ctx := newEffectiveOptions(nil, fmt.Errorf("load error"), "yaml", "all")
+	err := opts.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "load error")
+}
+
+func TestSolutionOptions_Run_EffectiveRoute_NoWorkflow(t *testing.T) {
+	t.Parallel()
+
+	sol := &solution.Solution{}
+	require.NoError(t, sol.UnmarshalFromBytes([]byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: no-workflow
+spec:
+  resolvers:
+    env:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: env
+`)))
+
+	opts, _, ctx := newEffectiveOptions(sol, nil, "yaml", "workflow")
+	err := opts.Run(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not define a workflow")
+}

--- a/pkg/cmd/scafctl/render/solution.go
+++ b/pkg/cmd/scafctl/render/solution.go
@@ -352,7 +352,7 @@ func (o *SolutionOptions) runEffective(ctx context.Context, lgr logr.Logger) err
 		return o.exitWithCode(err, exitcode.RenderFailed)
 	}
 
-	return o.writeOutput(ctx, rendered)
+	return o.writeEffectiveOutput(ctx, rendered)
 }
 
 // runActionGraph renders the action graph (default mode)
@@ -770,6 +770,24 @@ func (o *SolutionOptions) writeOutput(ctx context.Context, data []byte) error {
 
 	if w := writer.FromContext(ctx); w != nil {
 		w.Plainln(string(data))
+	}
+	return nil
+}
+
+// writeEffectiveOutput writes the effective solution document verbatim.
+//
+// Unlike writeOutput, it does NOT append a trailing newline and writes to
+// --output-file at the exact path given (no extension munging). This keeps
+// stdout byte-identical to both the bytes returned by effective.Render and the
+// bytes written via --output-file, which is essential for byte-exact
+// golden-file fidelity diffing.
+func (o *SolutionOptions) writeEffectiveOutput(ctx context.Context, data []byte) error {
+	if o.OutputFile != "" {
+		return os.WriteFile(o.OutputFile, data, 0o600)
+	}
+
+	if w := writer.FromContext(ctx); w != nil {
+		w.Plain(string(data))
 	}
 	return nil
 }

--- a/pkg/cmd/scafctl/render/solution.go
+++ b/pkg/cmd/scafctl/render/solution.go
@@ -27,6 +27,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/effective"
 	"github.com/oakwood-commons/scafctl/pkg/solution/get"
 	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
 	solrender "github.com/oakwood-commons/scafctl/pkg/solution/render"
@@ -74,6 +75,10 @@ type SolutionOptions struct {
 	Snapshot     bool   // --snapshot: Save execution snapshot
 	SnapshotFile string // --snapshot-file: Snapshot output file
 	Redact       bool   // --redact: Redact sensitive values in snapshot
+
+	// Effective mode flags
+	Effective bool   // --effective: Emit the effective (post-compose) solution document
+	Section   string // --section: Scope the effective output (all, workflow, resolvers)
 
 	// TestName is the desired test name when using -o test output format.
 	// When empty, a name is derived from the command and resolver parameters.
@@ -136,6 +141,12 @@ Examples:
   # Save snapshot with sensitive data redacted
   scafctl render solution -f ./solution.yaml --snapshot --snapshot-file=snapshot.json --redact
 
+  # Emit the effective (post-compose) solution document as YAML
+  scafctl render solution -f ./solution.yaml --effective -o yaml
+
+  # Emit only the effective workflow actions (for fidelity diffing)
+  scafctl render solution -f ./solution.yaml --effective --section workflow -o yaml > golden.yaml
+
   # Render solution from catalog by name
   scafctl render solution my-app
 
@@ -183,8 +194,18 @@ Examples:
 			if options.Snapshot {
 				modeCount++
 			}
+			if options.Effective {
+				modeCount++
+			}
 			if modeCount > 1 {
-				err := fmt.Errorf("--action-graph and --snapshot are mutually exclusive")
+				err := fmt.Errorf("--action-graph, --snapshot, and --effective are mutually exclusive")
+				writeSolutionError(options, err.Error())
+				return exitcode.WithCode(err, exitcode.InvalidInput)
+			}
+
+			// --section is only meaningful in effective mode.
+			if options.flagsChanged["section"] && !options.Effective {
+				err := fmt.Errorf("--section is only applicable with --effective")
 				writeSolutionError(options, err.Error())
 				return exitcode.WithCode(err, exitcode.InvalidInput)
 			}
@@ -215,6 +236,21 @@ Examples:
 				}
 			}
 
+			// Effective mode only supports json/yaml (not the test generator),
+			// and requires a valid --section.
+			if options.Effective {
+				if options.Output == "test" {
+					err := fmt.Errorf("--output test is not applicable with --effective; use json or yaml")
+					writeSolutionError(options, err.Error())
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
+				if err := output.ValidateOutputType(options.Section, effective.ValidSections); err != nil {
+					err = fmt.Errorf("invalid --section: %w", err)
+					writeSolutionError(options, err.Error())
+					return exitcode.WithCode(err, exitcode.InvalidInput)
+				}
+			}
+
 			return options.Run(ctx)
 		},
 		SilenceUsage: true,
@@ -240,6 +276,10 @@ Examples:
 	cCmd.Flags().BoolVar(&options.Snapshot, "snapshot", false, "Save execution snapshot instead of rendering")
 	cCmd.Flags().StringVar(&options.SnapshotFile, "snapshot-file", "", "Snapshot output file (required with --snapshot)")
 	cCmd.Flags().BoolVar(&options.Redact, "redact", false, "Redact sensitive values in snapshot")
+
+	// Effective mode flags
+	cCmd.Flags().BoolVar(&options.Effective, "effective", false, "Emit the effective (post-compose) solution document without executing resolvers")
+	cCmd.Flags().StringVar(&options.Section, "section", string(effective.SectionAll), fmt.Sprintf("Scope the effective output: %s (only with --effective)", strings.Join(effective.ValidSections, ", ")))
 
 	// Test generation flag
 	cCmd.Flags().StringVar(&options.TestName, "test-name", "", "Test name for -o test output (derived from command and args when not set)")
@@ -272,7 +312,47 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	if o.Snapshot {
 		return o.runSnapshot(ctx, *lgr)
 	}
+	if o.Effective {
+		return o.runEffective(ctx, *lgr)
+	}
 	return o.runActionGraph(ctx, *lgr)
+}
+
+// runEffective emits the effective (post-compose) solution document.
+//
+// Unlike the other render modes, this performs NO resolver execution and NO
+// provider calls. It loads the solution (compose is applied on load) and emits
+// the canonical, deterministic document for golden-file fidelity diffing and
+// composition debugging.
+func (o *SolutionOptions) runEffective(ctx context.Context, lgr logr.Logger) error {
+	lgr.V(1).Info("rendering effective solution",
+		"file", o.File,
+		"output", o.Output,
+		"section", o.Section)
+
+	sol, err := o.loadSolution(ctx)
+	if err != nil {
+		return o.exitWithCode(err, exitcode.FileNotFound)
+	}
+
+	// Effective mode defaults to YAML (the golden-file format), independent of
+	// the shared -o default of "json". Only switch to JSON when the user
+	// explicitly requested it via -o json.
+	format := effective.FormatYAML
+	if o.flagsChanged["output"] && o.Output == string(effective.FormatJSON) {
+		format = effective.FormatJSON
+	}
+
+	rendered, err := effective.Render(sol, effective.Options{
+		Section: effective.Section(o.Section),
+		Format:  format,
+		Compact: o.Compact,
+	})
+	if err != nil {
+		return o.exitWithCode(err, exitcode.RenderFailed)
+	}
+
+	return o.writeOutput(ctx, rendered)
 }
 
 // runActionGraph renders the action graph (default mode)

--- a/pkg/cmd/scafctl/render/solution_test.go
+++ b/pkg/cmd/scafctl/render/solution_test.go
@@ -499,7 +499,7 @@ func TestSolutionOptions_ModeValidation(t *testing.T) {
 		{
 			name:    "action-graph and snapshot are mutually exclusive",
 			args:    []string{"-f", solutionFile, "--action-graph", "--snapshot", "--snapshot-file=" + filepath.Join(t.TempDir(), "snap.json")},
-			wantErr: "--action-graph and --snapshot are mutually exclusive",
+			wantErr: "--action-graph, --snapshot, and --effective are mutually exclusive",
 		},
 		{
 			name:    "snapshot without snapshot-file is rejected",
@@ -515,6 +515,26 @@ func TestSolutionOptions_ModeValidation(t *testing.T) {
 			name:    "output-file flag incompatible with action-graph",
 			args:    []string{"-f", solutionFile, "--action-graph", "--output-file=out.json"},
 			wantErr: "--output-file is not applicable with --action-graph",
+		},
+		{
+			name:    "effective and snapshot are mutually exclusive",
+			args:    []string{"-f", solutionFile, "--effective", "--snapshot", "--snapshot-file=" + filepath.Join(t.TempDir(), "snap.json")},
+			wantErr: "--action-graph, --snapshot, and --effective are mutually exclusive",
+		},
+		{
+			name:    "section requires effective",
+			args:    []string{"-f", solutionFile, "--section", "workflow"},
+			wantErr: "--section is only applicable with --effective",
+		},
+		{
+			name:    "effective rejects output test",
+			args:    []string{"-f", solutionFile, "--effective", "-o", "test"},
+			wantErr: "--output test is not applicable with --effective",
+		},
+		{
+			name:    "effective rejects invalid section",
+			args:    []string{"-f", solutionFile, "--effective", "--section", "bogus"},
+			wantErr: "invalid --section",
 		},
 	}
 

--- a/pkg/examples/examples.go
+++ b/pkg/examples/examples.go
@@ -119,6 +119,14 @@ func Scan(category string) ([]Example, error) {
 			return nil
 		}
 
+		// Skip rendered "effective" golden artifacts (produced by
+		// `render solution --effective`). They are kind: Solution documents but
+		// are committed fixtures for fidelity diffing, not runnable examples, and
+		// would collide by name with their source solution.
+		if strings.HasSuffix(relPath, ".effective.yaml") || strings.HasSuffix(relPath, ".effective.yml") {
+			return nil
+		}
+
 		content, err := fs.ReadFile(examplesFS, fpath)
 		if err != nil {
 			return nil //nolint:nilerr // skip unreadable file, keep scanning

--- a/pkg/examples/examples_test.go
+++ b/pkg/examples/examples_test.go
@@ -327,6 +327,20 @@ func TestExampleNamesAreUnique(t *testing.T) {
 	}
 }
 
+func TestScanSkipsEffectiveGoldenArtifacts(t *testing.T) {
+	t.Parallel()
+	// Rendered `.effective.yaml` golden artifacts are kind: Solution documents
+	// but must not be listed as runnable examples (they collide by name with
+	// their source solution).
+	items, err := Scan("")
+	require.NoError(t, err)
+	for _, it := range items {
+		assert.False(t,
+			strings.HasSuffix(it.Path, ".effective.yaml") || strings.HasSuffix(it.Path, ".effective.yml"),
+			"effective golden artifact must not be listed as an example: %s", it.Path)
+	}
+}
+
 func TestResolveExample_NotFound(t *testing.T) {
 	t.Parallel()
 	_, err := ResolveExample("this-does-not-exist-anywhere")

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -140,6 +140,7 @@ func TestServerInfo(t *testing.T) {
 		// Phase 3 tools
 		assert.True(t, toolNames["evaluate_cel"])
 		assert.True(t, toolNames["render_solution"])
+		assert.True(t, toolNames["render_effective_solution"])
 		// Phase 4 tools
 		assert.True(t, toolNames["get_solution_schema"])
 		assert.True(t, toolNames["explain_kind"])

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -25,6 +25,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/effective"
 	"github.com/oakwood-commons/scafctl/pkg/solution/execute"
 	"github.com/oakwood-commons/scafctl/pkg/solution/inspect"
 	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
@@ -124,6 +125,33 @@ func (s *Server) registerSolutionTools() {
 		),
 	)
 	s.addTool(renderSolutionTool, s.handleRenderSolution)
+
+	// render_effective_solution
+	renderEffectiveSolutionTool := mcp.NewTool("render_effective_solution",
+		mcp.WithDescription("Render the effective (fully-composed) solution document as deterministic YAML or JSON WITHOUT executing resolvers or providers. This is the post-compose merge of the solution and its compose: partials, suitable for golden-file fidelity diffing, code review, and debugging composition (analogous to 'docker compose config' / 'kustomize build'). Use 'section' to scope the output to the whole document, spec.workflow, or spec.resolvers."),
+		mcp.WithTitleAnnotation("Render Effective Solution"),
+		mcp.WithToolIcons(toolIcons["solution"]),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("path",
+			mcp.Required(),
+			mcp.Description("Path to solution file, catalog name, or URL"),
+		),
+		mcp.WithString("section",
+			mcp.Description("Scope the output: all (default, whole document), workflow (spec.workflow), resolvers (spec.resolvers)"),
+			mcp.Enum(effective.ValidSections...),
+		),
+		mcp.WithString("format",
+			mcp.Description("Output format: yaml (default) or json"),
+			mcp.Enum(string(effective.FormatYAML), string(effective.FormatJSON)),
+		),
+		mcp.WithString("cwd",
+			mcp.Description(cwdDescDefault),
+		),
+	)
+	s.addTool(renderEffectiveSolutionTool, s.handleRenderEffectiveSolution)
 
 	// preview_resolvers
 	previewResolversTool := mcp.NewTool("preview_resolvers",
@@ -331,6 +359,51 @@ func (s *Server) handleInspectSolution(_ context.Context, request mcp.CallToolRe
 		mcp.NewResourceLink("solution://"+path+"/graph", "Dependency Graph", "Resolver dependency graph", "application/json"),
 	)
 	return result, nil
+}
+
+// handleRenderEffectiveSolution renders the effective (post-compose) solution
+// document as deterministic YAML or JSON without executing resolvers.
+func (s *Server) handleRenderEffectiveSolution(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	path, err := request.RequireString("path")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("path"),
+			WithSuggestion("Provide a solution file path, catalog name, or URL"),
+		), nil
+	}
+	cwd := request.GetString("cwd", "")
+	section := request.GetString("section", string(effective.SectionAll))
+	format := request.GetString("format", string(effective.FormatYAML))
+
+	ctx, err := s.contextWithCwd(cwd)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithField("cwd"),
+			WithSuggestion("Provide a valid existing directory path"),
+		), nil
+	}
+
+	sol, err := inspect.LoadSolution(ctx, path)
+	if err != nil {
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", err),
+			WithField("path"),
+			WithSuggestion("Check the file exists and contains valid YAML"),
+			WithRelatedTools("lint_solution"),
+		), nil
+	}
+
+	rendered, err := effective.Render(sol, effective.Options{
+		Section: effective.Section(section),
+		Format:  effective.Format(format),
+	})
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, fmt.Sprintf("rendering effective solution: %v", err),
+			WithField("section"),
+			WithSuggestion("Use section=all, workflow, or resolvers; the solution must define the requested section"),
+		), nil
+	}
+
+	return mcp.NewToolResultText(string(rendered)), nil
 }
 
 // handleLintSolution validates a solution file and returns structured findings.

--- a/pkg/mcp/tools_solution.go
+++ b/pkg/mcp/tools_solution.go
@@ -134,7 +134,10 @@ func (s *Server) registerSolutionTools() {
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
 		mcp.WithIdempotentHintAnnotation(true),
-		mcp.WithOpenWorldHintAnnotation(false),
+		// openWorld: the path may be a catalog name or URL that inspect.LoadSolution
+		// resolves against remote catalogs, so this tool can touch the network --
+		// matching inspect_solution and render_solution.
+		mcp.WithOpenWorldHintAnnotation(true),
 		mcp.WithString("path",
 			mcp.Required(),
 			mcp.Description("Path to solution file, catalog name, or URL"),

--- a/pkg/mcp/tools_solution_test.go
+++ b/pkg/mcp/tools_solution_test.go
@@ -415,6 +415,105 @@ spec:
 	})
 }
 
+func TestHandleRenderEffectiveSolution(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing path returns error", func(t *testing.T) {
+		t.Parallel()
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "render_effective_solution"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleRenderEffectiveSolution(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("nonexistent path returns error", func(t *testing.T) {
+		t.Parallel()
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "render_effective_solution"
+		request.Params.Arguments = map[string]any{
+			"path": "/nonexistent/solution.yaml",
+		}
+
+		result, err := srv.handleRenderEffectiveSolution(context.Background(), request)
+		require.NoError(t, err)
+		assert.True(t, result.IsError)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "loading solution")
+	})
+
+	t.Run("renders effective document as yaml by default", func(t *testing.T) {
+		t.Parallel()
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "render_effective_solution"
+		request.Params.Arguments = map[string]any{
+			"path": "../../examples/actions/hello-world.yaml",
+		}
+
+		result, err := srv.handleRenderEffectiveSolution(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.IsError)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "apiVersion:")
+		assert.Contains(t, text, "kind: Solution")
+	})
+
+	t.Run("renders workflow section as json", func(t *testing.T) {
+		t.Parallel()
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "render_effective_solution"
+		request.Params.Arguments = map[string]any{
+			"path":    "../../examples/actions/hello-world.yaml",
+			"section": "workflow",
+			"format":  "json",
+		}
+
+		result, err := srv.handleRenderEffectiveSolution(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		require.False(t, result.IsError)
+		text := result.Content[0].(mcp.TextContent).Text
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &parsed))
+		assert.Contains(t, parsed, "actions")
+	})
+
+	t.Run("invalid section returns error", func(t *testing.T) {
+		t.Parallel()
+		srv, err := NewServer(WithServerVersion("test"))
+		require.NoError(t, err)
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "render_effective_solution"
+		request.Params.Arguments = map[string]any{
+			"path":    "../../examples/actions/hello-world.yaml",
+			"section": "bogus",
+		}
+
+		result, err := srv.handleRenderEffectiveSolution(context.Background(), request)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.True(t, result.IsError)
+		text := result.Content[0].(mcp.TextContent).Text
+		assert.Contains(t, text, "rendering effective solution")
+	})
+}
+
 func TestHandlePreviewResolvers(t *testing.T) {
 	t.Run("missing path returns error", func(t *testing.T) {
 		srv, err := NewServer(WithServerVersion("test"))

--- a/pkg/solution/effective/effective.go
+++ b/pkg/solution/effective/effective.go
@@ -1,0 +1,134 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package effective renders the effective (fully-composed, canonicalized)
+// solution document as stable, deterministic JSON or YAML.
+//
+// The "effective" solution is the document that results after applying the
+// solution's compose: merges. Unlike rendering the action graph, this transform
+// performs NO resolver execution and NO provider calls -- it is a pure document
+// projection suitable for golden-file fidelity diffing, code review, and
+// debugging composition (mirroring `docker compose config`, `helm template`,
+// and `kustomize build`).
+//
+// Determinism: both encoding/json and gopkg.in/yaml.v3 marshal Go maps in
+// sorted-key order and structs in field-declaration order, so the output is
+// byte-stable across runs for a given input. This is what makes the output
+// safe to commit as a golden file and diff in CI.
+package effective
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"gopkg.in/yaml.v3"
+)
+
+// Section scopes the effective output to a portion of the solution.
+type Section string
+
+const (
+	// SectionAll emits the entire effective solution document.
+	SectionAll Section = "all"
+	// SectionWorkflow emits only spec.workflow (actions and finally).
+	SectionWorkflow Section = "workflow"
+	// SectionResolvers emits only spec.resolvers.
+	SectionResolvers Section = "resolvers"
+)
+
+// Format selects the output serialization.
+type Format string
+
+const (
+	// FormatYAML serializes the effective document as YAML.
+	FormatYAML Format = "yaml"
+	// FormatJSON serializes the effective document as JSON.
+	FormatJSON Format = "json"
+)
+
+// ValidSections lists the accepted --section values for help and validation.
+var ValidSections = []string{
+	string(SectionAll),
+	string(SectionWorkflow),
+	string(SectionResolvers),
+}
+
+// Options configures how the effective solution is rendered.
+type Options struct {
+	// Section scopes the output. Defaults to SectionAll when empty.
+	Section Section
+	// Format selects the serialization. Defaults to FormatYAML when empty.
+	Format Format
+	// Compact disables pretty-printing for JSON output. Ignored for YAML.
+	Compact bool
+}
+
+// Render serializes the effective (post-compose) solution into deterministic
+// bytes. The caller is responsible for loading the solution with compose
+// already applied (the standard getter does this on load).
+//
+// Render never executes resolvers or providers; it is a pure projection of the
+// already-composed document.
+func Render(sol *solution.Solution, opts Options) ([]byte, error) {
+	if sol == nil {
+		return nil, fmt.Errorf("solution is nil")
+	}
+
+	section := opts.Section
+	if section == "" {
+		section = SectionAll
+	}
+
+	value, err := project(sol, section)
+	if err != nil {
+		return nil, err
+	}
+
+	format := opts.Format
+	if format == "" {
+		format = FormatYAML
+	}
+
+	switch format {
+	case FormatYAML:
+		out, err := yaml.Marshal(value)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling effective solution to YAML: %w", err)
+		}
+		return out, nil
+	case FormatJSON:
+		var out []byte
+		if opts.Compact {
+			out, err = json.Marshal(value)
+		} else {
+			out, err = json.MarshalIndent(value, "", "  ")
+		}
+		if err != nil {
+			return nil, fmt.Errorf("marshaling effective solution to JSON: %w", err)
+		}
+		return out, nil
+	default:
+		return nil, fmt.Errorf("unsupported format %q (supported: %s, %s)", format, FormatYAML, FormatJSON)
+	}
+}
+
+// project returns the value to serialize for the requested section.
+func project(sol *solution.Solution, section Section) (any, error) {
+	switch section {
+	case SectionAll:
+		return sol, nil
+	case SectionWorkflow:
+		if !sol.Spec.HasWorkflow() {
+			return nil, fmt.Errorf("solution does not define a workflow")
+		}
+		return sol.Spec.Workflow, nil
+	case SectionResolvers:
+		if !sol.Spec.HasResolvers() {
+			return nil, fmt.Errorf("solution does not define any resolvers")
+		}
+		return sol.Spec.Resolvers, nil
+	default:
+		return nil, fmt.Errorf("invalid section %q (valid: %s, %s, %s)", section, SectionAll, SectionWorkflow, SectionResolvers)
+	}
+}

--- a/pkg/solution/effective/effective_test.go
+++ b/pkg/solution/effective/effective_test.go
@@ -1,0 +1,222 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package effective
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testSolution builds a solution with both resolvers and a workflow for
+// projection tests. It uses UnmarshalFromBytes to avoid the provider-validation
+// gate so the fixture stays self-contained.
+func testSolution(t *testing.T) *solution.Solution {
+	t.Helper()
+	sol := &solution.Solution{}
+	err := sol.UnmarshalFromBytes([]byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: effective-test
+  version: 1.0.0
+spec:
+  resolvers:
+    env:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: env
+  workflow:
+    actions:
+      deploy:
+        provider: shell
+        inputs:
+          command: "echo deploy"
+    finally:
+      cleanup:
+        provider: shell
+        inputs:
+          command: "echo cleanup"
+`))
+	require.NoError(t, err)
+	return sol
+}
+
+func TestRender_NilSolution(t *testing.T) {
+	_, err := Render(nil, Options{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "solution is nil")
+}
+
+func TestRender_SectionAll_DefaultsToYAML(t *testing.T) {
+	sol := testSolution(t)
+
+	out, err := Render(sol, Options{})
+	require.NoError(t, err)
+
+	text := string(out)
+	assert.Contains(t, text, "name: effective-test")
+	assert.Contains(t, text, "workflow:")
+	assert.Contains(t, text, "deploy:")
+	assert.Contains(t, text, "env:")
+}
+
+func TestRender_SectionAll_JSON(t *testing.T) {
+	sol := testSolution(t)
+
+	out, err := Render(sol, Options{Format: FormatJSON})
+	require.NoError(t, err)
+
+	text := string(out)
+	assert.Contains(t, text, `"name": "effective-test"`)
+	// Pretty-printed JSON is indented.
+	assert.Contains(t, text, "\n  ")
+}
+
+func TestRender_SectionAll_JSONCompact(t *testing.T) {
+	sol := testSolution(t)
+
+	out, err := Render(sol, Options{Format: FormatJSON, Compact: true})
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(out), "\n  ", "compact JSON should not be indented")
+}
+
+func TestRender_SectionWorkflow(t *testing.T) {
+	sol := testSolution(t)
+
+	out, err := Render(sol, Options{Section: SectionWorkflow})
+	require.NoError(t, err)
+
+	text := string(out)
+	assert.Contains(t, text, "deploy:")
+	assert.Contains(t, text, "cleanup:")
+	// Workflow projection must not carry the resolvers section.
+	assert.NotContains(t, text, "env:")
+}
+
+func TestRender_SectionWorkflow_NoWorkflow(t *testing.T) {
+	sol := &solution.Solution{}
+	require.NoError(t, sol.UnmarshalFromBytes([]byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: no-workflow
+spec:
+  resolvers:
+    env:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: env
+`)))
+
+	_, err := Render(sol, Options{Section: SectionWorkflow})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not define a workflow")
+}
+
+func TestRender_SectionResolvers(t *testing.T) {
+	sol := testSolution(t)
+
+	out, err := Render(sol, Options{Section: SectionResolvers})
+	require.NoError(t, err)
+
+	text := string(out)
+	assert.Contains(t, text, "env:")
+	// Resolver projection must not carry the workflow section.
+	assert.NotContains(t, text, "deploy:")
+}
+
+func TestRender_SectionResolvers_NoResolvers(t *testing.T) {
+	sol := &solution.Solution{}
+	require.NoError(t, sol.UnmarshalFromBytes([]byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: no-resolvers
+spec:
+  workflow:
+    actions:
+      deploy:
+        provider: shell
+        inputs:
+          command: "echo deploy"
+`)))
+
+	_, err := Render(sol, Options{Section: SectionResolvers})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not define any resolvers")
+}
+
+func TestRender_InvalidSection(t *testing.T) {
+	sol := testSolution(t)
+
+	_, err := Render(sol, Options{Section: Section("bogus")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid section")
+}
+
+func TestRender_UnsupportedFormat(t *testing.T) {
+	sol := testSolution(t)
+
+	_, err := Render(sol, Options{Format: Format("toml")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported format")
+}
+
+// TestRender_Deterministic guards the core promise: identical input yields
+// byte-identical output across runs, which is what makes the output safe as a
+// golden file for fidelity diffing.
+func TestRender_Deterministic(t *testing.T) {
+	for _, section := range []Section{SectionAll, SectionWorkflow, SectionResolvers} {
+		for _, format := range []Format{FormatYAML, FormatJSON} {
+			sol := testSolution(t)
+			first, err := Render(sol, Options{Section: section, Format: format})
+			require.NoError(t, err)
+			second, err := Render(sol, Options{Section: section, Format: format})
+			require.NoError(t, err)
+			assert.Equal(t, first, second, "section=%s format=%s should be deterministic", section, format)
+		}
+	}
+}
+
+func BenchmarkRender(b *testing.B) {
+	sol := &solution.Solution{}
+	if err := sol.UnmarshalFromBytes([]byte(`
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: bench
+  version: 1.0.0
+spec:
+  resolvers:
+    env:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              key: env
+  workflow:
+    actions:
+      deploy:
+        provider: shell
+        inputs:
+          command: "echo deploy"
+`)); err != nil {
+		b.Fatalf("failed to build fixture: %v", err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := Render(sol, Options{Format: FormatYAML}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -497,7 +497,7 @@ tasks:
         PASSED=0
         SKIPPED=0
 
-        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml|lint-tmpl-underscore/|lint-stress-test/|lint-resolver-cycle/|lint-missing-template-dependency/|lint-template-nonstandard-ext/|lint-undefined-dependency/|lint-resolve-foreach-missing-in/|compose-demo/workflow|compose-demo/resolvers|state/github-state"
+        EXCLUDE="bad-solution-yaml/|edge-cases/invalid-|edge-cases/null-resolver/|lint-schema/unknown-field/|lint-schema/unknown-nested-field/|lint-schema/unknown-field.yaml|lint-tmpl-underscore/|lint-stress-test/|lint-resolver-cycle/|lint-missing-template-dependency/|lint-template-nonstandard-ext/|lint-undefined-dependency/|lint-resolve-foreach-missing-in/|compose-demo/workflow|compose-demo/resolvers|compose-fidelity/workflow|compose-fidelity/resolvers|compose-fidelity/golden.effective|state/github-state"
 
         {
           find examples/solutions -name '*.yaml'

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -3135,6 +3135,84 @@ func TestIntegration_RenderSolution_GraphFlagRemoved(t *testing.T) {
 	assert.Contains(t, stderr, "unknown flag")
 }
 
+// TestIntegration_RenderSolution_Effective verifies the effective-document
+// renderer emits the fully-composed solution deterministically without running
+// resolvers, and honors --section and mutual-exclusion guards.
+func TestIntegration_RenderSolution_Effective(t *testing.T) {
+	t.Parallel()
+
+	const solPath = "examples/solutions/compose-fidelity/solution.yaml"
+
+	t.Run("full document is deterministic", func(t *testing.T) {
+		t.Parallel()
+		out1, _, code1 := runScafctl(t, "render", "solution", "-f", solPath, "--effective", "-o", "yaml")
+		require.Equal(t, 0, code1)
+		out2, _, code2 := runScafctl(t, "render", "solution", "-f", solPath, "--effective", "-o", "yaml")
+		require.Equal(t, 0, code2)
+
+		assert.Equal(t, out1, out2, "effective output must be byte-stable")
+		// Composed from both partials.
+		assert.Contains(t, out1, "app_name")
+		assert.Contains(t, out1, "environment")
+		assert.Contains(t, out1, "deploy")
+		// compose: field is cleared on the merged, self-contained document.
+		assert.NotContains(t, out1, "compose:")
+	})
+
+	t.Run("section workflow scopes output", func(t *testing.T) {
+		t.Parallel()
+		stdout, _, exitCode := runScafctl(t, "render", "solution", "-f", solPath,
+			"--effective", "--section", "workflow", "-o", "yaml")
+		require.Equal(t, 0, exitCode)
+		assert.Contains(t, stdout, "deploy")
+		// Only the workflow projection is emitted, not the resolvers map.
+		assert.NotContains(t, stdout, "resolvers:")
+	})
+
+	t.Run("section resolvers scopes output", func(t *testing.T) {
+		t.Parallel()
+		stdout, _, exitCode := runScafctl(t, "render", "solution", "-f", solPath,
+			"--effective", "--section", "resolvers", "-o", "yaml")
+		require.Equal(t, 0, exitCode)
+		assert.Contains(t, stdout, "app_name")
+		// Only the resolvers projection is emitted, not the workflow actions.
+		assert.NotContains(t, stdout, "actions:")
+	})
+
+	t.Run("json output", func(t *testing.T) {
+		t.Parallel()
+		stdout, _, exitCode := runScafctl(t, "render", "solution", "-f", solPath, "--effective", "-o", "json")
+		require.Equal(t, 0, exitCode)
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal([]byte(stdout), &parsed))
+		assert.Contains(t, parsed, "spec")
+	})
+
+	t.Run("defaults to yaml without -o", func(t *testing.T) {
+		t.Parallel()
+		stdout, _, exitCode := runScafctl(t, "render", "solution", "-f", solPath, "--effective")
+		require.Equal(t, 0, exitCode)
+		// YAML, not JSON, even though the shared -o flag defaults to json.
+		assert.Contains(t, stdout, "apiVersion: scafctl.io/v1")
+		assert.NotContains(t, stdout, `"apiVersion"`)
+	})
+
+	t.Run("section without effective is rejected", func(t *testing.T) {
+		t.Parallel()
+		_, stderr, exitCode := runScafctl(t, "render", "solution", "-f", solPath, "--section", "workflow")
+		assert.NotEqual(t, 0, exitCode)
+		assert.Contains(t, stderr, "--section is only applicable with --effective")
+	})
+
+	t.Run("effective and snapshot are mutually exclusive", func(t *testing.T) {
+		t.Parallel()
+		_, stderr, exitCode := runScafctl(t, "render", "solution", "-f", solPath,
+			"--effective", "--snapshot", "--snapshot-file", "x.json")
+		assert.NotEqual(t, 0, exitCode)
+		assert.Contains(t, stderr, "mutually exclusive")
+	})
+}
+
 func TestIntegration_ActionGraphMermaid(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t,

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -3159,6 +3159,17 @@ func TestIntegration_RenderSolution_Effective(t *testing.T) {
 		assert.NotContains(t, out1, "compose:")
 	})
 
+	t.Run("stdout matches committed golden byte-for-byte", func(t *testing.T) {
+		t.Parallel()
+		stdout, _, exitCode := runScafctl(t, "render", "solution", "-f", solPath, "--effective", "-o", "yaml")
+		require.Equal(t, 0, exitCode)
+		golden, err := os.ReadFile(filepath.Join(findProjectRoot(), "examples/solutions/compose-fidelity/golden.effective.yaml"))
+		require.NoError(t, err)
+		// Verbatim: stdout must equal the committed golden exactly (no extra
+		// trailing newline), which is the core golden-file fidelity guarantee.
+		assert.Equal(t, string(golden), stdout)
+	})
+
 	t.Run("section workflow scopes output", func(t *testing.T) {
 		t.Parallel()
 		stdout, _, exitCode := runScafctl(t, "render", "solution", "-f", solPath,


### PR DESCRIPTION
Add an effective-solution renderer that emits the deterministic
post-compose solution document (YAML/JSON) without executing any
resolvers or providers -- the scafctl analogue of `docker compose
config`, `helm template`, and `kustomize build`. This lets users see
and diff exactly what a composed solution resolves to on disk, enabling
golden-file fidelity checks in CI.

Closes #21

## Highlights

- **`pkg/solution/effective`**: new domain package with `Render(sol, Options)`.
  Sections `all`/`workflow`/`resolvers`, formats `yaml`/`json`. Nil-safe,
  defaults to `section=all` `format=yaml`. Output is byte-stable (sorted map
  keys, declaration-order structs) for golden-file diffing.
- **`render solution --effective` / `--section`**: new CLI flags with
  mutual-exclusion validation against `--action-graph`/`--snapshot`.
  Effective mode defaults to YAML (matching the MCP default and the
  golden-file purpose) while the rest of `render solution` still defaults to
  JSON; pass `-o json` to override. Rejects `-o test` and validates the section.
  Output is emitted verbatim: stdout, `--output-file`, and `effective.Render`
  are byte-identical (no trailing-newline drift, no extension munging), which
  is the core golden-file fidelity guarantee.
- **MCP**: new `render_effective_solution` tool (ReadOnly, `openWorld=true`
  to match `inspect_solution`/`render_solution`, since the path may be a
  catalog name or URL resolved against remote catalogs).
- **`docs/design/effective-solution-render.md`**: rationale, determinism,
  fidelity workflow, alternatives, out-of-scope (indexed under Core
  Architecture).
- **`examples/solutions/compose-fidelity`**: composed example with a committed
  `golden.effective.yaml` and a golden-file CI README (version pinned for
  build-independent determinism).
- **`pkg/examples`**: `Scan` skips `.effective.yaml`/`.effective.yml` golden
  artifacts so they don't collide by name with their source solution.

## Design notes

This is a pure document transform -- no resolver/provider execution -- so it is
safe and deterministic. Deepening `diff solution` to consume effective output is
intentionally left as a separate future PR.

Additive change; no breaking changes.

## Testing

- `go test ./...`: clean
- Coverage: effective pkg 93.9%, `runEffective` 100%, MCP handler 93.8%,
  `Render` 91.7% -- all above the 70% target
- `task lint:changed`: 0 issues
- `task test:e2e`: 919 passed, 0 failed; lint:solutions 157/0
