### PR TITLE
fix(mcp): declare host entrypoint "mcp" to the plugin pool

### DIFF
--- a/docs/design/mcp-server-implementation-guide.md
+++ b/docs/design/mcp-server-implementation-guide.md
@@ -47,6 +47,7 @@ go get github.com/mark3labs/mcp-go@latest
 ```
 
 This adds:
+
 - `github.com/mark3labs/mcp-go/mcp` — Types, tool builders, result helpers
 - `github.com/mark3labs/mcp-go/server` — Server implementation, stdio/SSE transports
 
@@ -136,6 +137,19 @@ func WithServerVersion(version string) ServerOption {
 func WithServerContext(ctx context.Context) ServerOption {
     return func(c *serverConfig) {
         c.ctx = ctx
+    }
+}
+
+// WithEntrypoint declares the host entrypoint this MCP server represents
+// (defaults to "mcp"). It is delivered to pooled plugins so the metadata
+// provider reports "mcp" rather than "unknown". Applied to the configured
+// plugin pool at construction only if the pool has not already declared an
+// entrypoint, so an embedder or the CLI that wired its own base
+// ProviderConfig always wins. Embedders wrapping pkg/mcp rarely need to set
+// this -- the "mcp" default is correct.
+func WithEntrypoint(entrypoint string) ServerOption {
+    return func(c *serverConfig) {
+        c.entrypoint = entrypoint
     }
 }
 ```
@@ -517,6 +531,7 @@ func (s *Server) handleToolName(ctx context.Context, request mcp.CallToolRequest
 ```
 
 **Important conventions:**
+
 - Tool errors are returned via `mcp.NewToolResultError()` (sets `isError: true`), **not** as Go errors. Go errors are only for protocol-level failures (e.g., the server itself is broken).
 - All tools use `s.ctx` (the pre-built MCP context) for library calls, not the handler's `ctx` parameter. The handler `ctx` is for MCP-level cancellation; `s.ctx` has the scafctl dependencies injected.
 - Progress notifications use the `ProgressToken` from `request.Params.Meta.ProgressToken` when available.
@@ -582,6 +597,7 @@ func (s *Server) handleListSolutions(ctx context.Context, request mcp.CallToolRe
 ```
 
 **Library integration points:**
+
 - `pkg/catalog.NewLocalCatalog()` → `List(ctx, "solution", name)`
 - Returns `[]ArtifactListItem` which has JSON tags
 
@@ -622,10 +638,12 @@ func (s *Server) handleInspectSolution(ctx context.Context, request mcp.CallTool
 ```
 
 **Library integration points:**
+
 - `explain.LoadSolution(ctx, path)` — loads solution from file/catalog/URL
 - `explain.BuildSolutionExplanation(sol)` — returns `*SolutionExplanation` with full JSON tags
 
 **Annotations:**
+
 - `OpenWorldHint: true` — may access remote catalog to load solution
 
 ### Step 2.3: `lint_solution` Tool
@@ -685,6 +703,7 @@ func (s *Server) handleLintSolution(ctx context.Context, request mcp.CallToolReq
 ```
 
 **Library integration points:**
+
 - `prepare.Solution(ctx, path)` — loads solution + builds registry
 - `lint.LintSolution(sol, path, reg)` — returns `*Result` with `[]Finding`
 - `lint.FilterBySeverity(result, severity)` — filters findings
@@ -780,6 +799,7 @@ func (s *Server) handleListProviders(ctx context.Context, request mcp.CallToolRe
 ```
 
 **Library integration points:**
+
 - `s.registry.ListProviders()` — already sorted, no CLI deps
 - `s.registry.ListByCapability()` / `ListByCategory()` — filter methods
 - `provider.Descriptor` — has all the metadata fields
@@ -818,6 +838,7 @@ func (s *Server) handleGetProviderSchema(ctx context.Context, request mcp.CallTo
 ```
 
 **Library integration points:**
+
 - `explain.LookupProvider(ctx, name, reg)` — returns `*provider.Descriptor` with full schema
 
 ### Step 2.6: `list_cel_functions` Tool
@@ -895,6 +916,7 @@ func (s *Server) handleListCELFunctions(ctx context.Context, request mcp.CallToo
 ```
 
 **Library integration points:**
+
 - `ext.All()`, `ext.Custom()`, `ext.BuiltIn()` — returns `celexp.ExtFunctionList`
 - `celexp.ExtFunction` struct has JSON tags
 
@@ -975,6 +997,7 @@ func (s *Server) handleEvaluateCEL(ctx context.Context, request mcp.CallToolRequ
 ```
 
 **Library integration points:**
+
 - `celexp.EvaluateExpression(ctx, exprStr, rootData, additionalVars)` — the primary evaluation API
 - CEL environment factory must be initialized (happens in `PersistentPreRun` → inherited by `scafctl mcp serve`)
 
@@ -1053,6 +1076,7 @@ func (s *Server) handleRenderSolution(ctx context.Context, request mcp.CallToolR
 ```
 
 **Annotations:**
+
 - `OpenWorldHint: true` — resolver execution may access external systems
 - `IdempotentHint: true` — same inputs produce the same graph
 
@@ -1136,6 +1160,7 @@ func (s *Server) handleAuthStatus(ctx context.Context, request mcp.CallToolReque
 ```
 
 **Library integration points:**
+
 - `s.authReg.All()` — returns `map[string]Handler`
 - `handler.Status(ctx)` — returns `*auth.Status` with `Authenticated`, `ExpiresAt`, `IdentityType`, etc.
 
@@ -1272,6 +1297,7 @@ Returns JSON Schema for a solution's input parameters.
 **Implementation note:** The design originally referenced a hypothetical `schema.GenerateConfigSchema(sol)` function. Instead, `generateSolutionInputSchema()` was implemented directly in `pkg/mcp/resources.go` — it introspects the solution's resolver definitions to identify which resolvers use the `parameter` provider (user-supplied inputs) and builds a JSON Schema from their type, description, and example fields. This approach avoids adding a new public API to the schema package for a single consumer.
 
 **Key behaviors:**
+
 - Only resolvers using the `parameter` provider are included in the schema
 - Resolvers with only a `parameter` source (no fallback chain) are marked as `required`
 - Resolver types are mapped to JSON Schema types (`int` → `integer`, `float` → `number`, etc.)
@@ -1545,6 +1571,7 @@ Structure (all sections implemented):
 ### Step 6.3: Update Design Docs ✅
 
 Updated `docs/design/mcp-server.md` with:
+
 - Marked all implementation phases (2-6) as complete in the Recommended Approach section
 - Added links to this implementation guide, the tutorial, and example configs
 - Updated step numbering to reflect the completed work and remaining deferred items
@@ -1552,6 +1579,7 @@ Updated `docs/design/mcp-server.md` with:
 ### Step 6.4: CLI Help Text ✅
 
 The `scafctl mcp serve` command's `Long` description (in `pkg/cmd/scafctl/mcp/serve.go`) already includes:
+
 - What the MCP server does (one paragraph)
 - Example VS Code configuration (copy-paste ready)
 - How to use `--info` for debugging
@@ -1716,11 +1744,13 @@ if err != nil {
 ### Error Messages
 
 Error messages should be:
+
 - **Actionable** — Tell the AI what went wrong and how to fix it
 - **Contextual** — Include the relevant input (file path, provider name, etc.)
 - **Not technical** — Avoid Go stack traces or internal package paths
 
 Examples:
+
 - `"Solution file not found: /path/to/solution.yaml — verify the file exists and the path is correct"`
 - `"Provider 'nonexistent' not found. Available providers: http, file, parameter, cel, ..."`
 - `"CEL evaluation error at position 15: undeclared reference to 'foo'. Available variables: _, __self"`

--- a/docs/tutorials/provider-reference.md
+++ b/docs/tutorials/provider-reference.md
@@ -2090,7 +2090,7 @@ None. The metadata provider accepts no inputs.
 | `version.buildTime` | string | Timestamp of the build |
 | `args` | string[] | Command-line arguments passed to scafctl |
 | `cwd` | string | Current working directory |
-| `entrypoint` | string | How scafctl was invoked: `"cli"`, `"api"`, `"mcp"`, or `"unknown"` |
+| `entrypoint` | string | How scafctl was invoked: `"cli"`, `"api"`, `"mcp"`, or `"unknown"`. Long-lived hosts declare their own entrypoint to the plugin pool: the CLI's `mcp serve` and the `pkg/mcp` server report `"mcp"`, the API server reports `"api"`. An embedder that wraps `pkg/mcp` gets `"mcp"` automatically (override via `mcp.WithEntrypoint`); `"unknown"` only appears when a custom pool-mode host neglects to declare one. |
 | `command` | string | The command path (e.g. `scafctl/run/solution`) |
 | `solution` | object | Metadata about the currently-running solution |
 | `solution.name` | string | Solution name |
@@ -2392,14 +2392,18 @@ Usage:
 
 {{< tabs "provider-reference-cmd-1" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl run solution -f sol.yaml -r environment=production
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl run solution -f sol.yaml -r environment=production
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -2449,16 +2453,20 @@ Manage secrets via CLI:
 
 {{< tabs "provider-reference-cmd-2" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl secrets set api-key "my-secret-value"
 scafctl secrets list
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl secrets set api-key "my-secret-value"
 scafctl secrets list
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/pkg/cmd/scafctl/mcp/serve.go
+++ b/pkg/cmd/scafctl/mcp/serve.go
@@ -232,6 +232,13 @@ func buildMCPPluginPool(ctx context.Context, cfg *config.Config, reg *provider.R
 	// args) to pooled plugins so the metadata provider and any other
 	// Settings-driven plugin behave the same under this long-lived host as
 	// under one-shot per-call hosts.
+	//
+	// pkg/mcp also defaults this pool's entrypoint to "mcp" (see
+	// mcp.WithEntrypoint / Pool.SetBaseProviderConfigIfAbsent), so this call is
+	// not strictly required for the entrypoint alone. It is kept as the CLI's
+	// explicit declaration of intent -- and because it also carries the resolved
+	// binary name and the full host-static blob -- and, being set first, it
+	// wins over the pkg/mcp default (which is a no-op once an entrypoint is set).
 	poolOpts = append(poolOpts, plugin.WithBaseProviderConfig(
 		prepare.HostStaticProviderConfig(settings.BinaryNameFromContext(ctx), prepare.EntrypointMCP),
 	))

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/provider/official"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
 )
 
 // configReloaderTTL is how long the MCP server caches config before
@@ -65,6 +66,10 @@ type Server struct {
 	// initialization and idle eviction. When set, provider tool handlers
 	// auto-resolve official plugins on demand.
 	pluginPool *plugin.Pool
+
+	// entrypoint is the host entrypoint this server declares to pooled plugins
+	// (e.g. "mcp"), so the metadata provider reports it. See WithEntrypoint.
+	entrypoint string
 
 	// cfgReloader provides TTL-based config reloading so long-lived MCP
 	// sessions pick up config changes (e.g. auth profile switches).
@@ -122,6 +127,7 @@ type serverConfig struct {
 	supplementalInstructions string
 	rootCmd                  *cobra.Command
 	pluginPool               *plugin.Pool
+	entrypoint               string
 	upstreamServers          map[string]config.MCPServerConfig
 }
 
@@ -139,6 +145,23 @@ func WithRootCommand(cmd *cobra.Command) ServerOption {
 func WithServerPluginPool(pool *plugin.Pool) ServerOption {
 	return func(c *serverConfig) {
 		c.pluginPool = pool
+	}
+}
+
+// WithEntrypoint declares the host entrypoint this MCP server represents (e.g.
+// "mcp", "api"), delivered to pooled plugins so the metadata provider reports it
+// instead of "unknown". It defaults to prepare.EntrypointMCP ("mcp") -- an MCP
+// server is by definition an MCP host -- so embedders rarely need to set it. It
+// exists so a custom host wrapping pkg/mcp can label itself accurately. An empty
+// value is normalized back to the "mcp" default.
+//
+// The entrypoint is applied to the configured plugin pool at construction only
+// if that pool does not already declare one (see
+// plugin.Pool.SetBaseProviderConfigIfAbsent), so an embedder or the CLI that
+// wired its own base ProviderConfig always wins.
+func WithEntrypoint(entrypoint string) ServerOption {
+	return func(c *serverConfig) {
+		c.entrypoint = entrypoint
 	}
 }
 
@@ -387,10 +410,27 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 		cfg.name = settings.CliBinaryName
 	}
 
+	// An MCP server is by definition an MCP host: default (and normalize an
+	// empty override of) the declared entrypoint to "mcp" so pooled plugins'
+	// metadata provider reports "mcp" rather than "unknown".
+	if strings.TrimSpace(cfg.entrypoint) == "" {
+		cfg.entrypoint = prepare.EntrypointMCP
+	}
+
 	// Validate that a registry is set when a plugin pool is configured,
 	// otherwise ensureProvider would panic on nil registry access.
 	if cfg.pluginPool != nil && cfg.registry == nil {
 		return nil, errors.New("WithServerPluginPool requires WithServerRegistry")
+	}
+
+	// Declare this host's entrypoint to the plugin pool so pooled plugins
+	// receive it at load time. This is set-once and skipped if the caller (an
+	// embedder or the CLI) already wired a base ProviderConfig carrying an
+	// entrypoint, so an explicit configuration always wins.
+	if cfg.pluginPool != nil {
+		cfg.pluginPool.SetBaseProviderConfigIfAbsent(
+			prepare.HostStaticProviderConfig(cfg.name, cfg.entrypoint),
+		)
 	}
 
 	// Build the MCP context for tool handlers
@@ -429,6 +469,7 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 		config:          cfg.config,
 		rootCmd:         cfg.rootCmd,
 		pluginPool:      cfg.pluginPool,
+		entrypoint:      cfg.entrypoint,
 		coreTools:       make(map[string]struct{}, 64),
 		corePrompts:     make(map[string]struct{}, 16),
 		upstreamTools:   make(map[string]string),

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/plugin"
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution/prepare"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -439,5 +440,69 @@ func TestNewServer_PluginPoolRequiresRegistry(t *testing.T) {
 		srv, err := NewServer(WithServerPluginPool(pool), WithServerRegistry(reg))
 		require.NoError(t, err)
 		assert.NotNil(t, srv)
+	})
+}
+
+func TestNewServer_DeclaresEntrypointToPool(t *testing.T) {
+	t.Run("defaults a bare pool's entrypoint to mcp", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard())
+		defer pool.Shutdown()
+
+		srv, err := NewServer(WithServerName("mycli"), WithServerPluginPool(pool), WithServerRegistry(reg))
+		require.NoError(t, err)
+		assert.Equal(t, prepare.EntrypointMCP, srv.entrypoint)
+		assert.Equal(t, prepare.EntrypointMCP, pool.BaseEntrypoint())
+		assert.Equal(t, "mycli", pool.BaseProviderConfig().BinaryName)
+	})
+
+	t.Run("WithEntrypoint overrides the default", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard())
+		defer pool.Shutdown()
+
+		srv, err := NewServer(
+			WithServerPluginPool(pool),
+			WithServerRegistry(reg),
+			WithEntrypoint(prepare.EntrypointAPI),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, prepare.EntrypointAPI, srv.entrypoint)
+		assert.Equal(t, prepare.EntrypointAPI, pool.BaseEntrypoint())
+	})
+
+	t.Run("empty WithEntrypoint normalizes to mcp", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard())
+		defer pool.Shutdown()
+
+		srv, err := NewServer(
+			WithServerPluginPool(pool),
+			WithServerRegistry(reg),
+			WithEntrypoint("   "),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, prepare.EntrypointMCP, srv.entrypoint)
+		assert.Equal(t, prepare.EntrypointMCP, pool.BaseEntrypoint())
+	})
+
+	t.Run("does not clobber a pool that already declares an entrypoint", func(t *testing.T) {
+		reg := provider.NewRegistry()
+		// Simulate the CLI (or an embedder) wiring its own base config first.
+		pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard(),
+			plugin.WithBaseProviderConfig(prepare.HostStaticProviderConfig("cli-name", prepare.EntrypointCLI)),
+		)
+		defer pool.Shutdown()
+
+		_, err := NewServer(WithServerPluginPool(pool), WithServerRegistry(reg))
+		require.NoError(t, err)
+		assert.Equal(t, prepare.EntrypointCLI, pool.BaseEntrypoint(), "explicit config must win")
+		assert.Equal(t, "cli-name", pool.BaseProviderConfig().BinaryName)
+	})
+
+	t.Run("no pool is a no-op", func(t *testing.T) {
+		srv, err := NewServer()
+		require.NoError(t, err)
+		assert.Equal(t, prepare.EntrypointMCP, srv.entrypoint)
 	})
 }

--- a/pkg/plugin/pool.go
+++ b/pkg/plugin/pool.go
@@ -576,6 +576,11 @@ func (p *Pool) spawn(ctx context.Context, entry *poolEntry, cancel context.Cance
 		// host-static runtime metadata (build info, entrypoint, command, args)
 		// so pooled plugins that read ProviderConfig.Settings match per-call
 		// hosts; it is empty by default.
+		//
+		// This lockless read of p.opts.baseConfig is race-free: baseConfig is
+		// frozen once any entry exists -- SetBaseProviderConfigIfAbsent refuses
+		// to mutate it when len(p.entries) > 0, and this entry was inserted
+		// under p.mu before this spawn goroutine ran.
 		if cErr := wrapper.Configure(ctx, p.opts.baseConfig); cErr != nil {
 			p.logger.V(1).Info("failed to configure plugin provider",
 				"plugin", entry.dep.Name, "provider", provName, "error", cErr)
@@ -824,7 +829,103 @@ func (p *Pool) ClientOptsLen() int {
 // Settings map is a deep clone (map and value bytes), so callers cannot mutate
 // the pool's stored config.
 func (p *Pool) BaseProviderConfig() ProviderConfig {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return cloneProviderConfig(p.opts.baseConfig)
+}
+
+// baseConfigMetadataKey is the ProviderConfig.Settings key under which host
+// runtime metadata (including the host entrypoint) is delivered to pooled
+// plugins. It mirrors the prepare package's hostMetadataSettingsKey; the value
+// must stay in sync, but the packages cannot share a constant without an import
+// cycle (prepare imports plugin).
+const baseConfigMetadataKey = "metadata"
+
+// BaseEntrypoint returns the host entrypoint (e.g. "cli", "api", "mcp") declared
+// in the pool's host-static base ProviderConfig -- that is, the "entrypoint"
+// field of Settings["metadata"]. It returns "" when no base config, no metadata
+// entry, or no (or malformed) entrypoint is present. Safe for concurrent use.
+func (p *Pool) BaseEntrypoint() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return baseEntrypoint(p.opts.baseConfig)
+}
+
+// baseEntrypoint extracts the host entrypoint from a base ProviderConfig without
+// locking; callers must hold p.mu (or own cfg exclusively).
+func baseEntrypoint(cfg ProviderConfig) string {
+	raw, ok := cfg.Settings[baseConfigMetadataKey]
+	if !ok {
+		return ""
+	}
+	var meta struct {
+		Entrypoint string `json:"entrypoint"`
+	}
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return ""
+	}
+	return meta.Entrypoint
+}
+
+// SetBaseProviderConfigIfAbsent declares the host-static metadata carried by
+// cfg (crucially its entrypoint) on the pool's base ProviderConfig, but ONLY IF
+// the pool has not yet declared a host entrypoint and no plugin has been loaded
+// (or adopted) yet. It is a guarded, one-time escape hatch for a host package
+// (e.g. pkg/mcp) to declare the entrypoint it represents on a caller-supplied
+// pool without violating the set-once contract of [WithBaseProviderConfig].
+//
+// It MERGES rather than replaces: cfg's Settings keys are overlaid onto any the
+// pool already carried (so an embedder's unrelated settings, e.g. "httpClient",
+// are preserved), and cfg.BinaryName is applied only when the pool does not
+// already have one. This avoids silently discarding a base config an embedder
+// wired for another reason but without an entrypoint.
+//
+// It is a deliberate no-op (returning false) when the pool already carries an
+// entrypoint -- so an embedder or CLI that declared its own entrypoint always
+// wins -- or when any plugin has already been loaded, because such a plugin was
+// already Configure'd with the previous base config and a late mutation would
+// create a configure/execute mismatch. cfg is deep-cloned before merge, and the
+// whole operation is mutex-guarded, so it is safe for concurrent use.
+//
+// Returns true if cfg was applied, false if the call was skipped.
+func (p *Pool) SetBaseProviderConfigIfAbsent(cfg ProviderConfig) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.closed {
+		return false
+	}
+	// A loaded/loading plugin was already configured with the current base
+	// config; mutating it now would desync configure- vs execute-time metadata.
+	if len(p.entries) > 0 {
+		return false
+	}
+	// Respect any entrypoint the caller already declared (set-once contract).
+	if baseEntrypoint(p.opts.baseConfig) != "" {
+		return false
+	}
+
+	incoming := cloneProviderConfig(cfg)
+	merged := p.opts.baseConfig
+
+	// Preserve an already-set binary name; otherwise adopt the incoming one.
+	if merged.BinaryName == "" {
+		merged.BinaryName = incoming.BinaryName
+	}
+
+	// Overlay incoming Settings keys onto any the pool already carried so
+	// unrelated embedder settings are never dropped.
+	if len(incoming.Settings) > 0 {
+		if merged.Settings == nil {
+			merged.Settings = make(map[string]json.RawMessage, len(incoming.Settings))
+		}
+		for k, v := range incoming.Settings {
+			merged.Settings[k] = v
+		}
+	}
+
+	p.opts.baseConfig = merged
+	return true
 }
 
 // Shutdown kills all managed plugin processes. Called once on server stop.

--- a/pkg/plugin/pool_test.go
+++ b/pkg/plugin/pool_test.go
@@ -156,6 +156,188 @@ func TestNewPool_WithBaseProviderConfig(t *testing.T) {
 	})
 }
 
+func TestPool_BaseEntrypoint(t *testing.T) {
+	reg := provider.NewRegistry()
+
+	t.Run("empty when no base config", func(t *testing.T) {
+		p := NewPool(context.Background(), nil, reg, logr.Discard())
+		defer p.Shutdown()
+		assert.Empty(t, p.BaseEntrypoint())
+	})
+
+	t.Run("empty when metadata key absent", func(t *testing.T) {
+		base := ProviderConfig{
+			BinaryName: "mycli",
+			Settings: map[string]json.RawMessage{
+				"httpClient": json.RawMessage(`{"allowPrivateIPs":true}`),
+			},
+		}
+		p := NewPool(context.Background(), nil, reg, logr.Discard(), WithBaseProviderConfig(base))
+		defer p.Shutdown()
+		assert.Empty(t, p.BaseEntrypoint())
+	})
+
+	t.Run("empty when entrypoint field absent", func(t *testing.T) {
+		base := ProviderConfig{
+			Settings: map[string]json.RawMessage{
+				"metadata": json.RawMessage(`{"version":"1.2.3"}`),
+			},
+		}
+		p := NewPool(context.Background(), nil, reg, logr.Discard(), WithBaseProviderConfig(base))
+		defer p.Shutdown()
+		assert.Empty(t, p.BaseEntrypoint())
+	})
+
+	t.Run("empty when metadata is malformed", func(t *testing.T) {
+		base := ProviderConfig{
+			Settings: map[string]json.RawMessage{
+				"metadata": json.RawMessage(`not-json`),
+			},
+		}
+		p := NewPool(context.Background(), nil, reg, logr.Discard(), WithBaseProviderConfig(base))
+		defer p.Shutdown()
+		assert.Empty(t, p.BaseEntrypoint())
+	})
+
+	t.Run("returns the declared entrypoint", func(t *testing.T) {
+		base := ProviderConfig{
+			Settings: map[string]json.RawMessage{
+				"metadata": json.RawMessage(`{"entrypoint":"mcp"}`),
+			},
+		}
+		p := NewPool(context.Background(), nil, reg, logr.Discard(), WithBaseProviderConfig(base))
+		defer p.Shutdown()
+		assert.Equal(t, "mcp", p.BaseEntrypoint())
+	})
+}
+
+func TestPool_SetBaseProviderConfigIfAbsent(t *testing.T) {
+	reg := provider.NewRegistry()
+
+	newBase := func(entrypoint string) ProviderConfig {
+		return ProviderConfig{
+			BinaryName: "mycli",
+			Settings: map[string]json.RawMessage{
+				"metadata": json.RawMessage(fmt.Sprintf(`{"entrypoint":%q}`, entrypoint)),
+			},
+		}
+	}
+
+	t.Run("applies when no entrypoint is present", func(t *testing.T) {
+		p := NewPool(context.Background(), nil, reg, logr.Discard())
+		defer p.Shutdown()
+
+		applied := p.SetBaseProviderConfigIfAbsent(newBase("mcp"))
+		assert.True(t, applied)
+		assert.Equal(t, "mcp", p.BaseEntrypoint())
+		assert.Equal(t, "mycli", p.BaseProviderConfig().BinaryName)
+	})
+
+	t.Run("no-op when an entrypoint is already declared", func(t *testing.T) {
+		p := NewPool(context.Background(), nil, reg, logr.Discard(), WithBaseProviderConfig(newBase("api")))
+		defer p.Shutdown()
+
+		applied := p.SetBaseProviderConfigIfAbsent(newBase("mcp"))
+		assert.False(t, applied)
+		assert.Equal(t, "api", p.BaseEntrypoint(), "existing entrypoint must win")
+	})
+
+	t.Run("no-op after a plugin has been loaded", func(t *testing.T) {
+		p := NewPool(context.Background(), nil, reg, logr.Discard())
+		defer p.Shutdown()
+
+		// Simulate a loaded plugin: any entry means a plugin was already
+		// Configure'd with the current (empty) base config.
+		p.mu.Lock()
+		p.entries["dummy"] = &poolEntry{}
+		p.mu.Unlock()
+
+		applied := p.SetBaseProviderConfigIfAbsent(newBase("mcp"))
+		assert.False(t, applied)
+		assert.Empty(t, p.BaseEntrypoint())
+	})
+
+	t.Run("no-op after shutdown", func(t *testing.T) {
+		p := NewPool(context.Background(), nil, reg, logr.Discard())
+		p.Shutdown()
+
+		applied := p.SetBaseProviderConfigIfAbsent(newBase("mcp"))
+		assert.False(t, applied)
+	})
+
+	t.Run("preserves unrelated settings and existing binary name on merge", func(t *testing.T) {
+		base := ProviderConfig{
+			BinaryName: "embedder-cli",
+			Settings: map[string]json.RawMessage{
+				"httpClient": json.RawMessage(`{"allowPrivateIPs":true}`),
+			},
+		}
+		p := NewPool(context.Background(), nil, reg, logr.Discard(), WithBaseProviderConfig(base))
+		defer p.Shutdown()
+
+		// The pool has settings but no entrypoint -- the merge must add the
+		// entrypoint without discarding httpClient or overwriting the name.
+		applied := p.SetBaseProviderConfigIfAbsent(newBase("mcp"))
+		assert.True(t, applied)
+
+		got := p.BaseProviderConfig()
+		assert.Equal(t, "mcp", p.BaseEntrypoint(), "entrypoint should be added")
+		assert.Equal(t, "embedder-cli", got.BinaryName, "existing binary name must be preserved")
+		assert.Equal(t, json.RawMessage(`{"allowPrivateIPs":true}`), got.Settings["httpClient"],
+			"unrelated settings must be preserved")
+	})
+
+	t.Run("adopts incoming binary name when pool has none", func(t *testing.T) {
+		base := ProviderConfig{
+			Settings: map[string]json.RawMessage{
+				"httpClient": json.RawMessage(`{"allowPrivateIPs":true}`),
+			},
+		}
+		p := NewPool(context.Background(), nil, reg, logr.Discard(), WithBaseProviderConfig(base))
+		defer p.Shutdown()
+
+		require.True(t, p.SetBaseProviderConfigIfAbsent(newBase("mcp")))
+		assert.Equal(t, "mycli", p.BaseProviderConfig().BinaryName)
+	})
+
+	t.Run("deep-clones the provided config", func(t *testing.T) {
+		p := NewPool(context.Background(), nil, reg, logr.Discard())
+		defer p.Shutdown()
+
+		base := newBase("mcp")
+		require.True(t, p.SetBaseProviderConfigIfAbsent(base))
+
+		// Mutating the caller's map/bytes afterward must not affect the pool.
+		base.Settings["metadata"][0] = 'X'
+		base.Settings["injected"] = json.RawMessage(`true`)
+
+		assert.Equal(t, "mcp", p.BaseEntrypoint())
+		assert.NotContains(t, p.BaseProviderConfig().Settings, "injected")
+	})
+
+	t.Run("concurrent callers apply exactly once", func(t *testing.T) {
+		p := NewPool(context.Background(), nil, reg, logr.Discard())
+		defer p.Shutdown()
+
+		const goroutines = 16
+		var applies atomic.Int32
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				defer wg.Done()
+				if p.SetBaseProviderConfigIfAbsent(newBase("mcp")) {
+					applies.Add(1)
+				}
+			}()
+		}
+		wg.Wait()
+
+		assert.Equal(t, int32(1), applies.Load(), "exactly one caller must apply the config")
+		assert.Equal(t, "mcp", p.BaseEntrypoint())
+	})
+}
+
 func TestBuildSpawnClientOpts(t *testing.T) {
 	// applyOpts applies a slice of ClientOption to a fresh clientOptions struct
 	// and returns the result for assertion.

--- a/pkg/solution/prepare/prepare_test.go
+++ b/pkg/solution/prepare/prepare_test.go
@@ -1250,6 +1250,20 @@ func TestHostEntrypoint(t *testing.T) {
 		assert.Equal(t, EntrypointMCP, got)
 	})
 
+	t.Run("reads entrypoint set via SetBaseProviderConfigIfAbsent (pkg/mcp path)", func(t *testing.T) {
+		// Regression for issue #715: a host (e.g. pkg/mcp) declaring its
+		// entrypoint on a bare pool via SetBaseProviderConfigIfAbsent must be
+		// honored by hostEntrypoint on the per-execution path, so the metadata
+		// provider reports "mcp" instead of "unknown".
+		reg := provider.NewRegistry()
+		pool := plugin.NewPool(context.Background(), nil, reg, logr.Discard())
+		applied := pool.SetBaseProviderConfigIfAbsent(HostStaticProviderConfig("mycli", EntrypointMCP))
+		require.True(t, applied)
+
+		got := hostEntrypoint(&prepareConfig{pluginPool: pool})
+		assert.Equal(t, EntrypointMCP, got)
+	})
+
 	t.Run("falls back to CLI heuristic when binary name set (per-call)", func(t *testing.T) {
 		got := hostEntrypoint(&prepareConfig{pluginCfg: &plugin.ProviderConfig{BinaryName: "scafctl"}})
 		assert.Equal(t, EntrypointCLI, got)


### PR DESCRIPTION
Fixes #715.

## Problem

The MCP-entrypoint wiring lived only in the CLI command layer (`pkg/cmd/scafctl/mcp/serve.go`), so an MCP server built on the reusable `pkg/mcp` package with an ordinary plugin pool reported `entrypoint: "unknown"` from the metadata provider instead of `"mcp"`. `pkg/mcp` is by definition an MCP host, so it should declare that entrypoint itself.

## Change

Make `pkg/mcp` declare its own entrypoint out of the box:

- **`mcp.WithEntrypoint(string)`** ServerOption, defaulting to `prepare.EntrypointMCP` (`"mcp"`); an empty value normalizes back to `"mcp"`. `NewServer` injects it into the supplied plugin pool at construction.
- **`plugin.Pool.SetBaseProviderConfigIfAbsent(cfg) bool`** -- a guarded, mutex-protected, set-once **merge** that applies the host-static config only if the pool has not already declared an entrypoint, no plugin has loaded (`len(entries)==0`), and the pool is not closed. It merges rather than replaces, preserving unrelated `Settings` keys (e.g. `httpClient`) and an existing `BinaryName`, so an embedder that wired a base config for another reason is never silently discarded.
- **`plugin.Pool.BaseEntrypoint() string`** accessor; `BaseProviderConfig()` now takes the pool lock.
- The CLI keeps its explicit `WithBaseProviderConfig` call as declared intent -- set first, it wins over the `pkg/mcp` default (which is then a no-op).

Because the guard is set-once and honors any entrypoint already present, an embedder or the CLI that declares its own entrypoint always wins.

## Out of scope

The metadata provider's output-schema enum `["cli","api","unknown"]` (missing `"mcp"`) lives in the external metadata provider component, not this repo -- a separate follow-up.

## Tests

- `pkg/plugin/pool_test.go`: `BaseEntrypoint` (5 cases) and `SetBaseProviderConfigIfAbsent` (set-once, post-load/post-shutdown no-op, merge/preserve, deep-clone isolation, concurrent-apply-exactly-once under `-race`).
- `pkg/mcp/server_test.go`: default `"mcp"`, `WithEntrypoint` override, blank normalization, does-not-clobber-existing, no-pool no-op.
- `pkg/solution/prepare/prepare_test.go`: regression asserting `hostEntrypoint` honors the `SetBaseProviderConfigIfAbsent` path end-to-end.
- 100% coverage on all new functions; `go test -race`, `go build ./...`, and `task lint:changed` (0 issues) all pass.

## Docs

- `docs/tutorials/provider-reference.md`: entrypoint field description.
- `docs/design/mcp-server-implementation-guide.md`: added `WithEntrypoint` to the embedder option surface.