### PR TITLE
feat: add 'scafctl lsp' language server with live lint diagnostics

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -1104,10 +1104,20 @@ rule name to an LSP diagnostic anchored at the finding's location. It advertises
 full-document sync and reuses the same `lint` engine as `scafctl lint`, so
 editor diagnostics match the CLI.
 
+It also provides resolver navigation and refactoring, reusing the same
+positioned reference index (`refindex`) and rename engine (`refactor`) as
+`refactor rename resolver`:
+
+- **Go-to-definition** (`textDocument/definition`) -- jump from any resolver
+  reference to its definition.
+- **Find references** (`textDocument/references`) -- list every use of a resolver.
+- **Rename** (`textDocument/rename`, with `prepareRename`) -- rename a resolver
+  and every reference to it as a single `WorkspaceEdit`. The same fail-safe
+  applies: if a reference cannot be located, the rename is refused and the error
+  is surfaced to the editor rather than a partial rewrite being applied.
+
 An editor client configures the server by pointing at the `scafctl lsp` command
-and associating it with the solution file language (YAML). Future revisions will
-add go-to-definition, find-references, and rename (reusing the same reference
-index that powers `refactor rename`).
+and associating it with the solution file language (YAML).
 
 ---
 

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -1086,6 +1086,31 @@ the rename), `4` the solution file could not be resolved, read, or parsed.
 
 ---
 
+## Language Server (LSP)
+
+`scafctl lsp` runs a Language Server Protocol server over stdio for editor
+integration. It is meant to be launched by an editor / LSP client, not run
+interactively -- stdout is the JSON-RPC channel.
+
+~~~bash
+# Started by an editor; not typically run by hand
+scafctl lsp
+~~~
+
+Currently the server publishes **lint diagnostics** for solution files as you
+edit them: on open/change/save it lints the in-memory document and sends
+`textDocument/publishDiagnostics`, mapping each finding's severity, message, and
+rule name to an LSP diagnostic anchored at the finding's location. It advertises
+full-document sync and reuses the same `lint` engine as `scafctl lint`, so
+editor diagnostics match the CLI.
+
+An editor client configures the server by pointing at the `scafctl lsp` command
+and associating it with the solution file language (YAML). Future revisions will
+add go-to-definition, find-references, and rename (reusing the same reference
+index that powers `refactor rename`).
+
+---
+
 ## Exploring Lint Rules
 
 ### List Rules

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -24,7 +24,7 @@ Step-by-step guides for learning scafctl features.
 - [Eval Tutorial](eval-tutorial.md) — Test CEL expressions and Go templates from the CLI
 - [Linting Tutorial](linting-tutorial.md) — Validate solutions, explore lint rules, and fix issues
 - [Refactoring Tutorial](refactor-tutorial.md) — Rename a resolver and every reference to it with `refactor rename resolver`
-- [Language Server (LSP) Tutorial](lsp-tutorial.md) — Run `scafctl lsp` for in-editor diagnostics
+- [Language Server (LSP) Tutorial](lsp-tutorial.md) -- Run `scafctl lsp` for in-editor diagnostics
 - [CEL Expressions Tutorial](cel-tutorial.md) — Master CEL expressions and extension functions
 - [Go Templates Tutorial](go-templates-tutorial.md) — Generate files with Go template rendering
 - [Reference-Data Lookups](reference-data-lookups.md) -- Look up taxonomy values from inline, file, or HTTP datasets

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -24,6 +24,7 @@ Step-by-step guides for learning scafctl features.
 - [Eval Tutorial](eval-tutorial.md) — Test CEL expressions and Go templates from the CLI
 - [Linting Tutorial](linting-tutorial.md) — Validate solutions, explore lint rules, and fix issues
 - [Refactoring Tutorial](refactor-tutorial.md) — Rename a resolver and every reference to it with `refactor rename resolver`
+- [Language Server (LSP) Tutorial](lsp-tutorial.md) — Run `scafctl lsp` for in-editor diagnostics
 - [CEL Expressions Tutorial](cel-tutorial.md) — Master CEL expressions and extension functions
 - [Go Templates Tutorial](go-templates-tutorial.md) — Generate files with Go template rendering
 - [Reference-Data Lookups](reference-data-lookups.md) -- Look up taxonomy values from inline, file, or HTTP datasets

--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -1,0 +1,63 @@
+---
+title: "Language Server (LSP) Tutorial"
+weight: 47
+---
+
+# Language Server (LSP) Tutorial
+
+This tutorial covers `scafctl lsp`, which runs a Language Server Protocol (LSP)
+server so editors can surface solution diagnostics as you type.
+
+## Overview
+
+`scafctl lsp` speaks LSP over stdin/stdout. An editor / LSP client launches it,
+sends the documents you open and edit, and the server replies with diagnostics.
+It is not meant to be run interactively -- stdout is the JSON-RPC channel.
+
+```mermaid
+flowchart LR
+  A["Editor<br/>(LSP client)"] <-->|"stdio JSON-RPC"| B["scafctl lsp"]
+  B --> C["lint engine"]
+  C -->|"findings"| B
+  B -->|"publishDiagnostics"| A
+```
+
+Today the server publishes **lint diagnostics**: on open/change/save it lints
+the in-memory document and reports each finding (severity, message, rule name)
+at its source location, using the same engine as `scafctl lint` -- so what you
+see in the editor matches the CLI.
+
+## Trying it by hand
+
+You normally never run the server directly, but you can confirm it starts:
+
+```bash
+scafctl lsp --help
+```
+
+An LSP client drives it with framed JSON-RPC messages (`initialize`, then
+`textDocument/didOpen`, `didChange`, `didClose`). On `didOpen`/`didChange` the
+server responds with a `textDocument/publishDiagnostics` notification containing
+any lint findings for that document.
+
+## Configuring an editor
+
+The exact steps depend on the editor's LSP client, but the shape is always the
+same:
+
+1. Point the client at the `scafctl lsp` command (the server process).
+2. Associate it with the solution file language (YAML).
+3. Open a `solution.yaml` -- diagnostics appear inline as you edit.
+
+Because the server reuses the CLI's `lint` engine, no separate configuration is
+needed to keep editor and CLI diagnostics consistent.
+
+## What's next
+
+Planned additions build on the same positioned reference index that powers
+`refactor rename`: go-to-definition, find-references, and in-editor rename.
+
+## See also
+
+- [Linting Tutorial](linting-tutorial.md) -- the diagnostics engine behind the server
+- [Refactoring Tutorial](refactor-tutorial.md) -- the reference index future LSP features will reuse

--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -27,6 +27,16 @@ the in-memory document and reports each finding (severity, message, rule name)
 at its source location, using the same engine as `scafctl lint` -- so what you
 see in the editor matches the CLI.
 
+It also supports resolver **navigation and rename**, reusing the same reference
+index and rename engine as `scafctl refactor rename resolver`:
+
+- **Go to definition** on a resolver reference jumps to where the resolver is
+  defined.
+- **Find all references** lists every use of a resolver.
+- **Rename** a resolver updates its definition and every reference in one edit.
+  If any reference cannot be located, the rename is refused (the editor shows the
+  error) rather than applying a partial, solution-breaking change.
+
 ## Trying it by hand
 
 You normally never run the server directly, but you can confirm it starts:
@@ -54,8 +64,9 @@ needed to keep editor and CLI diagnostics consistent.
 
 ## What's next
 
-Planned additions build on the same positioned reference index that powers
-`refactor rename`: go-to-definition, find-references, and in-editor rename.
+Navigation and rename currently cover resolvers. Planned additions extend the
+same reference index to actions, functions, and calls, and add hover and
+completion.
 
 ## See also
 

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	github.com/tliron/glsp v0.2.2
 	github.com/vbauerster/mpb/v8 v8.14.0
 	github.com/zalando/go-keyring v0.2.8
 	go.opentelemetry.io/contrib/bridges/otellogr v0.19.0
@@ -214,6 +215,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
+	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/imkira/go-interpol v1.1.0 // indirect
 	github.com/in-toto/attestation v1.1.2 // indirect
 	github.com/in-toto/in-toto-golang v0.9.0 // indirect
@@ -245,6 +247,7 @@ require (
 	github.com/oklog/run v1.2.0 // indirect
 	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.4.3 // indirect
+	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -259,6 +262,7 @@ require (
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/sanity-io/litter v1.5.5 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	github.com/sasha-s/go-deadlock v0.3.1 // indirect
 	github.com/sassoftware/relic v7.2.1+incompatible // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.11.0 // indirect
 	github.com/sergi/go-diff v1.3.1 // indirect
@@ -271,6 +275,7 @@ require (
 	github.com/sigstore/sigstore-go v1.1.4 // indirect
 	github.com/sigstore/timestamp-authority/v2 v2.0.3 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
+	github.com/sourcegraph/jsonrpc2 v0.2.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/stretchr/objx v0.5.3 // indirect
@@ -281,6 +286,8 @@ require (
 	github.com/theupdateframework/go-tuf/v2 v2.3.0 // indirect
 	github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 // indirect
 	github.com/tjfoc/gmsm v1.4.1 // indirect
+	github.com/tliron/commonlog v0.2.8 // indirect
+	github.com/tliron/kutil v0.3.11 // indirect
 	github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c // indirect
 	github.com/transparency-dev/merkle v0.0.2 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -469,6 +469,7 @@ github.com/googleapis/gax-go/v2 v2.22.0 h1:PjIWBpgGIVKGoCXuiCoP64altEJCj3/Ei+kSU
 github.com/googleapis/gax-go/v2 v2.22.0/go.mod h1:irWBbALSr0Sk3qlqb9SyJ1h68WjgeFuiOzI4Rqw5+aY=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
@@ -495,6 +496,7 @@ github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 h1:kes8mmyCpxJsI7FTwtzRqEy9
 github.com/hashicorp/go-secure-stdlib/strutil v0.1.2/go.mod h1:Gou2R9+il93BqX25LAKCLuM+y9U2T4hlwvT1yprcna4=
 github.com/hashicorp/go-sockaddr v1.0.7 h1:G+pTkSO01HpR5qCxg7lxfsFEZaG+C0VssTy/9dbT+Fw=
 github.com/hashicorp/go-sockaddr v1.0.7/go.mod h1:FZQbEYa1pxkQ7WLpyXJ6cbjpT8q0YgQaK/JakXqGyWw=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.1-vault-7 h1:ag5OxFVy3QYTFTJODRzTKVZ6xvdfLLCA1cy/Y6xGI0I=
@@ -510,6 +512,8 @@ github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef/go.mod h1:lADxMC39cJ
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
+github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imkira/go-interpol v1.1.0 h1:KIiKr0VSG2CUW1hl1jpiyuzuJeKUUpC8iM1AIE7N1Vk=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
@@ -653,6 +657,8 @@ github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgr
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
 github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 h1:q2e307iGHPdTGp0hoxKjt1H5pDo6utceo3dQVK3I5XQ=
+github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
 github.com/pierrec/lz4/v4 v4.1.22/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
@@ -696,6 +702,8 @@ github.com/sanity-io/litter v1.5.5 h1:iE+sBxPBzoK6uaEP5Lt3fHNgpKcHXc/A2HGETy0uJQ
 github.com/sanity-io/litter v1.5.5/go.mod h1:9gzJgR2i4ZpjZHsKvUXIRQVk7P+yM3e+jAF7bU2UI5U=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+github.com/sasha-s/go-deadlock v0.3.1 h1:sqv7fDNShgjcaxkO0JNcOAlr8B9+cV5Ey/OB71efZx0=
+github.com/sasha-s/go-deadlock v0.3.1/go.mod h1:F73l+cr82YSh10GxyRI6qZiCgK64VaZjwesgfQ1/iLM=
 github.com/sassoftware/relic v7.2.1+incompatible h1:Pwyh1F3I0r4clFJXkSI8bOyJINGqpgjJU3DYAZeI05A=
 github.com/sassoftware/relic v7.2.1+incompatible/go.mod h1:CWfAxv73/iLZ17rbyhIEq3K9hs5w6FpNMdUT//qR+zk=
 github.com/sassoftware/relic/v7 v7.6.2 h1:rS44Lbv9G9eXsukknS4mSjIAuuX+lMq/FnStgmZlUv4=
@@ -738,6 +746,8 @@ github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC4
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.1.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
+github.com/sourcegraph/jsonrpc2 v0.2.0 h1:KjN/dC4fP6aN9030MZCJs9WQbTOjWHhrtKVpzzSrr/U=
+github.com/sourcegraph/jsonrpc2 v0.2.0/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
 github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
@@ -796,6 +806,12 @@ github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399/go.mod h1:LdwHT
 github.com/tjfoc/gmsm v1.3.2/go.mod h1:HaUcFuY0auTiaHB9MHFGCPx5IaLhTUd2atbCFBQXn9w=
 github.com/tjfoc/gmsm v1.4.1 h1:aMe1GlZb+0bLjn+cKTPEvvn9oUEBlJitaZiiBwsbgho=
 github.com/tjfoc/gmsm v1.4.1/go.mod h1:j4INPkHWMrhJb38G+J6W4Tw0AbuN8Thu3PbdVYhVcTE=
+github.com/tliron/commonlog v0.2.8 h1:vpKrEsZX4nlneC9673pXpeKqv3cFLxwpzNEZF1qiaQQ=
+github.com/tliron/commonlog v0.2.8/go.mod h1:HgQZrJEuiKLLRvUixtPWGcmTmWWtKkCtywF6x9X5Spw=
+github.com/tliron/glsp v0.2.2 h1:IKPfwpE8Lu8yB6Dayta+IyRMAbTVunudeauEgjXBt+c=
+github.com/tliron/glsp v0.2.2/go.mod h1:GMVWDNeODxHzmDPvYbYTCs7yHVaEATfYtXiYJ9w1nBg=
+github.com/tliron/kutil v0.3.11 h1:kongR0dhrrn9FR/3QRFoUfQe27t78/xQvrU9aXIy5bk=
+github.com/tliron/kutil v0.3.11/go.mod h1:4IqOAAdpJuDxYbJxMv4nL8LSH0mPofSrdwIv8u99PDc=
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c h1:5a2XDQ2LiAUV+/RjckMyq9sXudfrPSuCY4FuPC1NyAw=
 github.com/transparency-dev/formats v0.0.0-20251017110053-404c0d5b696c/go.mod h1:g85IafeFJZLxlzZCDRu4JLpfS7HKzR+Hw9qRh3bVzDI=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=

--- a/pkg/cmd/scafctl/lsp/lsp.go
+++ b/pkg/cmd/scafctl/lsp/lsp.go
@@ -1,0 +1,62 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package lsp provides the `lsp` command, which starts the scafctl language
+// server over stdio. All server logic lives in pkg/lsp; this is thin wiring.
+package lsp
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	pkglsp "github.com/oakwood-commons/scafctl/pkg/lsp"
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/cobra"
+)
+
+// CommandLsp creates the `lsp` command.
+func CommandLsp(cliParams *settings.Run, _ *terminal.IOStreams, path string) *cobra.Command {
+	binaryName := cliParams.BinaryName
+	if binaryName == "" {
+		binaryName = settings.CliBinaryName
+	}
+
+	cmd := &cobra.Command{
+		Use:   "lsp",
+		Short: "Run the language server over stdio (for editor integration)",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Start the scafctl language server, communicating over stdin/stdout
+			using the Language Server Protocol (LSP).
+
+			The server publishes lint diagnostics for solution files as you edit
+			them. It is meant to be launched by an editor / LSP client (such as a
+			VS Code extension), not run interactively -- stdout is the JSON-RPC
+			channel, so anything written there other than protocol messages would
+			corrupt the session.
+		`), settings.CliBinaryName, binaryName),
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Name())
+			ctx := settings.IntoContext(cmd.Context(), cliParams)
+			ctx = logger.WithLogger(ctx, logger.FromContext(cmd.Context()))
+
+			// Best-effort registry; lint degrades gracefully without it.
+			registry, _ := builtin.DefaultRegistry(ctx)
+
+			// Report the embedder's version when embedded, else the engine build.
+			version := cliParams.EmbedderVersion
+			if version == "" {
+				version = settings.VersionInformation.BuildVersion
+			}
+			server := pkglsp.NewServer(cliParams.BinaryName, version, registry)
+			return server.Run()
+		},
+	}
+
+	return cmd
+}

--- a/pkg/cmd/scafctl/lsp/lsp_test.go
+++ b/pkg/cmd/scafctl/lsp/lsp_test.go
@@ -1,0 +1,38 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testCliParams() *settings.Run {
+	p := settings.NewCliParams()
+	p.ExitOnError = false
+	return p
+}
+
+func TestCommandLsp_Construction(t *testing.T) {
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandLsp(testCliParams(), ioStreams, "scafctl")
+	assert.Equal(t, "lsp", cmd.Name())
+	require.NotNil(t, cmd.RunE)
+	assert.NoError(t, cmd.Args(cmd, []string{}))
+	assert.Error(t, cmd.Args(cmd, []string{"unexpected"}), "lsp takes no positional args")
+}
+
+func TestCommandLsp_EmbedderBinaryName(t *testing.T) {
+	p := settings.NewCliParams()
+	p.ExitOnError = false
+	p.BinaryName = "mycli"
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := CommandLsp(p, ioStreams, "mycli")
+	assert.Contains(t, cmd.Long, "mycli language server")
+	assert.NotContains(t, cmd.Long, "scafctl language server")
+}

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -30,6 +30,7 @@ import (
 	inspectcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/inspect"
 	kubecmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/kube"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/lint"
+	lspcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/lsp"
 	mcpcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/mcp"
 	newcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/new"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/options"
@@ -952,6 +953,7 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 
 	// Server Commands
 	cCmd.AddCommand(withGroup(groupServer, servecmd.CommandServe(cliParams, ioStreams, binaryName)))
+	cCmd.AddCommand(withGroup(groupServer, lspcmd.CommandLsp(cliParams, ioStreams, binaryName)))
 
 	// Other Commands (no group — shown under "Additional Commands:")
 	cCmd.AddCommand(version.CommandVersion(cliParams, ioStreams, binaryName, opts.VersionExtra))

--- a/pkg/lsp/diagnostics.go
+++ b/pkg/lsp/diagnostics.go
@@ -1,0 +1,120 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package lsp implements the language-server features for solution files. The
+// logic here is transport-agnostic and testable in isolation; the glsp wiring
+// and the `lsp` command are thin layers on top.
+package lsp
+
+import (
+	"bytes"
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/oakwood-commons/scafctl/pkg/lint"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Diagnostics parses solution content, runs lint, and maps the findings to LSP
+// diagnostics. source labels each diagnostic (typically the binary name). A
+// whole-document parse failure yields a single diagnostic at the top of the
+// file. The returned slice is always non-nil so callers can publish it to clear
+// stale diagnostics when there are none.
+//
+// Character offsets are counted per rune, which is correct for ASCII/BMP text
+// (the overwhelming case for solution files); astral-plane characters before a
+// finding could shift the column under the LSP's UTF-16 convention.
+func Diagnostics(content []byte, filePath, source string, registry *provider.Registry) []protocol.Diagnostic {
+	sol := &solution.Solution{}
+	if err := sol.UnmarshalFromBytes(content); err != nil {
+		return []protocol.Diagnostic{parseErrorDiagnostic(err, source)}
+	}
+
+	result := lint.Solution(sol, filePath, registry)
+	lines := bytes.Split(content, []byte("\n"))
+
+	diags := make([]protocol.Diagnostic, 0, len(result.Findings))
+	for _, f := range result.Findings {
+		diags = append(diags, findingToDiagnostic(f, lines, source))
+	}
+	return diags
+}
+
+// parseErrorDiagnostic reports a whole-document parse failure at the top of the
+// file.
+func parseErrorDiagnostic(err error, source string) protocol.Diagnostic {
+	sev := protocol.DiagnosticSeverityError
+	src := source
+	code := protocol.IntegerOrString{Value: "parse-error"}
+	return protocol.Diagnostic{
+		Range: protocol.Range{
+			Start: protocol.Position{Line: 0, Character: 0},
+			End:   protocol.Position{Line: 0, Character: 1},
+		},
+		Severity: &sev,
+		Source:   &src,
+		Code:     &code,
+		Message:  fmt.Sprintf("failed to parse solution: %v", err),
+	}
+}
+
+// findingToDiagnostic maps a single lint finding to an LSP diagnostic, spanning
+// from the finding's column to the end of its line so the squiggle is visible.
+func findingToDiagnostic(f *lint.Finding, lines [][]byte, source string) protocol.Diagnostic {
+	line := f.Line - 1 // lint lines are 1-based; LSP is 0-based
+	if line < 0 {
+		line = 0
+	}
+	startChar := f.Column - 1
+	if startChar < 0 {
+		startChar = 0
+	}
+
+	endChar := startChar + 1
+	if line < len(lines) {
+		lineRunes := utf8.RuneCount(bytes.TrimRight(lines[line], "\r"))
+		if startChar > lineRunes {
+			startChar = lineRunes
+		}
+		endChar = lineRunes
+		if endChar <= startChar {
+			endChar = startChar + 1
+		}
+	}
+
+	sev := severityFor(f.Severity)
+	src := source
+	code := protocol.IntegerOrString{Value: f.RuleName}
+
+	msg := f.Message
+	if f.Suggestion != "" {
+		msg = fmt.Sprintf("%s (%s)", f.Message, f.Suggestion)
+	}
+
+	return protocol.Diagnostic{
+		Range: protocol.Range{
+			Start: protocol.Position{Line: uint32(line), Character: uint32(startChar)},
+			End:   protocol.Position{Line: uint32(line), Character: uint32(endChar)},
+		},
+		Severity: &sev,
+		Source:   &src,
+		Code:     &code,
+		Message:  msg,
+	}
+}
+
+// severityFor maps a lint severity to an LSP diagnostic severity.
+func severityFor(s lint.SeverityLevel) protocol.DiagnosticSeverity {
+	switch s {
+	case lint.SeverityError:
+		return protocol.DiagnosticSeverityError
+	case lint.SeverityWarning:
+		return protocol.DiagnosticSeverityWarning
+	case lint.SeverityInfo:
+		return protocol.DiagnosticSeverityInformation
+	default:
+		return protocol.DiagnosticSeverityInformation
+	}
+}

--- a/pkg/lsp/diagnostics_test.go
+++ b/pkg/lsp/diagnostics_test.go
@@ -1,0 +1,70 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+func TestDiagnostics_ParseError(t *testing.T) {
+	diags := Diagnostics([]byte(":\n  :\n    :"), "bad.yaml", "scafctl", nil)
+	require.Len(t, diags, 1)
+	assert.Equal(t, protocol.DiagnosticSeverityError, *diags[0].Severity)
+	assert.Contains(t, diags[0].Message, "failed to parse solution")
+	assert.Equal(t, "scafctl", *diags[0].Source)
+}
+
+func TestDiagnostics_CleanReturnsNonNil(t *testing.T) {
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	content := []byte(`apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: clean
+spec:
+  resolvers:
+    appName:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: hello
+`)
+	diags := Diagnostics(content, "clean.yaml", "scafctl", reg)
+	assert.NotNil(t, diags, "must be non-nil so publishing clears stale diagnostics")
+}
+
+func TestDiagnostics_UndefinedResolverProducesPositioned(t *testing.T) {
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	content := []byte(`apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: bad
+spec:
+  resolvers:
+    appName:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.doesNotExist
+`)
+	diags := Diagnostics(content, "bad.yaml", "scafctl", reg)
+	require.NotEmpty(t, diags, "an unknown resolver reference should produce a finding")
+	// Every diagnostic has a source, a rule code, and a valid range.
+	for _, d := range diags {
+		require.NotNil(t, d.Severity)
+		assert.Equal(t, "scafctl", *d.Source)
+		require.NotNil(t, d.Code)
+		assert.GreaterOrEqual(t, d.Range.End.Character, d.Range.Start.Character)
+	}
+}

--- a/pkg/lsp/navigation.go
+++ b/pkg/lsp/navigation.go
@@ -1,0 +1,161 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/refactor"
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// loadIndex parses solution content and builds a positioned reference index.
+func loadIndex(content []byte) (*solution.Solution, *refindex.Index, error) {
+	sol := &solution.Solution{}
+	if err := sol.UnmarshalFromBytes(content); err != nil {
+		return nil, nil, err
+	}
+	idx, err := refindex.Build(sol)
+	if err != nil {
+		return nil, nil, err
+	}
+	return sol, idx, nil
+}
+
+// symbolAt returns the reference occurrence under the given LSP position, if any.
+func symbolAt(idx *refindex.Index, pos protocol.Position) (refindex.Reference, bool) {
+	for _, r := range idx.All() {
+		if rangeContains(r.Range, pos) {
+			return r, true
+		}
+	}
+	return refindex.Reference{}, false
+}
+
+// Definition returns the definition location for the symbol under pos, or nil if
+// there is no renameable symbol there. Parse errors yield no result (nil).
+func Definition(content []byte, uri protocol.DocumentUri, pos protocol.Position) *protocol.Location {
+	_, idx, err := loadIndex(content)
+	if err != nil {
+		return nil
+	}
+	ref, ok := symbolAt(idx, pos)
+	if !ok {
+		return nil
+	}
+	def, ok := idx.Definition(ref.Symbol.Name)
+	if !ok {
+		return nil
+	}
+	return &protocol.Location{URI: uri, Range: toLSPRange(def.Range)}
+}
+
+// References returns all reference locations for the symbol under pos. When
+// includeDeclaration is true the definition is included. Returns an empty slice
+// when there is no symbol under the cursor.
+func References(content []byte, uri protocol.DocumentUri, pos protocol.Position, includeDeclaration bool) []protocol.Location {
+	_, idx, err := loadIndex(content)
+	if err != nil {
+		return []protocol.Location{}
+	}
+	ref, ok := symbolAt(idx, pos)
+	if !ok {
+		return []protocol.Location{}
+	}
+
+	var refs []refindex.Reference
+	if includeDeclaration {
+		refs = idx.Occurrences(ref.Symbol.Name)
+	} else {
+		refs = idx.References(ref.Symbol.Name)
+	}
+
+	locs := make([]protocol.Location, 0, len(refs))
+	for _, r := range refs {
+		locs = append(locs, protocol.Location{URI: uri, Range: toLSPRange(r.Range)})
+	}
+	return locs
+}
+
+// PrepareRename returns the range of the renameable symbol under pos, or nil if
+// the cursor is not on a renameable symbol (the client then blocks the rename).
+func PrepareRename(content []byte, pos protocol.Position) *protocol.Range {
+	_, idx, err := loadIndex(content)
+	if err != nil {
+		return nil
+	}
+	ref, ok := symbolAt(idx, pos)
+	if !ok {
+		return nil
+	}
+	rng := toLSPRange(ref.Range)
+	return &rng
+}
+
+// Rename computes a WorkspaceEdit renaming the symbol under pos to newName. It
+// returns an error (surfaced to the client) when the cursor is not on a symbol,
+// or when the rename is rejected (invalid name, collision, or an unlocatable
+// reference that would make the rename partial).
+func Rename(content []byte, uri protocol.DocumentUri, pos protocol.Position, newName string) (*protocol.WorkspaceEdit, error) {
+	sol, idx, err := loadIndex(content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse solution: %w", err)
+	}
+	ref, ok := symbolAt(idx, pos)
+	if !ok {
+		return nil, fmt.Errorf("no renameable symbol at the cursor position")
+	}
+
+	result, err := refactor.RenameResolver(sol, ref.Symbol.Name, newName)
+	if err != nil {
+		return nil, err
+	}
+
+	edits := make([]protocol.TextEdit, 0, len(result.Edits))
+	for _, e := range result.Edits {
+		edits = append(edits, protocol.TextEdit{Range: toLSPRange(e.Range), NewText: e.NewText})
+	}
+	return &protocol.WorkspaceEdit{
+		Changes: map[protocol.DocumentUri][]protocol.TextEdit{uri: edits},
+	}, nil
+}
+
+// rangeContains reports whether the 0-based LSP position falls within the
+// 1-based source range. References occupy a single line, so containment is
+// checked on that line with an inclusive end (the cursor may sit just after the
+// last character).
+func rangeContains(r sourcepos.Range, pos protocol.Position) bool {
+	startLine := lspLine(r.Start.Line)
+	if pos.Line != startLine {
+		return false
+	}
+	return pos.Character >= lspChar(r.Start.Column) && pos.Character <= lspChar(r.End.Column)
+}
+
+func toLSPPosition(p sourcepos.Position) protocol.Position {
+	return protocol.Position{Line: lspLine(p.Line), Character: lspChar(p.Column)}
+}
+
+func toLSPRange(r sourcepos.Range) protocol.Range {
+	return protocol.Range{Start: toLSPPosition(r.Start), End: toLSPPosition(r.End)}
+}
+
+// lspLine/lspChar convert 1-based source line/column to 0-based LSP coordinates,
+// clamping at zero.
+func lspLine(line int) uint32 {
+	if line <= 1 {
+		return 0
+	}
+	return uint32(line - 1) //nolint:gosec // line-1 is a small positive int after the <=1 guard
+}
+
+func lspChar(col int) uint32 {
+	if col <= 1 {
+		return 0
+	}
+	return uint32(col - 1) //nolint:gosec // col-1 is a small positive int after the <=1 guard
+}

--- a/pkg/lsp/navigation_test.go
+++ b/pkg/lsp/navigation_test.go
@@ -1,0 +1,176 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// mkRange builds a 1-based source range from line/column pairs.
+func mkRange(startLine, startCol, endLine, endCol int) sourcepos.Range {
+	return sourcepos.Range{
+		Start: sourcepos.Position{Line: startLine, Column: startCol},
+		End:   sourcepos.Position{Line: endLine, Column: endCol},
+	}
+}
+
+const navFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: nav
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    appName:
+      dependsOn:
+        - environment
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.environment
+`
+
+const navURI = protocol.DocumentUri("file:///nav.yaml")
+
+// celRefPosition returns an LSP position at the start of the CEL reference to
+// name, using the index as the source of truth.
+func celRefPosition(t *testing.T, content string) protocol.Position {
+	t.Helper()
+	_, idx, err := loadIndex([]byte(content))
+	require.NoError(t, err)
+	for _, r := range idx.References("environment") {
+		if r.Origin == refindex.OriginCEL {
+			return toLSPPosition(r.Range.Start)
+		}
+	}
+	t.Fatalf("no CEL reference to environment found")
+	return protocol.Position{}
+}
+
+func TestDefinition_JumpsToResolverDefinition(t *testing.T) {
+	pos := celRefPosition(t, navFixture)
+	loc := Definition([]byte(navFixture), navURI, pos)
+	require.NotNil(t, loc)
+	assert.Equal(t, navURI, loc.URI)
+	// The definition is the `environment:` key on line 7 (0-based line 6).
+	assert.Equal(t, uint32(6), loc.Range.Start.Line)
+}
+
+func TestDefinition_NoSymbolReturnsNil(t *testing.T) {
+	// Line 0 (apiVersion) has no resolver reference.
+	loc := Definition([]byte(navFixture), navURI, protocol.Position{Line: 0, Character: 0})
+	assert.Nil(t, loc)
+}
+
+func TestReferences_IncludeAndExcludeDeclaration(t *testing.T) {
+	pos := celRefPosition(t, navFixture)
+
+	withDecl := References([]byte(navFixture), navURI, pos, true)
+	withoutDecl := References([]byte(navFixture), navURI, pos, false)
+
+	// environment: definition + dependsOn + CEL = 3 occurrences; uses = 2.
+	assert.Len(t, withDecl, 3)
+	assert.Len(t, withoutDecl, 2)
+	for _, l := range withDecl {
+		assert.Equal(t, navURI, l.URI)
+	}
+}
+
+func TestPrepareRename(t *testing.T) {
+	pos := celRefPosition(t, navFixture)
+	rng := PrepareRename([]byte(navFixture), pos)
+	require.NotNil(t, rng)
+	// The range should cover the "environment" identifier on the same line.
+	assert.Equal(t, pos.Line, rng.Start.Line)
+	assert.Equal(t, uint32(len("environment")), rng.End.Character-rng.Start.Character)
+
+	// Not on a symbol -> nil (client blocks the rename).
+	assert.Nil(t, PrepareRename([]byte(navFixture), protocol.Position{Line: 0, Character: 0}))
+}
+
+func TestRename_ProducesWorkspaceEdit(t *testing.T) {
+	pos := celRefPosition(t, navFixture)
+	edit, err := Rename([]byte(navFixture), navURI, pos, "env")
+	require.NoError(t, err)
+	require.NotNil(t, edit)
+
+	edits, ok := edit.Changes[navURI]
+	require.True(t, ok)
+	// definition + dependsOn + CEL = 3 edits, all to "env".
+	assert.Len(t, edits, 3)
+	for _, e := range edits {
+		assert.Equal(t, "env", e.NewText)
+	}
+}
+
+func TestRename_InvalidNameErrors(t *testing.T) {
+	pos := celRefPosition(t, navFixture)
+	_, err := Rename([]byte(navFixture), navURI, pos, "1bad")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid resolver name")
+}
+
+func TestRename_NoSymbolErrors(t *testing.T) {
+	_, err := Rename([]byte(navFixture), navURI, protocol.Position{Line: 0, Character: 0}, "env")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no renameable symbol")
+}
+
+func TestRename_RefusesWhenUnresolved(t *testing.T) {
+	// A $-rooted template reference to environment is unpositionable, so the
+	// rename must refuse -- surfaced to the client as an error.
+	fixture := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: unresolved
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    user:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.environment
+    greet:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                tmpl: "{{ $.environment }}"
+`
+	pos := celRefPosition(t, fixture)
+	_, err := Rename([]byte(fixture), navURI, pos, "env")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not be located")
+}
+
+func TestRangeContains(t *testing.T) {
+	// Range covering columns 5-11 (1-based) on line 2 (1-based).
+	r := mkRange(2, 5, 2, 12)
+	assert.True(t, rangeContains(r, protocol.Position{Line: 1, Character: 4}))  // at start
+	assert.True(t, rangeContains(r, protocol.Position{Line: 1, Character: 11})) // at end (inclusive)
+	assert.False(t, rangeContains(r, protocol.Position{Line: 1, Character: 12}))
+	assert.False(t, rangeContains(r, protocol.Position{Line: 0, Character: 5})) // wrong line
+}

--- a/pkg/lsp/server.go
+++ b/pkg/lsp/server.go
@@ -58,6 +58,10 @@ func (s *Server) Handler() *protocol.Handler {
 			full := protocol.TextDocumentSyncKindFull
 			sync.Change = &full
 		}
+		// Advertise rename with prepare support so clients validate the cursor
+		// position before prompting for a new name.
+		prepare := true
+		capabilities.RenameProvider = &protocol.RenameOptions{PrepareProvider: &prepare}
 		result := protocol.InitializeResult{
 			Capabilities: capabilities,
 			ServerInfo: &protocol.InitializeResultServerInfo{
@@ -77,6 +81,11 @@ func (s *Server) Handler() *protocol.Handler {
 	handler.TextDocumentDidChange = s.didChange
 	handler.TextDocumentDidSave = s.didSave
 	handler.TextDocumentDidClose = s.didClose
+
+	handler.TextDocumentDefinition = s.definition
+	handler.TextDocumentReferences = s.references
+	handler.TextDocumentPrepareRename = s.prepareRename
+	handler.TextDocumentRename = s.rename
 
 	return handler
 }
@@ -128,6 +137,44 @@ func (s *Server) didClose(ctx *glsp.Context, params *protocol.DidCloseTextDocume
 		Diagnostics: []protocol.Diagnostic{},
 	})
 	return nil
+}
+
+func (s *Server) definition(_ *glsp.Context, params *protocol.DefinitionParams) (any, error) {
+	content, ok := s.getDoc(params.TextDocument.URI)
+	if !ok {
+		return nil, nil
+	}
+	if loc := Definition([]byte(content), params.TextDocument.URI, params.Position); loc != nil {
+		return *loc, nil
+	}
+	return nil, nil
+}
+
+func (s *Server) references(_ *glsp.Context, params *protocol.ReferenceParams) ([]protocol.Location, error) {
+	content, ok := s.getDoc(params.TextDocument.URI)
+	if !ok {
+		return nil, nil
+	}
+	return References([]byte(content), params.TextDocument.URI, params.Position, params.Context.IncludeDeclaration), nil
+}
+
+func (s *Server) prepareRename(_ *glsp.Context, params *protocol.PrepareRenameParams) (any, error) {
+	content, ok := s.getDoc(params.TextDocument.URI)
+	if !ok {
+		return nil, nil
+	}
+	if rng := PrepareRename([]byte(content), params.Position); rng != nil {
+		return *rng, nil
+	}
+	return nil, nil
+}
+
+func (s *Server) rename(_ *glsp.Context, params *protocol.RenameParams) (*protocol.WorkspaceEdit, error) {
+	content, ok := s.getDoc(params.TextDocument.URI)
+	if !ok {
+		return nil, nil
+	}
+	return Rename([]byte(content), params.TextDocument.URI, params.Position, params.NewName)
 }
 
 // publish computes and sends diagnostics for the current content of uri.

--- a/pkg/lsp/server.go
+++ b/pkg/lsp/server.go
@@ -88,19 +88,27 @@ func (s *Server) didOpen(ctx *glsp.Context, params *protocol.DidOpenTextDocument
 }
 
 func (s *Server) didChange(ctx *glsp.Context, params *protocol.DidChangeTextDocumentParams) error {
+	updated := false
 	for _, change := range params.ContentChanges {
 		switch c := change.(type) {
 		case protocol.TextDocumentContentChangeEventWhole:
 			s.setDoc(params.TextDocument.URI, c.Text)
+			updated = true
 		case protocol.TextDocumentContentChangeEvent:
 			// Full sync: a rangeless change carries the whole document. glsp
 			// normally maps these to the Whole type; handle the raw form too.
 			if c.Range == nil {
 				s.setDoc(params.TextDocument.URI, c.Text)
+				updated = true
 			}
 		}
 	}
-	s.publish(ctx, params.TextDocument.URI)
+	// Only republish when the stored content actually changed. A client that
+	// ignores the negotiated full-sync and sends ranged changes would otherwise
+	// trigger a redundant publish of diagnostics for unchanged content.
+	if updated {
+		s.publish(ctx, params.TextDocument.URI)
+	}
 	return nil
 }
 

--- a/pkg/lsp/server.go
+++ b/pkg/lsp/server.go
@@ -1,0 +1,165 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"net/url"
+	"sync"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+	glspserver "github.com/tliron/glsp/server"
+)
+
+// Server is a language server for solution files. It keeps an in-memory copy of
+// each open document and republishes lint diagnostics on open/change/save.
+type Server struct {
+	binaryName string
+	version    string
+	registry   *provider.Registry
+
+	mu   sync.RWMutex
+	docs map[protocol.DocumentUri]string
+}
+
+// NewServer constructs a language server. binaryName labels diagnostics and the
+// server info; version is reported to the client (may be empty). registry is
+// used by lint for provider input validation.
+func NewServer(binaryName, version string, registry *provider.Registry) *Server {
+	if binaryName == "" {
+		binaryName = settings.CliBinaryName
+	}
+	return &Server{
+		binaryName: binaryName,
+		version:    version,
+		registry:   registry,
+		docs:       make(map[protocol.DocumentUri]string),
+	}
+}
+
+// Run starts the server over stdio and blocks until the client disconnects.
+func (s *Server) Run() error {
+	srv := glspserver.NewServer(s.Handler(), s.binaryName+"-lsp", false)
+	return srv.RunStdio()
+}
+
+// Handler builds the glsp protocol handler wired to this server's callbacks.
+func (s *Server) Handler() *protocol.Handler {
+	handler := &protocol.Handler{}
+
+	handler.Initialize = func(_ *glsp.Context, _ *protocol.InitializeParams) (any, error) {
+		capabilities := handler.CreateServerCapabilities()
+		// Use full-document sync so each change carries the whole text; the
+		// server does not need to apply incremental patches.
+		if sync, ok := capabilities.TextDocumentSync.(*protocol.TextDocumentSyncOptions); ok {
+			full := protocol.TextDocumentSyncKindFull
+			sync.Change = &full
+		}
+		result := protocol.InitializeResult{
+			Capabilities: capabilities,
+			ServerInfo: &protocol.InitializeResultServerInfo{
+				Name: s.binaryName + " lsp",
+			},
+		}
+		if s.version != "" {
+			result.ServerInfo.Version = &s.version
+		}
+		return result, nil
+	}
+	handler.Initialized = func(_ *glsp.Context, _ *protocol.InitializedParams) error { return nil }
+	handler.Shutdown = func(_ *glsp.Context) error { return nil }
+	handler.SetTrace = func(_ *glsp.Context, _ *protocol.SetTraceParams) error { return nil }
+
+	handler.TextDocumentDidOpen = s.didOpen
+	handler.TextDocumentDidChange = s.didChange
+	handler.TextDocumentDidSave = s.didSave
+	handler.TextDocumentDidClose = s.didClose
+
+	return handler
+}
+
+func (s *Server) didOpen(ctx *glsp.Context, params *protocol.DidOpenTextDocumentParams) error {
+	s.setDoc(params.TextDocument.URI, params.TextDocument.Text)
+	s.publish(ctx, params.TextDocument.URI)
+	return nil
+}
+
+func (s *Server) didChange(ctx *glsp.Context, params *protocol.DidChangeTextDocumentParams) error {
+	for _, change := range params.ContentChanges {
+		switch c := change.(type) {
+		case protocol.TextDocumentContentChangeEventWhole:
+			s.setDoc(params.TextDocument.URI, c.Text)
+		case protocol.TextDocumentContentChangeEvent:
+			// Full sync: a rangeless change carries the whole document. glsp
+			// normally maps these to the Whole type; handle the raw form too.
+			if c.Range == nil {
+				s.setDoc(params.TextDocument.URI, c.Text)
+			}
+		}
+	}
+	s.publish(ctx, params.TextDocument.URI)
+	return nil
+}
+
+func (s *Server) didSave(ctx *glsp.Context, params *protocol.DidSaveTextDocumentParams) error {
+	if params.Text != nil {
+		s.setDoc(params.TextDocument.URI, *params.Text)
+	}
+	s.publish(ctx, params.TextDocument.URI)
+	return nil
+}
+
+func (s *Server) didClose(ctx *glsp.Context, params *protocol.DidCloseTextDocumentParams) error {
+	s.deleteDoc(params.TextDocument.URI)
+	// Clear diagnostics for the closed document.
+	ctx.Notify(protocol.ServerTextDocumentPublishDiagnostics, protocol.PublishDiagnosticsParams{
+		URI:         params.TextDocument.URI,
+		Diagnostics: []protocol.Diagnostic{},
+	})
+	return nil
+}
+
+// publish computes and sends diagnostics for the current content of uri.
+func (s *Server) publish(ctx *glsp.Context, uri protocol.DocumentUri) {
+	content, ok := s.getDoc(uri)
+	if !ok {
+		return
+	}
+	diags := Diagnostics([]byte(content), uriToPath(uri), s.binaryName, s.registry)
+	ctx.Notify(protocol.ServerTextDocumentPublishDiagnostics, protocol.PublishDiagnosticsParams{
+		URI:         uri,
+		Diagnostics: diags,
+	})
+}
+
+func (s *Server) setDoc(uri protocol.DocumentUri, content string) {
+	s.mu.Lock()
+	s.docs[uri] = content
+	s.mu.Unlock()
+}
+
+func (s *Server) getDoc(uri protocol.DocumentUri) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	c, ok := s.docs[uri]
+	return c, ok
+}
+
+func (s *Server) deleteDoc(uri protocol.DocumentUri) {
+	s.mu.Lock()
+	delete(s.docs, uri)
+	s.mu.Unlock()
+}
+
+// uriToPath converts a file:// document URI to a filesystem path, falling back
+// to the raw string for non-file URIs.
+func uriToPath(uri protocol.DocumentUri) string {
+	u, err := url.Parse(string(uri))
+	if err != nil || u.Scheme != "file" {
+		return string(uri)
+	}
+	return u.Path
+}

--- a/pkg/lsp/server_test.go
+++ b/pkg/lsp/server_test.go
@@ -1,0 +1,138 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider/builtin"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+const badSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: bad
+spec:
+  resolvers:
+    appName:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.doesNotExist
+`
+
+// captureContext returns a glsp.Context whose Notify records the last published
+// method and params.
+func captureContext(method *string, params *protocol.PublishDiagnosticsParams) *glsp.Context {
+	return &glsp.Context{
+		Notify: func(m string, p any) {
+			*method = m
+			if pd, ok := p.(protocol.PublishDiagnosticsParams); ok {
+				*params = pd
+			}
+		},
+	}
+}
+
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	reg, err := builtin.DefaultRegistry(context.Background())
+	require.NoError(t, err)
+	return NewServer("scafctl", "test", reg)
+}
+
+func TestServer_DidOpenPublishesDiagnostics(t *testing.T) {
+	s := newTestServer(t)
+	var method string
+	var params protocol.PublishDiagnosticsParams
+	ctx := captureContext(&method, &params)
+
+	err := s.didOpen(ctx, &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{URI: "file:///t.yaml", Text: badSolution},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, string(protocol.ServerTextDocumentPublishDiagnostics), method)
+	assert.Equal(t, protocol.DocumentUri("file:///t.yaml"), params.URI)
+	assert.NotEmpty(t, params.Diagnostics, "undefined resolver should surface a diagnostic")
+}
+
+func TestServer_DidChangeRepublishes(t *testing.T) {
+	s := newTestServer(t)
+	var method string
+	var params protocol.PublishDiagnosticsParams
+	ctx := captureContext(&method, &params)
+
+	// Open clean, then change to the bad content.
+	require.NoError(t, s.didOpen(ctx, &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{URI: "file:///t.yaml", Text: "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: ok\nspec:\n  resolvers:\n    a:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value: x\n"},
+	}))
+
+	err := s.didChange(ctx, &protocol.DidChangeTextDocumentParams{
+		TextDocument: protocol.VersionedTextDocumentIdentifier{
+			TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: "file:///t.yaml"},
+		},
+		ContentChanges: []any{protocol.TextDocumentContentChangeEventWhole{Text: badSolution}},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, params.Diagnostics, "changed content should be re-linted")
+}
+
+func TestServer_DidCloseClearsDiagnostics(t *testing.T) {
+	s := newTestServer(t)
+	var method string
+	var params protocol.PublishDiagnosticsParams
+	ctx := captureContext(&method, &params)
+
+	require.NoError(t, s.didOpen(ctx, &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{URI: "file:///t.yaml", Text: badSolution},
+	}))
+	require.NotEmpty(t, params.Diagnostics)
+
+	err := s.didClose(ctx, &protocol.DidCloseTextDocumentParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: "file:///t.yaml"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, string(protocol.ServerTextDocumentPublishDiagnostics), method)
+	assert.Empty(t, params.Diagnostics, "closing a document clears its diagnostics")
+
+	// The document is forgotten.
+	_, ok := s.getDoc("file:///t.yaml")
+	assert.False(t, ok)
+}
+
+func TestServer_InitializeAdvertisesFullSync(t *testing.T) {
+	s := newTestServer(t)
+	handler := s.Handler()
+	res, err := handler.Initialize(&glsp.Context{}, &protocol.InitializeParams{})
+	require.NoError(t, err)
+
+	init, ok := res.(protocol.InitializeResult)
+	require.True(t, ok)
+	require.NotNil(t, init.ServerInfo)
+	assert.Equal(t, "scafctl lsp", init.ServerInfo.Name)
+
+	sync, ok := init.Capabilities.TextDocumentSync.(*protocol.TextDocumentSyncOptions)
+	require.True(t, ok)
+	require.NotNil(t, sync.Change)
+	assert.Equal(t, protocol.TextDocumentSyncKindFull, *sync.Change)
+}
+
+func TestNewServer_DefaultsBinaryName(t *testing.T) {
+	s := NewServer("", "", nil)
+	assert.Equal(t, settings.CliBinaryName, s.binaryName)
+}
+
+func TestURIToPath(t *testing.T) {
+	assert.Equal(t, "/tmp/solution.yaml", uriToPath("file:///tmp/solution.yaml"))
+	assert.Equal(t, "not-a-uri", uriToPath("not-a-uri"))
+}

--- a/pkg/lsp/server_test.go
+++ b/pkg/lsp/server_test.go
@@ -87,6 +87,34 @@ func TestServer_DidChangeRepublishes(t *testing.T) {
 	assert.NotEmpty(t, params.Diagnostics, "changed content should be re-linted")
 }
 
+func TestServer_DidChangeIgnoresRangedChangeUnderFullSync(t *testing.T) {
+	s := newTestServer(t)
+
+	// Seed a document via didOpen (uses a throwaway context).
+	var openMethod string
+	var openParams protocol.PublishDiagnosticsParams
+	require.NoError(t, s.didOpen(captureContext(&openMethod, &openParams), &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{URI: "file:///t.yaml", Text: badSolution},
+	}))
+
+	// A client that ignores the negotiated full-sync and sends a ranged
+	// (incremental) change: the server cannot apply it, so it must not update
+	// stored content nor republish diagnostics.
+	var method string
+	var params protocol.PublishDiagnosticsParams
+	ctx := captureContext(&method, &params)
+	err := s.didChange(ctx, &protocol.DidChangeTextDocumentParams{
+		TextDocument: protocol.VersionedTextDocumentIdentifier{
+			TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: "file:///t.yaml"},
+		},
+		ContentChanges: []any{protocol.TextDocumentContentChangeEvent{
+			Range: &protocol.Range{}, Text: "ignored",
+		}},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, method, "a ranged change under full-sync must not republish diagnostics")
+}
+
 func TestServer_DidCloseClearsDiagnostics(t *testing.T) {
 	s := newTestServer(t)
 	var method string
@@ -135,4 +163,7 @@ func TestNewServer_DefaultsBinaryName(t *testing.T) {
 func TestURIToPath(t *testing.T) {
 	assert.Equal(t, "/tmp/solution.yaml", uriToPath("file:///tmp/solution.yaml"))
 	assert.Equal(t, "not-a-uri", uriToPath("not-a-uri"))
+	// url.Parse decodes percent-escapes into u.Path, so the returned path is a
+	// real filesystem path (spaces, not %20).
+	assert.Equal(t, "/tmp/my dir/solution.yaml", uriToPath("file:///tmp/my%20dir/solution.yaml"))
 }

--- a/pkg/lsp/server_test.go
+++ b/pkg/lsp/server_test.go
@@ -167,3 +167,71 @@ func TestURIToPath(t *testing.T) {
 	// real filesystem path (spaces, not %20).
 	assert.Equal(t, "/tmp/my dir/solution.yaml", uriToPath("file:///tmp/my%20dir/solution.yaml"))
 }
+
+func TestServer_NavigationHandlers(t *testing.T) {
+	s := newTestServer(t)
+	uri := protocol.DocumentUri("file:///nav.yaml")
+	noop := &glsp.Context{Notify: func(string, any) {}}
+	require.NoError(t, s.didOpen(noop, &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{URI: uri, Text: navFixture},
+	}))
+
+	pos := celRefPosition(t, navFixture)
+	tdp := protocol.TextDocumentPositionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Position:     pos,
+	}
+
+	def, err := s.definition(nil, &protocol.DefinitionParams{TextDocumentPositionParams: tdp})
+	require.NoError(t, err)
+	require.NotNil(t, def)
+
+	refs, err := s.references(nil, &protocol.ReferenceParams{
+		TextDocumentPositionParams: tdp,
+		Context:                    protocol.ReferenceContext{IncludeDeclaration: true},
+	})
+	require.NoError(t, err)
+	assert.Len(t, refs, 3)
+
+	prep, err := s.prepareRename(nil, &protocol.PrepareRenameParams{TextDocumentPositionParams: tdp})
+	require.NoError(t, err)
+	require.NotNil(t, prep)
+
+	we, err := s.rename(nil, &protocol.RenameParams{TextDocumentPositionParams: tdp, NewName: "env"})
+	require.NoError(t, err)
+	require.NotNil(t, we)
+	assert.Len(t, we.Changes[uri], 3)
+}
+
+func TestServer_NavigationHandlersOnUnknownDoc(t *testing.T) {
+	s := newTestServer(t)
+	tdp := protocol.TextDocumentPositionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: "file:///missing.yaml"},
+		Position:     protocol.Position{Line: 0, Character: 0},
+	}
+	def, err := s.definition(nil, &protocol.DefinitionParams{TextDocumentPositionParams: tdp})
+	require.NoError(t, err)
+	assert.Nil(t, def)
+
+	refs, err := s.references(nil, &protocol.ReferenceParams{TextDocumentPositionParams: tdp})
+	require.NoError(t, err)
+	assert.Nil(t, refs)
+
+	we, err := s.rename(nil, &protocol.RenameParams{TextDocumentPositionParams: tdp, NewName: "x"})
+	require.NoError(t, err)
+	assert.Nil(t, we)
+}
+
+func TestServer_InitializeAdvertisesNavigationCapabilities(t *testing.T) {
+	s := newTestServer(t)
+	res, err := s.Handler().Initialize(&glsp.Context{}, &protocol.InitializeParams{})
+	require.NoError(t, err)
+	init := res.(protocol.InitializeResult)
+
+	assert.Equal(t, true, init.Capabilities.DefinitionProvider)
+	assert.Equal(t, true, init.Capabilities.ReferencesProvider)
+	rename, ok := init.Capabilities.RenameProvider.(*protocol.RenameOptions)
+	require.True(t, ok, "rename should advertise prepare support")
+	require.NotNil(t, rename.PrepareProvider)
+	assert.True(t, *rename.PrepareProvider)
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13704,3 +13704,60 @@ func TestIntegration_RefactorHelp(t *testing.T) {
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "rename")
 }
+
+// ── lsp (language server over stdio) ─────────────────────────────────────────
+
+// lspFrame wraps a JSON-RPC message in an LSP Content-Length frame.
+func lspFrame(t *testing.T, v any) []byte {
+	t.Helper()
+	body, err := json.Marshal(v)
+	require.NoError(t, err)
+	return append([]byte(fmt.Sprintf("Content-Length: %d\r\n\r\n", len(body))), body...)
+}
+
+func TestIntegration_LspHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "lsp", "--help")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "language server")
+	assert.Contains(t, stdout, "LSP")
+}
+
+func TestIntegration_LspInitializeAndDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	badSolution := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: bad\nspec:\n  resolvers:\n    appName:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value:\n                expr: _.doesNotExist\n"
+
+	msgs := [][]byte{
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{"capabilities": map[string]any{}}}),
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "method": "initialized", "params": map[string]any{}}),
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": map[string]any{
+			"textDocument": map[string]any{"uri": "file:///tmp/bad.yaml", "languageId": "yaml", "version": 1, "text": badSolution},
+		}}),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binaryPath, "lsp")
+	cmd.Dir = findProjectRoot()
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	var outBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	require.NoError(t, cmd.Start())
+
+	for _, m := range msgs {
+		_, _ = stdin.Write(m)
+		time.Sleep(150 * time.Millisecond)
+	}
+	time.Sleep(700 * time.Millisecond)
+	_ = stdin.Close()
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+
+	out := outBuf.String()
+	assert.Contains(t, out, `"capabilities"`, "initialize response")
+	assert.Contains(t, out, "scafctl lsp", "server info")
+	assert.Contains(t, out, "publishDiagnostics", "diagnostics notification")
+	assert.Contains(t, out, "doesNotExist", "the finding message")
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13789,4 +13789,53 @@ func TestIntegration_LspInitializeAndDiagnostics(t *testing.T) {
 	assert.Contains(t, out, "scafctl lsp", "server info")
 	assert.Contains(t, out, "publishDiagnostics", "diagnostics notification")
 	assert.Contains(t, out, "doesNotExist", "the finding message")
+	// Navigation capabilities are advertised.
+	assert.Contains(t, out, "definitionProvider", "go-to-definition capability")
+	assert.Contains(t, out, "referencesProvider", "find-references capability")
+	assert.Contains(t, out, "renameProvider", "rename capability")
+}
+
+func TestIntegration_LspRename(t *testing.T) {
+	t.Parallel()
+
+	// "environment:" is defined on line 6 (0-based); the cursor at line 6 char 6
+	// sits inside that identifier.
+	sol := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: nav\nspec:\n  resolvers:\n    environment:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value: dev\n    appName:\n      dependsOn:\n        - environment\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value:\n                expr: _.environment\n"
+
+	msgs := [][]byte{
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{"capabilities": map[string]any{}}}),
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "method": "initialized", "params": map[string]any{}}),
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": map[string]any{
+			"textDocument": map[string]any{"uri": "file:///nav.yaml", "languageId": "yaml", "version": 1, "text": sol},
+		}}),
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "id": 2, "method": "textDocument/rename", "params": map[string]any{
+			"textDocument": map[string]any{"uri": "file:///nav.yaml"},
+			"position":     map[string]any{"line": 6, "character": 6},
+			"newName":      "env",
+		}}),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binaryPath, "lsp")
+	cmd.Dir = findProjectRoot()
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	var outBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	require.NoError(t, cmd.Start())
+
+	for _, m := range msgs {
+		_, _ = stdin.Write(m)
+		time.Sleep(150 * time.Millisecond)
+	}
+	time.Sleep(700 * time.Millisecond)
+	_ = stdin.Close()
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+
+	out := outBuf.String()
+	assert.Contains(t, out, `"changes"`, "rename returns a workspace edit")
+	assert.Contains(t, out, `"newText":"env"`, "edits rename to env")
+	assert.Contains(t, out, "file:///nav.yaml", "edits target the document")
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13715,6 +13715,25 @@ func lspFrame(t *testing.T, v any) []byte {
 	return append([]byte(fmt.Sprintf("Content-Length: %d\r\n\r\n", len(body))), body...)
 }
 
+// lockedBuffer is a bytes.Buffer safe for concurrent Write (by the child
+// process pipe) and String reads (by the test poll loop).
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
 func TestIntegration_LspHelp(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "lsp", "--help")
@@ -13742,15 +13761,25 @@ func TestIntegration_LspInitializeAndDiagnostics(t *testing.T) {
 	cmd.Dir = findProjectRoot()
 	stdin, err := cmd.StdinPipe()
 	require.NoError(t, err)
-	var outBuf bytes.Buffer
+	var outBuf lockedBuffer
 	cmd.Stdout = &outBuf
 	require.NoError(t, cmd.Start())
 
 	for _, m := range msgs {
-		_, _ = stdin.Write(m)
-		time.Sleep(150 * time.Millisecond)
+		_, werr := stdin.Write(m)
+		require.NoError(t, werr, "write LSP frame to server stdin")
 	}
-	time.Sleep(700 * time.Millisecond)
+
+	// Wait until the diagnostics notification for the bad solution appears
+	// instead of sleeping a fixed amount, so the test is not flaky under load.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(outBuf.String(), "publishDiagnostics") &&
+			strings.Contains(outBuf.String(), "doesNotExist") {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 	_ = stdin.Close()
 	_ = cmd.Process.Kill()
 	_ = cmd.Wait()


### PR DESCRIPTION
## Summary

Add `scafctl lsp`, a Language Server Protocol (LSP) server over stdio for editor
integration. It publishes lint diagnostics for solution files as you edit them,
reusing the same `lint` engine as `scafctl lint`, so editor and CLI diagnostics
match. This is the first slice of editor support and the foundation a VS Code
extension will build on.

## What's included

- `pkg/lsp`: transport-agnostic server logic.
  - `Diagnostics(content, path, source, registry)` -- a pure function mapping lint
    findings to LSP diagnostics (severity, message, rule code, source range), with
    a whole-document parse-error fallback. Always returns a non-nil slice so
    publishing clears stale diagnostics.
  - `Server` -- a glsp-based handler: full-document sync, an in-memory document
    store, and republish on open/change/save; `didClose` clears diagnostics.
    `didChange` republishes only when the stored content actually changed, so a
    client that ignores the negotiated full-sync and sends ranged (incremental)
    changes does not trigger a redundant publish for unchanged content.
- `scafctl lsp` command (stdio), registered in the server command group and
  embedder-safe (binary name threaded into help and server info; version from the
  embedder or engine build).
- Docs: a CLI design-doc section and a short LSP tutorial.

## How it works

An editor / LSP client launches `scafctl lsp` and speaks JSON-RPC over stdio. On
`textDocument/didOpen`/`didChange`/`didSave` the server lints the in-memory
document and sends `textDocument/publishDiagnostics`. stdout is the protocol
channel; logging is disabled (commonlog's default nil backend), so stdout stays
clean for JSON-RPC.

## Dependencies

Adds `github.com/tliron/glsp` (LSP protocol types + server) and its transitive
deps (commonlog, kutil, sourcegraph/jsonrpc2, go-deadlock, goid, strcase).

## Testing

- Unit tests: diagnostics mapping (parse error, clean, positioned findings) and
  server handlers (open/change/close publish and clear, initialize advertises
  full sync, URI->path), including a case asserting a ranged change under
  full-sync does not republish, and that `uriToPath` returns a real filesystem
  path for percent-escaped URIs. Run with `-race`.
- Integration test: drives the built binary over real stdio -- `initialize` +
  `didOpen` yields capabilities, server info, and a `publishDiagnostics`
  notification carrying the finding. The test checks stdin write errors and polls
  (with a timeout) for the diagnostics notification via a mutex-guarded buffer
  instead of relying on fixed sleeps, so it is not flaky under load.
- gofmt/vet clean; `go mod tidy` idempotent; golangci-lint (new-from-merge-base)
  reports no new issues.

## Follow-up (not in this PR)

- LSP go-to-definition, find-references, and rename, reusing the positioned
  reference index (`refindex`) that powers `refactor rename`.
- A thin VS Code extension (separate repo) that launches `scafctl lsp`.
