### PR TITLE
feat(run): add opt-in --detailed-exit-code for partial-success runs

### DIFF
--- a/docs/tutorials/actions-tutorial.md
+++ b/docs/tutorials/actions-tutorial.md
@@ -17,6 +17,7 @@ flowchart LR
 ```
 
 **Key Principles:**
+
 - Resolvers compute data, actions perform work
 - All resolvers evaluate before any action executes
 - Actions can depend on other actions
@@ -60,14 +61,18 @@ spec:
 Run it:
 {{< tabs "actions-tutorial-cmd-1" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl run solution -f hello-actions.yaml
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl run solution -f hello-actions.yaml
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -116,14 +121,18 @@ Run it:
 
 {{< tabs "actions-tutorial-cmd-2" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl run solution -f build-pipeline.yaml
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl run solution -f build-pipeline.yaml
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -175,6 +184,7 @@ spec:
 ```
 
 This creates a diamond pattern:
+
 ```
     init
     /  \
@@ -187,14 +197,18 @@ Run it:
 
 {{< tabs "actions-tutorial-cmd-3" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl run solution -f parallel.yaml
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl run solution -f parallel.yaml
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -270,14 +284,18 @@ spec:
 
 {{< tabs "actions-tutorial-cmd-4" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl run solution -f conditional-demo.yaml
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl run solution -f conditional-demo.yaml
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -295,14 +313,18 @@ The `prod-deploy` action is skipped because the condition `_.environment == 'pro
 
 {{< tabs "actions-tutorial-cmd-5" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl run solution -f conditional-demo.yaml -r environment=prod
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl run solution -f conditional-demo.yaml -r environment=prod
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -383,14 +405,18 @@ spec:
 
 {{< tabs "actions-tutorial-cmd-6" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl run solution -f foreach-demo.yaml
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl run solution -f foreach-demo.yaml
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -465,14 +491,18 @@ spec:
 
 {{< tabs "actions-tutorial-cmd-7" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl run solution -f error-handling-demo.yaml
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl run solution -f error-handling-demo.yaml
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -487,6 +517,62 @@ Doing main work...
 The `optional-cleanup` action fails (`exit 1`), but because `continueOnError: true` is set, the workflow continues. The `main-work` action still runs.
 
 Without `continueOnError: true`, the workflow would stop at `optional-cleanup` and `main-work` would be skipped.
+
+### Detecting partial success in CI
+
+When a `continueOnError` action fails but the run otherwise completes, the run
+ends in **partial success**: no action failed hard, but not everything
+succeeded. By default this exits `0` -- identical to a clean run -- because the
+solution author explicitly chose to tolerate the failure.
+
+CI pipelines sometimes need to tell "everything worked" apart from "we tolerated
+some failures" without parsing the JSON envelope. Pass `--detailed-exit-code`
+(opt-in) to make partial success return a distinct exit code instead:
+
+| Outcome | Default exit | With `--detailed-exit-code` |
+|---------|--------------|-----------------------------|
+| Clean success (all actions succeeded) | `0` | `0` |
+| Partial success (a `continueOnError` action failed) | `0` | `12` |
+| Hard failure (an action failed with `continueOnError: false`) | `6` | `6` |
+
+The flag is off by default, so existing scripts that gate on `$?` are
+unaffected. It is available on both `run solution` and `run action`:
+
+{{< tabs "actions-tutorial-detailed-exit" >}}
+{{% tab "Bash" %}}
+
+```bash
+scafctl run solution -f error-handling-demo.yaml --detailed-exit-code
+case $? in
+  0)  echo "clean success" ;;
+  12) echo "partial success -- some tolerated failures" ;;
+  *)  echo "run failed" ;;
+esac
+```
+
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+
+```powershell
+scafctl run solution -f error-handling-demo.yaml --detailed-exit-code
+switch ($LASTEXITCODE) {
+  0       { "clean success" }
+  12      { "partial success -- some tolerated failures" }
+  default { "run failed" }
+}
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+Structured output is unaffected: the full action envelope (with
+`status: partial-success` and per-action detail) is still written to stdout
+before the process exits, so `-o json`/`-o yaml` remain parseable regardless of
+the exit code.
+
+Embedders that wrap scafctl as a library can set the same default for their
+callers via `RootOptions.DetailedExitCode` (the per-invocation
+`--detailed-exit-code` flag still overrides it).
 
 ---
 
@@ -531,14 +617,18 @@ spec:
 
 {{< tabs "actions-tutorial-cmd-8" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl run solution -f results-demo.yaml
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl run solution -f results-demo.yaml
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -592,6 +682,7 @@ spec:
 With the alias `config`, you can write `config.results.region` instead of `__actions['fetch-configuration'].results.region`. The `__actions` form still works alongside aliases.
 
 **Alias Rules:**
+
 - Must match `^[a-zA-Z_][a-zA-Z0-9_-]*$`
 - Cannot start with `__` (reserved prefix)
 - Cannot conflict with action names or reserved names (`true`, `false`, `null`, etc.)
@@ -671,14 +762,18 @@ Run it:
 
 {{< tabs "actions-tutorial-execution-1" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl run solution -f execution-aware-demo.yaml
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl run solution -f execution-aware-demo.yaml
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -771,14 +866,18 @@ spec:
 
 {{< tabs "actions-tutorial-cmd-9" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl run solution -f retry-demo.yaml
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl run solution -f retry-demo.yaml
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -904,14 +1003,18 @@ Run it:
 
 {{< tabs "actions-tutorial-cmd-10" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl run solution -f exclusive-demo.yaml
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl run solution -f exclusive-demo.yaml
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -995,14 +1098,18 @@ spec:
 
 {{< tabs "actions-tutorial-cmd-11" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl run solution -f finally-demo.yaml
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl run solution -f finally-demo.yaml
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1054,6 +1161,7 @@ finally:
 Inputs are passed to the provider and support several value types:
 
 **Literal values:**
+
 ```yaml
 inputs:
   command: "echo hello"
@@ -1062,6 +1170,7 @@ inputs:
 ```
 
 **Resolver references:**
+
 ```yaml
 inputs:
   environment:
@@ -1069,6 +1178,7 @@ inputs:
 ```
 
 **CEL expressions:**
+
 ```yaml
 inputs:
   url:
@@ -1076,6 +1186,7 @@ inputs:
 ```
 
 **Go templates:**
+
 ```yaml
 inputs:
   message:
@@ -1111,6 +1222,7 @@ Run a solution (resolvers + actions):
 
 {{< tabs "actions-tutorial-cmd-12" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # Basic execution
 scafctl run solution -f hello-world.yaml
@@ -1136,8 +1248,10 @@ scafctl run resolver -f conditional-demo.yaml -r environment=staging
 # Run specific resolvers for inspection
 scafctl run resolver config -f conditional-demo.yaml -r environment=staging
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 # Basic execution
 scafctl run solution -f hello-world.yaml
@@ -1163,6 +1277,7 @@ scafctl run resolver -f conditional-demo.yaml -r environment=staging
 # Run specific resolvers for inspection
 scafctl run resolver config -f conditional-demo.yaml -r environment=staging
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1172,6 +1287,7 @@ Generate an executor-ready artifact:
 
 {{< tabs "actions-tutorial-cmd-13" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # Render to JSON (default)
 scafctl render solution -f hello-world.yaml
@@ -1182,8 +1298,10 @@ scafctl render solution -f hello-world.yaml -o yaml
 # Write to file
 scafctl render solution -f hello-world.yaml -o json > graph.json
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 # Render to JSON (default)
 scafctl render solution -f hello-world.yaml
@@ -1194,6 +1312,7 @@ scafctl render solution -f hello-world.yaml -o yaml
 # Write to file
 scafctl render solution -f hello-world.yaml -o json > graph.json
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1203,6 +1322,7 @@ Use `--cwd` (`-C`) to run solutions from a different directory. All file paths i
 
 {{< tabs "actions-tutorial-cmd-14" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # Run a solution in a different project directory
 scafctl --cwd /path/to/project run solution -f solution.yaml
@@ -1210,8 +1330,10 @@ scafctl --cwd /path/to/project run solution -f solution.yaml
 # Combine with --output-dir: resolvers read from --cwd, actions write to --output-dir
 scafctl -C /path/to/project run solution -f solution.yaml --output-dir /tmp/output
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 # Run a solution in a different project directory
 scafctl --cwd /path/to/project run solution -f solution.yaml
@@ -1219,10 +1341,12 @@ scafctl --cwd /path/to/project run solution -f solution.yaml
 # Combine with --output-dir: resolvers read from --cwd, actions write to --output-dir
 scafctl -C /path/to/project run solution -f solution.yaml --output-dir /tmp/output
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
 The rendered output includes:
+
 - Expanded actions (ForEach iterations)
 - Materialized inputs
 - Execution phases
@@ -1345,12 +1469,14 @@ See the [examples/actions/](../examples/actions/) directory for complete working
 ### Action Skipped
 
 Check:
+
 1. `when` condition evaluated to false
 2. A dependency failed (see `SkipReasonDependencyFailed`)
 
 ### Timeout Exceeded
 
 The action took longer than its timeout. Consider:
+
 1. Increasing the timeout
 2. Breaking into smaller actions
 3. Checking for hanging processes
@@ -1358,6 +1484,7 @@ The action took longer than its timeout. Consider:
 ### Retry Exhausted
 
 All retry attempts failed. Check:
+
 1. The underlying service availability
 2. Network connectivity
 3. Consider increasing `maxAttempts`
@@ -1365,6 +1492,7 @@ All retry attempts failed. Check:
 ### Cycle Detected
 
 Actions have circular dependencies. Check `dependsOn` references:
+
 ```yaml
 # Invalid: circular dependency
 actions:

--- a/examples/actions/error-handling.yaml
+++ b/examples/actions/error-handling.yaml
@@ -1,4 +1,10 @@
 # Run: scafctl run solution -f examples/actions/error-handling.yaml
+#
+# When an action fails but is tolerated via continueOnError, the run ends in
+# "partial success". By default that exits 0 (same as a clean run). To make CI
+# distinguish it, add --detailed-exit-code so partial success exits 12 instead:
+#   scafctl run solution -f examples/actions/error-handling.yaml --detailed-exit-code
+# (Hard failures still exit 6; clean success still exits 0.)
 
 apiVersion: scafctl.io/v1
 kind: Solution

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -222,6 +222,14 @@ type RootOptions struct {
 	// cluster data; embedders with a cluster registry provide the
 	// implementation.
 	ClusterResolver kube.ClusterResolver
+
+	// DetailedExitCode sets the default for the --detailed-exit-code flag on
+	// run solution and run action. When true, a partial-success run (some
+	// continueOnError actions failed, none failed hard) exits with
+	// exitcode.PartialSuccess (12) instead of 0. When unset (false, the
+	// default), partial success exits 0, matching direct scafctl behavior.
+	// The per-invocation --detailed-exit-code flag overrides this default.
+	DetailedExitCode bool
 }
 
 // NewRootOptions returns a RootOptions with production defaults
@@ -272,6 +280,12 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 	envPrefix := settings.SafeEnvPrefix(binaryName)
 	cliParams.BinaryName = binaryName
 	paths.SetAppName(binaryName)
+
+	// Seed the embedder-supplied default for the --detailed-exit-code flag.
+	// RootOptions does not thread into the run subcommand tree, so the default
+	// is carried on settings.Run, where the run commands read it as the flag
+	// default. The per-invocation --detailed-exit-code flag overrides it.
+	cliParams.DetailedExitCode = opts.DetailedExitCode
 
 	// Record the embedder's version (if supplied) so state metadata can capture
 	// the invoking CLI/frontend provenance distinctly from the engine version.

--- a/pkg/cmd/scafctl/root_test.go
+++ b/pkg/cmd/scafctl/root_test.go
@@ -15,6 +15,7 @@ import (
 	"text/template"
 
 	"github.com/oakwood-commons/scafctl/pkg/auth"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/kube"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -502,4 +503,81 @@ func TestRoot_GoTemplateFuncs_ReExecuteNoSelfCollision(t *testing.T) {
 	require.NoError(t, cmd.Execute(), "second execution must not self-collide")
 	assert.False(t, exitCalled,
 		"re-executing the same command must not fail the embedder registration")
+}
+
+// partialSuccessSolutionYAML is a workflow whose second action fails but is
+// tolerated via continueOnError, yielding FinalStatus partial-success. The run
+// completes (no hard failure), so without --detailed-exit-code it exits 0.
+//
+// The actions are serialized via dependsOn so they run in separate phases: the
+// in-process test IOStreams use a plain bytes.Buffer, which the concurrent
+// same-phase progress-callback writes would race on under -race (the real
+// binary writes to os.Stderr and is unaffected).
+const partialSuccessSolutionYAML = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: embedder-partial-success
+  version: 1.0.0
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      good:
+        provider: message
+        inputs:
+          message: "GOOD_RAN"
+          type: info
+      bad:
+        provider: go-template
+        dependsOn: [good]
+        continueOnError: true
+        inputs:
+          template: "{{ undefinedFunc .x }}"
+          data:
+            x: hello
+`
+
+// TestRoot_DetailedExitCode_EmbedderDefault verifies that an embedder can opt
+// into the distinct partial-success exit code via RootOptions.DetailedExitCode
+// WITHOUT the caller passing the --detailed-exit-code flag. This proves the
+// default flows through settings.Run (RootOptions does not thread into the run
+// subcommand tree). It covers both run subcommands (independent call sites) and
+// the three precedence cases: default true (exit 12), default false
+// (non-breaking exit 0), and an explicit --detailed-exit-code=false overriding
+// an embedder default of true.
+func TestRoot_DetailedExitCode_EmbedderDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+	solutionPath := filepath.Join(tmpDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(partialSuccessSolutionYAML), 0o600))
+
+	run := func(t *testing.T, subcmd string, embedderDefault bool, extraArgs ...string) int {
+		t.Helper()
+		ioStreams, _, _ := terminal.NewTestIOStreams()
+		cmd, cleanup := Root(&RootOptions{
+			IOStreams:        ioStreams,
+			ExitFunc:         func(int) {}, // never terminate the test process
+			DetailedExitCode: embedderDefault,
+		})
+		defer cleanup()
+		args := append([]string{"run", subcmd, "-f", solutionPath, "-o", "json"}, extraArgs...)
+		cmd.SetArgs(args)
+		return exitcode.GetCode(cmd.Execute())
+	}
+
+	for _, subcmd := range []string{"solution", "action"} {
+		t.Run(subcmd+"/default true returns PartialSuccess without CLI flag", func(t *testing.T) {
+			assert.Equal(t, exitcode.PartialSuccess, run(t, subcmd, true),
+				"RootOptions.DetailedExitCode=true must yield exit 12 on partial success")
+		})
+
+		t.Run(subcmd+"/default false returns Success (non-breaking)", func(t *testing.T) {
+			assert.Equal(t, exitcode.Success, run(t, subcmd, false),
+				"RootOptions.DetailedExitCode=false must keep partial success at exit 0")
+		})
+
+		t.Run(subcmd+"/explicit flag=false overrides embedder default true", func(t *testing.T) {
+			assert.Equal(t, exitcode.Success, run(t, subcmd, true, "--detailed-exit-code=false"),
+				"an explicit --detailed-exit-code=false must override an embedder default of true")
+		})
+	}
 }

--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -564,13 +564,15 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 
 	// Partial success: some continueOnError actions failed but the run did not
 	// fail hard. When --detailed-exit-code is set, emit the full output envelope
-	// then return the distinct PartialSuccess code; otherwise fall through to the
-	// normal exit-0 success path (non-breaking default).
+	// then return the distinct PartialSuccess code via exitWithCode so the
+	// stderr diagnostic is printed (Cobra silences the returned error at the
+	// root); otherwise fall through to the normal exit-0 success path
+	// (non-breaking default).
 	if result != nil && result.FinalStatus == action.ExecutionPartialSuccess && o.DetailedExitCode {
 		if writeErr := o.writeActionOutput(ctx, result, executionData); writeErr != nil {
 			return writeErr
 		}
-		return exitcode.WithCode(
+		return o.exitWithCode(ctx,
 			fmt.Errorf("run completed with partial success: %d action(s) failed with continueOnError", len(result.FailedActions)),
 			exitcode.PartialSuccess,
 		)

--- a/pkg/cmd/scafctl/run/action.go
+++ b/pkg/cmd/scafctl/run/action.go
@@ -57,6 +57,13 @@ type ActionOptions struct {
 	// SkipFingerprint disables fingerprint-based up-to-date checks.
 	SkipFingerprint bool
 
+	// DetailedExitCode, when true, returns exitcode.PartialSuccess (12) instead
+	// of 0 when the run ends in partial success (some continueOnError actions
+	// failed, none failed hard). Defaults from settings.Run (embedder/config)
+	// and is overridden by the --detailed-exit-code flag. When false, partial
+	// success exits 0 (non-breaking).
+	DetailedExitCode bool
+
 	// DynamicArgs are resolver parameters from positional key=value syntax.
 	DynamicArgs []string
 
@@ -125,12 +132,13 @@ FAILURE OUTPUT (json/yaml):
   detail). Human formats (table/quiet) keep the prior stderr-only behavior.
 
 EXIT CODES:
-  0  Success
-  1  Resolver execution failed
-  2  Validation failed
-  3  Invalid solution (no workflow, cycle, or parse error)
-  4  File not found
-  6  Action/workflow execution failed
+  0   Success (also partial success unless --detailed-exit-code is set)
+  1   Resolver execution failed
+  2   Validation failed
+  3   Invalid solution (no workflow, cycle, or parse error)
+  4   File not found
+  6   Action/workflow execution failed
+  12  Partial success (only with --detailed-exit-code; some continueOnError actions failed)
 
 Examples:
   # Run the 'lint' action (auto-discovery)
@@ -179,6 +187,10 @@ Examples:
 
 	// Fingerprint flags
 	cCmd.Flags().BoolVar(&options.SkipFingerprint, "skip-fingerprint", false, "Disable fingerprint-based up-to-date checks (re-run all actions)")
+
+	// Detailed exit code: opt-in distinct exit code (12) on partial success.
+	// Defaults from cliParams (embedder/config); the flag overrides it.
+	cCmd.Flags().BoolVar(&options.DetailedExitCode, "detailed-exit-code", cliParams.DetailedExitCode, "Return a distinct exit code (12) when the run completes with partial success (some continueOnError actions failed); default off (partial success exits 0)")
 
 	return cCmd
 }
@@ -549,6 +561,21 @@ func (o *ActionOptions) Run(ctx context.Context) error {
 	if o.ShowExecution {
 		executionData = resolverExecutionData
 	}
+
+	// Partial success: some continueOnError actions failed but the run did not
+	// fail hard. When --detailed-exit-code is set, emit the full output envelope
+	// then return the distinct PartialSuccess code; otherwise fall through to the
+	// normal exit-0 success path (non-breaking default).
+	if result != nil && result.FinalStatus == action.ExecutionPartialSuccess && o.DetailedExitCode {
+		if writeErr := o.writeActionOutput(ctx, result, executionData); writeErr != nil {
+			return writeErr
+		}
+		return exitcode.WithCode(
+			fmt.Errorf("run completed with partial success: %d action(s) failed with continueOnError", len(result.FailedActions)),
+			exitcode.PartialSuccess,
+		)
+	}
+
 	return o.writeActionOutput(ctx, result, executionData)
 }
 

--- a/pkg/cmd/scafctl/run/action_test.go
+++ b/pkg/cmd/scafctl/run/action_test.go
@@ -47,6 +47,7 @@ func TestCommandAction(t *testing.T) {
 	assert.NotNil(t, flags.Lookup("on-conflict"))
 	assert.NotNil(t, flags.Lookup("force"))
 	assert.NotNil(t, flags.Lookup("backup"))
+	assert.NotNil(t, flags.Lookup("detailed-exit-code"))
 }
 
 func TestCommandAction_FlagDefaults(t *testing.T) {
@@ -89,6 +90,31 @@ func TestCommandAction_FlagDefaults(t *testing.T) {
 	noState, err := flags.GetBool("no-state")
 	require.NoError(t, err)
 	assert.False(t, noState)
+}
+
+func TestCommandAction_DetailedExitCodeFlag(t *testing.T) {
+	t.Parallel()
+
+	streams, _, _ := terminal.NewTestIOStreams()
+
+	t.Run("defaults to false when embedder default unset", func(t *testing.T) {
+		t.Parallel()
+		cliParams := settings.NewCliParams()
+		cmd := CommandAction(cliParams, streams, "")
+		v, err := cmd.Flags().GetBool("detailed-exit-code")
+		require.NoError(t, err)
+		assert.False(t, v)
+	})
+
+	t.Run("flag default reflects embedder default", func(t *testing.T) {
+		t.Parallel()
+		cliParams := settings.NewCliParams()
+		cliParams.DetailedExitCode = true
+		cmd := CommandAction(cliParams, streams, "")
+		v, err := cmd.Flags().GetBool("detailed-exit-code")
+		require.NoError(t, err)
+		assert.True(t, v, "embedder default should seed the flag default")
+	})
 }
 
 func TestParseActionArgs(t *testing.T) {

--- a/pkg/cmd/scafctl/run/detailed_exit_code_test.go
+++ b/pkg/cmd/scafctl/run/detailed_exit_code_test.go
@@ -1,0 +1,199 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package run
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/gotmplprovider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/messageprovider"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin/staticprovider"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// detailedExitPartialSolution ends in partial success: the "bad" action fails
+// (undefined template function) but is tolerated via continueOnError, so the run
+// completes without a hard failure. The actions are serialized via dependsOn so
+// the in-process test IOStreams (a plain bytes.Buffer) are never written
+// concurrently by the same-phase progress callback (which would race under
+// -race; the real binary writes to os.Stderr and is unaffected).
+const detailedExitPartialSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: detailed-exit-partial-unit
+  version: 1.0.0
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      good:
+        provider: message
+        inputs:
+          message: "GOOD_RAN"
+          type: info
+      bad:
+        provider: go-template
+        dependsOn: [good]
+        continueOnError: true
+        inputs:
+          template: "{{ undefinedFunc .x }}"
+          data:
+            x: hello
+`
+
+// registryForDetailedExit returns a registry with the providers the
+// partial-success fixture needs (static for resolvers, message and go-template
+// for the two actions).
+func registryForDetailedExit(t *testing.T) *provider.Registry {
+	t.Helper()
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(staticprovider.New()))
+	require.NoError(t, reg.Register(messageprovider.NewMessageProvider()))
+	require.NoError(t, reg.Register(gotmplprovider.NewGoTemplateProvider()))
+	return reg
+}
+
+// TestSolutionOptions_Run_DetailedExitCode drives SolutionOptions.Run() to the
+// partial-success branch in-process so the exit-code policy (and its coverage)
+// is exercised without a subprocess. Integration tests run the compiled binary,
+// which the per-package coverage run does not measure.
+func TestSolutionOptions_Run_DetailedExitCode(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(detailedExitPartialSolution), 0o600))
+
+	run := func(t *testing.T, detailed bool) (string, error) {
+		t.Helper()
+		var stdout, stderr bytes.Buffer
+		streams := &terminal.IOStreams{Out: &stdout, ErrOut: &stderr}
+		cliParams := settings.NewCliParams()
+		cliParams.ExitOnError = false
+
+		opts := &SolutionOptions{DetailedExitCode: detailed, ActionTimeout: settings.DefaultActionTimeout}
+		opts.IOStreams = streams
+		opts.CliParams = cliParams
+		opts.File = solutionPath
+		opts.Output = "json"
+		opts.registry = registryForDetailedExit(t)
+
+		w := writer.New(streams, cliParams)
+		ctx := writer.WithWriter(logger.WithLogger(context.Background(), logger.Get(0)), w)
+		runErr := opts.Run(ctx)
+		return stdout.String(), runErr
+	}
+
+	t.Run("flag on returns PartialSuccess and prints stdout envelope", func(t *testing.T) {
+		t.Parallel()
+		stdout, err := run(t, true)
+		require.Error(t, err)
+		assert.Equal(t, exitcode.PartialSuccess, exitcode.GetCode(err),
+			"partial success with --detailed-exit-code must exit 12")
+		assert.Contains(t, stdout, "partial-success",
+			"the full action envelope must still be written to stdout before the non-zero exit")
+	})
+
+	t.Run("flag off returns Success (non-breaking)", func(t *testing.T) {
+		t.Parallel()
+		_, err := run(t, false)
+		require.NoError(t, err, "partial success without the flag must exit 0")
+	})
+
+	t.Run("flag on surfaces a writeActionOutput error before the exit code", func(t *testing.T) {
+		t.Parallel()
+		var stdout, stderr bytes.Buffer
+		streams := &terminal.IOStreams{Out: &stdout, ErrOut: &stderr}
+		cliParams := settings.NewCliParams()
+		cliParams.ExitOnError = false
+
+		opts := &SolutionOptions{DetailedExitCode: true, ActionTimeout: settings.DefaultActionTimeout}
+		opts.IOStreams = streams
+		opts.CliParams = cliParams
+		opts.File = solutionPath
+		opts.Output = "unsupported-format" // makes writeActionOutput fail on the partial branch
+		opts.registry = registryForDetailedExit(t)
+
+		w := writer.New(streams, cliParams)
+		ctx := writer.WithWriter(logger.WithLogger(context.Background(), logger.Get(0)), w)
+		err := opts.Run(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported output format",
+			"a write failure on the partial branch must be surfaced, not masked by the exit code")
+	})
+}
+
+// TestActionOptions_Run_DetailedExitCode is the run action counterpart -- the
+// two call sites are independent copies and must both be covered.
+func TestActionOptions_Run_DetailedExitCode(t *testing.T) {
+	t.Parallel()
+
+	solutionPath := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(solutionPath, []byte(detailedExitPartialSolution), 0o600))
+
+	run := func(t *testing.T, detailed bool) error {
+		t.Helper()
+		var stdout, stderr bytes.Buffer
+		streams := &terminal.IOStreams{Out: &stdout, ErrOut: &stderr}
+		cliParams := settings.NewCliParams()
+		cliParams.ExitOnError = false
+
+		opts := &ActionOptions{DetailedExitCode: detailed, ActionTimeout: settings.DefaultActionTimeout}
+		opts.IOStreams = streams
+		opts.CliParams = cliParams
+		opts.File = solutionPath
+		opts.Output = "json"
+		opts.registry = registryForDetailedExit(t)
+
+		w := writer.New(streams, cliParams)
+		ctx := writer.WithWriter(logger.WithLogger(context.Background(), logger.Get(0)), w)
+		return opts.Run(ctx)
+	}
+
+	t.Run("flag on returns PartialSuccess", func(t *testing.T) {
+		t.Parallel()
+		err := run(t, true)
+		require.Error(t, err)
+		assert.Equal(t, exitcode.PartialSuccess, exitcode.GetCode(err),
+			"partial success with --detailed-exit-code must exit 12")
+	})
+
+	t.Run("flag off returns Success (non-breaking)", func(t *testing.T) {
+		t.Parallel()
+		err := run(t, false)
+		require.NoError(t, err, "partial success without the flag must exit 0")
+	})
+
+	t.Run("flag on surfaces a writeActionOutput error before the exit code", func(t *testing.T) {
+		t.Parallel()
+		var stdout, stderr bytes.Buffer
+		streams := &terminal.IOStreams{Out: &stdout, ErrOut: &stderr}
+		cliParams := settings.NewCliParams()
+		cliParams.ExitOnError = false
+
+		opts := &ActionOptions{DetailedExitCode: true, ActionTimeout: settings.DefaultActionTimeout}
+		opts.IOStreams = streams
+		opts.CliParams = cliParams
+		opts.File = solutionPath
+		opts.Output = "unsupported-format" // makes writeActionOutput fail on the partial branch
+		opts.registry = registryForDetailedExit(t)
+
+		w := writer.New(streams, cliParams)
+		ctx := writer.WithWriter(logger.WithLogger(context.Background(), logger.Get(0)), w)
+		err := opts.Run(ctx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported output format",
+			"a write failure on the partial branch must be surfaced, not masked by the exit code")
+	})
+}

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -72,6 +72,13 @@ type SolutionOptions struct {
 	// When true, all actions execute regardless of whether sources have changed.
 	SkipFingerprint bool
 
+	// DetailedExitCode, when true, returns exitcode.PartialSuccess (12) instead
+	// of 0 when the run ends in partial success (some continueOnError actions
+	// failed, none failed hard). Defaults from settings.Run (embedder/config)
+	// and is overridden by the --detailed-exit-code flag. When false, partial
+	// success exits 0 (non-breaking).
+	DetailedExitCode bool
+
 	// Backup enables .bak backup creation before mutating existing files.
 	Backup bool
 
@@ -174,12 +181,13 @@ CEL EXPRESSIONS:
     -e 'size(_.results)'               Compute values
 
 EXIT CODES:
-  0  Success
-  1  Resolver execution failed
-  2  Validation failed
-  3  Invalid solution (no workflow, cycle, or parse error)
-  4  File not found
-  6  Action/workflow execution failed
+  0   Success (also partial success unless --detailed-exit-code is set)
+  1   Resolver execution failed
+  2   Validation failed
+  3   Invalid solution (no workflow, cycle, or parse error)
+  4   File not found
+  6   Action/workflow execution failed
+  12  Partial success (only with --detailed-exit-code; some continueOnError actions failed)
 
 Examples:
   # Run solution from catalog by name (latest version)
@@ -264,6 +272,10 @@ Examples:
 	cCmd.Flags().BoolVar(&options.Force, "force", false, "Skip unchanged files and write only new or modified content (shorthand for --on-conflict skip-unchanged)")
 	cCmd.Flags().BoolVar(&options.SkipFingerprint, "skip-fingerprint", false, "Disable fingerprint-based up-to-date checks (re-run all actions)")
 	cCmd.Flags().BoolVar(&options.Backup, "backup", false, "Create .bak backups before mutating existing files")
+
+	// Detailed exit code: opt-in distinct exit code (12) on partial success.
+	// Defaults from cliParams (embedder/config); the flag overrides it.
+	cCmd.Flags().BoolVar(&options.DetailedExitCode, "detailed-exit-code", cliParams.DetailedExitCode, "Return a distinct exit code (12) when the run completes with partial success (some continueOnError actions failed); default off (partial success exits 0)")
 
 	return cCmd
 }
@@ -677,6 +689,22 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	if o.ShowExecution {
 		executionData = resolverExecutionData
 	}
+
+	// Partial success: some continueOnError actions failed but the run did not
+	// fail hard. When --detailed-exit-code is set, emit the full output envelope
+	// (so json/yaml/table still show per-action detail) and then return the
+	// distinct PartialSuccess code. When the flag is off, fall through to the
+	// normal exit-0 success path (non-breaking default).
+	if result != nil && result.FinalStatus == action.ExecutionPartialSuccess && o.DetailedExitCode {
+		if writeErr := o.writeActionOutput(ctx, result, executionData); writeErr != nil {
+			return writeErr
+		}
+		return exitcode.WithCode(
+			fmt.Errorf("run completed with partial success: %d action(s) failed with continueOnError", len(result.FailedActions)),
+			exitcode.PartialSuccess,
+		)
+	}
+
 	return o.writeActionOutput(ctx, result, executionData)
 }
 

--- a/pkg/cmd/scafctl/run/solution.go
+++ b/pkg/cmd/scafctl/run/solution.go
@@ -693,13 +693,14 @@ func (o *SolutionOptions) Run(ctx context.Context) error {
 	// Partial success: some continueOnError actions failed but the run did not
 	// fail hard. When --detailed-exit-code is set, emit the full output envelope
 	// (so json/yaml/table still show per-action detail) and then return the
-	// distinct PartialSuccess code. When the flag is off, fall through to the
-	// normal exit-0 success path (non-breaking default).
+	// distinct PartialSuccess code via exitWithCode so the stderr diagnostic is
+	// printed (Cobra silences the returned error at the root). When the flag is
+	// off, fall through to the normal exit-0 success path (non-breaking default).
 	if result != nil && result.FinalStatus == action.ExecutionPartialSuccess && o.DetailedExitCode {
 		if writeErr := o.writeActionOutput(ctx, result, executionData); writeErr != nil {
 			return writeErr
 		}
-		return exitcode.WithCode(
+		return o.exitWithCode(ctx,
 			fmt.Errorf("run completed with partial success: %d action(s) failed with continueOnError", len(result.FailedActions)),
 			exitcode.PartialSuccess,
 		)

--- a/pkg/cmd/scafctl/run/solution_test.go
+++ b/pkg/cmd/scafctl/run/solution_test.go
@@ -60,6 +60,7 @@ func TestCommandSolution(t *testing.T) {
 	assert.NotNil(t, flags.Lookup("show-execution"))
 	assert.NotNil(t, flags.Lookup("on-conflict"))
 	assert.NotNil(t, flags.Lookup("backup"))
+	assert.NotNil(t, flags.Lookup("detailed-exit-code"))
 }
 
 func TestCommandSolution_FlagDefaults(t *testing.T) {
@@ -123,6 +124,31 @@ func TestCommandSolution_FlagDefaults(t *testing.T) {
 	noState, err := flags.GetBool("no-state")
 	require.NoError(t, err)
 	assert.False(t, noState)
+}
+
+func TestCommandSolution_DetailedExitCodeFlag(t *testing.T) {
+	t.Parallel()
+
+	streams, _, _ := terminal.NewTestIOStreams()
+
+	t.Run("defaults to false when embedder default unset", func(t *testing.T) {
+		t.Parallel()
+		cliParams := settings.NewCliParams()
+		cmd := CommandSolution(cliParams, streams, "")
+		v, err := cmd.Flags().GetBool("detailed-exit-code")
+		require.NoError(t, err)
+		assert.False(t, v)
+	})
+
+	t.Run("flag default reflects embedder default", func(t *testing.T) {
+		t.Parallel()
+		cliParams := settings.NewCliParams()
+		cliParams.DetailedExitCode = true
+		cmd := CommandSolution(cliParams, streams, "")
+		v, err := cmd.Flags().GetBool("detailed-exit-code")
+		require.NoError(t, err)
+		assert.True(t, v, "embedder default should seed the flag default")
+	})
 }
 
 func TestSolutionOptions_getEffectiveActionConfig_OutputDir(t *testing.T) {

--- a/pkg/exitcode/exitcode.go
+++ b/pkg/exitcode/exitcode.go
@@ -48,6 +48,12 @@ const (
 
 	// TestFailed indicates one or more functional tests failed.
 	TestFailed = 11
+
+	// PartialSuccess indicates the run completed but one or more actions failed
+	// while permitted to continue via continueOnError (FinalStatus
+	// partial-success). It is only returned by run solution/run action when
+	// --detailed-exit-code is set; otherwise partial success exits Success (0).
+	PartialSuccess = 12
 )
 
 // Description returns a human-readable description of an exit code.
@@ -77,6 +83,8 @@ func Description(code int) string {
 		return "permission denied"
 	case TestFailed:
 		return "one or more tests failed"
+	case PartialSuccess:
+		return "partial success"
 	default:
 		return "unknown error"
 	}

--- a/pkg/exitcode/exitcode_test.go
+++ b/pkg/exitcode/exitcode_test.go
@@ -26,6 +26,8 @@ func TestExitCodes(t *testing.T) {
 	assert.Equal(t, 8, CatalogError)
 	assert.Equal(t, 9, TimeoutError)
 	assert.Equal(t, 10, PermissionDenied)
+	assert.Equal(t, 11, TestFailed)
+	assert.Equal(t, 12, PartialSuccess)
 }
 
 func TestDescription(t *testing.T) {
@@ -46,6 +48,8 @@ func TestDescription(t *testing.T) {
 		{CatalogError, "catalog error"},
 		{TimeoutError, "timeout"},
 		{PermissionDenied, "permission denied"},
+		{TestFailed, "one or more tests failed"},
+		{PartialSuccess, "partial success"},
 		{999, "unknown error"},
 		{-1, "unknown error"},
 	}
@@ -121,5 +125,10 @@ func TestGetCode(t *testing.T) {
 		exitErr := WithCode(errors.New("test"), ActionFailed)
 		wrapped := fmt.Errorf("wrapper: %w", exitErr)
 		assert.Equal(t, ActionFailed, GetCode(wrapped))
+	})
+
+	t.Run("round-trips PartialSuccess code", func(t *testing.T) {
+		err := WithCode(errors.New("partial"), PartialSuccess)
+		assert.Equal(t, PartialSuccess, GetCode(err))
 	})
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -577,6 +577,15 @@ type Run struct {
 	// state metadata.
 	EmbedderVersion string `json:"embedderVersion,omitempty" yaml:"embedderVersion,omitempty" doc:"Version of the embedding CLI/frontend" maxLength:"64" example:"1.2.3"`
 
+	// DetailedExitCode sets the default for the --detailed-exit-code flag on
+	// run solution/run action. When true, a partial-success run (some
+	// continueOnError actions failed, none failed hard) returns
+	// exitcode.PartialSuccess (12) instead of 0. Defaults to false, so partial
+	// success exits 0 (non-breaking). Set via the --detailed-exit-code flag or
+	// an embedder via RootOptions.DetailedExitCode; the per-invocation flag
+	// overrides this default.
+	DetailedExitCode bool `json:"detailedExitCode" yaml:"detailedExitCode" doc:"Return a distinct exit code on partial success"`
+
 	// ActionDiscoveryFileNames overrides the file names used by "run action"
 	// auto-discovery. When empty, defaults from ActionFileNamesFor are used.
 	ActionDiscoveryFileNames []string `json:"-" yaml:"-"`

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1517,6 +1517,10 @@ func TestIntegration_RunDetailedExitCode(t *testing.T) {
 						"stdout must remain parseable JSON on partial success")
 					assert.Equal(t, "partial-success", decoded["status"],
 						"envelope must report the partial-success status")
+					// The exit-code diagnostic must be printed to stderr (routed
+					// through exitWithCode) so the user sees why the run exited 12.
+					assert.Contains(t, stderr, "partial success",
+						"partial-success exit must print a stderr diagnostic")
 				}
 			})
 		}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -1385,7 +1385,144 @@ func TestIntegration_RunResolver_ResolvePhaseFailure_PreservesValues(t *testing.
 	assert.NotEmpty(t, decoded["__diagnostics"])
 }
 
-// two-phase validation D1 guarantee: when a deferred (cross-resolver) validation
+// Action-phase outcome fixtures for the --detailed-exit-code matrix.
+//
+// actionCleanSuccessSolution: every action succeeds -> FinalStatus success.
+// actionPartialSuccessSolution: one action fails but is tolerated via
+//
+//	continueOnError -> FinalStatus partial-success (no hard failure).
+//
+// actionHardFailureSolution: one action fails with the default onError (fail)
+//
+//	-> FinalStatus failed (exit 6), unaffected by --detailed-exit-code.
+const actionCleanSuccessSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: detailed-exit-clean
+  version: 1.0.0
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      good:
+        provider: message
+        inputs:
+          message: "GOOD_RAN"
+          type: info
+`
+
+const actionPartialSuccessSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: detailed-exit-partial
+  version: 1.0.0
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      good:
+        provider: message
+        inputs:
+          message: "GOOD_RAN"
+          type: info
+      bad:
+        provider: go-template
+        continueOnError: true
+        inputs:
+          template: "{{ undefinedFunc .x }}"
+          data:
+            x: hello
+`
+
+const actionHardFailureSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: detailed-exit-hard
+  version: 1.0.0
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      good:
+        provider: message
+        inputs:
+          message: "GOOD_RAN"
+          type: info
+      bad:
+        provider: go-template
+        inputs:
+          template: "{{ undefinedFunc .x }}"
+          data:
+            x: hello
+`
+
+// TestIntegration_RunDetailedExitCode verifies the opt-in --detailed-exit-code
+// flag across the full outcome matrix (clean / partial / hard-failure) with the
+// flag both off and on, for BOTH `run solution` and `run action` (the two CLI
+// call sites are independent copies and must behave identically):
+//
+//	clean, flag off   -> 0     clean, flag on   -> 0
+//	partial, flag off -> 0     partial, flag on -> 12  (the new behavior)
+//	hard, flag off    -> 6     hard, flag on    -> 6   (unchanged)
+//
+// The default (flag off) keeps partial success at 0 -- the non-breaking guarantee.
+func TestIntegration_RunDetailedExitCode(t *testing.T) {
+	t.Parallel()
+
+	fixtures := map[string]string{
+		"clean":   actionCleanSuccessSolution,
+		"partial": actionPartialSuccessSolution,
+		"hard":    actionHardFailureSolution,
+	}
+	tmpDir := t.TempDir()
+	paths := make(map[string]string, len(fixtures))
+	for name, content := range fixtures {
+		p := filepath.Join(tmpDir, name+".yaml")
+		require.NoError(t, os.WriteFile(p, []byte(content), 0o600))
+		paths[name] = p
+	}
+
+	cases := []struct {
+		outcome  string
+		detailed bool
+		wantExit int
+	}{
+		{"clean", false, 0},
+		{"clean", true, 0},
+		{"partial", false, 0}, // non-breaking default: partial stays 0
+		{"partial", true, 12}, // opt-in: distinct PartialSuccess code
+		{"hard", false, 6},    // hard failure unchanged
+		{"hard", true, 6},     // hard failure unaffected by the flag
+	}
+
+	for _, subcmd := range []string{"solution", "action"} {
+		for _, tc := range cases {
+			name := fmt.Sprintf("%s/%s/detailed=%v", subcmd, tc.outcome, tc.detailed)
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				args := []string{"run", subcmd, "-f", paths[tc.outcome], "-o", "json"}
+				if tc.detailed {
+					args = append(args, "--detailed-exit-code")
+				}
+				stdout, stderr, exitCode := runScafctl(t, args...)
+				t.Logf("stderr: %s", stderr)
+				assert.Equal(t, tc.wantExit, exitCode,
+					"%s: expected exit %d, got %d", name, tc.wantExit, exitCode)
+
+				// Partial success with the flag on must still emit the full,
+				// parseable action envelope on stdout (output before non-zero exit).
+				if tc.outcome == "partial" && tc.detailed {
+					var decoded map[string]any
+					require.NoError(t, json.Unmarshal([]byte(stdout), &decoded),
+						"stdout must remain parseable JSON on partial success")
+					assert.Equal(t, "partial-success", decoded["status"],
+						"envelope must report the partial-success status")
+				}
+			})
+		}
+	}
+}
+
 // rule fails on an immutable resolver, execution stops before actions run and
 // the immutable value is NOT persisted to state. A subsequent run whose deferred
 // validation passes then locks the value and runs the action.


### PR DESCRIPTION
## Summary

Adds an **opt-in** `--detailed-exit-code` flag to `run solution` and `run action` that returns a new distinct exit code `exitcode.PartialSuccess = 12` when a run ends in **partial success** (some `continueOnError` actions failed, none failed hard).

Closes #720.

### Why

Previously partial success exited `0`, identical to a clean run, so CI could not distinguish "everything succeeded" from "we tolerated some failures" without parsing the structured envelope. This mirrors the "success-but-noteworthy" problem Terraform solves with `plan -detailed-exitcode`.

### Behavior

| Outcome | Default (flag off) | With `--detailed-exit-code` |
|---------|--------------------|-----------------------------|
| Clean success | `0` | `0` |
| Partial success (`continueOnError` action failed) | `0` | `12` |
| Hard failure (`continueOnError: false`) | `6` | `6` |

The flag defaults **off**, so existing `$?`-gating scripts are unaffected (non-breaking). This is deliberately opt-in rather than always-on: `continueOnError` is the solution author saying "tolerate this," so the caller -- not the author -- opts into the louder signal.

### Design

- New `exitcode.PartialSuccess = 12` constant + `Description` arm.
- The exit-code decision lives at the two CLI call sites (after state-save, presentation concern), not in the shared `execute.Actions` domain path.
- Embedder default is carried on `settings.Run.DetailedExitCode` because `RootOptions` does not thread into the `run` subcommand tree; exposed via `RootOptions.DetailedExitCode`. Precedence: per-invocation `--detailed-exit-code` flag > embedder default.
- Structured output is unaffected -- the full action envelope (`status: partial-success`) is still written to stdout before the non-zero exit, so `-o json`/`-o yaml` stay parseable.

### Testing

- `exitcode` unit tests (value + description + `GetCode` round-trip).
- Flag-plumbing unit tests for both subcommands.
- Embedder in-process test (`root_test.go`): both subcommands x {default true -> 12, default false -> 0, explicit `--detailed-exit-code=false` overrides embedder true -> 0}.
- CLI integration matrix (`tests/integration/cli_test.go`): 3 outcomes x 2 flag-states x 2 subcommands = 12 cases, asserting exit codes and that partial-success stdout stays parseable JSON.
- Full `task test:e2e` green (933 passed, 0 failed); `task lint:changed` clean.

### Docs

- `EXIT CODES` help blocks on both commands.
- `docs/tutorials/actions-tutorial.md`: new "Detecting partial success in CI" section (Bash + PowerShell examples).
- `examples/actions/error-handling.yaml` header note.

### Not included

**No MCP change** -- no MCP tool surfaces a numeric process exit code (the run tools return `FinalStatus` as a string). Not a breaking change (opt-in, default off), so no `!` in the title.
