### PR TITLE
feat(catalog): add interactive display schema for catalog list

### DIFF
--- a/pkg/cmd/scafctl/catalog/list.go
+++ b/pkg/cmd/scafctl/catalog/list.go
@@ -5,6 +5,7 @@ package catalog
 
 import (
 	"context"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -53,6 +54,9 @@ type ArtifactListItem struct {
 	Catalog     string `json:"catalog" yaml:"catalog"`
 }
 
+//go:embed list_schema.json
+var listSchemaJSON []byte
+
 // listColumnHints controls table column display for catalog list.
 var listColumnHints = map[string]tui.ColumnHint{
 	"name":        {MaxWidth: 30, Priority: 10},
@@ -61,29 +65,10 @@ var listColumnHints = map[string]tui.ColumnHint{
 	"displayName": {MaxWidth: 25, Priority: 6, DisplayName: "display name"},
 	"category":    {MaxWidth: 15, Priority: 4},
 	"catalog":     {MaxWidth: 25, Priority: 8},
+	"createdAt":   {Hidden: true},
+	"digest":      {Hidden: true},
+	"version":     {Hidden: true},
 }
-
-// artifactListSchema controls table column display. Columns in the "required" array
-// (name, tag, kind, catalog) resist truncation.
-// version, createdAt, and digest are hidden in table view but included in json/yaml output.
-var artifactListSchema = []byte(`{
-	"type": "array",
-	"items": {
-		"type": "object",
-		"required": ["name", "tag", "kind", "catalog"],
-		"properties": {
-			"name":        { "type": "string", "title": "Name" },
-			"tag":         { "type": "string", "title": "Tag" },
-			"kind":        { "type": "string", "title": "Kind" },
-			"displayName": { "type": "string", "title": "Display Name" },
-			"category":    { "type": "string", "title": "Category" },
-			"catalog":     { "type": "string", "title": "Catalog" },
-			"version":     { "type": "string", "deprecated": true },
-			"digest":      { "type": "string", "deprecated": true },
-			"createdAt":   { "type": "string", "deprecated": true }
-		}
-	}
-}`)
 
 // CommandList creates the list command.
 func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ string) *cobra.Command {
@@ -158,7 +143,7 @@ func CommandList(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 			kvxOpts := flags.ToKvxOutputOptions(&options.KvxOutputFlags,
 				kvx.WithIOStreams(ioStreams),
 				kvx.WithOutputColumnOrder([]string{"name", "tag", "kind", "displayName", "category", "digest", "catalog"}),
-				kvx.WithOutputSchemaJSON(artifactListSchema),
+				kvx.WithOutputDisplaySchemaJSON(listSchemaJSON),
 				kvx.WithOutputColumnHints(listColumnHints),
 			)
 			return runList(cmd.Context(), options, kvxOpts)

--- a/pkg/cmd/scafctl/catalog/list_schema.json
+++ b/pkg/cmd/scafctl/catalog/list_schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Catalog Artifact List",
+  "description": "Schema for catalog artifact list with display extensions",
+  "type": "array",
+
+  "x-kvx-icon": "📦",
+  "x-kvx-collectionTitle": "Artifacts",
+
+  "x-kvx-list": {
+    "titleField": "name",
+    "subtitleField": "displayName",
+    "subtitleMaxLines": 1,
+    "badgeFields": ["kind", "category"]
+  },
+
+  "x-kvx-detail": {
+    "titleField": "name",
+    "hiddenFields": [],
+    "sections": [
+      {
+        "title": "",
+        "fields": ["name", "tag", "kind"],
+        "layout": "inline"
+      },
+      {
+        "title": "Display Name",
+        "fields": ["displayName"],
+        "layout": "paragraph"
+      },
+      {
+        "title": "Catalog",
+        "fields": ["catalog"],
+        "layout": "paragraph"
+      },
+      {
+        "title": "Category",
+        "fields": ["category"],
+        "layout": "inline"
+      },
+      {
+        "title": "Metadata",
+        "fields": ["version", "digest", "createdAt"],
+        "layout": "table"
+      }
+    ]
+  },
+
+  "items": {
+    "type": "object",
+    "required": ["name", "tag", "kind", "catalog"],
+    "properties": {
+      "name": {
+        "type": "string",
+        "title": "Name",
+        "maxLength": 30,
+        "x-kvx-priority": 10
+      },
+      "tag": {
+        "type": "string",
+        "title": "Tag",
+        "maxLength": 12,
+        "x-kvx-priority": 8
+      },
+      "kind": {
+        "type": "string",
+        "title": "Kind",
+        "maxLength": 12,
+        "x-kvx-priority": 10
+      },
+      "displayName": {
+        "type": "string",
+        "title": "Display Name",
+        "maxLength": 25,
+        "x-kvx-priority": 6
+      },
+      "category": {
+        "type": "string",
+        "title": "Category",
+        "maxLength": 15,
+        "x-kvx-priority": 4
+      },
+      "catalog": {
+        "type": "string",
+        "title": "Catalog",
+        "maxLength": 25,
+        "x-kvx-priority": 8
+      },
+      "version": {
+        "type": "string",
+        "title": "Version",
+        "deprecated": true
+      },
+      "digest": {
+        "type": "string",
+        "title": "Digest",
+        "deprecated": true
+      },
+      "createdAt": {
+        "type": "string",
+        "title": "Created At",
+        "deprecated": true
+      }
+    }
+  }
+}

--- a/pkg/cmd/scafctl/catalog/list_test.go
+++ b/pkg/cmd/scafctl/catalog/list_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/oakwood-commons/kvx/pkg/tui"
 	catalogpkg "github.com/oakwood-commons/scafctl/pkg/catalog"
 	appconfig "github.com/oakwood-commons/scafctl/pkg/config"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
@@ -185,8 +186,8 @@ func TestArtifactListSchema_ValidJSON(t *testing.T) {
 	t.Parallel()
 
 	var schema map[string]any
-	err := json.Unmarshal(artifactListSchema, &schema)
-	require.NoError(t, err, "artifactListSchema must be valid JSON")
+	err := json.Unmarshal(listSchemaJSON, &schema)
+	require.NoError(t, err, "list_schema.json must be valid JSON")
 
 	items, ok := schema["items"].(map[string]any)
 	require.True(t, ok, "schema must have items object")
@@ -206,7 +207,7 @@ func TestArtifactListSchema_RequiredFields(t *testing.T) {
 	t.Parallel()
 
 	var schema map[string]any
-	err := json.Unmarshal(artifactListSchema, &schema)
+	err := json.Unmarshal(listSchemaJSON, &schema)
 	require.NoError(t, err)
 
 	items := schema["items"].(map[string]any)
@@ -228,39 +229,54 @@ func TestArtifactListSchema_RequiredFields(t *testing.T) {
 	assert.NotContains(t, requiredNames, "digest")
 }
 
+func TestListSchemaJSON_ParsesWithDisplay(t *testing.T) {
+	t.Parallel()
+	hints, ds, err := tui.ParseSchemaWithDisplay(listSchemaJSON)
+	require.NoError(t, err, "list_schema.json must parse without error")
+	assert.NotNil(t, hints, "should produce column hints")
+	assert.NotNil(t, ds, "should produce display schema")
+}
+
 func TestArtifactListSchema_DigestHiddenInTable(t *testing.T) {
 	t.Parallel()
 
 	var schema map[string]any
-	err := json.Unmarshal(artifactListSchema, &schema)
+	err := json.Unmarshal(listSchemaJSON, &schema)
 	require.NoError(t, err)
 
 	items := schema["items"].(map[string]any)
 	props := items["properties"].(map[string]any)
 	digest := props["digest"].(map[string]any)
 
-	// Digest should be hidden from table view (deprecated flag set)
+	// Digest should be hidden from table view (deprecated flag in schema)
 	deprecated, ok := digest["deprecated"]
 	assert.True(t, ok, "digest column should have deprecated flag")
 	assert.Equal(t, true, deprecated, "digest column should be deprecated (hidden from table view)")
+
+	// Column hint also marks it hidden (the mechanism that drives table output)
+	assert.True(t, listColumnHints["digest"].Hidden, "digest column hint should be Hidden")
 }
 
 func TestArtifactListSchema_HiddenFields(t *testing.T) {
 	t.Parallel()
 
 	var schema map[string]any
-	err := json.Unmarshal(artifactListSchema, &schema)
+	err := json.Unmarshal(listSchemaJSON, &schema)
 	require.NoError(t, err)
 
 	items := schema["items"].(map[string]any)
 	props := items["properties"].(map[string]any)
 
-	// version, createdAt, and digest should be hidden
+	// version, createdAt, and digest should be hidden in both schema and column hints
 	for _, field := range []string{"version", "createdAt", "digest"} {
 		fieldMap := props[field].(map[string]any)
 		deprecated, ok := fieldMap["deprecated"]
 		assert.True(t, ok, "field %q should have deprecated", field)
 		assert.Equal(t, true, deprecated, "field %q should be deprecated", field)
+
+		hint, exists := listColumnHints[field]
+		assert.True(t, exists, "field %q should have a column hint", field)
+		assert.True(t, hint.Hidden, "field %q column hint should be Hidden", field)
 	}
 }
 


### PR DESCRIPTION
## Description

Replace inline JSON schema in catalog list with an embedded `list_schema.json` file containing `x-kvx-list` and `x-kvx-detail` extensions, enabling the `-i` interactive TUI card-list and detail view.

- Add `list_schema.json` with card view (title=name, subtitle=displayName, badges=kind+category) and detail sections (identity, display name, category, metadata)
- Wire schema via `kvx.WithOutputDisplaySchemaJSON` in `list.go`
- Update tests to reference new embedded schema variable
- Add `ParseSchemaWithDisplay` validation test

## Related Issues

N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My commits follow conventional commit format
- [x] I have added/updated tests for my changes
- [x] `go test ./...` passes
- [x] `task lint` passes
- [x] I have signed off my commits (`git commit -s -S`)
