### PR TITLE
feat: add positioned reference index and 'refactor rename resolver' command

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -75,6 +75,7 @@ scafctl <verb> <kind> <name[@version(or constraint)]> [flags]
 Names identify an object within a kind.
 
 Versions are optional and may be:
+
 - an exact version (`1.0.0`)
 - a constraint (`^1.2`, `>=1.0 <2.0`) *(planned - requires catalog)*
 - omitted (default resolution rules apply)
@@ -153,6 +154,7 @@ Show metadata of version 1.0.0 of the example solution:
 ~~~bash
 scafctl get solution example@1.0.0
 ~~~
+
 ### Listing Resources
 
 Following kubectl conventions, use singular or plural forms:
@@ -170,7 +172,7 @@ scafctl get solution example
 
 Both singular and plural forms without a name will list all resources of that kind.
 
-The `get providers` output includes a `source` column indicating whether each provider is `builtin` (compiled in) or `official` (auto-fetched from the OCI catalog). When filters (`--capability`, `--category`) are active, only built-in providers are shown since official providers do not expose capability/category metadata.
+The `get providers` output includes a `source` column indicating whether each provider is `builtin` (compiled in) or `official` (auto-fetched from the OCI catalog). When filters (`--capability`, `--category`) are active, only built-in providers are shown since official providers do not expose capability/category metadata
 ---
 
 ## Rendering a Solution
@@ -304,6 +306,7 @@ scafctl run solution example \
 #### Usage Patterns
 
 **Separate flags (traditional):**
+
 ~~~bash
 scafctl run solution example \
   -r key1=value1 \
@@ -311,12 +314,14 @@ scafctl run solution example \
 ~~~
 
 **CSV in single flag (convenient for multiple pairs):**
+
 ~~~bash
 scafctl run solution example \
   -r "key1=value1,key2=value2"
 ~~~
 
 **Mixed approach:**
+
 ~~~bash
 scafctl run solution example \
   -r "env=prod,region=us-east1" \
@@ -353,6 +358,7 @@ scafctl run solution example \
 **Important**: The scheme prefix is preserved and should be processed by your solution logic.
 
 **Validation**: Values with URI schemes are automatically validated:
+
 - `json://` - Validated as well-formed JSON
 - `yaml://` - Validated as well-formed YAML
 - `base64://` - Validated as proper base64 encoding
@@ -411,6 +417,7 @@ scafctl run resolver -f solution.yaml -r name=Alice body=@template.txt
 > A single trailing newline is trimmed automatically (matching shell `echo` behavior).
 
 **Restrictions:**
+
 - `@-` can only appear once (stdin is consumed on first read) — this applies across both standalone `@-` and `key=@-`
 - `@-` cannot be combined with `-f -` (both read from stdin)
 
@@ -703,6 +710,7 @@ These flags are available on all commands. Run `scafctl options` to see them:
 **Note**: The `-o/--output` flag is available per-command (not global) on commands that support structured output.
 
 **Output format support**:
+
 - `get`, `render`, `explain`, `config view`: Full support for `-o` flag
 - `run`: Supports `-o` flag for result output
 - `auth status`, `secrets list`: Support `-o` flag
@@ -823,6 +831,7 @@ scafctl secrets rotate
 ~~~
 
 Secrets are encrypted with AES-256-GCM and stored in platform-specific locations:
+
 - **macOS**: `~/.local/share/scafctl/secrets/`
 - **Linux**: `~/.local/share/scafctl/secrets/`
 - **Windows**: `%APPDATA%\scafctl\secrets\`
@@ -849,6 +858,7 @@ scafctl auth logout entra
 ~~~
 
 **Supported auth handlers**:
+
 - `entra` - Microsoft Entra ID (formerly Azure AD)
 
 ---
@@ -1046,6 +1056,36 @@ invalid, `4` a file was not found.
 
 ---
 
+## Refactoring Solutions
+
+`refactor` applies source-preserving edits to a solution. `refactor rename
+resolver <old> <new>` renames a resolver and rewrites every reference to it --
+the definition, `dependsOn` entries, `rslvr:` values, CEL `_.name` uses, and
+explicit template `._.name` uses -- replacing only the exact bytes of each
+occurrence, so comments, key order, and formatting are preserved (no YAML
+round-trip).
+
+~~~bash
+# Preview the change without writing (lists every occurrence and location)
+scafctl refactor rename resolver environment env -f ./solution.yaml --dry-run
+
+# Apply it in place (auto-discovers the solution file if -f is omitted)
+scafctl refactor rename resolver environment env
+~~~
+
+The rename is all-or-nothing: if any reference to the target resolver cannot be
+located byte-exact -- a context-dependent bare `{{ .name }}` accessor, a
+`$`-rooted `{{ $.name }}` accessor, or a reference nested inside a literal
+value -- it aborts rather than performing a partial rewrite that would silently
+break the solution. The check is name-scoped, so an unlocatable reference to a
+*different* resolver does not block the rename.
+
+Exit codes: `0` applied (or previewed), `2` a validation error (invalid new
+name, name collision, undefined resolver, or an unlocatable reference blocked
+the rename), `4` the solution file could not be resolved, read, or parsed.
+
+---
+
 ## Exploring Lint Rules
 
 ### List Rules
@@ -1074,7 +1114,6 @@ scafctl lint rule <rule-id> -o json
 
 > The former `scafctl lint explain <rule-id>` still works as a hidden,
 > deprecated alias for `scafctl lint rule <rule-id>`.
-
 
 ---
 

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -23,6 +23,7 @@ Step-by-step guides for learning scafctl features.
 - [Authentication Tutorial](auth-tutorial.md) — Set up authentication for your workflows
 - [Eval Tutorial](eval-tutorial.md) — Test CEL expressions and Go templates from the CLI
 - [Linting Tutorial](linting-tutorial.md) — Validate solutions, explore lint rules, and fix issues
+- [Refactoring Tutorial](refactor-tutorial.md) — Rename a resolver and every reference to it with `refactor rename resolver`
 - [CEL Expressions Tutorial](cel-tutorial.md) — Master CEL expressions and extension functions
 - [Go Templates Tutorial](go-templates-tutorial.md) — Generate files with Go template rendering
 - [Reference-Data Lookups](reference-data-lookups.md) -- Look up taxonomy values from inline, file, or HTTP datasets

--- a/docs/tutorials/refactor-tutorial.md
+++ b/docs/tutorials/refactor-tutorial.md
@@ -1,0 +1,154 @@
+---
+title: "Refactoring Tutorial"
+weight: 46
+---
+
+# Refactoring Tutorial
+
+This tutorial covers `scafctl refactor`, which applies source-preserving edits to
+a solution file. The first refactoring is `refactor rename resolver`, which
+renames a resolver and rewrites every reference to it.
+
+## Overview
+
+Renaming a resolver by hand is error-prone: a resolver can be referenced in
+several different ways, and missing one leaves a dangling reference that breaks
+the solution. `refactor rename resolver` finds and rewrites all of them in a
+single, comment-preserving edit.
+
+```mermaid
+flowchart LR
+  A["Solution<br/>YAML"] --> B["scafctl refactor<br/>rename resolver"] --> C["Same file,<br/>all references renamed"]
+```
+
+It updates every form of reference:
+
+- the resolver definition (the map key under `spec.resolvers`)
+- `dependsOn` entries
+- `rslvr:` references
+- CEL `_.name` uses (in inputs and in `when`/`until` conditions)
+- explicit Go-template `._.name` uses
+
+Only the exact bytes of each reference are replaced, so comments, key order, and
+formatting are preserved -- there is no YAML round-trip.
+
+## A solution to rename
+
+The example solution at `examples/refactor/solution.yaml` references the
+`environment` resolver four different ways:
+
+~~~yaml
+spec:
+  resolvers:
+    environment:                       # the definition
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    appName:
+      dependsOn:
+        - environment                  # dependsOn reference
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: '_.environment == "dev" ? "app-dev" : "app-prod"'  # CEL reference
+    greeting:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              template:
+                tmpl: "Deploying {{ ._.appName }} to {{ ._.environment }}"  # template reference
+    envAlias:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                rslvr: environment      # rslvr reference
+~~~
+
+## Preview a rename with --dry-run
+
+Always preview first. `--dry-run` lists every occurrence that would change and
+leaves the file untouched:
+
+```bash
+scafctl refactor rename resolver environment env \
+  -f examples/refactor/solution.yaml --dry-run
+```
+
+```text
+Would rename resolver "environment" to "env" (5 occurrence(s)):
+  examples/refactor/solution.yaml:13:5   environment -> env
+  examples/refactor/solution.yaml:23:11  environment -> env
+  examples/refactor/solution.yaml:30:26  environment -> env
+  examples/refactor/solution.yaml:39:60  environment -> env
+  examples/refactor/solution.yaml:48:24  environment -> env
+```
+
+## Apply the rename
+
+Drop `--dry-run` to write the change in place:
+
+```bash
+scafctl refactor rename resolver environment env -f examples/refactor/solution.yaml
+```
+
+```text
+Renamed resolver "environment" to "env" (5 occurrence(s)) in examples/refactor/solution.yaml
+```
+
+The definition, the `dependsOn` entry, the CEL expression, the template, and the
+`rslvr` reference are all updated; every comment and blank line is preserved.
+
+If you omit `-f`, the command auto-discovers a solution file in the current
+directory. Because rename modifies a file, discovery is strict: if more than one
+solution file matches, the command errors and asks you to pass `-f`.
+
+## The safety guarantee: it refuses partial renames
+
+A rename either updates every reference or does nothing. If the tool cannot
+locate a reference to the target resolver byte-exact, it aborts with a non-zero
+exit code rather than performing a partial (and potentially breaking) rewrite.
+
+References that cannot be positioned today include:
+
+- a context-dependent bare template accessor, `{{ .name }}`
+- a `$`-rooted template accessor, `{{ $.name }}`
+- an inline reference nested inside a literal value (for example a `rslvr:`
+  buried in a literal map or list)
+
+If any such reference targets the resolver you are renaming, you will see:
+
+```text
+rename resolver: N reference(s) to "environment" could not be located; aborting to avoid a partial rename
+```
+
+This check is name-scoped: an unlocatable reference to a *different* resolver
+does not block your rename. When a rename is refused, update the ambiguous
+reference to an explicit form (`._.name` in templates, `_.name` in CEL) and try
+again.
+
+## Exit codes
+
+| Code | Meaning |
+| ---- | ------- |
+| 0    | Rename applied (or previewed with `--dry-run`) |
+| 2    | Validation error: invalid new name, name collision, undefined resolver, or an unlocatable reference blocked the rename |
+| 4    | The solution file could not be resolved, read, or parsed |
+
+## Summary
+
+- `refactor rename resolver <old> <new>` renames a resolver and every reference
+  to it, preserving comments and formatting.
+- Use `--dry-run` to preview; use `-f` to target a specific file.
+- The rename refuses rather than performing a partial, solution-breaking rewrite.
+
+## See also
+
+- [Resolver Tutorial](resolver-tutorial.md) -- how resolvers and references work
+- [Linting Tutorial](linting-tutorial.md) -- validate a solution after refactoring

--- a/examples/README.md
+++ b/examples/README.md
@@ -69,6 +69,7 @@ scafctl get examples -o json
 | [mcp/](mcp/) | MCP server configurations for AI clients |
 
 > **Terminology Note**: The `plugins/` directory contains go-plugin source code for developing custom providers. When distributing via the catalog, these are pushed as **provider** or **auth-handler** artifacts:
+>
 > ```bash
 > # Package and push a provider to the catalog
 > scafctl package plugin --name my-provider --kind provider --version 1.0.0 --platform linux/amd64=./my-provider
@@ -195,6 +196,16 @@ Snapshots capture resolver execution state for debugging, testing, and compariso
 
 ---
 
+## Refactor Examples
+
+Source-preserving edits to a solution with `scafctl refactor`.
+
+| Example | Description | Run |
+|---------|-------------|-----|
+| [refactor/solution.yaml](refactor/solution.yaml) | A resolver referenced five ways (dependsOn, CEL, template, rslvr, definition) for `refactor rename resolver` | `scafctl refactor rename resolver environment env -f examples/refactor/solution.yaml --dry-run` |
+
+---
+
 ## Catalog Examples
 
 Catalog build and distribution examples.
@@ -273,21 +284,25 @@ AI client configuration examples for connecting to scafctl's MCP server.
 ## Tips
 
 ### View Output as JSON
+
 ```bash
 scafctl run resolver -f examples/resolvers/hello-world.yaml -o json
 ```
 
 ### Dry Run Mode
+
 ```bash
 scafctl run solution -f examples/actions/hello-world.yaml --dry-run
 ```
 
 ### Debug Logging
+
 ```bash
 scafctl run resolver -f examples/resolvers/dependencies.yaml -v
 ```
 
 ### Pass Multiple Parameters
+
 ```bash
 scafctl run resolver -f examples/resolvers/parameters.yaml \
   -r name=Bob \
@@ -296,18 +311,21 @@ scafctl run resolver -f examples/resolvers/parameters.yaml \
 ```
 
 ### Interactive Mode
+
 ```bash
 # Explore output in a TUI (navigate, search, filter)
 scafctl run resolver -f examples/resolvers/dependencies.yaml -i
 ```
 
 ### Filter with CEL Expressions
+
 ```bash
 # Extract specific values from output
 scafctl run resolver -f examples/resolvers/dependencies.yaml -e '_.fullName'
 ```
 
 ### Snapshots
+
 ```bash
 # Capture a snapshot during render
 scafctl render solution -f examples/snapshots/basic-snapshot.yaml \
@@ -325,6 +343,7 @@ scafctl diff snapshot /tmp/snap-a.json /tmp/snap-b.json
 ## Catalog Workflows
 
 ### Build and Run from Catalog
+
 ```bash
 # Package a solution into the catalog
 scafctl package solution -f examples/resolver-demo.yaml --version 1.0.0
@@ -337,6 +356,7 @@ scafctl catalog list
 ```
 
 ### Export and Import (Air-Gapped Transfer)
+
 ```bash
 # Build and export a solution
 scafctl package solution -f examples/resolver-demo.yaml --version 1.0.0
@@ -350,6 +370,7 @@ scafctl run resolver resolver-demo
 ```
 
 ### Version Management
+
 ```bash
 # Build multiple versions
 scafctl package solution -f examples/resolver-demo.yaml --version 1.0.0

--- a/examples/refactor/solution.yaml
+++ b/examples/refactor/solution.yaml
@@ -1,0 +1,48 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: refactor-rename-demo
+  description: >-
+    Demonstrates `scafctl refactor rename resolver`. The resolver `environment`
+    is referenced four different ways -- a dependsOn entry, a CEL `_.name` use,
+    an explicit template `._.name` use, and a rslvr reference -- so a single
+    rename must update all of them while preserving comments and formatting.
+spec:
+  resolvers:
+    # The resolver we will rename (try: refactor rename resolver environment env).
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+
+    # Reference #1: an explicit dependsOn entry.
+    appName:
+      dependsOn:
+        - environment
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              # Reference #2: a CEL expression using the `_.` resolver namespace.
+              value:
+                expr: '_.environment == "dev" ? "app-dev" : "app-prod"'
+
+    # Reference #3: an explicit Go-template resolver reference (`._.name`).
+    greeting:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              template:
+                tmpl: "Deploying {{ ._.appName }} to {{ ._.environment }}"
+
+    # Reference #4: a direct rslvr reference.
+    envAlias:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                rslvr: environment

--- a/pkg/celexp/refs.go
+++ b/pkg/celexp/refs.go
@@ -119,7 +119,7 @@ func (e Expression) GetUnderscoreVariablesByOptionality(ctx context.Context) (ha
 
 	hardSet := make(map[string]struct{})
 	optionalSet := make(map[string]struct{})
-	walkVariablesWithPrefix(parsedExpr.GetExpr(), "_.", func(name string, opt bool) {
+	walkVariablesWithPrefix(parsedExpr.GetExpr(), "_.", func(name string, _ int64, opt bool) {
 		if opt {
 			optionalSet[name] = struct{}{}
 		} else {
@@ -269,16 +269,18 @@ func (e Expression) RequiredVariables(ctx context.Context) ([]string, error) {
 	return result, nil
 }
 
-// refVisitor receives each discovered prefix-scoped reference along with whether
-// it was reached through optional-access syntax (_.?name or _[?"name"]). The same
-// name may be reported more than once (e.g. both hard and optional); callers
-// reconcile duplicates (a hard occurrence dominates an optional one).
-type refVisitor func(name string, optional bool)
+// refVisitor receives each discovered prefix-scoped reference along with the id
+// of the AST node that produced it (usable to look up its source offset via
+// SourceInfo.Positions) and whether it was reached through optional-access
+// syntax (_.?name or _[?"name"]). The same name may be reported more than once
+// (e.g. both hard and optional); callers reconcile duplicates (a hard
+// occurrence dominates an optional one).
+type refVisitor func(name string, id int64, optional bool)
 
 // extractVariablesWithPrefix recursively walks the AST and collects variable
 // names starting with the given prefix into vars, ignoring optionality.
 func extractVariablesWithPrefix(expr *exprpb.Expr, prefix string, vars map[string]struct{}) {
-	walkVariablesWithPrefix(expr, prefix, func(name string, _ bool) {
+	walkVariablesWithPrefix(expr, prefix, func(name string, _ int64, _ bool) {
 		vars[name] = struct{}{}
 	})
 }
@@ -318,7 +320,7 @@ func walkVariablesWithPrefix(expr *exprpb.Expr, prefix string, visit refVisitor)
 			// For "$" style, check if identifier starts with prefix
 			if len(ident) >= len(prefix) && ident[:len(prefix)] == prefix {
 				// Store without the prefix
-				visit(ident[len(prefix):], false)
+				visit(ident[len(prefix):], expr.GetId(), false)
 			}
 		}
 
@@ -330,7 +332,7 @@ func walkVariablesWithPrefix(expr *exprpb.Expr, prefix string, visit refVisitor)
 			// For "_." style prefix, check if the operand is the base identifier
 			if operand.GetIdentExpr() != nil && operand.GetIdentExpr().GetName() == baseIdent {
 				// This is a _.something expression - capture it as a hard reference.
-				visit(selectExpr.GetField(), false)
+				visit(selectExpr.GetField(), expr.GetId(), false)
 			} else {
 				// Continue traversing for other variables
 				walkVariablesWithPrefix(operand, prefix, visit)
@@ -360,7 +362,7 @@ func walkVariablesWithPrefix(expr *exprpb.Expr, prefix string, visit refVisitor)
 					if key.GetConstExpr() != nil && key.GetConstExpr().GetStringValue() != "" {
 						// Only the two optional operators signal optionality; a
 						// plain bracket index (_[_]) is a hard reference.
-						visit(key.GetConstExpr().GetStringValue(), fn != "_[_]")
+						visit(key.GetConstExpr().GetStringValue(), expr.GetId(), fn != "_[_]")
 					}
 				}
 			}

--- a/pkg/celexp/refs_position.go
+++ b/pkg/celexp/refs_position.go
@@ -22,10 +22,11 @@ type VariableRef struct {
 	// Name is the referenced name with the "_." (or "_[\"...\"]") prefix removed.
 	Name string
 
-	// Offset is the 0-based BYTE offset of Name within the expression source.
-	// It is a byte offset (not a rune offset) so callers can compose it directly
-	// with byte-based file positions; CEL's internal rune offsets are converted
-	// here.
+	// Offset is the 0-based BYTE offset of Name within the expression source, or
+	// -1 when the occurrence could not be positioned (its exact bytes could not
+	// be located, e.g. a bracket key whose decoded value differs from the source
+	// due to escapes). A -1 offset signals to consumers that the occurrence
+	// exists but must be treated as unpositioned rather than silently dropped.
 	Offset int
 
 	// Len is the byte length of Name (== len(Name)). Offset+Len is the exclusive
@@ -43,6 +44,10 @@ func (r VariableRef) End() int { return r.Offset + r.Len }
 // UnderscoreVariableRefs parses the expression and returns every "_"-scoped
 // reference occurrence with its byte range within the expression source, in
 // source order (by offset).
+//
+// Every occurrence is returned: one that could not be located byte-exact is
+// reported with Offset == -1 (unpositioned) rather than dropped, so consumers
+// such as rename can fail safe instead of silently missing a reference.
 //
 // It uses the CEL AST to decide WHICH names are genuine "_"-scoped references
 // (so a name that only appears inside a string literal is not matched), then an
@@ -82,8 +87,11 @@ func (e Expression) UnderscoreVariableRefs(ctx context.Context) ([]VariableRef, 
 		anchor := int(positions[id])
 		runeOff := findIdentNear(exprRunes, []rune(name), anchor)
 		if runeOff < 0 {
-			// Could not locate the occurrence (should not happen for valid
-			// identifier references); skip rather than emit a wrong range.
+			// The occurrence exists but its exact bytes could not be located
+			// (e.g. a bracket key with escapes). Report it as unpositioned
+			// (Offset -1) instead of dropping it, so a rename fails safe rather
+			// than silently missing this reference.
+			refs = append(refs, VariableRef{Name: name, Offset: -1, Len: len(name), Optional: optional})
 			return
 		}
 		byteOff := len(string(exprRunes[:runeOff]))

--- a/pkg/celexp/refs_position.go
+++ b/pkg/celexp/refs_position.go
@@ -1,0 +1,163 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package celexp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/google/cel-go/cel"
+)
+
+// VariableRef is a single textual occurrence of a "_"-scoped reference within a
+// CEL expression, located by its byte range inside the expression source.
+//
+// Unlike GetUnderscoreVariables (which returns a deduplicated, sorted set of
+// names), a VariableRef is emitted once per occurrence and carries the exact
+// span of the referenced name, so tools can highlight, navigate to, or rewrite
+// each individual use (e.g. renaming a resolver and every reference to it).
+type VariableRef struct {
+	// Name is the referenced name with the "_." (or "_[\"...\"]") prefix removed.
+	Name string
+
+	// Offset is the 0-based BYTE offset of Name within the expression source.
+	// It is a byte offset (not a rune offset) so callers can compose it directly
+	// with byte-based file positions; CEL's internal rune offsets are converted
+	// here.
+	Offset int
+
+	// Len is the byte length of Name (== len(Name)). Offset+Len is the exclusive
+	// end of the occurrence.
+	Len int
+
+	// Optional reports whether the reference was reached through optional-access
+	// syntax (_.?name or _[?"name"]).
+	Optional bool
+}
+
+// End returns the exclusive end byte offset of the reference (Offset + Len).
+func (r VariableRef) End() int { return r.Offset + r.Len }
+
+// UnderscoreVariableRefs parses the expression and returns every "_"-scoped
+// reference occurrence with its byte range within the expression source, in
+// source order (by offset).
+//
+// It uses the CEL AST to decide WHICH names are genuine "_"-scoped references
+// (so a name that only appears inside a string literal is not matched), then an
+// AST-anchored, word-boundaried text scan to pin down each occurrence's exact
+// range. This hybrid is robust to the fact that a CEL SelectExpr's recorded
+// position points at the "." operator rather than the field, and to the same
+// name appearing multiple times.
+//
+// Example:
+//
+//	refs, _ := celexp.Expression(`_.a + _.b`).UnderscoreVariableRefs(ctx)
+//	// refs == [{Name:"a", Offset:2, Len:1}, {Name:"b", Offset:8, Len:1}]
+func (e Expression) UnderscoreVariableRefs(ctx context.Context) ([]VariableRef, error) {
+	env, err := NewParseEnv(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	parsed, issues := env.Parse(string(e))
+	if issues != nil && issues.Err() != nil {
+		return nil, fmt.Errorf("failed to parse CEL expression: %w", issues.Err())
+	}
+
+	parsedExpr, err := cel.AstToParsedExpr(parsed)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert AST: %w", err)
+	}
+
+	// SourceInfo.Positions maps AST node id -> RUNE offset in the source. The
+	// offset anchors near (at or just before) the reference; we scan for the
+	// exact identifier from there.
+	positions := parsedExpr.GetSourceInfo().GetPositions()
+	exprRunes := []rune(string(e))
+
+	var refs []VariableRef
+	walkVariablesWithPrefix(parsedExpr.GetExpr(), "_.", func(name string, id int64, optional bool) {
+		anchor := int(positions[id])
+		runeOff := findIdentNear(exprRunes, []rune(name), anchor)
+		if runeOff < 0 {
+			// Could not locate the occurrence (should not happen for valid
+			// identifier references); skip rather than emit a wrong range.
+			return
+		}
+		byteOff := len(string(exprRunes[:runeOff]))
+		refs = append(refs, VariableRef{
+			Name:     name,
+			Offset:   byteOff,
+			Len:      len(name),
+			Optional: optional,
+		})
+	})
+
+	sort.Slice(refs, func(i, j int) bool { return refs[i].Offset < refs[j].Offset })
+	return refs, nil
+}
+
+// findIdentNear returns the rune offset of target in runes, choosing the
+// word-boundaried occurrence nearest to anchor. It returns -1 if target does
+// not appear with identifier boundaries on both sides. Boundaries prevent a
+// short name (e.g. "app") from matching inside a longer identifier
+// (e.g. "appName").
+func findIdentNear(runes, target []rune, anchor int) int {
+	if len(target) == 0 {
+		return -1
+	}
+	best := -1
+	bestDist := int(^uint(0) >> 1) // max int
+	for i := 0; i+len(target) <= len(runes); i++ {
+		if !runesMatchAt(runes, target, i) {
+			continue
+		}
+		// Left boundary: the preceding rune must not be an identifier rune.
+		if i > 0 && isIdentRune(runes[i-1]) {
+			continue
+		}
+		// Right boundary: the following rune must not be an identifier rune.
+		if i+len(target) < len(runes) && isIdentRune(runes[i+len(target)]) {
+			continue
+		}
+		d := i - anchor
+		if d < 0 {
+			d = -d
+		}
+		if d < bestDist {
+			bestDist = d
+			best = i
+		}
+	}
+	return best
+}
+
+// runesMatchAt reports whether target matches runes starting at index i.
+func runesMatchAt(runes, target []rune, i int) bool {
+	for j := range target {
+		if runes[i+j] != target[j] {
+			return false
+		}
+	}
+	return true
+}
+
+// isIdentRune reports whether r can be part of a CEL/identifier token. Non-ASCII
+// runes are treated as identifier runes so multibyte content forms a boundary
+// consistently.
+func isIdentRune(r rune) bool {
+	switch {
+	case r == '_':
+		return true
+	case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z':
+		return true
+	case r >= '0' && r <= '9':
+		return true
+	case r >= 0x80:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/celexp/refs_position_test.go
+++ b/pkg/celexp/refs_position_test.go
@@ -1,0 +1,183 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package celexp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnderscoreVariableRefs(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		expr string
+		want []VariableRef
+	}{
+		{
+			name: "single ref",
+			expr: `_.appName`,
+			want: []VariableRef{{Name: "appName", Offset: 2, Len: 7}},
+		},
+		{
+			name: "two refs in source order",
+			expr: `_.a + _.b`,
+			want: []VariableRef{
+				{Name: "a", Offset: 2, Len: 1},
+				{Name: "b", Offset: 8, Len: 1},
+			},
+		},
+		{
+			name: "duplicate name -> two distinct occurrences",
+			expr: `_.a + _.a`,
+			want: []VariableRef{
+				{Name: "a", Offset: 2, Len: 1},
+				{Name: "a", Offset: 8, Len: 1},
+			},
+		},
+		{
+			name: "optional access flagged",
+			expr: `_.?maybe.orValue("")`,
+			want: []VariableRef{{Name: "maybe", Offset: 3, Len: 5, Optional: true}},
+		},
+		{
+			name: "bracket access",
+			expr: `_["bracketed"]`,
+			want: []VariableRef{{Name: "bracketed", Offset: 3, Len: 9}},
+		},
+		{
+			name: "string literal is NOT matched",
+			expr: `_.a + "a"`,
+			want: []VariableRef{{Name: "a", Offset: 2, Len: 1}},
+		},
+		{
+			name: "short name does not match inside longer identifier",
+			expr: `_.app + _.appName`,
+			want: []VariableRef{
+				{Name: "app", Offset: 2, Len: 3},
+				{Name: "appName", Offset: 10, Len: 7},
+			},
+		},
+		{
+			name: "no underscore refs",
+			expr: `1 + 2 + foo.bar`,
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			refs, err := Expression(tt.expr).UnderscoreVariableRefs(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, refs)
+
+			// Byte-exact invariant: every reported range slices out exactly the name.
+			raw := []byte(tt.expr)
+			for _, r := range refs {
+				require.LessOrEqual(t, r.End(), len(raw))
+				assert.Equalf(t, r.Name, string(raw[r.Offset:r.End()]),
+					"range [%d:%d] must slice to %q", r.Offset, r.End(), r.Name)
+			}
+		})
+	}
+}
+
+func TestUnderscoreVariableRefs_MultibytePrefix(t *testing.T) {
+	ctx := context.Background()
+	// A 2-byte rune before the reference must shift the BYTE offset by 2 even
+	// though CEL's internal offset counts it as one rune.
+	expr := `"é" + _.afterMultibyte`
+	refs, err := Expression(expr).UnderscoreVariableRefs(ctx)
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+
+	r := refs[0]
+	assert.Equal(t, "afterMultibyte", r.Name)
+	// Byte-exact: the offset accounts for the 2-byte 'é'.
+	assert.Equal(t, "afterMultibyte", string([]byte(expr)[r.Offset:r.End()]))
+}
+
+func TestUnderscoreVariableRefs_HardAndOptionalSameName(t *testing.T) {
+	ctx := context.Background()
+	// Both occurrences are reported (per-occurrence semantics), each with its
+	// own optionality -- unlike GetUnderscoreVariablesByOptionality which
+	// collapses to a name set where hard dominates.
+	refs, err := Expression(`_.a + _.?a.orValue("")`).UnderscoreVariableRefs(ctx)
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+
+	assert.Equal(t, "a", refs[0].Name)
+	assert.False(t, refs[0].Optional)
+	assert.Equal(t, "a", refs[1].Name)
+	assert.True(t, refs[1].Optional)
+}
+
+func TestUnderscoreVariableRefs_ParseError(t *testing.T) {
+	ctx := context.Background()
+	_, err := Expression(`_.a +`).UnderscoreVariableRefs(ctx)
+	assert.Error(t, err)
+}
+
+func TestVariableRef_End(t *testing.T) {
+	assert.Equal(t, 9, VariableRef{Offset: 2, Len: 7}.End())
+}
+
+func TestIsIdentRune(t *testing.T) {
+	tests := []struct {
+		r    rune
+		want bool
+	}{
+		{'_', true},
+		{'a', true},
+		{'Z', true},
+		{'5', true},
+		{'é', true}, // non-ASCII treated as ident rune (forms a boundary)
+		{'.', false},
+		{' ', false},
+		{'"', false},
+		{'[', false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.r), func(t *testing.T) {
+			assert.Equal(t, tt.want, isIdentRune(tt.r))
+		})
+	}
+}
+
+func TestFindIdentNear(t *testing.T) {
+	tests := []struct {
+		name   string
+		src    string
+		target string
+		anchor int
+		want   int
+	}{
+		{"basic", "_.abc", "abc", 1, 2},
+		{"nearest to anchor picks second", "a + a", "a", 4, 4},
+		{"nearest to anchor picks first", "a + a", "a", 0, 0},
+		{"no match", "xyz", "abc", 0, -1},
+		{"boundary rejects substring", "appName", "app", 0, -1},
+		{"empty target", "abc", "", 0, -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findIdentNear([]rune(tt.src), []rune(tt.target), tt.anchor)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func BenchmarkUnderscoreVariableRefs(b *testing.B) {
+	ctx := context.Background()
+	expr := Expression(`_.a + _.b.field + _.?c.orValue("") + _["d"] + map.merge(_.e, _.f)`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = expr.UnderscoreVariableRefs(ctx)
+	}
+}

--- a/pkg/celexp/refs_position_test.go
+++ b/pkg/celexp/refs_position_test.go
@@ -181,3 +181,15 @@ func BenchmarkUnderscoreVariableRefs(b *testing.B) {
 		_, _ = expr.UnderscoreVariableRefs(ctx)
 	}
 }
+
+func TestUnderscoreVariableRefs_UnpositionableIsReportedNotDropped(t *testing.T) {
+	// A bracket key whose decoded value differs from the source (escaped quote)
+	// cannot be located byte-exact. It must be reported with Offset -1 (so a
+	// rename can fail safe) rather than silently dropped.
+	ctx := context.Background()
+	refs, err := Expression(`_["a\"b"]`).UnderscoreVariableRefs(ctx)
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+	assert.Equal(t, `a"b`, refs[0].Name)
+	assert.Equal(t, -1, refs[0].Offset, "unpositionable occurrence must be reported with Offset -1")
+}

--- a/pkg/cmd/scafctl/refactor/refactor.go
+++ b/pkg/cmd/scafctl/refactor/refactor.go
@@ -1,0 +1,57 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package refactor provides the `refactor` command group: source-preserving
+// refactorings for solution files (rename and friends). All business logic
+// lives in pkg/refactor; these commands are thin wiring.
+package refactor
+
+import (
+	"fmt"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/cmdutil"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/cobra"
+)
+
+// CommandRefactor creates the `refactor` parent command.
+func CommandRefactor(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	cCmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
+		Use:   "refactor",
+		Short: "Source-preserving edits to solutions (rename, ...)",
+		Long: heredoc.Doc(`
+			Apply structural edits to a solution while preserving comments,
+			key order, and formatting.
+
+			Edits replace only the exact bytes of each affected token, so the
+			rest of the file is left byte-for-byte unchanged. Refactorings refuse
+			to run when they cannot locate every affected reference, rather than
+			performing a partial (and potentially breaking) rewrite.
+
+			  refactor rename resolver <old> <new>   Rename a resolver everywhere
+		`),
+		SilenceUsage: true,
+	})
+
+	cCmd.AddCommand(CommandRename(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
+	return cCmd
+}
+
+// CommandRename creates the `refactor rename` parent command.
+func CommandRename(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
+	cCmd := cmdutil.MakeHelpOnlyGroup(&cobra.Command{
+		Use:   "rename",
+		Short: "Rename a symbol and update every reference to it",
+		Long: heredoc.Doc(`
+			Rename a symbol and rewrite every reference to it in place.
+
+			  refactor rename resolver <old> <new>   Rename a resolver
+		`),
+		SilenceUsage: true,
+	})
+
+	cCmd.AddCommand(CommandRenameResolver(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
+	return cCmd
+}

--- a/pkg/cmd/scafctl/refactor/rename_resolver.go
+++ b/pkg/cmd/scafctl/refactor/rename_resolver.go
@@ -122,12 +122,43 @@ func runRenameResolver(ctx context.Context, opts *renameResolverOptions, oldName
 	if fi, statErr := os.Stat(resolvedPath); statErr == nil {
 		mode = fi.Mode().Perm()
 	}
-	if err := os.WriteFile(resolvedPath, newContent, mode); err != nil { //nolint:gosec // path resolved from user-provided solution reference
+	if err := writeFileAtomic(resolvedPath, newContent, mode); err != nil {
 		return fail(w, exitcode.GeneralError, fmt.Errorf("failed to write %s: %w", resolvedPath, err))
 	}
 
 	if w != nil {
 		w.Successf("Renamed resolver %q to %q (%d occurrence(s)) in %s", oldName, newName, len(result.Edits), resolvedPath)
+	}
+	return nil
+}
+
+// writeFileAtomic writes data to path atomically by writing to a temporary file
+// in the same directory and renaming it over path. os.Rename is atomic on the
+// same filesystem, so a crash mid-write cannot leave the solution file
+// truncated or partially written.
+func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*") //nolint:gosec // temp file created in the target's own directory
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we return before a successful rename; a no-op once
+	// the temp file has been renamed away.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, mode); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil { //nolint:gosec // path resolved from user-provided solution reference
+		return err
 	}
 	return nil
 }

--- a/pkg/cmd/scafctl/refactor/rename_resolver.go
+++ b/pkg/cmd/scafctl/refactor/rename_resolver.go
@@ -1,0 +1,154 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refactor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	pkgrefactor "github.com/oakwood-commons/scafctl/pkg/refactor"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// renameResolverOptions holds flags for the rename resolver command.
+type renameResolverOptions struct {
+	File      string
+	DryRun    bool
+	CliParams *settings.Run
+}
+
+// CommandRenameResolver creates the `refactor rename resolver` command.
+func CommandRenameResolver(cliParams *settings.Run, _ *terminal.IOStreams, path string) *cobra.Command {
+	opts := &renameResolverOptions{CliParams: cliParams}
+
+	binaryName := cliParams.BinaryName
+	if binaryName == "" {
+		binaryName = settings.CliBinaryName
+	}
+
+	cmd := &cobra.Command{
+		Use:   "resolver <old-name> <new-name>",
+		Short: "Rename a resolver and update every reference to it",
+		Long: heredoc.Doc(`
+			Rename a resolver and rewrite every reference to it -- dependsOn
+			entries, rslvr values, CEL '_.name' uses, explicit template
+			'._.name' uses, and the definition itself -- preserving comments,
+			key order, and formatting.
+
+			The rename refuses to run when any reference to the target resolver
+			cannot be located byte-exact (for example a context-dependent bare
+			'{{ .field }}' template reference, a '$'-rooted reference, or an
+			inline reference nested inside a literal), so it never performs a
+			partial rewrite that would silently break the solution.
+		`),
+		Example: strings.ReplaceAll(heredoc.Doc(`
+			# Rename resolver 'environment' to 'env' in the discovered solution
+			scafctl refactor rename resolver environment env
+
+			# Target a specific file and preview the change without writing
+			scafctl refactor rename resolver environment env -f ./solution.yaml --dry-run
+		`), settings.CliBinaryName, binaryName),
+		Args:         cobra.ExactArgs(2),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Name())
+			ctx := settings.IntoContext(cmd.Context(), cliParams)
+			ctx = logger.WithLogger(ctx, logger.FromContext(cmd.Context()))
+			return runRenameResolver(ctx, opts, args[0], args[1])
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.File, "file", "f", "", "Solution file path (auto-discovered if not provided)")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would change without modifying the file")
+
+	return cmd
+}
+
+// runRenameResolver resolves the target file, computes the rename edits via
+// pkg/refactor, and either writes the result or previews it (--dry-run).
+func runRenameResolver(ctx context.Context, opts *renameResolverOptions, oldName, newName string) error {
+	w := writer.FromContext(ctx)
+
+	getter := get.NewGetterFromContext(ctx)
+	// Rename mutates a file, so ambiguous auto-discovery must error (high risk)
+	// rather than silently pick one of several matches.
+	resolvedPath, err := get.Resolve(ctx, getter, opts.File, "", get.ResolveOptions{Risk: get.DiscoveryRiskHigh})
+	if err != nil {
+		return fail(w, exitcode.FileNotFound, fmt.Errorf("failed to resolve solution: %w", err))
+	}
+	if resolvedPath == "-" {
+		return fail(w, exitcode.ValidationFailed, errors.New("refactor rename requires a file path; stdin ('-') is not supported"))
+	}
+
+	raw, err := os.ReadFile(resolvedPath) //nolint:gosec // path resolved from user-provided solution reference
+	if err != nil {
+		return fail(w, exitcode.FileNotFound, fmt.Errorf("failed to read %s: %w", resolvedPath, err))
+	}
+
+	sol := &solution.Solution{}
+	if err := sol.UnmarshalFromBytes(raw); err != nil {
+		return fail(w, exitcode.FileNotFound, fmt.Errorf("failed to parse %s: %w", resolvedPath, err))
+	}
+
+	result, err := pkgrefactor.RenameResolver(sol, oldName, newName)
+	if err != nil {
+		return fail(w, exitcode.ValidationFailed, err)
+	}
+
+	newContent, err := result.Apply(raw)
+	if err != nil {
+		return fail(w, exitcode.GeneralError, fmt.Errorf("failed to apply rename: %w", err))
+	}
+
+	if opts.DryRun {
+		printRenamePreview(w, resolvedPath, result)
+		return nil
+	}
+
+	mode := os.FileMode(0o644)
+	if fi, statErr := os.Stat(resolvedPath); statErr == nil {
+		mode = fi.Mode().Perm()
+	}
+	if err := os.WriteFile(resolvedPath, newContent, mode); err != nil { //nolint:gosec // path resolved from user-provided solution reference
+		return fail(w, exitcode.GeneralError, fmt.Errorf("failed to write %s: %w", resolvedPath, err))
+	}
+
+	if w != nil {
+		w.Successf("Renamed resolver %q to %q (%d occurrence(s)) in %s", oldName, newName, len(result.Edits), resolvedPath)
+	}
+	return nil
+}
+
+// fail prints err to stderr (when a writer is present) and returns it wrapped
+// with the given exit code. The root command silences returned errors, so
+// commands must surface their own messages.
+func fail(w *writer.Writer, code int, err error) error {
+	if w != nil {
+		w.Error(err.Error())
+	}
+	return exitcode.WithCode(err, code)
+}
+
+// printRenamePreview lists the planned edits without modifying the file.
+func printRenamePreview(w *writer.Writer, path string, res *pkgrefactor.RenameResult) {
+	if w == nil {
+		return
+	}
+	w.Plainlnf("Would rename resolver %q to %q (%d occurrence(s)):", res.OldName, res.NewName, len(res.Edits))
+	for _, e := range res.Edits {
+		w.Plainlnf("  %s:%d:%d  %s -> %s", path, e.Range.Start.Line, e.Range.Start.Column, res.OldName, res.NewName)
+	}
+}

--- a/pkg/cmd/scafctl/refactor/rename_resolver_test.go
+++ b/pkg/cmd/scafctl/refactor/rename_resolver_test.go
@@ -1,0 +1,167 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refactor
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const cmdFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: cmd-test # comment stays
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    appName:
+      dependsOn:
+        - environment
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.environment
+`
+
+func testCliParams() *settings.Run {
+	p := settings.NewCliParams()
+	p.ExitOnError = false
+	return p
+}
+
+func testContext(t *testing.T) (context.Context, *bytesBuffers) {
+	t.Helper()
+	ioStreams, out, errOut := terminal.NewTestIOStreams()
+	ctx := logger.WithLogger(context.Background(), logger.GetNoopLogger())
+	ctx = writer.WithWriter(ctx, writer.New(ioStreams, testCliParams()))
+	return ctx, &bytesBuffers{out: out, errOut: errOut}
+}
+
+type bytesBuffers struct {
+	out    interface{ String() string }
+	errOut interface{ String() string }
+}
+
+func writeFixture(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func TestRunRenameResolver_HappyPath(t *testing.T) {
+	path := writeFixture(t, cmdFixture)
+	ctx, bufs := testContext(t)
+
+	err := runRenameResolver(ctx, &renameResolverOptions{File: path, CliParams: testCliParams()}, "environment", "env")
+	require.NoError(t, err)
+
+	got, readErr := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, readErr)
+	assert.NotContains(t, string(got), "environment")
+	assert.Contains(t, string(got), "env:")
+	assert.Contains(t, string(got), "# comment stays")
+	assert.Contains(t, bufs.out.String(), "Renamed resolver")
+}
+
+func TestRunRenameResolver_DryRunLeavesFileUnchanged(t *testing.T) {
+	path := writeFixture(t, cmdFixture)
+	ctx, bufs := testContext(t)
+
+	err := runRenameResolver(ctx, &renameResolverOptions{File: path, DryRun: true, CliParams: testCliParams()}, "environment", "env")
+	require.NoError(t, err)
+
+	got, _ := os.ReadFile(path) //nolint:gosec // test-controlled path
+	assert.Equal(t, cmdFixture, string(got), "dry-run must not modify the file")
+	assert.Contains(t, bufs.out.String(), "Would rename resolver")
+	assert.Contains(t, bufs.out.String(), "environment -> env")
+}
+
+func TestRunRenameResolver_Errors(t *testing.T) {
+	tests := []struct {
+		name     string
+		old      string
+		newName  string
+		wantCode int
+		wantMsg  string
+	}{
+		{"collision", "environment", "appName", exitcode.ValidationFailed, "already exists"},
+		{"invalid name", "environment", "1bad", exitcode.ValidationFailed, "not a valid resolver name"},
+		{"undefined", "missing", "x", exitcode.ValidationFailed, "is not defined"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeFixture(t, cmdFixture)
+			ctx, bufs := testContext(t)
+
+			err := runRenameResolver(ctx, &renameResolverOptions{File: path, CliParams: testCliParams()}, tt.old, tt.newName)
+			require.Error(t, err)
+			assert.Equal(t, tt.wantCode, exitcode.GetCode(err))
+			assert.Contains(t, bufs.errOut.String(), tt.wantMsg)
+
+			// The file must be untouched on any error.
+			got, _ := os.ReadFile(path) //nolint:gosec // test-controlled path
+			assert.Equal(t, cmdFixture, string(got))
+		})
+	}
+}
+
+func TestRunRenameResolver_FileNotFound(t *testing.T) {
+	ctx, _ := testContext(t)
+	err := runRenameResolver(ctx, &renameResolverOptions{File: "/no/such/solution.yaml", CliParams: testCliParams()}, "a", "b")
+	require.Error(t, err)
+	assert.Equal(t, exitcode.FileNotFound, exitcode.GetCode(err))
+}
+
+func TestCommandRefactor_Tree(t *testing.T) {
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	root := CommandRefactor(testCliParams(), ioStreams, "scafctl")
+	assert.Equal(t, "refactor", root.Name())
+
+	rename, _, err := root.Find([]string{"rename"})
+	require.NoError(t, err)
+	assert.Equal(t, "rename", rename.Name())
+
+	resolver, _, err := root.Find([]string{"rename", "resolver"})
+	require.NoError(t, err)
+	assert.Equal(t, "resolver", resolver.Name())
+	require.NotNil(t, resolver.Flags().Lookup("file"))
+	require.NotNil(t, resolver.Flags().Lookup("dry-run"))
+	// Exactly two positional args (old, new).
+	assert.Error(t, resolver.Args(resolver, []string{"only-one"}))
+	assert.NoError(t, resolver.Args(resolver, []string{"a", "b"}))
+}
+
+func TestCommandRefactor_EmbedderBinaryName(t *testing.T) {
+	// An embedder with a non-default binary name must see it in generated help
+	// examples, not a hardcoded "scafctl".
+	p := settings.NewCliParams()
+	p.ExitOnError = false
+	p.BinaryName = "mycli"
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+
+	root := CommandRefactor(p, ioStreams, "mycli")
+	resolver, _, err := root.Find([]string{"rename", "resolver"})
+	require.NoError(t, err)
+	assert.Contains(t, resolver.Example, "mycli refactor rename resolver")
+	assert.NotContains(t, resolver.Example, "scafctl refactor rename resolver")
+}

--- a/pkg/cmd/scafctl/refactor/rename_resolver_test.go
+++ b/pkg/cmd/scafctl/refactor/rename_resolver_test.go
@@ -165,3 +165,24 @@ func TestCommandRefactor_EmbedderBinaryName(t *testing.T) {
 	assert.Contains(t, resolver.Example, "mycli refactor rename resolver")
 	assert.NotContains(t, resolver.Example, "scafctl refactor rename resolver")
 }
+
+func TestWriteFileAtomic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("original"), 0o640))
+
+	require.NoError(t, writeFileAtomic(path, []byte("replaced content"), 0o640))
+
+	got, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	assert.Equal(t, "replaced content", string(got))
+
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o640), fi.Mode().Perm(), "mode preserved")
+
+	// No leftover temp files in the directory.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "no temp files left behind")
+}

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -35,6 +35,7 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/options"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/packagecmd"
 	pluginscmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/plugins"
+	refactorcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/refactor"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/render"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/run"
 	secretscmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/secrets"
@@ -921,6 +922,7 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 	cCmd.AddCommand(withGroup(groupCore, lint.CommandLint(cliParams, ioStreams, binaryName)))
 	cCmd.AddCommand(withGroup(groupCore, testcmd.CommandTest(cliParams, ioStreams, binaryName)))
 	cCmd.AddCommand(withGroup(groupCore, validatecmd.CommandValidate(cliParams, ioStreams, binaryName)))
+	cCmd.AddCommand(withGroup(groupCore, refactorcmd.CommandRefactor(cliParams, ioStreams, binaryName)))
 
 	// Inspection Commands — explore and understand solutions
 	cCmd.AddCommand(withGroup(groupInspect, get.CommandGet(cliParams, ioStreams, binaryName)))

--- a/pkg/gotmpl/refs.go
+++ b/pkg/gotmpl/refs.go
@@ -73,14 +73,7 @@ func (s *Service) GetReferences(ctx context.Context, opts TemplateOptions) ([]Te
 	// extension functions (e.g. index, printf, sprig helpers). Without this,
 	// templates that call these functions fail to parse and their variable
 	// references are silently lost.
-	funcNames := make(map[string]any, len(s.defaultFuncs)+len(goTemplateBuiltins))
-	for _, name := range goTemplateBuiltins {
-		funcNames[name] = true
-	}
-	for k := range s.defaultFuncs {
-		funcNames[k] = true // parse.Parse only checks existence, not the value
-	}
-	trees, err := parse.Parse(opts.Name, opts.Content, leftDelim, rightDelim, funcNames)
+	trees, err := parse.Parse(opts.Name, opts.Content, leftDelim, rightDelim, s.templateFuncNames())
 	if err != nil {
 		lgr.Error(err, "failed to parse template for reference extraction",
 			"name", opts.Name)

--- a/pkg/gotmpl/refs_position.go
+++ b/pkg/gotmpl/refs_position.go
@@ -1,0 +1,269 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gotmpl
+
+import (
+	"fmt"
+	"strings"
+	"text/template/parse"
+)
+
+// RefKind classifies a positioned root-level template reference.
+type RefKind int
+
+const (
+	// RefKindField is a bare data-context accessor ({{ .name }}). Whether it is
+	// a resolver dependency is context-dependent (data-input keys, forEach
+	// aliases) and is decided by the caller, not here.
+	RefKindField RefKind = iota
+	// RefKindExplicitResolver is an explicit resolver reference ({{ ._.name }}
+	// or {{ ._name }}), which always names a resolver.
+	RefKindExplicitResolver
+)
+
+// PositionedRef is a single root-level reference occurrence in a Go template,
+// with the byte range of the referenced NAME within the template source.
+//
+// One PositionedRef is emitted per textual occurrence (no de-duplication) so
+// tools can locate, highlight, or rewrite each individual use. Special
+// variables ({{ .__self }}) and the bare resolver context ({{ ._ }}) are not
+// emitted; scoped references (inside {{ with }}/{{ range }} bodies) are emitted
+// with Scoped set true so callers can filter them.
+type PositionedRef struct {
+	// Name is the referenced name with any resolver prefix ("_." / "_") removed.
+	Name string
+
+	// Offset is the 0-based BYTE offset of Name within the template source.
+	Offset int
+
+	// Len is the byte length of Name. Offset+Len is the exclusive end.
+	Len int
+
+	// Kind classifies the reference syntax.
+	Kind RefKind
+
+	// Scoped reports that the reference sits inside a {{ with }}/{{ range }}
+	// body where dot has been rebound, so it refers to the narrowed context
+	// rather than the template root.
+	Scoped bool
+}
+
+// End returns the exclusive end byte offset of the reference (Offset + Len).
+func (r PositionedRef) End() int { return r.Offset + r.Len }
+
+// GetPositionedReferences parses a Go template and returns every root-level
+// field reference with the byte range of its root name within the template
+// source, in source order. It is the positioned counterpart of GetReferences:
+// GetReferences returns deduplicated dotted paths for dependency inference,
+// whereas this returns one located occurrence per use for navigation/rewriting.
+//
+// Chained ({{ (index .a .b) }} handles its args) and nested-pipe references are
+// traversed. Variable-rooted references ({{ $.name }}) and chain nodes are not
+// yet positioned; callers needing exhaustive coverage should cross-check
+// against GetReferences and fail safe when a name lacks a located range.
+func (s *Service) GetPositionedReferences(opts TemplateOptions) ([]PositionedRef, error) {
+	if opts.Content == "" {
+		return nil, fmt.Errorf("template content cannot be empty")
+	}
+
+	leftDelim := opts.LeftDelim
+	rightDelim := opts.RightDelim
+	if leftDelim == "" {
+		leftDelim = DefaultLeftDelim
+	}
+	if rightDelim == "" {
+		rightDelim = DefaultRightDelim
+	}
+
+	name := opts.Name
+	if name == "" {
+		name = "unnamed-template"
+	}
+
+	trees, err := parse.Parse(name, opts.Content, leftDelim, rightDelim, s.templateFuncNames())
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	var out []PositionedRef
+	for _, tree := range trees {
+		if tree.Root != nil {
+			walkPositioned(tree.Root, opts.Content, 0, &out)
+		}
+	}
+	return out, nil
+}
+
+// GetGoTemplatePositionedReferences is a convenience wrapper that extracts
+// positioned references without constructing a Service.
+func GetGoTemplatePositionedReferences(templateContent, leftDelim, rightDelim string) ([]PositionedRef, error) {
+	return NewService(nil).GetPositionedReferences(TemplateOptions{
+		Content:    templateContent,
+		LeftDelim:  leftDelim,
+		RightDelim: rightDelim,
+	})
+}
+
+// templateFuncNames returns the set of function names known to templates parsed
+// by this service (built-ins plus registered custom funcs). parse.Parse only
+// checks existence (not the value), so placeholders suffice.
+func (s *Service) templateFuncNames() map[string]any {
+	funcNames := make(map[string]any, len(s.defaultFuncs)+len(goTemplateBuiltins))
+	for _, name := range goTemplateBuiltins {
+		funcNames[name] = true
+	}
+	for k := range s.defaultFuncs {
+		funcNames[k] = true
+	}
+	return funcNames
+}
+
+// walkPositioned recursively walks the parse tree, emitting a PositionedRef for
+// each root-level FieldNode. scopeDepth tracks {{ with }}/{{ range }} bodies
+// where dot is rebound (matching walkNodes in refs.go).
+func walkPositioned(node parse.Node, src string, scopeDepth int, out *[]PositionedRef) {
+	switch n := node.(type) {
+	case *parse.ListNode:
+		if n == nil {
+			return
+		}
+		for _, child := range n.Nodes {
+			walkPositioned(child, src, scopeDepth, out)
+		}
+
+	case *parse.ActionNode:
+		walkPositionedPipe(n.Pipe, src, scopeDepth, out)
+
+	case *parse.IfNode:
+		walkPositionedPipe(n.Pipe, src, scopeDepth, out)
+		walkPositioned(n.List, src, scopeDepth, out)
+		walkPositioned(n.ElseList, src, scopeDepth, out)
+
+	case *parse.RangeNode:
+		// The pipe is evaluated in the outer scope; the body rebinds dot.
+		walkPositionedPipe(n.Pipe, src, scopeDepth, out)
+		walkPositioned(n.List, src, scopeDepth+1, out)
+		walkPositioned(n.ElseList, src, scopeDepth, out)
+
+	case *parse.WithNode:
+		walkPositionedPipe(n.Pipe, src, scopeDepth, out)
+		walkPositioned(n.List, src, scopeDepth+1, out)
+		walkPositioned(n.ElseList, src, scopeDepth, out)
+
+	case *parse.TemplateNode:
+		walkPositionedPipe(n.Pipe, src, scopeDepth, out)
+	}
+}
+
+func walkPositionedPipe(p *parse.PipeNode, src string, scopeDepth int, out *[]PositionedRef) {
+	if p == nil {
+		return
+	}
+	for _, cmd := range p.Cmds {
+		for _, arg := range cmd.Args {
+			switch a := arg.(type) {
+			case *parse.FieldNode:
+				if ref, ok := fieldRootRange(src, a, scopeDepth > 0); ok {
+					*out = append(*out, ref)
+				}
+			case *parse.PipeNode:
+				walkPositionedPipe(a, src, scopeDepth, out)
+			}
+		}
+	}
+}
+
+// fieldRootRange computes the byte range of the resolver-relevant root name of a
+// FieldNode, classifying the syntax. It returns ok=false for special variables
+// ({{ .__x }}) and the bare resolver context ({{ ._ }}), which never name a
+// resolver.
+func fieldRootRange(src string, fn *parse.FieldNode, scoped bool) (PositionedRef, bool) {
+	if len(fn.Ident) == 0 {
+		return PositionedRef{}, false
+	}
+
+	fieldStart, ok := fieldStartOffset(src, fn)
+	if !ok {
+		return PositionedRef{}, false
+	}
+
+	// segStart returns the byte offset of segment i within src.
+	segStart := func(i int) int {
+		off := fieldStart + 1 // skip leading '.'
+		for j := 0; j < i; j++ {
+			off += len(fn.Ident[j]) + 1 // segment + its trailing '.'
+		}
+		return off
+	}
+
+	id0 := fn.Ident[0]
+	switch {
+	case len(fn.Ident) >= 2 && id0 == "_":
+		// {{ ._.name ... }} -- explicit resolver; the name is the second segment.
+		name := fn.Ident[1]
+		if name == "" {
+			return PositionedRef{}, false
+		}
+		return PositionedRef{Name: name, Offset: segStart(1), Len: len(name), Kind: RefKindExplicitResolver, Scoped: scoped}, true
+
+	case strings.HasPrefix(id0, "__"), id0 == "_":
+		// Special variable ({{ .__self }}) or bare resolver context ({{ ._ }}).
+		return PositionedRef{}, false
+
+	case strings.HasPrefix(id0, "_"):
+		// {{ ._name ... }} -- explicit resolver; the name is id0 without the
+		// leading underscore, so the source range starts one byte in.
+		name := id0[1:]
+		return PositionedRef{Name: name, Offset: segStart(0) + 1, Len: len(name), Kind: RefKindExplicitResolver, Scoped: scoped}, true
+
+	default:
+		// {{ .name ... }} -- bare data-context accessor; the root is id0.
+		return PositionedRef{Name: id0, Offset: segStart(0), Len: len(id0), Kind: RefKindField, Scoped: scoped}, true
+	}
+}
+
+// fieldStartOffset returns the byte offset of the leading '.' of a FieldNode.
+//
+// text/template's FieldNode.Pos points at the dot BEFORE the FINAL identifier
+// (not the leading dot), so the leading position is reconstructed from the full
+// field text length. The result is validated against src; if it does not match
+// (delimiter/whitespace edge cases), it falls back to locating the field text
+// nearest to Pos.
+func fieldStartOffset(src string, fn *parse.FieldNode) (int, bool) {
+	full := "." + strings.Join(fn.Ident, ".")
+	last := fn.Ident[len(fn.Ident)-1]
+	start := int(fn.Pos) + 1 + len(last) - len(full)
+
+	if start >= 0 && start+len(full) <= len(src) && src[start:start+len(full)] == full {
+		return start, true
+	}
+	if idx := indexNearest(src, full, int(fn.Pos)); idx >= 0 {
+		return idx, true
+	}
+	return 0, false
+}
+
+// indexNearest returns the start index of the occurrence of sub in src whose
+// start is nearest to pos, or -1 if sub does not occur.
+func indexNearest(src, sub string, pos int) int {
+	best := -1
+	bestDist := int(^uint(0) >> 1)
+	for from := 0; ; {
+		i := strings.Index(src[from:], sub)
+		if i < 0 {
+			break
+		}
+		at := from + i
+		d := at - pos
+		if d < 0 {
+			d = -d
+		}
+		if d < bestDist {
+			bestDist = d
+			best = at
+		}
+		from = at + 1
+	}
+	return best
+}

--- a/pkg/gotmpl/refs_position_test.go
+++ b/pkg/gotmpl/refs_position_test.go
@@ -1,0 +1,225 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gotmpl
+
+import (
+	"testing"
+	"text/template/parse"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPositionedReferences(t *testing.T) {
+	tests := []struct {
+		name string
+		tmpl string
+		want []PositionedRef
+	}{
+		{
+			name: "bare field",
+			tmpl: `{{ .appName }}`,
+			want: []PositionedRef{{Name: "appName", Offset: 4, Len: 7, Kind: RefKindField}},
+		},
+		{
+			name: "explicit resolver dot form",
+			tmpl: `{{ ._.resolverRef }}`,
+			want: []PositionedRef{{Name: "resolverRef", Offset: 6, Len: 11, Kind: RefKindExplicitResolver}},
+		},
+		{
+			name: "explicit resolver underscore form skips leading underscore",
+			tmpl: `{{ ._name }}`,
+			want: []PositionedRef{{Name: "name", Offset: 5, Len: 4, Kind: RefKindExplicitResolver}},
+		},
+		{
+			name: "special variable is skipped",
+			tmpl: `{{ .__self }}`,
+			want: nil,
+		},
+		{
+			name: "bare resolver context is skipped",
+			tmpl: `{{ ._ }}`,
+			want: nil,
+		},
+		{
+			name: "root segment of a chained field",
+			tmpl: `{{ .config.host }}`,
+			want: []PositionedRef{{Name: "config", Offset: 4, Len: 6, Kind: RefKindField}},
+		},
+		{
+			name: "two refs across the template in source order",
+			tmpl: `prefix {{ .a.b }} mid {{ .c }}`,
+			want: []PositionedRef{
+				{Name: "a", Offset: 11, Len: 1, Kind: RefKindField},
+				{Name: "c", Offset: 26, Len: 1, Kind: RefKindField},
+			},
+		},
+		{
+			name: "nested pipe argument",
+			tmpl: `{{ printf "%s" .x }}`,
+			want: []PositionedRef{{Name: "x", Offset: 16, Len: 1, Kind: RefKindField}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetGoTemplatePositionedReferences(tt.tmpl, "", "")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+
+			// Byte-exact invariant: every reported range slices out exactly the name.
+			for _, r := range got {
+				require.LessOrEqual(t, r.End(), len(tt.tmpl))
+				assert.Equalf(t, r.Name, tt.tmpl[r.Offset:r.End()],
+					"range [%d:%d] must slice to %q", r.Offset, r.End(), r.Name)
+			}
+		})
+	}
+}
+
+func TestGetPositionedReferences_Scoped(t *testing.T) {
+	// Inside {{ range }} the dot is rebound: .items is unscoped, .inner is scoped.
+	tmpl := `{{ range .items }}{{ .inner }}{{ end }}`
+	got, err := GetGoTemplatePositionedReferences(tmpl, "", "")
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	assert.Equal(t, "items", got[0].Name)
+	assert.False(t, got[0].Scoped)
+	assert.Equal(t, "inner", got[1].Name)
+	assert.True(t, got[1].Scoped)
+
+	for _, r := range got {
+		assert.Equal(t, r.Name, tmpl[r.Offset:r.End()])
+	}
+}
+
+func TestGetPositionedReferences_MultibytePrefix(t *testing.T) {
+	// A 2-byte rune before the reference must shift the BYTE offset accordingly.
+	tmpl := `{{ "é" }}{{ .afterMultibyte }}`
+	got, err := GetGoTemplatePositionedReferences(tmpl, "", "")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+
+	r := got[0]
+	assert.Equal(t, "afterMultibyte", r.Name)
+	assert.Equal(t, "afterMultibyte", tmpl[r.Offset:r.End()])
+}
+
+func TestGetPositionedReferences_CustomDelims(t *testing.T) {
+	got, err := GetGoTemplatePositionedReferences(`[[ ._.env ]]`, "[[", "]]")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, PositionedRef{Name: "env", Offset: 6, Len: 3, Kind: RefKindExplicitResolver}, got[0])
+	assert.Equal(t, "env", `[[ ._.env ]]`[got[0].Offset:got[0].End()])
+}
+
+func TestGetPositionedReferences_Errors(t *testing.T) {
+	_, err := GetGoTemplatePositionedReferences("", "", "")
+	assert.Error(t, err, "empty content")
+
+	_, err = GetGoTemplatePositionedReferences(`{{ .x `, "", "")
+	assert.Error(t, err, "unterminated action")
+}
+
+func TestPositionedRef_End(t *testing.T) {
+	assert.Equal(t, 11, PositionedRef{Offset: 4, Len: 7}.End())
+}
+
+// TestGetPositionedReferences_ControlFlow exercises if/else, range/else,
+// with/else, and template nodes so every branch of walkPositioned is covered.
+func TestGetPositionedReferences_ControlFlow(t *testing.T) {
+	type wantRef struct {
+		name   string
+		scoped bool
+	}
+	tests := []struct {
+		name string
+		tmpl string
+		want []wantRef
+	}{
+		{
+			name: "if/else",
+			tmpl: `{{ if .cond }}{{ .a }}{{ else }}{{ .b }}{{ end }}`,
+			want: []wantRef{{"cond", false}, {"a", false}, {"b", false}},
+		},
+		{
+			name: "range with else",
+			tmpl: `{{ range .items }}{{ .x }}{{ else }}{{ .empty }}{{ end }}`,
+			want: []wantRef{{"items", false}, {"x", true}, {"empty", false}},
+		},
+		{
+			name: "with and else",
+			tmpl: `{{ with .ctx }}{{ .inner }}{{ else }}{{ .fallback }}{{ end }}`,
+			want: []wantRef{{"ctx", false}, {"inner", true}, {"fallback", false}},
+		},
+		{
+			name: "template node pipe",
+			tmpl: `{{ template "sub" .data }}`,
+			want: []wantRef{{"data", false}},
+		},
+		{
+			name: "parenthesized sub-pipe argument",
+			tmpl: `{{ len (.items) }}`,
+			want: []wantRef{{"items", false}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetGoTemplatePositionedReferences(tt.tmpl, "", "")
+			require.NoError(t, err)
+			require.Len(t, got, len(tt.want))
+			for i, w := range tt.want {
+				assert.Equalf(t, w.name, got[i].Name, "ref %d name", i)
+				assert.Equalf(t, w.scoped, got[i].Scoped, "ref %d scoped", i)
+				assert.Equal(t, got[i].Name, tt.tmpl[got[i].Offset:got[i].End()])
+			}
+		})
+	}
+}
+
+// TestFieldStartOffset_Fallback white-box tests the defensive fallback: when the
+// Pos-based arithmetic does not validate against src, the field text is located
+// by scanning.
+func TestFieldStartOffset_Fallback(t *testing.T) {
+	// ".a" lives at index 3, but a deliberately wrong Pos makes the arithmetic
+	// out of range so the fallback scan must recover it.
+	fn := &parse.FieldNode{NodeType: parse.NodeField, Pos: 100, Ident: []string{"a"}}
+	start, ok := fieldStartOffset("xx .a yy", fn)
+	require.True(t, ok)
+	assert.Equal(t, 3, start)
+
+	// When the field text is absent, it reports failure.
+	_, ok = fieldStartOffset("nothing here", fn)
+	assert.False(t, ok)
+}
+
+func TestIndexNearest(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		sub  string
+		pos  int
+		want int
+	}{
+		{"single", "abc._.x def", "._.x", 3, 3},
+		{"nearest of two", "._.x ._.x", "._.x", 6, 5},
+		{"not found", "abc", "._.x", 0, -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, indexNearest(tt.src, tt.sub, tt.pos))
+		})
+	}
+}
+
+func BenchmarkGetPositionedReferences(b *testing.B) {
+	tmpl := `{{ ._.a }}-{{ .b.c }}{{ range .items }}{{ .inner }}{{ end }}{{ printf "%s" ._.d }}`
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = GetGoTemplatePositionedReferences(tmpl, "", "")
+	}
+}

--- a/pkg/gotmpl/resolverdeps.go
+++ b/pkg/gotmpl/resolverdeps.go
@@ -145,6 +145,54 @@ func ExtractResolverDeps(in ResolverDepsInput) []string {
 	return deps
 }
 
+// UnscopedResolverRef is a root-level, unscoped reference candidate in a Go
+// template that could denote a resolver, with whether it was written using
+// explicit resolver syntax.
+type UnscopedResolverRef struct {
+	// Name is the root reference name (with any resolver prefix removed).
+	Name string
+	// Explicit reports that the reference used explicit resolver syntax
+	// ({{ ._.name }} / {{ ._name }}) as opposed to a bare or $-rooted accessor.
+	Explicit bool
+}
+
+// UnscopedResolverRefs returns every root-level, unscoped reference in a
+// template that could denote a resolver -- explicit resolver refs
+// ({{ ._.name }} / {{ ._name }}), bare data-context accessors ({{ .name }}),
+// and $-rooted accessors ({{ $.name }}) -- each flagged with whether it used
+// explicit resolver syntax. Special variables ({{ .__x }}) and scoped
+// references (inside {{ with }}/{{ range }} bodies) are excluded.
+//
+// This is the authoritative set a positioned-reference consumer must reconcile
+// against: any name returned here that a positioned walker cannot locate is a
+// reference that must be treated as unresolved (so a rename fails safe rather
+// than silently missing it). Results are de-duplicated per (name, explicit)
+// pair, preserving first-seen order. Parse errors yield a nil slice and error.
+func UnscopedResolverRefs(template, leftDelim, rightDelim string) ([]UnscopedResolverRef, error) {
+	refs, err := GetGoTemplateReferences(template, leftDelim, rightDelim)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := make(map[UnscopedResolverRef]bool)
+	var out []UnscopedResolverRef
+	for _, ref := range refs {
+		if ref.Scoped {
+			continue
+		}
+		name, kind := classifyTemplatePath(ref.Path)
+		if name == "" || kind == pathSpecial {
+			continue
+		}
+		u := UnscopedResolverRef{Name: name, Explicit: kind == pathExplicitResolver}
+		if !seen[u] {
+			seen[u] = true
+			out = append(out, u)
+		}
+	}
+	return out, nil
+}
+
 // ExtractExplicitResolverRefs returns only the resolver names referenced with
 // EXPLICIT resolver syntax ({{ ._.name }} / {{ ._name }}) in a Go template.
 //

--- a/pkg/gotmpl/resolverdeps_test.go
+++ b/pkg/gotmpl/resolverdeps_test.go
@@ -201,3 +201,56 @@ func TestExtractExplicitResolverRefs(t *testing.T) {
 		})
 	}
 }
+
+func TestUnscopedResolverRefs(t *testing.T) {
+	tests := []struct {
+		name string
+		tmpl string
+		want []UnscopedResolverRef
+	}{
+		{
+			name: "explicit and bare and dollar",
+			tmpl: `{{ ._.a }}{{ .b }}{{ $.c }}`,
+			want: []UnscopedResolverRef{
+				{Name: "a", Explicit: true},
+				{Name: "b", Explicit: false},
+				{Name: "c", Explicit: false},
+			},
+		},
+		{
+			name: "underscore form is explicit",
+			tmpl: `{{ ._d }}`,
+			want: []UnscopedResolverRef{{Name: "d", Explicit: true}},
+		},
+		{
+			name: "special variables excluded",
+			tmpl: `{{ .__self }}{{ .__item }}`,
+			want: nil,
+		},
+		{
+			name: "scoped references excluded",
+			tmpl: `{{ range .items }}{{ .inner }}{{ end }}`,
+			want: []UnscopedResolverRef{{Name: "items", Explicit: false}},
+		},
+		{
+			name: "same name explicit and bare both reported",
+			tmpl: `{{ ._.env }}{{ .env }}`,
+			want: []UnscopedResolverRef{
+				{Name: "env", Explicit: true},
+				{Name: "env", Explicit: false},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := UnscopedResolverRefs(tt.tmpl, "", "")
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestUnscopedResolverRefs_ParseError(t *testing.T) {
+	_, err := UnscopedResolverRefs(`{{ .x `, "", "")
+	assert.Error(t, err)
+}

--- a/pkg/refactor/refactor.go
+++ b/pkg/refactor/refactor.go
@@ -1,0 +1,152 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package refactor performs source-preserving refactorings on solution files.
+//
+// Refactorings are expressed as a set of TextEdits (a Range plus replacement
+// text). Applying edits replaces only the exact bytes of each occurrence, so
+// comments, key order, and formatting are preserved verbatim -- there is no YAML
+// round-trip. The same edits drive a CLI rewrite (Apply to bytes) and an LSP
+// WorkspaceEdit (map each TextEdit to an LSP edit).
+//
+// Correctness is guarded, not best-effort: RenameResolver refuses to produce
+// edits when the reference index is incomplete (refindex.Unresolved() > 0),
+// because a missed reference would silently break the solution. It is safer to
+// abort a rename than to perform a partial one.
+package refactor
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"sort"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
+)
+
+// ResolverNamePattern is the canonical pattern a resolver name must match. It
+// mirrors the pattern enforced on resolver names and rslvr references in the
+// spec struct tags.
+const ResolverNamePattern = `^[a-zA-Z_][a-zA-Z0-9_-]*$`
+
+var resolverNameRe = regexp.MustCompile(ResolverNamePattern)
+
+// TextEdit is a single replacement of a source Range with NewText.
+type TextEdit struct {
+	// Range is the half-open span of source to replace.
+	Range sourcepos.Range
+	// NewText is the replacement text.
+	NewText string
+}
+
+// RenameResult is the outcome of a rename: the names involved and the edits
+// that carry it out.
+type RenameResult struct {
+	OldName string
+	NewName string
+	Edits   []TextEdit
+}
+
+// Apply applies the result's edits to raw and returns the rewritten bytes.
+func (r *RenameResult) Apply(raw []byte) ([]byte, error) {
+	return Apply(raw, r.Edits)
+}
+
+// RenameResolver computes the edits to rename a resolver and every reference to
+// it (dependsOn entries, rslvr values, CEL _.name uses, explicit template
+// ._.name uses, and the definition key).
+//
+// It returns an error, producing NO edits, when:
+//   - newName is not a valid resolver name;
+//   - newName equals oldName;
+//   - oldName is not defined in the solution;
+//   - newName already names a resolver (collision); or
+//   - the reference index is incomplete (some references could not be located),
+//     which would make a rename partial and unsafe.
+func RenameResolver(sol *solution.Solution, oldName, newName string) (*RenameResult, error) {
+	if sol == nil {
+		return nil, fmt.Errorf("rename resolver: nil solution")
+	}
+	if !resolverNameRe.MatchString(newName) {
+		return nil, fmt.Errorf("rename resolver: %q is not a valid resolver name (must match %s)", newName, ResolverNamePattern)
+	}
+	if oldName == newName {
+		return nil, fmt.Errorf("rename resolver: new name equals old name %q", oldName)
+	}
+
+	idx, err := refindex.Build(sol)
+	if err != nil {
+		return nil, fmt.Errorf("rename resolver: %w", err)
+	}
+
+	if _, ok := idx.Definition(oldName); !ok {
+		return nil, fmt.Errorf("rename resolver: resolver %q is not defined", oldName)
+	}
+	if _, ok := idx.Definition(newName); ok {
+		return nil, fmt.Errorf("rename resolver: resolver %q already exists", newName)
+	}
+
+	// Refuse a partial rewrite: if any reference to oldName could not be located
+	// byte-exact, a rename might miss it and silently break the solution. This is
+	// name-scoped -- unlocatable references to OTHER resolvers do not block this
+	// rename, but references whose target could not be determined at all do.
+	if n := idx.UnresolvedFor(oldName); n > 0 {
+		return nil, fmt.Errorf("rename resolver: %d reference(s) to %q could not be located; aborting to avoid a partial rename", n, oldName)
+	}
+
+	occ := idx.Occurrences(oldName)
+	edits := make([]TextEdit, 0, len(occ))
+	for _, r := range occ {
+		edits = append(edits, TextEdit{Range: r.Range, NewText: newName})
+	}
+
+	return &RenameResult{OldName: oldName, NewName: newName, Edits: edits}, nil
+}
+
+// Apply applies edits to raw and returns the rewritten bytes. Edits are applied
+// left-to-right against the original byte offsets (resolved via a LineIndex);
+// overlapping edits are rejected. The input is not mutated.
+func Apply(raw []byte, edits []TextEdit) ([]byte, error) {
+	if len(edits) == 0 {
+		return append([]byte(nil), raw...), nil
+	}
+
+	li := sourcepos.NewLineIndex(raw, "")
+
+	type span struct {
+		start, end int
+		text       string
+	}
+	spans := make([]span, 0, len(edits))
+	for _, e := range edits {
+		start := li.Offset(e.Range.Start)
+		end := li.Offset(e.Range.End)
+		if start < 0 || end > len(raw) || start > end {
+			return nil, fmt.Errorf("apply: edit range %s is out of bounds", e.Range)
+		}
+		spans = append(spans, span{start: start, end: end, text: e.NewText})
+	}
+
+	sort.Slice(spans, func(i, j int) bool {
+		if spans[i].start != spans[j].start {
+			return spans[i].start < spans[j].start
+		}
+		return spans[i].end < spans[j].end
+	})
+
+	var buf bytes.Buffer
+	buf.Grow(len(raw))
+	last := 0
+	for _, sp := range spans {
+		if sp.start < last {
+			return nil, fmt.Errorf("apply: overlapping edits at byte %d", sp.start)
+		}
+		buf.Write(raw[last:sp.start])
+		buf.WriteString(sp.text)
+		last = sp.end
+	}
+	buf.Write(raw[last:])
+	return buf.Bytes(), nil
+}

--- a/pkg/refactor/refactor_test.go
+++ b/pkg/refactor/refactor_test.go
@@ -1,0 +1,297 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refactor
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const renameFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: rename-test # keep this comment
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    appName:
+      dependsOn:
+        - environment
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.environment
+    greeting:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                tmpl: "{{ ._.appName }}-{{ ._.environment }}"
+`
+
+func loadSolution(t *testing.T, y string) *solution.Solution {
+	t.Helper()
+	sol := &solution.Solution{}
+	require.NoError(t, sol.UnmarshalFromBytes([]byte(y)))
+	return sol
+}
+
+func TestRenameResolver_HappyPath(t *testing.T) {
+	sol := loadSolution(t, renameFixture)
+
+	res, err := RenameResolver(sol, "environment", "env")
+	require.NoError(t, err)
+	require.Equal(t, "environment", res.OldName)
+	require.Equal(t, "env", res.NewName)
+	// definition + dependsOn + CEL + template = 4 occurrences.
+	require.Len(t, res.Edits, 4)
+
+	raw := sol.RawContent()
+	out, err := res.Apply(raw)
+	require.NoError(t, err)
+
+	// Exactly the four occurrences shrank from "environment" (11) to "env" (3).
+	assert.Equal(t, len(raw)-4*(len("environment")-len("env")), len(out))
+	assert.NotContains(t, string(out), "environment")
+
+	// Formatting/comments are preserved verbatim.
+	assert.Contains(t, string(out), "# keep this comment")
+	assert.Contains(t, string(out), "  name: rename-test")
+
+	// The rewritten content re-parses and the rename is complete and consistent.
+	newSol := loadSolution(t, string(out))
+	idx, err := refindex.Build(newSol)
+	require.NoError(t, err)
+	assert.Zero(t, idx.Unresolved())
+	def, ok := idx.Definition("env")
+	require.True(t, ok)
+	assert.True(t, def.IsDef)
+	assert.Len(t, idx.Occurrences("env"), 4)
+	_, stillThere := idx.Definition("environment")
+	assert.False(t, stillThere)
+}
+
+func TestRenameResolver_Guards(t *testing.T) {
+	sol := loadSolution(t, renameFixture)
+
+	tests := []struct {
+		name    string
+		old     string
+		newName string
+		wantMsg string
+	}{
+		{"invalid new name", "environment", "1bad", "not a valid resolver name"},
+		{"equal names", "environment", "environment", "equals old name"},
+		{"undefined old", "missing", "whatever", "is not defined"},
+		{"collision", "environment", "appName", "already exists"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := RenameResolver(sol, tt.old, tt.newName)
+			require.Error(t, err)
+			assert.Nil(t, res)
+			assert.Contains(t, err.Error(), tt.wantMsg)
+		})
+	}
+}
+
+func TestRenameResolver_NilSolution(t *testing.T) {
+	res, err := RenameResolver(nil, "a", "b")
+	require.Error(t, err)
+	assert.Nil(t, res)
+}
+
+func TestRenameResolver_RefusesWhenUnresolved(t *testing.T) {
+	// A bare-field template reference to the SAME name being renamed cannot be
+	// positioned (context-dependent), so the rename must refuse rather than risk
+	// missing it. (Name-scoped: a bare field of an unrelated name would NOT block.)
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: unresolved
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    user:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                tmpl: "{{ .environment }}"
+`
+	sol := loadSolution(t, y)
+	res, err := RenameResolver(sol, "environment", "env")
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.Contains(t, err.Error(), "could not be located")
+}
+
+func TestRenameResolver_RefusesOnNestedLiteralRef(t *testing.T) {
+	// A nested inline {rslvr: environment} inside a literal is a real reference
+	// that is not positioned; the rename must refuse.
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: nested
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    user:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                settings:
+                  env:
+                    rslvr: environment
+`
+	sol := loadSolution(t, y)
+	res, err := RenameResolver(sol, "environment", "env")
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.Contains(t, err.Error(), "could not be located")
+}
+
+func TestRenameResolver_NameScopedFailSafe(t *testing.T) {
+	// An unlocatable reference to a DIFFERENT resolver must not block this rename.
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: scoped
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    region:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: us
+    user:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                tmpl: "{{ .region }}"
+`
+	sol := loadSolution(t, y)
+	// Renaming "environment" is fine even though "region" has an unpositioned
+	// bare-field reference.
+	res, err := RenameResolver(sol, "environment", "env")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	// Renaming "region" (the one with the unlocatable ref) must refuse.
+	_, err = RenameResolver(sol, "region", "zone")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not be located")
+}
+
+func TestApply_EmptyEditsReturnsCopy(t *testing.T) {
+	raw := []byte("unchanged content")
+	out, err := Apply(raw, nil)
+	require.NoError(t, err)
+	assert.Equal(t, raw, out)
+	// It must be a distinct slice (not aliasing the input).
+	if len(out) > 0 {
+		out[0] = 'X'
+		assert.Equal(t, byte('u'), raw[0])
+	}
+}
+
+func TestApply_MultipleEditsPreserveSurroundings(t *testing.T) {
+	raw := []byte("aaa bbb ccc")
+	li := sourcepos.NewLineIndex(raw, "")
+	edits := []TextEdit{
+		{Range: li.Range(0, 3), NewText: "XX"},   // "aaa" -> "XX"
+		{Range: li.Range(8, 11), NewText: "YYY"}, // "ccc" -> "YYY"
+	}
+	out, err := Apply(raw, edits)
+	require.NoError(t, err)
+	assert.Equal(t, "XX bbb YYY", string(out))
+}
+
+func TestApply_RejectsOverlappingEdits(t *testing.T) {
+	raw := []byte("hello world")
+	li := sourcepos.NewLineIndex(raw, "")
+	edits := []TextEdit{
+		{Range: li.Range(0, 5), NewText: "X"},
+		{Range: li.Range(3, 8), NewText: "Y"}, // overlaps the first
+	}
+	_, err := Apply(raw, edits)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "overlapping")
+}
+
+func TestApply_RejectsInvertedRange(t *testing.T) {
+	raw := []byte("hello world")
+	li := sourcepos.NewLineIndex(raw, "")
+	// Start resolves after End (byte 8 > byte 2), so start > end triggers the
+	// bounds guard.
+	edits := []TextEdit{{Range: sourcepos.Range{
+		Start: li.Position(8),
+		End:   li.Position(2),
+	}, NewText: "x"}}
+	_, err := Apply(raw, edits)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of bounds")
+}
+
+func TestApply_InsertionAtOffset(t *testing.T) {
+	raw := []byte("abcdef")
+	li := sourcepos.NewLineIndex(raw, "")
+	// Zero-width range == insertion.
+	edits := []TextEdit{{Range: li.Range(3, 3), NewText: "-"}}
+	out, err := Apply(raw, edits)
+	require.NoError(t, err)
+	assert.Equal(t, "abc-def", string(out))
+}
+
+func BenchmarkRenameResolver(b *testing.B) {
+	sol := &solution.Solution{}
+	if err := sol.UnmarshalFromBytes([]byte(renameFixture)); err != nil {
+		b.Fatal(err)
+	}
+	raw := sol.RawContent()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		res, err := RenameResolver(sol, "environment", "env")
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, _ = Apply(raw, res.Edits)
+	}
+}

--- a/pkg/refindex/refindex.go
+++ b/pkg/refindex/refindex.go
@@ -335,6 +335,12 @@ func (b *builder) addCELRefs(basePath string, expr *celexp.Expression) {
 	attempted := make(map[string]bool, len(refs))
 	for _, r := range refs {
 		attempted[r.Name] = true
+		if r.Offset < 0 {
+			// The occurrence exists but could not be positioned; treat it as
+			// unlocatable so a rename of this name fails safe.
+			b.markUnresolved(r.Name)
+			continue
+		}
 		b.emitAt(start+r.Offset, r.Name, OriginCEL, false)
 	}
 	// Cross-check: any authoritative underscore variable that the positioned

--- a/pkg/refindex/refindex.go
+++ b/pkg/refindex/refindex.go
@@ -1,0 +1,633 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package refindex builds a positioned reference index over a solution: every
+// occurrence of a symbol (currently resolvers) -- its definition and every
+// reference to it -- located by an exact source Range.
+//
+// It is the shared backbone for editor/refactoring features: find-references
+// (all uses of a name), go-to-definition (the defining site), and rename
+// (rewrite every occurrence). It composes three layers:
+//
+//   - walk.Walk provides the semantic structure (which ValueRefs, conditions,
+//     and dependsOn entries exist, and their logical paths).
+//   - a value-node map + sourcepos.LineIndex turn a logical path into the exact
+//     bytes of the underlying YAML scalar (style-aware).
+//   - celexp.UnderscoreVariableRefs and gotmpl.GetPositionedReferences locate
+//     each reference within an expression/template.
+//
+// Every emitted reference is validated byte-exact against the raw source: a
+// candidate range whose bytes do not equal the referenced name is dropped and
+// counted in Unresolved(), so consumers (notably rename) can refuse to act when
+// coverage is incomplete rather than corrupt unrelated text.
+package refindex
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/walk"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"gopkg.in/yaml.v3"
+)
+
+// SymbolKind classifies the kind of entity a reference points at.
+type SymbolKind int
+
+const (
+	// SymbolResolver is a resolver defined under spec.resolvers.
+	SymbolResolver SymbolKind = iota
+)
+
+// String returns the lowercase kind name.
+func (k SymbolKind) String() string {
+	switch k {
+	case SymbolResolver:
+		return "resolver"
+	default:
+		return "unknown"
+	}
+}
+
+// Symbol identifies a named entity in a solution.
+type Symbol struct {
+	Kind SymbolKind
+	Name string
+}
+
+// Origin describes the syntactic form a reference took.
+type Origin int
+
+const (
+	// OriginDefinition is the defining site of the symbol (the map key).
+	OriginDefinition Origin = iota
+	// OriginDependsOn is an explicit dependsOn list entry.
+	OriginDependsOn
+	// OriginResolverRef is a rslvr: value reference.
+	OriginResolverRef
+	// OriginCEL is a _.name reference inside a CEL expression or condition.
+	OriginCEL
+	// OriginTemplate is an explicit ._.name reference inside a Go template.
+	OriginTemplate
+)
+
+// String returns a short label for the origin.
+func (o Origin) String() string {
+	switch o {
+	case OriginDefinition:
+		return "definition"
+	case OriginDependsOn:
+		return "dependsOn"
+	case OriginResolverRef:
+		return "rslvr"
+	case OriginCEL:
+		return "cel"
+	case OriginTemplate:
+		return "template"
+	default:
+		return "unknown"
+	}
+}
+
+// Reference is a single located occurrence of a symbol.
+type Reference struct {
+	Symbol Symbol
+	Range  sourcepos.Range
+	Origin Origin
+	// IsDef reports whether this occurrence is the symbol's definition.
+	IsDef bool
+}
+
+// Index is a queryable set of positioned references over one solution.
+type Index struct {
+	file   string
+	refs   []Reference
+	byName map[string][]Reference
+	// unresolvedByName counts references that were identified semantically but
+	// could not be located byte-exact, attributed to the resolver name they
+	// target. This makes the fail-safe name-scoped: a rename of X is blocked
+	// only by unlocatable references to X, not by unrelated ones.
+	unresolvedByName map[string]int
+	// unresolvedOther counts unlocatable references whose target name could not
+	// be determined (e.g. an expression/template that failed to parse). These
+	// conservatively block every rename, since they might reference any name.
+	unresolvedOther int
+}
+
+// All returns every reference (definitions and uses), sorted by position.
+func (i *Index) All() []Reference {
+	out := make([]Reference, len(i.refs))
+	copy(out, i.refs)
+	return out
+}
+
+// Occurrences returns every occurrence of name (definition and uses), sorted by
+// position. This is the set a rename must rewrite.
+func (i *Index) Occurrences(name string) []Reference {
+	src := i.byName[name]
+	out := make([]Reference, len(src))
+	copy(out, src)
+	return out
+}
+
+// References returns the non-definition uses of name, sorted by position.
+func (i *Index) References(name string) []Reference {
+	var out []Reference
+	for _, r := range i.byName[name] {
+		if !r.IsDef {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// Definition returns the defining occurrence of name, if one exists.
+func (i *Index) Definition(name string) (Reference, bool) {
+	for _, r := range i.byName[name] {
+		if r.IsDef {
+			return r, true
+		}
+	}
+	return Reference{}, false
+}
+
+// Names returns the sorted set of symbol names known to the index.
+func (i *Index) Names() []string {
+	out := make([]string, 0, len(i.byName))
+	for n := range i.byName {
+		out = append(out, n)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Unresolved returns the total number of references that were identified
+// semantically but could not be located byte-exact in the source. A non-zero
+// value means the index is not a complete picture of every reference.
+func (i *Index) Unresolved() int {
+	total := i.unresolvedOther
+	for _, n := range i.unresolvedByName {
+		total += n
+	}
+	return total
+}
+
+// UnresolvedFor returns the number of unlocatable references that could affect a
+// rename of name: those attributed to name plus any whose target could not be
+// determined. A rename of name must refuse when this is non-zero, or it risks a
+// partial (solution-breaking) rewrite.
+func (i *Index) UnresolvedFor(name string) int {
+	return i.unresolvedByName[name] + i.unresolvedOther
+}
+
+// Build constructs a positioned reference index for the solution. It returns an
+// empty (non-nil) index when sol is nil.
+func Build(sol *solution.Solution) (*Index, error) {
+	idx := &Index{byName: map[string][]Reference{}, unresolvedByName: map[string]int{}}
+	if sol == nil {
+		return idx, nil
+	}
+
+	raw := sol.RawContent()
+	idx.file = sol.GetPath()
+
+	nodes, err := buildValueNodeMap(raw)
+	if err != nil {
+		return nil, fmt.Errorf("refindex: %w", err)
+	}
+
+	b := &builder{
+		idx:   idx,
+		raw:   raw,
+		li:    sourcepos.NewLineIndex(raw, idx.file),
+		sm:    sol.SourceMap(),
+		nodes: nodes,
+	}
+
+	v := &walk.Visitor{
+		Resolver: func(path, name string, r *resolver.Resolver) error {
+			b.addDefinition(path, name)
+			for i, dep := range r.DependsOn {
+				b.addWholeScalarRef(fmt.Sprintf("%s.dependsOn[%d]", path, i), dep, OriginDependsOn)
+			}
+			return nil
+		},
+		Condition: func(path, _ string, expr *celexp.Expression) error {
+			b.addCELRefs(path, expr)
+			return nil
+		},
+		ValueRef: func(path string, vr *spec.ValueRef) error {
+			switch {
+			case vr.Resolver != nil:
+				b.addWholeScalarRef(path+".rslvr", *vr.Resolver, OriginResolverRef)
+			case vr.Expr != nil:
+				b.addCELRefs(path, vr.Expr)
+			case vr.Tmpl != nil:
+				b.addTemplateRefs(path+".tmpl", vr.Tmpl)
+			case vr.Literal != nil:
+				// walk.Walk does not descend into literal maps/arrays, but scafctl
+				// resolves inline ValueRefs ({rslvr}/{expr}/{tmpl}) nested inside
+				// them. Those references are not positioned here, so record their
+				// target names as unresolved to keep rename fail-safe (C1).
+				b.markLiteralResolverRefs(vr.Literal)
+			}
+			return nil
+		},
+	}
+
+	if err := walk.Walk(sol, v); err != nil {
+		return nil, fmt.Errorf("refindex: walk: %w", err)
+	}
+
+	idx.finalize()
+	return idx, nil
+}
+
+// builder accumulates references during the walk.
+type builder struct {
+	idx   *Index
+	raw   []byte
+	li    *sourcepos.LineIndex
+	sm    *sourcepos.SourceMap
+	nodes map[string]*yaml.Node
+}
+
+// markUnresolved records that a reference to name could not be located.
+func (b *builder) markUnresolved(name string) { b.idx.unresolvedByName[name]++ }
+
+// markUnresolvedUnknown records an unlocatable reference whose target name could
+// not be determined (e.g. a parse failure). It conservatively blocks every
+// rename.
+func (b *builder) markUnresolvedUnknown() { b.idx.unresolvedOther++ }
+
+// addDefinition records the defining site of a resolver, located at its map key.
+func (b *builder) addDefinition(path, name string) {
+	pos, ok := b.sm.Get(path)
+	if !ok {
+		b.markUnresolved(name)
+		return
+	}
+	start := b.li.Offset(pos)
+	b.emitAt(start, name, OriginDefinition, true)
+}
+
+// addWholeScalarRef records a reference whose entire scalar value is the name
+// (dependsOn entries, rslvr values).
+func (b *builder) addWholeScalarRef(path, name string, origin Origin) {
+	node, ok := b.scalarAt(path)
+	if !ok {
+		b.markUnresolved(name)
+		return
+	}
+	start, ok := b.contentStart(node)
+	if !ok {
+		b.markUnresolved(name)
+		return
+	}
+	b.emitAt(start, name, origin, false)
+}
+
+// addCELRefs records every _.name reference inside a CEL expression. basePath is
+// the ValueRef or condition path; the scalar is at basePath.expr (object form)
+// or basePath itself (condition scalar shorthand).
+//
+// It reconciles the positioned references against the authoritative underscore
+// variable set: any resolver name the parser reports that a positioned ref did
+// not cover is recorded as unresolved, so a rename fails safe.
+func (b *builder) addCELRefs(basePath string, expr *celexp.Expression) {
+	if expr == nil {
+		return
+	}
+	node := b.celScalar(basePath)
+	if node == nil {
+		// No scalar to position against; treat all underscore vars as unresolved.
+		if names, err := expr.GetUnderscoreVariables(context.Background()); err == nil {
+			for _, name := range names {
+				b.markUnresolved(name)
+			}
+		} else {
+			b.markUnresolvedUnknown()
+		}
+		return
+	}
+
+	refs, err := expr.UnderscoreVariableRefs(context.Background())
+	if err != nil {
+		b.markUnresolvedUnknown()
+		return
+	}
+	start, ok := b.contentStart(node)
+	if !ok {
+		for _, r := range refs {
+			b.markUnresolved(r.Name)
+		}
+		return
+	}
+
+	attempted := make(map[string]bool, len(refs))
+	for _, r := range refs {
+		attempted[r.Name] = true
+		b.emitAt(start+r.Offset, r.Name, OriginCEL, false)
+	}
+	// Cross-check: any authoritative underscore variable that the positioned
+	// walker never returned (e.g. an occurrence it could not anchor) is unlocatable.
+	if auth, err := expr.GetUnderscoreVariables(context.Background()); err == nil {
+		for _, name := range auth {
+			if !attempted[name] {
+				b.markUnresolved(name)
+			}
+		}
+	}
+}
+
+// addTemplateRefs records explicit ._.name resolver references inside a Go
+// template, and reconciles against the authoritative unscoped reference set so
+// that references it cannot position -- bare {{ .field }}, $-rooted {{ $.name }},
+// or an explicit ref whose bytes do not validate -- are recorded as unresolved
+// (C2). Bare/$ references are conservatively attributed by name: they only block
+// renaming a resolver that shares that exact name.
+func (b *builder) addTemplateRefs(path string, tmpl *gotmpl.GoTemplatingContent) {
+	if tmpl == nil {
+		return
+	}
+	tmplStr := string(*tmpl)
+
+	candidates, cerr := gotmpl.UnscopedResolverRefs(tmplStr, "", "")
+	if cerr != nil {
+		b.markUnresolvedUnknown()
+		return
+	}
+
+	node, ok := b.scalarAt(path)
+	if !ok {
+		for _, c := range candidates {
+			b.markUnresolved(c.Name)
+		}
+		return
+	}
+	start, ok := b.contentStart(node)
+	if !ok {
+		for _, c := range candidates {
+			b.markUnresolved(c.Name)
+		}
+		return
+	}
+
+	refs, err := gotmpl.GetGoTemplatePositionedReferences(tmplStr, "", "")
+	if err != nil {
+		b.markUnresolvedUnknown()
+		return
+	}
+
+	// Emit the explicit resolver references we can position byte-exact.
+	positionedExplicit := make(map[string]bool)
+	for _, r := range refs {
+		if r.Scoped || r.Kind != gotmpl.RefKindExplicitResolver {
+			continue
+		}
+		if b.emitAt(start+r.Offset, r.Name, OriginTemplate, false) {
+			positionedExplicit[r.Name] = true
+		}
+	}
+
+	// Reconcile against the authoritative candidate set.
+	for _, c := range candidates {
+		if c.Explicit {
+			if !positionedExplicit[c.Name] {
+				b.markUnresolved(c.Name)
+			}
+			continue
+		}
+		// Bare or $-rooted reference: cannot be safely positioned.
+		b.markUnresolved(c.Name)
+	}
+}
+
+// emitAt validates that the bytes at [start, start+len(name)) equal name and, if
+// so, records the reference and returns true. A mismatch (or out-of-range span)
+// is attributed to name as unresolved and returns false.
+func (b *builder) emitAt(start int, name string, origin Origin, isDef bool) bool {
+	end := start + len(name)
+	if start < 0 || end > len(b.raw) || string(b.raw[start:end]) != name {
+		b.markUnresolved(name)
+		return false
+	}
+	b.idx.record(Reference{
+		Symbol: Symbol{Kind: SymbolResolver, Name: name},
+		Range:  b.li.Range(start, end),
+		Origin: origin,
+		IsDef:  isDef,
+	})
+	return true
+}
+
+// maxLiteralDepth bounds recursion into literal maps/arrays when scanning for
+// nested inline ValueRefs, mirroring spec's nested ValueRef depth limit.
+const maxLiteralDepth = 32
+
+// markLiteralResolverRefs scans a literal value for inline ValueRef patterns
+// ({rslvr}/{expr}/{tmpl}) nested inside maps/arrays and records the resolver
+// names they reference as unresolved. These nested references are real (scafctl
+// resolves them at runtime) but are not positioned by this index, so recording
+// them keeps rename fail-safe rather than silently missing them.
+func (b *builder) markLiteralResolverRefs(v any) {
+	b.markLiteralResolverRefsDepth(v, 0)
+}
+
+func (b *builder) markLiteralResolverRefsDepth(v any, depth int) {
+	if depth > maxLiteralDepth {
+		return
+	}
+	switch t := v.(type) {
+	case map[string]any:
+		if payload, kind, ok := literalValueRef(t); ok {
+			b.markLiteralValueRef(payload, kind)
+			return
+		}
+		for _, elem := range t {
+			b.markLiteralResolverRefsDepth(elem, depth+1)
+		}
+	case []any:
+		for _, elem := range t {
+			b.markLiteralResolverRefsDepth(elem, depth+1)
+		}
+	}
+}
+
+// markLiteralValueRef records the resolver names referenced by a single nested
+// inline ValueRef as unresolved.
+func (b *builder) markLiteralValueRef(payload, kind string) {
+	switch kind {
+	case "rslvr":
+		b.markUnresolved(payload)
+	case "expr":
+		expr := celexp.Expression(payload)
+		if names, err := expr.GetUnderscoreVariables(context.Background()); err == nil {
+			for _, n := range names {
+				b.markUnresolved(n)
+			}
+		} else {
+			b.markUnresolvedUnknown()
+		}
+	case "tmpl":
+		if cands, err := gotmpl.UnscopedResolverRefs(payload, "", ""); err == nil {
+			for _, c := range cands {
+				b.markUnresolved(c.Name)
+			}
+		} else {
+			b.markUnresolvedUnknown()
+		}
+	}
+}
+
+// literalValueRef reports whether m is a single-key inline ValueRef map
+// ({rslvr}/{expr}/{tmpl}) with a string payload, returning the payload and key.
+func literalValueRef(m map[string]any) (payload, kind string, ok bool) {
+	if len(m) != 1 {
+		return "", "", false
+	}
+	for _, k := range []string{"rslvr", "expr", "tmpl"} {
+		v, present := m[k]
+		if !present {
+			continue
+		}
+		s, isStr := v.(string)
+		if !isStr {
+			return "", "", false
+		}
+		return s, k, true
+	}
+	return "", "", false
+}
+
+// scalarAt returns the scalar value node at path, if present.
+func (b *builder) scalarAt(path string) (*yaml.Node, bool) {
+	n, ok := b.nodes[path]
+	if !ok || n.Kind != yaml.ScalarNode {
+		return nil, false
+	}
+	return n, true
+}
+
+// celScalar returns the CEL scalar node for a ValueRef/condition path, trying
+// the object form (path.expr) before the condition scalar shorthand (path).
+func (b *builder) celScalar(basePath string) *yaml.Node {
+	if n, ok := b.scalarAt(basePath + ".expr"); ok {
+		return n
+	}
+	if n, ok := b.scalarAt(basePath); ok {
+		return n
+	}
+	return nil
+}
+
+// contentStart returns the byte offset of a scalar's content, adjusting for
+// quote style and block indicators.
+func (b *builder) contentStart(n *yaml.Node) (int, bool) {
+	base := b.li.Offset(sourcepos.Position{Line: n.Line, Column: n.Column})
+	switch {
+	case n.Style&(yaml.DoubleQuotedStyle|yaml.SingleQuotedStyle) != 0:
+		return base + 1, true
+	case n.Style&(yaml.LiteralStyle|yaml.FoldedStyle) != 0:
+		// The node position points at the block indicator; content begins at the
+		// first non-empty decoded line within the raw bytes after base.
+		first := firstNonEmptyLine(n.Value)
+		if first == "" {
+			return base, true
+		}
+		if i := bytes.Index(b.raw[base:], []byte(first)); i >= 0 {
+			return base + i, true
+		}
+		return base, false
+	default:
+		return base, true
+	}
+}
+
+// finalize sorts references by position for deterministic output.
+func (i *Index) finalize() {
+	sort.SliceStable(i.refs, func(a, c int) bool { return lessRange(i.refs[a].Range, i.refs[c].Range) })
+	for name := range i.byName {
+		refs := i.byName[name]
+		sort.SliceStable(refs, func(a, c int) bool { return lessRange(refs[a].Range, refs[c].Range) })
+		i.byName[name] = refs
+	}
+}
+
+func (i *Index) record(r Reference) {
+	i.refs = append(i.refs, r)
+	i.byName[r.Symbol.Name] = append(i.byName[r.Symbol.Name], r)
+}
+
+func lessRange(a, b sourcepos.Range) bool {
+	if a.Start.Line != b.Start.Line {
+		return a.Start.Line < b.Start.Line
+	}
+	return a.Start.Column < b.Start.Column
+}
+
+// buildValueNodeMap parses raw YAML and returns a map from logical path to the
+// VALUE node at that path, using the same path scheme as sourcepos and walk.Walk
+// (dotted keys, [i] for sequence elements).
+func buildValueNodeMap(raw []byte) (map[string]*yaml.Node, error) {
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("parse yaml: %w", err)
+	}
+	m := make(map[string]*yaml.Node)
+	var walkNode func(n *yaml.Node, path string)
+	walkNode = func(n *yaml.Node, path string) {
+		if n == nil {
+			return
+		}
+		switch n.Kind {
+		case yaml.DocumentNode:
+			for _, c := range n.Content {
+				walkNode(c, path)
+			}
+		case yaml.MappingNode:
+			for i := 0; i+1 < len(n.Content); i += 2 {
+				key := n.Content[i].Value
+				val := n.Content[i+1]
+				childPath := key
+				if path != "" {
+					childPath = path + "." + key
+				}
+				m[childPath] = val
+				walkNode(val, childPath)
+			}
+		case yaml.SequenceNode:
+			for i, c := range n.Content {
+				childPath := fmt.Sprintf("%s[%d]", path, i)
+				m[childPath] = c
+				walkNode(c, childPath)
+			}
+		case yaml.ScalarNode:
+			// Leaf node: nothing to recurse into. Scalars are recorded by their
+			// parent mapping/sequence at the appropriate path.
+		case yaml.AliasNode:
+			if n.Alias != nil {
+				walkNode(n.Alias, path)
+			}
+		}
+	}
+	walkNode(&doc, "")
+	return m, nil
+}
+
+func firstNonEmptyLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if t := strings.TrimSpace(line); t != "" {
+			return t
+		}
+	}
+	return ""
+}

--- a/pkg/refindex/refindex_test.go
+++ b/pkg/refindex/refindex_test.go
@@ -459,3 +459,26 @@ spec:
 	assert.Positive(t, idx.UnresolvedFor("environment"))
 	assert.Positive(t, idx.UnresolvedFor("anything-at-all"))
 }
+
+func TestBuild_UnpositionableCELRefIsUnresolved(t *testing.T) {
+	// A CEL bracket key with an escaped quote cannot be positioned byte-exact;
+	// it must be recorded as unresolved (attributed to that name) rather than
+	// silently dropped, so a rename of that name fails safe.
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: unpositionable
+spec:
+  resolvers:
+    weird:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: '_["a\"b"]'
+`
+	idx, _, _ := buildFixture(t, y)
+	assert.Positive(t, idx.Unresolved())
+	assert.Positive(t, idx.UnresolvedFor(`a"b`))
+}

--- a/pkg/refindex/refindex_test.go
+++ b/pkg/refindex/refindex_test.go
@@ -1,0 +1,461 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refindex
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const fixtureYAML = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: refindex-test
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    appName:
+      dependsOn:
+        - environment
+      when:
+        expr: _.environment == "dev"
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.environment
+    greeting:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                tmpl: "{{ ._.appName }}/{{ ._.environment }}"
+    aliasRef:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                rslvr: appName
+`
+
+func buildFixture(t *testing.T, y string) (*Index, []byte, *sourcepos.LineIndex) {
+	t.Helper()
+	sol := &solution.Solution{}
+	require.NoError(t, sol.UnmarshalFromBytes([]byte(y)))
+	idx, err := Build(sol)
+	require.NoError(t, err)
+	raw := sol.RawContent()
+	return idx, raw, sourcepos.NewLineIndex(raw, "")
+}
+
+// assertByteExact verifies the reference's Range slices out exactly its name.
+func assertByteExact(t *testing.T, raw []byte, li *sourcepos.LineIndex, r Reference) {
+	t.Helper()
+	start := li.Offset(r.Range.Start)
+	end := li.Offset(r.Range.End)
+	require.GreaterOrEqual(t, start, 0)
+	require.LessOrEqual(t, end, len(raw))
+	assert.Equalf(t, r.Symbol.Name, string(raw[start:end]),
+		"range %s (origin %s) must slice to %q", r.Range, r.Origin, r.Symbol.Name)
+}
+
+func TestBuild_NamesAndDefinitions(t *testing.T) {
+	idx, raw, li := buildFixture(t, fixtureYAML)
+
+	assert.Equal(t, []string{"aliasRef", "appName", "environment", "greeting"}, idx.Names())
+	assert.Zero(t, idx.Unresolved(), "clean fixture should have no unresolved refs")
+
+	for _, name := range idx.Names() {
+		def, ok := idx.Definition(name)
+		require.Truef(t, ok, "definition for %q", name)
+		assert.True(t, def.IsDef)
+		assert.Equal(t, OriginDefinition, def.Origin)
+		assert.Equal(t, SymbolResolver, def.Symbol.Kind)
+		assertByteExact(t, raw, li, def)
+	}
+}
+
+func TestBuild_ReferencesByOrigin(t *testing.T) {
+	idx, raw, li := buildFixture(t, fixtureYAML)
+
+	// "environment" is referenced four ways: dependsOn, CEL (when), CEL (expr),
+	// and template.
+	envRefs := idx.References("environment")
+	origins := map[Origin]int{}
+	for _, r := range envRefs {
+		origins[r.Origin]++
+		assert.False(t, r.IsDef)
+		assertByteExact(t, raw, li, r)
+	}
+	assert.Equal(t, 1, origins[OriginDependsOn], "dependsOn ref")
+	assert.Equal(t, 2, origins[OriginCEL], "when + expr CEL refs")
+	assert.Equal(t, 1, origins[OriginTemplate], "template ref")
+	assert.Len(t, envRefs, 4)
+
+	// "appName" is referenced by a template (._.appName) and a rslvr.
+	appRefs := idx.References("appName")
+	appOrigins := map[Origin]int{}
+	for _, r := range appRefs {
+		appOrigins[r.Origin]++
+		assertByteExact(t, raw, li, r)
+	}
+	assert.Equal(t, 1, appOrigins[OriginTemplate])
+	assert.Equal(t, 1, appOrigins[OriginResolverRef])
+	assert.Len(t, appRefs, 2)
+}
+
+func TestBuild_Occurrences_IncludesDefinition(t *testing.T) {
+	idx, raw, li := buildFixture(t, fixtureYAML)
+
+	occ := idx.Occurrences("environment")
+	// 1 definition + 4 uses.
+	assert.Len(t, occ, 5)
+
+	defCount := 0
+	for _, r := range occ {
+		if r.IsDef {
+			defCount++
+		}
+		assertByteExact(t, raw, li, r)
+	}
+	assert.Equal(t, 1, defCount)
+
+	// Occurrences are sorted by position (definition comes first in the file).
+	assert.True(t, occ[0].IsDef, "first occurrence is the definition")
+}
+
+func TestBuild_AllSortedAndByteExact(t *testing.T) {
+	idx, raw, li := buildFixture(t, fixtureYAML)
+
+	all := idx.All()
+	require.NotEmpty(t, all)
+
+	prevLine, prevCol := 0, 0
+	for _, r := range all {
+		// Non-decreasing position order.
+		if r.Range.Start.Line == prevLine {
+			assert.GreaterOrEqual(t, r.Range.Start.Column, prevCol)
+		} else {
+			assert.Greater(t, r.Range.Start.Line, prevLine)
+		}
+		prevLine, prevCol = r.Range.Start.Line, r.Range.Start.Column
+		assertByteExact(t, raw, li, r)
+	}
+}
+
+func TestBuild_ConditionScalarShorthand(t *testing.T) {
+	// A condition in scalar shorthand form (when: <expr>) rather than {expr: ...}.
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: shorthand
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    gated:
+      when: _.environment == "prod"
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: yes
+`
+	idx, raw, li := buildFixture(t, y)
+	refs := idx.References("environment")
+	require.Len(t, refs, 1)
+	assert.Equal(t, OriginCEL, refs[0].Origin)
+	assertByteExact(t, raw, li, refs[0])
+}
+
+func TestBuild_SingleQuotedExpr(t *testing.T) {
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: single-quoted
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    user:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: '_.environment'
+`
+	idx, raw, li := buildFixture(t, y)
+	refs := idx.References("environment")
+	require.Len(t, refs, 1)
+	assert.Equal(t, OriginCEL, refs[0].Origin)
+	assertByteExact(t, raw, li, refs[0])
+	assert.Zero(t, idx.Unresolved())
+}
+
+func TestBuild_BlockTemplateAndBareField(t *testing.T) {
+	// A block-literal template: line 1 resolves; the bare-field ref counts as
+	// unresolved (context-dependent, not yet positioned); the line-2 explicit
+	// ref lands past the block's stripped indentation and is dropped by the
+	// byte-exact gate (documented block limitation) -- also counted unresolved.
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: block
+spec:
+  resolvers:
+    appName:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: app
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    banner:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                tmpl: |
+                  {{ ._.appName }}
+                  {{ ._.environment }}
+    other:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                tmpl: "{{ .someDataField }}"
+`
+	idx, raw, li := buildFixture(t, y)
+
+	// Line-1 explicit ref in the block resolves byte-exact.
+	appRefs := idx.References("appName")
+	require.Len(t, appRefs, 1)
+	assert.Equal(t, OriginTemplate, appRefs[0].Origin)
+	assertByteExact(t, raw, li, appRefs[0])
+
+	// The bare {{ .someDataField }} and the line-2 block ref are unresolved.
+	assert.GreaterOrEqual(t, idx.Unresolved(), 1, "bare field / block line-2 unresolved")
+}
+
+func TestBuild_Nil(t *testing.T) {
+	idx, err := Build(nil)
+	require.NoError(t, err)
+	assert.Empty(t, idx.All())
+	assert.Empty(t, idx.Names())
+	_, ok := idx.Definition("x")
+	assert.False(t, ok)
+}
+
+func TestBuild_EmptyReferencesForUnknown(t *testing.T) {
+	idx, _, _ := buildFixture(t, fixtureYAML)
+	assert.Empty(t, idx.References("does-not-exist"))
+	assert.Empty(t, idx.Occurrences("does-not-exist"))
+}
+
+func TestBuild_MalformedExpressionsAreSkipped(t *testing.T) {
+	// Malformed CEL and template content parse as strings but fail reference
+	// extraction; Build must skip them without error or panic.
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: malformed
+spec:
+  resolvers:
+    broken:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              bad_expr:
+                expr: "_.a +"
+              bad_tmpl:
+                tmpl: "{{ .x "
+`
+	sol := &solution.Solution{}
+	require.NoError(t, sol.UnmarshalFromBytes([]byte(y)))
+	idx, err := Build(sol)
+	require.NoError(t, err)
+	assert.Empty(t, idx.References("a"))
+	assert.Empty(t, idx.References("x"))
+	_, ok := idx.Definition("broken")
+	assert.True(t, ok)
+}
+
+func TestSymbolKindString(t *testing.T) {
+	assert.Equal(t, "resolver", SymbolResolver.String())
+	assert.Equal(t, "unknown", SymbolKind(99).String())
+}
+
+func TestOriginString(t *testing.T) {
+	cases := map[Origin]string{
+		OriginDefinition:  "definition",
+		OriginDependsOn:   "dependsOn",
+		OriginResolverRef: "rslvr",
+		OriginCEL:         "cel",
+		OriginTemplate:    "template",
+		Origin(99):        "unknown",
+	}
+	for o, want := range cases {
+		assert.Equal(t, want, o.String())
+	}
+}
+
+func BenchmarkBuild(b *testing.B) {
+	sol := &solution.Solution{}
+	if err := sol.UnmarshalFromBytes([]byte(fixtureYAML)); err != nil {
+		b.Fatal(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = Build(sol)
+	}
+}
+
+func TestBuild_NestedLiteralAndDollarRefsAreUnresolvedByName(t *testing.T) {
+	// C1: nested inline {rslvr}/{expr} inside a literal map/array, and
+	// C2: a $-rooted template reference -- all reference "environment" but are
+	// not positioned, so they must be attributed to "environment" as unresolved
+	// (blocking a rename of environment) while leaving other names unaffected.
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: fail-safe
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    other:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: x
+    nestedRslvr:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                settings:
+                  env:
+                    rslvr: environment
+    nestedExpr:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                items:
+                  - expr: _.environment
+    dollarTmpl:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                tmpl: "{{ $.environment }}"
+`
+	idx, _, _ := buildFixture(t, y)
+
+	// Every reference above targets "environment" and is unpositioned.
+	assert.GreaterOrEqual(t, idx.UnresolvedFor("environment"), 3,
+		"nested rslvr + nested expr + $-template must all count against environment")
+
+	// The fail-safe is name-scoped: renaming an unrelated resolver is not blocked.
+	assert.Zero(t, idx.UnresolvedFor("other"))
+	assert.Zero(t, idx.UnresolvedFor("nestedRslvr"))
+}
+
+func TestBuild_CleanFixtureHasNoPerNameUnresolved(t *testing.T) {
+	idx, _, _ := buildFixture(t, fixtureYAML)
+	for _, name := range idx.Names() {
+		assert.Zerof(t, idx.UnresolvedFor(name), "resolver %q should have no unresolved refs", name)
+	}
+}
+
+func TestBuild_NestedLiteralTemplateRefIsUnresolved(t *testing.T) {
+	// A nested {tmpl: ...} inside a literal list references environment via an
+	// explicit ._.name; it must be attributed to environment as unresolved.
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: nested-tmpl
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    banner:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                items:
+                  - tmpl: "{{ ._.environment }}"
+`
+	idx, _, _ := buildFixture(t, y)
+	assert.GreaterOrEqual(t, idx.UnresolvedFor("environment"), 1)
+}
+
+func TestBuild_MalformedNestedExprBlocksAllRenames(t *testing.T) {
+	// A malformed nested expression cannot be parsed, so its target name is
+	// unknown; it conservatively blocks every rename (unresolvedOther).
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: malformed-nested
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                wrapper:
+                  expr: "_.a +"
+`
+	idx, _, _ := buildFixture(t, y)
+	assert.Positive(t, idx.Unresolved())
+	// unresolvedOther is included for every name.
+	assert.Positive(t, idx.UnresolvedFor("environment"))
+	assert.Positive(t, idx.UnresolvedFor("anything-at-all"))
+}

--- a/pkg/sourcepos/lineindex.go
+++ b/pkg/sourcepos/lineindex.go
@@ -1,0 +1,149 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package sourcepos
+
+import (
+	"fmt"
+	"sort"
+	"unicode/utf8"
+)
+
+// Range is a half-open span [Start, End) between two positions in a source
+// document. It describes the exact extent of a token -- a resolver reference,
+// a field name, an expression -- so tools can highlight it, navigate to it, or
+// rewrite it (e.g. a rename that replaces just the identifier bytes).
+//
+// End is exclusive: for the identifier "appName" starting at column 5, Start is
+// column 5 and End is column 12, so End.Column - Start.Column == len("appName").
+type Range struct {
+	// Start is the inclusive start position of the span.
+	Start Position `json:"start" yaml:"start" doc:"Inclusive start position of the span"`
+
+	// End is the exclusive end position of the span.
+	End Position `json:"end" yaml:"end" doc:"Exclusive end position of the span"`
+}
+
+// String returns a human-readable representation of the range.
+func (r Range) String() string {
+	return fmt.Sprintf("%s-%s", r.Start.String(), r.End.String())
+}
+
+// IsZero reports whether the range has no meaningful location.
+func (r Range) IsZero() bool {
+	return r.Start.IsZero() && r.End.IsZero()
+}
+
+// LineIndex provides fast, bidirectional conversion between byte offsets and
+// 1-based line/column positions in a source document.
+//
+// Columns are counted in RUNES (Unicode code points), not bytes, matching YAML
+// and editor conventions: a multibyte character such as "e-acute" advances the
+// column by one, not by its UTF-8 byte length. This is what lets positioned
+// reference extraction stay accurate when an expression contains non-ASCII text
+// before an identifier.
+//
+// A LineIndex holds a reference to the source bytes it was built from; callers
+// must not mutate that slice while the index is in use.
+type LineIndex struct {
+	src       []byte
+	file      string
+	lineStart []int // lineStart[i] = byte offset of the first byte of line i+1
+}
+
+// NewLineIndex builds a LineIndex over src. The file argument is recorded in
+// every Position the index produces, which matters for multi-file (compose)
+// scenarios. Lines are split on "\n"; a trailing "\n" yields a final empty
+// line, consistent with editor behavior.
+func NewLineIndex(src []byte, file string) *LineIndex {
+	// Line 1 always begins at offset 0. Each "\n" starts a new line at the
+	// byte immediately after it.
+	lineStart := make([]int, 1, 1+len(src)/32)
+	lineStart[0] = 0
+	for i, b := range src {
+		if b == '\n' {
+			lineStart = append(lineStart, i+1)
+		}
+	}
+	return &LineIndex{src: src, file: file, lineStart: lineStart}
+}
+
+// Len returns the number of lines in the indexed document.
+func (li *LineIndex) Len() int {
+	if li == nil {
+		return 0
+	}
+	return len(li.lineStart)
+}
+
+// Position converts a byte offset to a 1-based line/column Position. The offset
+// is clamped to [0, len(src)], so out-of-range offsets return the nearest valid
+// boundary position rather than panicking.
+func (li *LineIndex) Position(byteOffset int) Position {
+	if li == nil {
+		return Position{}
+	}
+	if byteOffset < 0 {
+		byteOffset = 0
+	}
+	if byteOffset > len(li.src) {
+		byteOffset = len(li.src)
+	}
+
+	// Find the line whose start is the greatest offset <= byteOffset.
+	// sort.Search returns the first index whose start is > byteOffset.
+	idx := sort.Search(len(li.lineStart), func(k int) bool {
+		return li.lineStart[k] > byteOffset
+	}) - 1
+	if idx < 0 {
+		idx = 0
+	}
+
+	lineByteStart := li.lineStart[idx]
+	// Column is the number of runes between the line start and the offset,
+	// plus one (columns are 1-based).
+	column := utf8.RuneCount(li.src[lineByteStart:byteOffset]) + 1
+
+	return Position{Line: idx + 1, Column: column, File: li.file}
+}
+
+// Offset converts a 1-based line/column Position back to a byte offset. It is
+// the inverse of Position for in-range inputs. Out-of-range lines clamp to the
+// document bounds; a column past the end of its line clamps to the line end.
+func (li *LineIndex) Offset(pos Position) int {
+	if li == nil || pos.Line < 1 {
+		return 0
+	}
+	if pos.Line > len(li.lineStart) {
+		return len(li.src)
+	}
+
+	lineByteStart := li.lineStart[pos.Line-1]
+	lineByteEnd := len(li.src)
+	if pos.Line < len(li.lineStart) {
+		// Exclude the trailing "\n" (which lives at lineStart[pos.Line]-1) so an
+		// over-long column clamps to the end of the visible content, not onto
+		// the newline of the next line.
+		lineByteEnd = li.lineStart[pos.Line] - 1
+	}
+
+	// Advance (Column-1) runes from the line start, without crossing into the
+	// next line.
+	off := lineByteStart
+	for c := 1; c < pos.Column && off < lineByteEnd; c++ {
+		_, size := utf8.DecodeRune(li.src[off:lineByteEnd])
+		if size == 0 {
+			break
+		}
+		off += size
+	}
+	return off
+}
+
+// Range builds a Range from a half-open byte span [startByte, endByte).
+func (li *LineIndex) Range(startByte, endByte int) Range {
+	return Range{
+		Start: li.Position(startByte),
+		End:   li.Position(endByte),
+	}
+}

--- a/pkg/sourcepos/lineindex_test.go
+++ b/pkg/sourcepos/lineindex_test.go
@@ -1,0 +1,180 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package sourcepos
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLineIndex_Position(t *testing.T) {
+	// "line1\nline2\ncafé x\n"
+	//  offsets: l=0..4 \n=5 | line2=6..10 \n=11 | café x=12.. (é is 2 bytes)
+	src := []byte("line1\nline2\ncafé x\n")
+
+	tests := []struct {
+		name       string
+		byteOffset int
+		wantLine   int
+		wantCol    int
+	}{
+		{"start of file", 0, 1, 1},
+		{"mid line1", 3, 1, 4},
+		{"end of line1 (the newline)", 5, 1, 6},
+		{"start of line2", 6, 2, 1},
+		{"start of line3", 12, 3, 1},
+		// Column must count runes: 'c','a','f','é' -> the space after é is col 5,
+		// not col 6, even though é is 2 bytes. Byte offset of the space is 17.
+		{"after multibyte rune", 17, 3, 5},
+		{"the x after multibyte", 18, 3, 6},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			li := NewLineIndex(src, "f.yaml")
+			pos := li.Position(tt.byteOffset)
+			assert.Equal(t, tt.wantLine, pos.Line, "line")
+			assert.Equal(t, tt.wantCol, pos.Column, "column")
+			assert.Equal(t, "f.yaml", pos.File, "file")
+		})
+	}
+}
+
+func TestLineIndex_Position_Clamping(t *testing.T) {
+	src := []byte("ab\ncd")
+	li := NewLineIndex(src, "")
+
+	// Negative clamps to start.
+	neg := li.Position(-5)
+	assert.Equal(t, 1, neg.Line)
+	assert.Equal(t, 1, neg.Column)
+
+	// Beyond end clamps to the final position (offset len(src) == 5 -> line 2, col 3).
+	over := li.Position(9999)
+	assert.Equal(t, 2, over.Line)
+	assert.Equal(t, 3, over.Column)
+}
+
+func TestLineIndex_Position_EmptySource(t *testing.T) {
+	li := NewLineIndex([]byte(""), "empty.yaml")
+	assert.Equal(t, 1, li.Len())
+	pos := li.Position(0)
+	assert.Equal(t, 1, pos.Line)
+	assert.Equal(t, 1, pos.Column)
+	assert.Equal(t, "empty.yaml", pos.File)
+}
+
+func TestLineIndex_Offset_RoundTrip(t *testing.T) {
+	src := []byte("apiVersion: v1\nspec:\n  expr: _.café\n")
+	li := NewLineIndex(src, "")
+
+	// For every byte offset that begins a rune, Position -> Offset must be
+	// stable (idempotent round-trip).
+	for off := 0; off <= len(src); off++ {
+		// Skip offsets that land in the middle of a multibyte rune.
+		if off < len(src) && !utf8RuneStart(src[off]) {
+			continue
+		}
+		pos := li.Position(off)
+		got := li.Offset(pos)
+		assert.Equalf(t, off, got, "round-trip failed at byte offset %d (pos %s)", off, pos)
+	}
+}
+
+func TestLineIndex_Offset_Clamping(t *testing.T) {
+	src := []byte("abc\ndef")
+	li := NewLineIndex(src, "")
+
+	// Line below 1 -> offset 0.
+	assert.Equal(t, 0, li.Offset(Position{Line: 0, Column: 5}))
+	// Line beyond the document -> end of source.
+	assert.Equal(t, len(src), li.Offset(Position{Line: 99, Column: 1}))
+	// Column beyond the end of its line clamps to the line end (before the '\n').
+	assert.Equal(t, 3, li.Offset(Position{Line: 1, Column: 99}))
+}
+
+func TestLineIndex_Range(t *testing.T) {
+	// The identifier "appName" sits on line 2. End is exclusive.
+	src := []byte("spec:\n  expr: _.appName\n")
+	li := NewLineIndex(src, "sol.yaml")
+
+	// Byte span of "appName": find it.
+	start := indexOf(src, "appName")
+	end := start + len("appName")
+
+	r := li.Range(start, end)
+	assert.Equal(t, 2, r.Start.Line)
+	assert.Equal(t, 2, r.End.Line)
+	// The sliced bytes must equal the identifier -- the invariant rename relies on.
+	assert.Equal(t, "appName", string(src[li.Offset(r.Start):li.Offset(r.End)]))
+	assert.False(t, r.IsZero())
+}
+
+func TestLineIndex_NilSafety(t *testing.T) {
+	var li *LineIndex
+	assert.Equal(t, 0, li.Len())
+	assert.True(t, li.Position(0).IsZero())
+	assert.Equal(t, 0, li.Offset(Position{Line: 1, Column: 1}))
+}
+
+func TestLineIndex_CRLF(t *testing.T) {
+	// Documented behavior: lines split on "\n"; a "\r" before it counts as a
+	// rune in the column. This locks the behavior so it is a conscious choice.
+	src := []byte("ab\r\ncd")
+	li := NewLineIndex(src, "")
+	// 'c' is at byte offset 4 (a,b,\r,\n,c) -> line 2, col 1.
+	assert.Equal(t, Position{Line: 2, Column: 1}, li.Position(4))
+	// The "\r" is at offset 2 -> still line 1, col 3.
+	assert.Equal(t, Position{Line: 1, Column: 3}, li.Position(2))
+}
+
+func TestRange_String(t *testing.T) {
+	r := Range{
+		Start: Position{Line: 2, Column: 11, File: "s.yaml"},
+		End:   Position{Line: 2, Column: 18, File: "s.yaml"},
+	}
+	assert.Equal(t, "s.yaml:2:11-s.yaml:2:18", r.String())
+}
+
+func TestRange_IsZero(t *testing.T) {
+	assert.True(t, Range{}.IsZero())
+	assert.False(t, Range{Start: Position{Line: 1, Column: 1}}.IsZero())
+}
+
+// --- helpers ---
+
+func utf8RuneStart(b byte) bool {
+	// Continuation bytes are 0b10xxxxxx.
+	return b&0xC0 != 0x80
+}
+
+func indexOf(src []byte, sub string) int {
+	s := string(src)
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func BenchmarkLineIndex_Position(b *testing.B) {
+	src := []byte("apiVersion: v1\nkind: Solution\nspec:\n  resolvers:\n    appName:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value: _.environment\n")
+	li := NewLineIndex(src, "bench.yaml")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = li.Position(len(src) - 5)
+	}
+}
+
+func BenchmarkNewLineIndex(b *testing.B) {
+	src := []byte("apiVersion: v1\nkind: Solution\nspec:\n  resolvers:\n    appName:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value: _.environment\n")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = NewLineIndex(src, "bench.yaml")
+	}
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13623,3 +13623,84 @@ func TestIntegration_StateClearPreservesMetadata(t *testing.T) {
 	assert.NotContains(t, string(data), "k1")
 	assert.NotContains(t, string(data), "k2")
 }
+
+// ── refactor rename resolver ─────────────────────────────────────────────────
+
+const refactorRenameFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: refactor-int # keep this comment
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    appName:
+      dependsOn:
+        - environment
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.environment
+`
+
+func writeRefactorFixture(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(refactorRenameFixture), 0o600))
+	return path
+}
+
+func TestIntegration_RefactorRenameDryRun(t *testing.T) {
+	t.Parallel()
+	path := writeRefactorFixture(t)
+
+	stdout, _, exitCode := runScafctl(t, "refactor", "rename", "resolver", "environment", "env", "-f", path, "--dry-run")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Would rename resolver")
+	assert.Contains(t, stdout, "environment -> env")
+
+	// Dry-run must not modify the file.
+	got, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	assert.Equal(t, refactorRenameFixture, string(got))
+}
+
+func TestIntegration_RefactorRenameApply(t *testing.T) {
+	t.Parallel()
+	path := writeRefactorFixture(t)
+
+	stdout, _, exitCode := runScafctl(t, "refactor", "rename", "resolver", "environment", "env", "-f", path)
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Renamed resolver")
+
+	got, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	assert.NotContains(t, string(got), "environment")
+	assert.Contains(t, string(got), "env:")
+	assert.Contains(t, string(got), "- env")
+	assert.Contains(t, string(got), "expr: _.env")
+	// Comments/formatting preserved.
+	assert.Contains(t, string(got), "# keep this comment")
+}
+
+func TestIntegration_RefactorRenameCollision(t *testing.T) {
+	t.Parallel()
+	path := writeRefactorFixture(t)
+
+	_, stderr, exitCode := runScafctl(t, "refactor", "rename", "resolver", "environment", "appName", "-f", path)
+	assert.Equal(t, exitcode.ValidationFailed, exitCode)
+	assert.Contains(t, stderr, "already exists")
+}
+
+func TestIntegration_RefactorHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "refactor", "--help")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "rename")
+}


### PR DESCRIPTION
## Summary

Add a positioned reference index over solutions and a source-preserving
`refactor rename resolver` command that renames a resolver and every reference
to it (the definition, dependsOn entries, rslvr values, CEL `_.name` uses, and
explicit template `._.name` uses) by replacing only the exact bytes of each
occurrence -- comments, key order, and formatting are preserved, with no YAML
round-trip.

The design intentionally avoids a bespoke AST: it composes byte-exact source
ranges from three layers and drives edits as text replacements, which keeps the
implementation reviewable and reusable by a future LSP / editor extension.

## What's included

- `sourcepos.LineIndex` + `Range`: rune-correct byte<->line/column conversion.
- `celexp.UnderscoreVariableRefs`: positioned CEL `_.name` references, located
  via an AST-anchored scan (rune-vs-byte handled).
- `gotmpl.GetPositionedReferences` + `gotmpl.UnscopedResolverRefs`: positioned
  template references plus the authoritative unscoped-reference set used to
  reconcile coverage.
- `refindex.Build`: a unified `{Symbol, Range, Origin, IsDef}` index built from
  `walk.Walk` semantics, a value-node map, and a byte-exact validation gate.
- `refactor.RenameResolver` + `Apply`: TextEdit-based, guarded, source-preserving
  rename.
- `scafctl refactor rename resolver <old> <new>` (`-f`, `--dry-run`), registered
  under the core command group and embedder-safe. The rewrite is atomic (write
  to a temp file, then rename) so a crash mid-write cannot corrupt the solution.
- Docs: a refactoring tutorial, a CLI design-doc section, and an example solution.

## Safety guarantee

Rename is all-or-nothing. Every emitted reference is validated byte-exact against
the source; references that cannot be located -- a context-dependent bare
`{{ .field }}`, a `$`-rooted `{{ $.name }}`, or an inline reference nested inside
a literal -- are recorded as unresolved and attributed by name. `RenameResolver`
refuses (non-zero exit, no edits) when the target resolver has any unlocatable
reference, so it never performs a partial rewrite that would silently break the
solution. The check is name-scoped: an unlocatable reference to a different
resolver does not block the rename.

## Testing

- Unit tests (with `-race`) across all six packages; the byte-exact invariant is
  asserted on every reference; regression tests prove nested-literal and
  `$.name` references now refuse rather than corrupt the solution.
- CLI unit + integration tests: dry-run, apply with comment preservation,
  collision, help, and embedder binary-name.
- gofmt/vet clean; golangci-lint (new-from-merge-base) reports no new issues.

## Follow-up (not in this PR)

- Expose rename / positioned find-references as an MCP tool (decide: a new tool
  vs. extending `extract_resolver_refs`).
- Extend the index to actions/functions/calls and build an LSP server that
  reuses `refindex` / `refactor`.
