### PR TITLE
fix: generate lint --help rule catalog from KnownRules to fix severity drift

### DIFF
--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -81,33 +81,13 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 		Use:     "lint [name[@version]]",
 		Aliases: []string{"l", "check"},
 		Short:   "Report authoring warnings and best practices (the advisory subset of 'validate')",
-		Long: heredoc.Doc(`
+		Long: strings.ReplaceAll(heredoc.Docf(`
 			Analyze a solution file for potential issues, anti-patterns, and best practices.
 
-			LINT RULES:
-			  Errors (will cause execution failures):
-			    - unused-resolver          Resolver defined but never referenced
-			    - invalid-dependency       Action depends on non-existent action
-			    - resolver-undefined-dependency  Resolver dependsOn references an undefined resolver
-			    - missing-provider         Referenced provider not registered
-			    - invalid-expression       Invalid CEL expression syntax
-			    - invalid-template         Invalid Go template syntax
-			    - unbundled-test-file      Test file not covered by bundle.include
-			    - invalid-test-name        Test name does not match naming pattern
-			    - schema-violation         Solution YAML violates the JSON Schema
-			    - unknown-provider-input   Input key not declared in provider schema
-			    - invalid-provider-input-type  Literal input value violates provider schema type
+			%s
 
-			  Warnings (may cause problems):
-			    - empty-workflow       Workflow defined but no actions
-			    - finally-with-foreach forEach not allowed in finally actions
-			    - unused-template      Test template not referenced by any extends
-
-			  Info (suggestions):
-			    - missing-description  Action/resolver lacks description
-			    - long-timeout        Timeout exceeds recommended maximum
-			    - unused-finally      Finally actions with no regular actions
-			    - undefined-optional-reference  Optional CEL ref (_.?name) targets an undefined resolver
+			  Run 'scafctl lint rules' for the full rule list with descriptions,
+			  or 'scafctl lint rule <name>' to explain a single rule.
 
 			SOME OUTPUT FORMATS:
 			  table   Human-readable bordered table
@@ -117,7 +97,7 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 			  Use -o to select a format, -i for interactive exploration,
 			  -e for CEL expression filtering, -w for per-finding filters.
-		`),
+		`, pkglint.RuleSummaryText()), settings.CliBinaryName, cliParams.BinaryName),
 		Example: strings.ReplaceAll(heredoc.Doc(`
 			# Lint a solution file
 			scafctl lint -f ./solution.yaml

--- a/pkg/cmd/scafctl/lint/lint_test.go
+++ b/pkg/cmd/scafctl/lint/lint_test.go
@@ -6,6 +6,7 @@ package lint
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,6 +43,41 @@ func TestCommandLint(t *testing.T) {
 	assert.Contains(t, cmdNames, "rules")
 	assert.Contains(t, cmdNames, "rule")
 	assert.Contains(t, cmdNames, "explain")
+}
+
+func TestCommandLint_LongHelpGeneratedRuleSummary(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandLint(cliParams, ioStreams, "scafctl")
+
+	// The rule catalog in Long is generated from KnownRules, so it must include
+	// rules the old hand-maintained block omitted (regression against drift).
+	for _, rule := range []string{"resolver-cycle", "exec-command-injection", "deprecated-field"} {
+		assert.Containsf(t, cmd.Long, rule, "generated help should list rule %q", rule)
+	}
+
+	// Regression pins for issue #748: the two mis-tiered rules and the total.
+	assert.Contains(t, cmd.Long, fmt.Sprintf("LINT RULES (%d total):", len(pkglint.KnownRules)))
+	assert.Contains(t, cmd.Long, "unused-resolver")
+	assert.Contains(t, cmd.Long, "finally-with-foreach")
+
+	// Help stays self-contained but points at the detail commands.
+	assert.Contains(t, cmd.Long, "scafctl lint rules")
+	assert.Contains(t, cmd.Long, "scafctl lint rule <name>")
+}
+
+func TestCommandLint_LongHelpEmbedderSafe(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandLint(cliParams, ioStreams, "mycli")
+
+	// Pointer commands must use the embedder's binary name, never hardcoded
+	// "scafctl". Rule identifiers themselves are not binary names, so the
+	// assertion targets the command references only.
+	assert.Contains(t, cmd.Long, "mycli lint rules")
+	assert.Contains(t, cmd.Long, "mycli lint rule <name>")
+	assert.NotContains(t, cmd.Long, "scafctl lint rule")
 }
 
 func TestCommandLint_Flags(t *testing.T) {

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -3,7 +3,11 @@
 
 package lint
 
-import "sort"
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
 
 // RuleMeta describes a single lint rule, including its severity, category,
 // and human-readable guidance. This is the authoritative source of truth
@@ -702,4 +706,66 @@ func ListRules() []RuleMeta {
 func GetRule(name string) (RuleMeta, bool) {
 	r, ok := KnownRules[name]
 	return r, ok
+}
+
+// summaryTiers lists the severity tiers in display order alongside their
+// human-readable heading. It is the single ordering used by RuleSummaryText so
+// the generated help block always presents errors, then warnings, then info.
+var summaryTiers = []struct {
+	severity string
+	heading  string
+}{
+	{string(SeverityError), "Errors"},
+	{string(SeverityWarning), "Warnings"},
+	{string(SeverityInfo), "Info"},
+}
+
+// RuleSummaryText renders a compact, drift-proof summary of every lint rule in
+// KnownRules, grouped by severity tier (errors, then warnings, then info) and
+// by category within each tier. It is derived entirely from the authoritative
+// registry via ListRules(), so the tier labels can never diverge from the rule
+// definitions -- unlike a hand-maintained catalog.
+//
+// The output is intended for embedding in the 'lint' command's Long help text.
+// It lists rule names only (not descriptions) to stay scannable; readers are
+// pointed at 'lint rules' / 'lint rule <name>' for full detail. Output is
+// deterministic: tiers follow summaryTiers, categories and rule names are
+// sorted alphabetically.
+func RuleSummaryText() string {
+	// Bucket rules by severity, then by category. ListRules() already sorts by
+	// severity then rule name, so per-category name slices come out sorted.
+	byTier := make(map[string]map[string][]string)
+	counts := make(map[string]int)
+	total := 0
+	for _, r := range ListRules() {
+		if byTier[r.Severity] == nil {
+			byTier[r.Severity] = make(map[string][]string)
+		}
+		byTier[r.Severity][r.Category] = append(byTier[r.Severity][r.Category], r.Rule)
+		counts[r.Severity]++
+		total++
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "LINT RULES (%d total):", total)
+
+	for _, tier := range summaryTiers {
+		categories := byTier[tier.severity]
+		if len(categories) == 0 {
+			continue
+		}
+		fmt.Fprintf(&b, "\n  %s (%d):", tier.heading, counts[tier.severity])
+
+		catNames := make([]string, 0, len(categories))
+		for cat := range categories {
+			catNames = append(catNames, cat)
+		}
+		sort.Strings(catNames)
+
+		for _, cat := range catNames {
+			fmt.Fprintf(&b, "\n    %-16s %s", cat+":", strings.Join(categories[cat], ", "))
+		}
+	}
+
+	return b.String()
 }

--- a/pkg/lint/rules_test.go
+++ b/pkg/lint/rules_test.go
@@ -4,6 +4,8 @@
 package lint
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,4 +74,103 @@ func TestGetRule(t *testing.T) {
 		_, ok := GetRule("nonexistent-rule")
 		assert.False(t, ok)
 	})
+}
+
+// parseSummaryTiers parses RuleSummaryText output into a map of severity tier
+// heading ("Errors"/"Warnings"/"Info") to the set of rule names listed under
+// it. It mirrors the exact format produced by RuleSummaryText so the drift
+// guard tests can assert every rule lands under its true severity tier.
+func parseSummaryTiers(t *testing.T, summary string) map[string]map[string]bool {
+	t.Helper()
+	tiers := map[string]map[string]bool{}
+	current := ""
+	for _, line := range strings.Split(summary, "\n") {
+		switch {
+		case strings.HasPrefix(line, "    "): // category line: "    cat:  rule1, rule2"
+			require.NotEmpty(t, current, "category line before any tier heading: %q", line)
+			_, rest, ok := strings.Cut(strings.TrimSpace(line), ":")
+			require.True(t, ok, "category line missing colon: %q", line)
+			for _, name := range strings.Split(rest, ",") {
+				name = strings.TrimSpace(name)
+				if name != "" {
+					tiers[current][name] = true
+				}
+			}
+		case strings.HasPrefix(line, "  "): // tier heading: "  Errors (38):"
+			heading := strings.TrimSpace(line)
+			heading, _, _ = strings.Cut(heading, " ") // drop the " (N):" suffix
+			current = heading
+			if tiers[current] == nil {
+				tiers[current] = map[string]bool{}
+			}
+		}
+	}
+	return tiers
+}
+
+func TestRuleSummaryText(t *testing.T) {
+	summary := RuleSummaryText()
+
+	// Header reports the exact total from the registry.
+	assert.Contains(t, summary, fmt.Sprintf("LINT RULES (%d total):", len(KnownRules)))
+
+	tiers := parseSummaryTiers(t, summary)
+
+	headingForSeverity := map[string]string{
+		string(SeverityError):   "Errors",
+		string(SeverityWarning): "Warnings",
+		string(SeverityInfo):    "Info",
+	}
+
+	// Drift guard: every rule appears exactly once, under its true severity
+	// tier. This is the structural protection the hand-maintained catalog
+	// lacked -- it cannot diverge from KnownRules because it is generated from
+	// it and verified against it here.
+	seen := map[string]int{}
+	for _, tier := range tiers {
+		for name := range tier {
+			seen[name]++
+		}
+	}
+	for name, rule := range KnownRules {
+		wantHeading := headingForSeverity[rule.Severity]
+		require.NotEmpty(t, wantHeading, "rule %q has unknown severity %q", name, rule.Severity)
+		assert.Truef(t, tiers[wantHeading][name],
+			"rule %q (severity %q) must be listed under %q", name, rule.Severity, wantHeading)
+		assert.Equalf(t, 1, seen[name], "rule %q must appear exactly once in summary", name)
+	}
+
+	// Per-tier counts match ListRules() grouping.
+	wantCounts := map[string]int{}
+	for _, r := range ListRules() {
+		wantCounts[headingForSeverity[r.Severity]]++
+	}
+	for heading, names := range tiers {
+		assert.Equalf(t, wantCounts[heading], len(names),
+			"tier %q count mismatch", heading)
+	}
+}
+
+func TestRuleSummaryTextRegressionPins(t *testing.T) {
+	// Regression pins for issue #748: the hand-maintained catalog listed these
+	// two rules under the wrong tier. Assert they now render under their real
+	// severity, so the drift can never silently return.
+	tiers := parseSummaryTiers(t, RuleSummaryText())
+
+	assert.True(t, tiers["Warnings"]["unused-resolver"],
+		"unused-resolver is a warning, not an error")
+	assert.False(t, tiers["Errors"]["unused-resolver"],
+		"unused-resolver must not be listed under Errors")
+
+	assert.True(t, tiers["Errors"]["finally-with-foreach"],
+		"finally-with-foreach is an error, not a warning")
+	assert.False(t, tiers["Warnings"]["finally-with-foreach"],
+		"finally-with-foreach must not be listed under Warnings")
+}
+
+func BenchmarkRuleSummaryText(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		_ = RuleSummaryText()
+	}
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -4321,9 +4321,36 @@ func TestIntegration_Lint_Help(t *testing.T) {
 
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "Analyze a solution file")
-	assert.Contains(t, stdout, "LINT RULES:")
+	// The rule catalog is generated from KnownRules (issue #748): the header
+	// reports a total and the help points at the detail commands.
+	assert.Contains(t, stdout, "LINT RULES (")
+	assert.Contains(t, stdout, "scafctl lint rules")
+	assert.Contains(t, stdout, "scafctl lint rule <name>")
+	// Rules must not be presented under the wrong severity tier. unused-resolver
+	// is a warning and finally-with-foreach is an error; assert both land in the
+	// correct block rather than the mis-tiered locations the old catalog used.
+	errorsBlock, warningsBlock := lintHelpSeverityBlocks(t, stdout)
+	assert.Contains(t, warningsBlock, "unused-resolver")
+	assert.NotContains(t, errorsBlock, "unused-resolver")
+	assert.Contains(t, errorsBlock, "finally-with-foreach")
+	assert.NotContains(t, warningsBlock, "finally-with-foreach")
 	assert.Contains(t, stdout, "--file")
 	assert.Contains(t, stdout, "--severity")
+}
+
+// lintHelpSeverityBlocks splits the generated LINT RULES section of `lint
+// --help` output into the text under "Errors (" and under "Warnings (" so a
+// test can assert a rule appears in the correct severity tier. The "Info ("
+// heading terminates the warnings block.
+func lintHelpSeverityBlocks(t *testing.T, help string) (errorsBlock, warningsBlock string) {
+	t.Helper()
+	errStart := strings.Index(help, "\n  Errors (")
+	warnStart := strings.Index(help, "\n  Warnings (")
+	infoStart := strings.Index(help, "\n  Info (")
+	require.GreaterOrEqual(t, errStart, 0, "help should contain an Errors tier")
+	require.Greater(t, warnStart, errStart, "Warnings tier should follow Errors")
+	require.Greater(t, infoStart, warnStart, "Info tier should follow Warnings")
+	return help[errStart:warnStart], help[warnStart:infoStart]
 }
 
 func TestIntegration_Lint_RequiresFile(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #748. The `lint` command's `Long` help hardcoded a hand-maintained `LINT RULES` catalog that had drifted from the authoritative `KnownRules` registry:

- `unused-resolver` was listed under **Errors** -- it is a **warning** (context-dependent: warning with a workflow, info without).
- `finally-with-foreach` was listed under **Warnings** -- it is an **error**.
- Only **18 of 69** rules were listed at all.

Root cause: the catalog was a static `heredoc.Doc` string in a CLI file with no drift guard, while the `lint rules` / `lint rule` subcommands and the MCP `list_lint_rules` / `explain_lint_rule` tools all derive from `KnownRules` and never drift.

## Change

- **`pkg/lint/rules.go`** -- new `RuleSummaryText()` generates a compact, deterministic summary of all rules grouped by severity tier (errors, warnings, info) then category, derived entirely from `ListRules()`/`KnownRules`. The header total is computed from the actually-bucketed rules so header and body can never disagree.
- **`pkg/cmd/scafctl/lint/lint.go`** -- `Long` injects the generated summary via `heredoc.Docf` + embedder-safe `strings.ReplaceAll(settings.CliBinaryName, cliParams.BinaryName)`, and points readers at `lint rules` / `lint rule <name>` for full descriptions. This keeps `--help` self-contained (the one surface a reader cannot escape to run a second command) while eliminating drift structurally rather than via a catch-up test.
- Business logic stays in `pkg/lint`; the CLI file only wires and substitutes.

## Tests

- **Drift guard** (`TestRuleSummaryText`): every `KnownRules` entry appears exactly once, under its true severity tier; per-tier counts match `ListRules()`.
- **Regression pins** (`TestRuleSummaryTextRegressionPins`): the two mis-tiered rules render under the correct tier.
- **Benchmark** `BenchmarkRuleSummaryText`.
- **CLI tests**: generated-content assertions + embedder-safety with a non-default binary name (`mycli`).
- **Integration**: `TestIntegration_Lint_Help` rewritten to assert the generated header/pointers and correct severity placement.

## Verification

- `task lint:changed`: 0 issues.
- `task test:e2e`: 933 passed, 0 failed.
- Local review gate: code review APPROVE (0 blocking); artifact audit: no gaps.

No breaking changes (help text only; no flags, output formats, or exit codes changed).
