### PR TITLE
feat: add LSP go-to-definition, find-references, and rename for resolvers

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -1104,10 +1104,20 @@ rule name to an LSP diagnostic anchored at the finding's location. It advertises
 full-document sync and reuses the same `lint` engine as `scafctl lint`, so
 editor diagnostics match the CLI.
 
+It also provides resolver navigation and refactoring, reusing the same
+positioned reference index (`refindex`) and rename engine (`refactor`) as
+`refactor rename resolver`:
+
+- **Go-to-definition** (`textDocument/definition`) -- jump from any resolver
+  reference to its definition.
+- **Find references** (`textDocument/references`) -- list every use of a resolver.
+- **Rename** (`textDocument/rename`, with `prepareRename`) -- rename a resolver
+  and every reference to it as a single `WorkspaceEdit`. The same fail-safe
+  applies: if a reference cannot be located, the rename is refused and the error
+  is surfaced to the editor rather than a partial rewrite being applied.
+
 An editor client configures the server by pointing at the `scafctl lsp` command
-and associating it with the solution file language (YAML). Future revisions will
-add go-to-definition, find-references, and rename (reusing the same reference
-index that powers `refactor rename`).
+and associating it with the solution file language (YAML).
 
 ---
 

--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -27,6 +27,16 @@ the in-memory document and reports each finding (severity, message, rule name)
 at its source location, using the same engine as `scafctl lint` -- so what you
 see in the editor matches the CLI.
 
+It also supports resolver **navigation and rename**, reusing the same reference
+index and rename engine as `scafctl refactor rename resolver`:
+
+- **Go to definition** on a resolver reference jumps to where the resolver is
+  defined.
+- **Find all references** lists every use of a resolver.
+- **Rename** a resolver updates its definition and every reference in one edit.
+  If any reference cannot be located, the rename is refused (the editor shows the
+  error) rather than applying a partial, solution-breaking change.
+
 ## Trying it by hand
 
 You normally never run the server directly, but you can confirm it starts:
@@ -54,8 +64,9 @@ needed to keep editor and CLI diagnostics consistent.
 
 ## What's next
 
-Planned additions build on the same positioned reference index that powers
-`refactor rename`: go-to-definition, find-references, and in-editor rename.
+Navigation and rename currently cover resolvers. Planned additions extend the
+same reference index to actions, functions, and calls, and add hover and
+completion.
 
 ## See also
 

--- a/pkg/lsp/navigation.go
+++ b/pkg/lsp/navigation.go
@@ -1,0 +1,161 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/refactor"
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// loadIndex parses solution content and builds a positioned reference index.
+func loadIndex(content []byte) (*solution.Solution, *refindex.Index, error) {
+	sol := &solution.Solution{}
+	if err := sol.UnmarshalFromBytes(content); err != nil {
+		return nil, nil, err
+	}
+	idx, err := refindex.Build(sol)
+	if err != nil {
+		return nil, nil, err
+	}
+	return sol, idx, nil
+}
+
+// symbolAt returns the reference occurrence under the given LSP position, if any.
+func symbolAt(idx *refindex.Index, pos protocol.Position) (refindex.Reference, bool) {
+	for _, r := range idx.All() {
+		if rangeContains(r.Range, pos) {
+			return r, true
+		}
+	}
+	return refindex.Reference{}, false
+}
+
+// Definition returns the definition location for the symbol under pos, or nil if
+// there is no renameable symbol there. Parse errors yield no result (nil).
+func Definition(content []byte, uri protocol.DocumentUri, pos protocol.Position) *protocol.Location {
+	_, idx, err := loadIndex(content)
+	if err != nil {
+		return nil
+	}
+	ref, ok := symbolAt(idx, pos)
+	if !ok {
+		return nil
+	}
+	def, ok := idx.Definition(ref.Symbol.Name)
+	if !ok {
+		return nil
+	}
+	return &protocol.Location{URI: uri, Range: toLSPRange(def.Range)}
+}
+
+// References returns all reference locations for the symbol under pos. When
+// includeDeclaration is true the definition is included. Returns an empty slice
+// when there is no symbol under the cursor.
+func References(content []byte, uri protocol.DocumentUri, pos protocol.Position, includeDeclaration bool) []protocol.Location {
+	_, idx, err := loadIndex(content)
+	if err != nil {
+		return []protocol.Location{}
+	}
+	ref, ok := symbolAt(idx, pos)
+	if !ok {
+		return []protocol.Location{}
+	}
+
+	var refs []refindex.Reference
+	if includeDeclaration {
+		refs = idx.Occurrences(ref.Symbol.Name)
+	} else {
+		refs = idx.References(ref.Symbol.Name)
+	}
+
+	locs := make([]protocol.Location, 0, len(refs))
+	for _, r := range refs {
+		locs = append(locs, protocol.Location{URI: uri, Range: toLSPRange(r.Range)})
+	}
+	return locs
+}
+
+// PrepareRename returns the range of the renameable symbol under pos, or nil if
+// the cursor is not on a renameable symbol (the client then blocks the rename).
+func PrepareRename(content []byte, pos protocol.Position) *protocol.Range {
+	_, idx, err := loadIndex(content)
+	if err != nil {
+		return nil
+	}
+	ref, ok := symbolAt(idx, pos)
+	if !ok {
+		return nil
+	}
+	rng := toLSPRange(ref.Range)
+	return &rng
+}
+
+// Rename computes a WorkspaceEdit renaming the symbol under pos to newName. It
+// returns an error (surfaced to the client) when the cursor is not on a symbol,
+// or when the rename is rejected (invalid name, collision, or an unlocatable
+// reference that would make the rename partial).
+func Rename(content []byte, uri protocol.DocumentUri, pos protocol.Position, newName string) (*protocol.WorkspaceEdit, error) {
+	sol, idx, err := loadIndex(content)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse solution: %w", err)
+	}
+	ref, ok := symbolAt(idx, pos)
+	if !ok {
+		return nil, fmt.Errorf("no renameable symbol at the cursor position")
+	}
+
+	result, err := refactor.RenameResolver(sol, ref.Symbol.Name, newName)
+	if err != nil {
+		return nil, err
+	}
+
+	edits := make([]protocol.TextEdit, 0, len(result.Edits))
+	for _, e := range result.Edits {
+		edits = append(edits, protocol.TextEdit{Range: toLSPRange(e.Range), NewText: e.NewText})
+	}
+	return &protocol.WorkspaceEdit{
+		Changes: map[protocol.DocumentUri][]protocol.TextEdit{uri: edits},
+	}, nil
+}
+
+// rangeContains reports whether the 0-based LSP position falls within the
+// 1-based source range. References occupy a single line, so containment is
+// checked on that line with an inclusive end (the cursor may sit just after the
+// last character).
+func rangeContains(r sourcepos.Range, pos protocol.Position) bool {
+	startLine := lspLine(r.Start.Line)
+	if pos.Line != startLine {
+		return false
+	}
+	return pos.Character >= lspChar(r.Start.Column) && pos.Character <= lspChar(r.End.Column)
+}
+
+func toLSPPosition(p sourcepos.Position) protocol.Position {
+	return protocol.Position{Line: lspLine(p.Line), Character: lspChar(p.Column)}
+}
+
+func toLSPRange(r sourcepos.Range) protocol.Range {
+	return protocol.Range{Start: toLSPPosition(r.Start), End: toLSPPosition(r.End)}
+}
+
+// lspLine/lspChar convert 1-based source line/column to 0-based LSP coordinates,
+// clamping at zero.
+func lspLine(line int) uint32 {
+	if line <= 1 {
+		return 0
+	}
+	return uint32(line - 1) //nolint:gosec // line-1 is a small positive int after the <=1 guard
+}
+
+func lspChar(col int) uint32 {
+	if col <= 1 {
+		return 0
+	}
+	return uint32(col - 1) //nolint:gosec // col-1 is a small positive int after the <=1 guard
+}

--- a/pkg/lsp/navigation_test.go
+++ b/pkg/lsp/navigation_test.go
@@ -1,0 +1,176 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// mkRange builds a 1-based source range from line/column pairs.
+func mkRange(startLine, startCol, endLine, endCol int) sourcepos.Range {
+	return sourcepos.Range{
+		Start: sourcepos.Position{Line: startLine, Column: startCol},
+		End:   sourcepos.Position{Line: endLine, Column: endCol},
+	}
+}
+
+const navFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: nav
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    appName:
+      dependsOn:
+        - environment
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.environment
+`
+
+const navURI = protocol.DocumentUri("file:///nav.yaml")
+
+// celRefPosition returns an LSP position at the start of the CEL reference to
+// name, using the index as the source of truth.
+func celRefPosition(t *testing.T, content string) protocol.Position {
+	t.Helper()
+	_, idx, err := loadIndex([]byte(content))
+	require.NoError(t, err)
+	for _, r := range idx.References("environment") {
+		if r.Origin == refindex.OriginCEL {
+			return toLSPPosition(r.Range.Start)
+		}
+	}
+	t.Fatalf("no CEL reference to environment found")
+	return protocol.Position{}
+}
+
+func TestDefinition_JumpsToResolverDefinition(t *testing.T) {
+	pos := celRefPosition(t, navFixture)
+	loc := Definition([]byte(navFixture), navURI, pos)
+	require.NotNil(t, loc)
+	assert.Equal(t, navURI, loc.URI)
+	// The definition is the `environment:` key on line 7 (0-based line 6).
+	assert.Equal(t, uint32(6), loc.Range.Start.Line)
+}
+
+func TestDefinition_NoSymbolReturnsNil(t *testing.T) {
+	// Line 0 (apiVersion) has no resolver reference.
+	loc := Definition([]byte(navFixture), navURI, protocol.Position{Line: 0, Character: 0})
+	assert.Nil(t, loc)
+}
+
+func TestReferences_IncludeAndExcludeDeclaration(t *testing.T) {
+	pos := celRefPosition(t, navFixture)
+
+	withDecl := References([]byte(navFixture), navURI, pos, true)
+	withoutDecl := References([]byte(navFixture), navURI, pos, false)
+
+	// environment: definition + dependsOn + CEL = 3 occurrences; uses = 2.
+	assert.Len(t, withDecl, 3)
+	assert.Len(t, withoutDecl, 2)
+	for _, l := range withDecl {
+		assert.Equal(t, navURI, l.URI)
+	}
+}
+
+func TestPrepareRename(t *testing.T) {
+	pos := celRefPosition(t, navFixture)
+	rng := PrepareRename([]byte(navFixture), pos)
+	require.NotNil(t, rng)
+	// The range should cover the "environment" identifier on the same line.
+	assert.Equal(t, pos.Line, rng.Start.Line)
+	assert.Equal(t, uint32(len("environment")), rng.End.Character-rng.Start.Character)
+
+	// Not on a symbol -> nil (client blocks the rename).
+	assert.Nil(t, PrepareRename([]byte(navFixture), protocol.Position{Line: 0, Character: 0}))
+}
+
+func TestRename_ProducesWorkspaceEdit(t *testing.T) {
+	pos := celRefPosition(t, navFixture)
+	edit, err := Rename([]byte(navFixture), navURI, pos, "env")
+	require.NoError(t, err)
+	require.NotNil(t, edit)
+
+	edits, ok := edit.Changes[navURI]
+	require.True(t, ok)
+	// definition + dependsOn + CEL = 3 edits, all to "env".
+	assert.Len(t, edits, 3)
+	for _, e := range edits {
+		assert.Equal(t, "env", e.NewText)
+	}
+}
+
+func TestRename_InvalidNameErrors(t *testing.T) {
+	pos := celRefPosition(t, navFixture)
+	_, err := Rename([]byte(navFixture), navURI, pos, "1bad")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid resolver name")
+}
+
+func TestRename_NoSymbolErrors(t *testing.T) {
+	_, err := Rename([]byte(navFixture), navURI, protocol.Position{Line: 0, Character: 0}, "env")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no renameable symbol")
+}
+
+func TestRename_RefusesWhenUnresolved(t *testing.T) {
+	// A $-rooted template reference to environment is unpositionable, so the
+	// rename must refuse -- surfaced to the client as an error.
+	fixture := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: unresolved
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    user:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.environment
+    greet:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                tmpl: "{{ $.environment }}"
+`
+	pos := celRefPosition(t, fixture)
+	_, err := Rename([]byte(fixture), navURI, pos, "env")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not be located")
+}
+
+func TestRangeContains(t *testing.T) {
+	// Range covering columns 5-11 (1-based) on line 2 (1-based).
+	r := mkRange(2, 5, 2, 12)
+	assert.True(t, rangeContains(r, protocol.Position{Line: 1, Character: 4}))  // at start
+	assert.True(t, rangeContains(r, protocol.Position{Line: 1, Character: 11})) // at end (inclusive)
+	assert.False(t, rangeContains(r, protocol.Position{Line: 1, Character: 12}))
+	assert.False(t, rangeContains(r, protocol.Position{Line: 0, Character: 5})) // wrong line
+}

--- a/pkg/lsp/server.go
+++ b/pkg/lsp/server.go
@@ -58,6 +58,10 @@ func (s *Server) Handler() *protocol.Handler {
 			full := protocol.TextDocumentSyncKindFull
 			sync.Change = &full
 		}
+		// Advertise rename with prepare support so clients validate the cursor
+		// position before prompting for a new name.
+		prepare := true
+		capabilities.RenameProvider = &protocol.RenameOptions{PrepareProvider: &prepare}
 		result := protocol.InitializeResult{
 			Capabilities: capabilities,
 			ServerInfo: &protocol.InitializeResultServerInfo{
@@ -77,6 +81,11 @@ func (s *Server) Handler() *protocol.Handler {
 	handler.TextDocumentDidChange = s.didChange
 	handler.TextDocumentDidSave = s.didSave
 	handler.TextDocumentDidClose = s.didClose
+
+	handler.TextDocumentDefinition = s.definition
+	handler.TextDocumentReferences = s.references
+	handler.TextDocumentPrepareRename = s.prepareRename
+	handler.TextDocumentRename = s.rename
 
 	return handler
 }
@@ -128,6 +137,44 @@ func (s *Server) didClose(ctx *glsp.Context, params *protocol.DidCloseTextDocume
 		Diagnostics: []protocol.Diagnostic{},
 	})
 	return nil
+}
+
+func (s *Server) definition(_ *glsp.Context, params *protocol.DefinitionParams) (any, error) {
+	content, ok := s.getDoc(params.TextDocument.URI)
+	if !ok {
+		return nil, nil
+	}
+	if loc := Definition([]byte(content), params.TextDocument.URI, params.Position); loc != nil {
+		return *loc, nil
+	}
+	return nil, nil
+}
+
+func (s *Server) references(_ *glsp.Context, params *protocol.ReferenceParams) ([]protocol.Location, error) {
+	content, ok := s.getDoc(params.TextDocument.URI)
+	if !ok {
+		return nil, nil
+	}
+	return References([]byte(content), params.TextDocument.URI, params.Position, params.Context.IncludeDeclaration), nil
+}
+
+func (s *Server) prepareRename(_ *glsp.Context, params *protocol.PrepareRenameParams) (any, error) {
+	content, ok := s.getDoc(params.TextDocument.URI)
+	if !ok {
+		return nil, nil
+	}
+	if rng := PrepareRename([]byte(content), params.Position); rng != nil {
+		return *rng, nil
+	}
+	return nil, nil
+}
+
+func (s *Server) rename(_ *glsp.Context, params *protocol.RenameParams) (*protocol.WorkspaceEdit, error) {
+	content, ok := s.getDoc(params.TextDocument.URI)
+	if !ok {
+		return nil, nil
+	}
+	return Rename([]byte(content), params.TextDocument.URI, params.Position, params.NewName)
 }
 
 // publish computes and sends diagnostics for the current content of uri.

--- a/pkg/lsp/server_test.go
+++ b/pkg/lsp/server_test.go
@@ -167,3 +167,71 @@ func TestURIToPath(t *testing.T) {
 	// real filesystem path (spaces, not %20).
 	assert.Equal(t, "/tmp/my dir/solution.yaml", uriToPath("file:///tmp/my%20dir/solution.yaml"))
 }
+
+func TestServer_NavigationHandlers(t *testing.T) {
+	s := newTestServer(t)
+	uri := protocol.DocumentUri("file:///nav.yaml")
+	noop := &glsp.Context{Notify: func(string, any) {}}
+	require.NoError(t, s.didOpen(noop, &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{URI: uri, Text: navFixture},
+	}))
+
+	pos := celRefPosition(t, navFixture)
+	tdp := protocol.TextDocumentPositionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Position:     pos,
+	}
+
+	def, err := s.definition(nil, &protocol.DefinitionParams{TextDocumentPositionParams: tdp})
+	require.NoError(t, err)
+	require.NotNil(t, def)
+
+	refs, err := s.references(nil, &protocol.ReferenceParams{
+		TextDocumentPositionParams: tdp,
+		Context:                    protocol.ReferenceContext{IncludeDeclaration: true},
+	})
+	require.NoError(t, err)
+	assert.Len(t, refs, 3)
+
+	prep, err := s.prepareRename(nil, &protocol.PrepareRenameParams{TextDocumentPositionParams: tdp})
+	require.NoError(t, err)
+	require.NotNil(t, prep)
+
+	we, err := s.rename(nil, &protocol.RenameParams{TextDocumentPositionParams: tdp, NewName: "env"})
+	require.NoError(t, err)
+	require.NotNil(t, we)
+	assert.Len(t, we.Changes[uri], 3)
+}
+
+func TestServer_NavigationHandlersOnUnknownDoc(t *testing.T) {
+	s := newTestServer(t)
+	tdp := protocol.TextDocumentPositionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: "file:///missing.yaml"},
+		Position:     protocol.Position{Line: 0, Character: 0},
+	}
+	def, err := s.definition(nil, &protocol.DefinitionParams{TextDocumentPositionParams: tdp})
+	require.NoError(t, err)
+	assert.Nil(t, def)
+
+	refs, err := s.references(nil, &protocol.ReferenceParams{TextDocumentPositionParams: tdp})
+	require.NoError(t, err)
+	assert.Nil(t, refs)
+
+	we, err := s.rename(nil, &protocol.RenameParams{TextDocumentPositionParams: tdp, NewName: "x"})
+	require.NoError(t, err)
+	assert.Nil(t, we)
+}
+
+func TestServer_InitializeAdvertisesNavigationCapabilities(t *testing.T) {
+	s := newTestServer(t)
+	res, err := s.Handler().Initialize(&glsp.Context{}, &protocol.InitializeParams{})
+	require.NoError(t, err)
+	init := res.(protocol.InitializeResult)
+
+	assert.Equal(t, true, init.Capabilities.DefinitionProvider)
+	assert.Equal(t, true, init.Capabilities.ReferencesProvider)
+	rename, ok := init.Capabilities.RenameProvider.(*protocol.RenameOptions)
+	require.True(t, ok, "rename should advertise prepare support")
+	require.NotNil(t, rename.PrepareProvider)
+	assert.True(t, *rename.PrepareProvider)
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13789,4 +13789,53 @@ func TestIntegration_LspInitializeAndDiagnostics(t *testing.T) {
 	assert.Contains(t, out, "scafctl lsp", "server info")
 	assert.Contains(t, out, "publishDiagnostics", "diagnostics notification")
 	assert.Contains(t, out, "doesNotExist", "the finding message")
+	// Navigation capabilities are advertised.
+	assert.Contains(t, out, "definitionProvider", "go-to-definition capability")
+	assert.Contains(t, out, "referencesProvider", "find-references capability")
+	assert.Contains(t, out, "renameProvider", "rename capability")
+}
+
+func TestIntegration_LspRename(t *testing.T) {
+	t.Parallel()
+
+	// "environment:" is defined on line 6 (0-based); the cursor at line 6 char 6
+	// sits inside that identifier.
+	sol := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: nav\nspec:\n  resolvers:\n    environment:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value: dev\n    appName:\n      dependsOn:\n        - environment\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value:\n                expr: _.environment\n"
+
+	msgs := [][]byte{
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{"capabilities": map[string]any{}}}),
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "method": "initialized", "params": map[string]any{}}),
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": map[string]any{
+			"textDocument": map[string]any{"uri": "file:///nav.yaml", "languageId": "yaml", "version": 1, "text": sol},
+		}}),
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "id": 2, "method": "textDocument/rename", "params": map[string]any{
+			"textDocument": map[string]any{"uri": "file:///nav.yaml"},
+			"position":     map[string]any{"line": 6, "character": 6},
+			"newName":      "env",
+		}}),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binaryPath, "lsp")
+	cmd.Dir = findProjectRoot()
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	var outBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	require.NoError(t, cmd.Start())
+
+	for _, m := range msgs {
+		_, _ = stdin.Write(m)
+		time.Sleep(150 * time.Millisecond)
+	}
+	time.Sleep(700 * time.Millisecond)
+	_ = stdin.Close()
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+
+	out := outBuf.String()
+	assert.Contains(t, out, `"changes"`, "rename returns a workspace edit")
+	assert.Contains(t, out, `"newText":"env"`, "edits rename to env")
+	assert.Contains(t, out, "file:///nav.yaml", "edits target the document")
 }


### PR DESCRIPTION
## Summary

Extend the language server (#753) with resolver navigation and refactoring,
reusing the positioned reference index (`refindex`) and rename engine
(`refactor`):

- **Go-to-definition** (`textDocument/definition`) -- jump from a resolver
  reference to its definition.
- **Find references** (`textDocument/references`) -- list every use of a
  resolver (optionally including the declaration).
- **Rename** (`textDocument/rename` + `prepareRename`) -- rename a resolver and
  every reference to it as a single `WorkspaceEdit`.

The rename fail-safe carries into the editor: if a reference cannot be located
byte-exact, the rename is refused and the error is surfaced to the client rather
than a partial rewrite being applied.

## What's included

- `pkg/lsp/navigation.go` -- pure functions (`Definition`, `References`,
  `PrepareRename`, `Rename`) that resolve the symbol under the cursor via
  `refindex` and produce LSP locations / a `WorkspaceEdit`, with conversion
  between 1-based source coordinates and 0-based LSP coordinates.
- Server handlers wired for definition/references/prepareRename/rename; the
  initialize response advertises the capabilities (rename with prepare support).
- Docs updated (CLI section + tutorial).

## Testing

- Unit tests: definition jumps to the resolver key; references include/exclude
  the declaration; prepareRename returns the identifier range (nil off-symbol);
  rename produces the expected edits and surfaces invalid-name / no-symbol /
  unresolved (refused) errors.
- Server handler tests via a captured glsp context, including capability
  advertisement, with `-race`.
- Integration: real stdio `initialize` advertises definition/references/rename
  capabilities, and a `textDocument/rename` round-trip returns a `WorkspaceEdit`
  renaming to `env`.
- gofmt/vet clean; golangci-lint (new-from-merge-base) reports no new issues.

## Stacked on #753

This branch targets `feat/lsp-server` (#753) -- it builds on `pkg/lsp` from that
PR and should merge after it.

## Follow-up

- Extend navigation/rename to actions, functions, and calls.
- Hover and completion.
