### PR TITLE
fix(cache): support all KVX output formats in `cache info`

### DIFF
--- a/docs/tutorials/cache-tutorial.md
+++ b/docs/tutorials/cache-tutorial.md
@@ -65,13 +65,43 @@ scafctl cache info
 
 Output:
 ```
- 💡 Cache Information
-HTTP Cache:  2.4 MB (156 files)
-             ~/.cache/scafctl/http-cache
-Build Cache:  324 B (1 files)
-             ~/.cache/scafctl/build-cache
+NAME             SIZE      FILES  DESCRIPTION
+HTTP Cache       2.4 MB      156  HTTP response cache
+Build Cache      324 B         1  Incremental build fingerprints
+Artifact Cache   0 B           0  Downloaded catalog artifacts (TTL-based)
 Total: 2.4 MB (157 files)
 ```
+
+### Table, CSV, and Interactive Output
+
+Use standard output format flags:
+
+{{< tabs "cache-tutorial-cmd-2b" >}}
+{{% tab "Bash" %}}
+```bash
+# Table format (default)
+scafctl cache info -o table
+
+# CSV for spreadsheets/scripting
+scafctl cache info -o csv
+
+# Interactive TUI for browsing
+scafctl cache info -i
+```
+{{% /tab %}}
+{{% tab "PowerShell" %}}
+```powershell
+# Table format (default)
+scafctl cache info -o table
+
+# CSV for spreadsheets/scripting
+scafctl cache info -o csv
+
+# Interactive TUI for browsing
+scafctl cache info -i
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### JSON Output
 
@@ -109,6 +139,14 @@ Output:
       "sizeHuman": "324 B",
       "fileCount": 1,
       "description": "Incremental build fingerprints"
+    },
+    {
+      "name": "Artifact Cache",
+      "path": "/Users/me/.cache/scafctl/artifact-cache",
+      "size": 0,
+      "sizeHuman": "0 B",
+      "fileCount": 0,
+      "description": "Downloaded catalog artifacts (TTL-based)"
     }
   ],
   "totalSize": 2516906,

--- a/pkg/cmd/scafctl/cache/cache_info_schema.json
+++ b/pkg/cmd/scafctl/cache/cache_info_schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Cache Information",
+  "description": "Schema for scafctl cache directory information with display extensions",
+  "type": "array",
+
+  "x-kvx-icon": "💾",
+  "x-kvx-collectionTitle": "Caches",
+
+  "x-kvx-list": {
+    "titleField": "name",
+    "subtitleField": "description",
+    "subtitleMaxLines": 1,
+    "badgeFields": ["sizeHuman", "fileCount"]
+  },
+
+  "x-kvx-detail": {
+    "titleField": "name",
+    "hiddenFields": ["size"],
+    "sections": [
+      {
+        "title": "",
+        "fields": ["name", "description"],
+        "layout": "inline"
+      },
+      {
+        "title": "Storage",
+        "fields": ["sizeHuman", "fileCount", "path"],
+        "layout": "table"
+      }
+    ]
+  },
+
+  "items": {
+    "type": "object",
+    "required": ["name"],
+    "properties": {
+      "name": {
+        "type": "string",
+        "title": "Name",
+        "description": "Cache directory name"
+      },
+      "path": {
+        "type": "string",
+        "title": "Path",
+        "description": "Filesystem path to the cache directory"
+      },
+      "size": {
+        "type": "integer",
+        "title": "Size (bytes)",
+        "description": "Total size in bytes"
+      },
+      "sizeHuman": {
+        "type": "string",
+        "title": "Size",
+        "description": "Human-readable size"
+      },
+      "fileCount": {
+        "type": "integer",
+        "title": "Files",
+        "description": "Number of cached files"
+      },
+      "description": {
+        "type": "string",
+        "title": "Description",
+        "description": "What this cache stores"
+      }
+    }
+  }
+}

--- a/pkg/cmd/scafctl/cache/cache_test.go
+++ b/pkg/cmd/scafctl/cache/cache_test.go
@@ -4,12 +4,17 @@
 package cache
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/oakwood-commons/kvx/pkg/tui"
+	cachelib "github.com/oakwood-commons/scafctl/pkg/cache"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestCommandCache(t *testing.T) {
@@ -105,4 +110,150 @@ func TestCommandCache_UnknownSubcommandErrors(t *testing.T) {
 	cmd2.SilenceErrors = true
 	cmd2.SilenceUsage = true
 	assert.NoError(t, cmd2.Execute())
+}
+
+// ── cache info output format tests ───────────────────────────────────────────
+
+func TestCommandInfo_JSON(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, out, _ := terminal.NewTestIOStreams()
+	cmd := CommandInfo(cliParams, ioStreams, "scafctl/cache")
+	cmd.SetArgs([]string{"-o", "json"})
+
+	require.NoError(t, cmd.Execute())
+
+	var output cachelib.InfoOutput
+	require.NoError(t, json.Unmarshal(out.Bytes(), &output), "output must be valid JSON InfoOutput")
+	assert.Len(t, output.Caches, 3, "should have 3 cache entries")
+	for _, item := range output.Caches {
+		assert.NotEmpty(t, item.Name, "each cache must have a name")
+		assert.NotEmpty(t, item.Path, "each cache must have a path")
+		assert.NotEmpty(t, item.Description, "each cache must have a description")
+	}
+	assert.NotEmpty(t, output.TotalHuman, "totalHuman should be set")
+}
+
+func TestCommandInfo_YAML(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, out, _ := terminal.NewTestIOStreams()
+	cmd := CommandInfo(cliParams, ioStreams, "scafctl/cache")
+	cmd.SetArgs([]string{"-o", "yaml"})
+
+	require.NoError(t, cmd.Execute())
+
+	var output cachelib.InfoOutput
+	require.NoError(t, yaml.Unmarshal(out.Bytes(), &output), "output must be valid YAML InfoOutput")
+	assert.Len(t, output.Caches, 3, "should have 3 cache entries")
+	assert.NotEmpty(t, output.TotalHuman, "totalHuman should be set")
+}
+
+func TestCommandInfo_Quiet(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, out, _ := terminal.NewTestIOStreams()
+	cmd := CommandInfo(cliParams, ioStreams, "scafctl/cache")
+	cmd.SetArgs([]string{"-o", "quiet"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Empty(t, out.String(), "quiet mode should produce no stdout output")
+}
+
+func TestCommandInfo_DefaultFormat(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, out, _ := terminal.NewTestIOStreams()
+	cmd := CommandInfo(cliParams, ioStreams, "scafctl/cache")
+	// No -o flag: default auto format (non-TTY falls back to text)
+	cmd.SetArgs([]string{})
+
+	require.NoError(t, cmd.Execute())
+	output := out.String()
+	assert.Contains(t, output, "HTTP Cache", "default output should contain cache names")
+	assert.Contains(t, output, "Build Cache")
+	assert.Contains(t, output, "Artifact Cache")
+}
+
+func TestCommandInfo_TotalsSummaryOnStderr(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, _, errBuf := terminal.NewTestIOStreams()
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(t.Context(), w)
+
+	cmd := CommandInfo(cliParams, ioStreams, "scafctl/cache")
+	cmd.SetContext(ctx)
+	cmd.SetArgs([]string{})
+
+	require.NoError(t, cmd.Execute())
+	stderr := errBuf.String()
+	assert.Contains(t, stderr, "Total:", "stderr should contain totals summary")
+	assert.Contains(t, stderr, "files)", "stderr should contain file count")
+}
+
+func TestCommandInfo_NoTotalsForStructuredFormats(t *testing.T) {
+	t.Parallel()
+	for _, format := range []string{"json", "yaml", "csv"} {
+		t.Run(format, func(t *testing.T) {
+			t.Parallel()
+			cliParams := settings.NewCliParams()
+			ioStreams, _, errBuf := terminal.NewTestIOStreams()
+			w := writer.New(ioStreams, cliParams)
+			ctx := writer.WithWriter(t.Context(), w)
+
+			cmd := CommandInfo(cliParams, ioStreams, "scafctl/cache")
+			cmd.SetContext(ctx)
+			cmd.SetArgs([]string{"-o", format})
+
+			require.NoError(t, cmd.Execute())
+			assert.NotContains(t, errBuf.String(), "Total:", "structured format %q should not print totals on stderr", format)
+		})
+	}
+}
+
+func TestCommandInfo_CSV(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	ioStreams, out, _ := terminal.NewTestIOStreams()
+	cmd := CommandInfo(cliParams, ioStreams, "scafctl/cache")
+	cmd.SetArgs([]string{"-o", "csv"})
+
+	require.NoError(t, cmd.Execute())
+	output := out.String()
+	assert.NotEmpty(t, output, "CSV output should not be empty")
+	assert.Contains(t, output, "HTTP Cache", "CSV output should contain cache data")
+	assert.Contains(t, output, "Build Cache", "CSV output should contain all cache entries")
+	assert.Contains(t, output, "Artifact Cache", "CSV output should contain all cache entries")
+}
+
+func TestCommandInfo_EmbedderBinaryName(t *testing.T) {
+	t.Parallel()
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = "mycli"
+	ioStreams, out, _ := terminal.NewTestIOStreams()
+	cmd := CommandInfo(cliParams, ioStreams, "mycli/cache")
+	cmd.SetArgs([]string{"-o", "json"})
+
+	require.NoError(t, cmd.Execute())
+
+	var output cachelib.InfoOutput
+	require.NoError(t, json.Unmarshal(out.Bytes(), &output))
+	assert.Len(t, output.Caches, 3)
+}
+
+// ── Display schema tests ─────────────────────────────────────────────────────
+
+func TestCacheInfoDisplaySchema_IsValidJSON(t *testing.T) {
+	t.Parallel()
+	assert.True(t, json.Valid(cacheInfoSchemaJSON), "cache_info_schema.json must be valid JSON")
+}
+
+func TestCacheInfoDisplaySchema_ParsesWithDisplay(t *testing.T) {
+	t.Parallel()
+	hints, ds, err := tui.ParseSchemaWithDisplay(cacheInfoSchemaJSON)
+	require.NoError(t, err, "cache_info_schema.json must parse without error")
+	assert.NotNil(t, hints, "should produce column hints")
+	assert.NotNil(t, ds, "should produce display schema")
+	assert.Equal(t, "name", ds.List.TitleField, "list titleField should be name")
 }

--- a/pkg/cmd/scafctl/cache/info.go
+++ b/pkg/cmd/scafctl/cache/info.go
@@ -5,10 +5,12 @@ package cache
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
+	_ "embed"
+
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/kvx/pkg/tui"
 	cachelib "github.com/oakwood-commons/scafctl/pkg/cache"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
 	"github.com/oakwood-commons/scafctl/pkg/paths"
@@ -19,6 +21,9 @@ import (
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
 	"github.com/spf13/cobra"
 )
+
+//go:embed cache_info_schema.json
+var cacheInfoSchemaJSON []byte
 
 // InfoOptions holds options for the info command.
 type InfoOptions struct {
@@ -51,11 +56,16 @@ func CommandInfo(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 
 			  # Show cache info as JSON
 			  scafctl cache info -o json
+
+			  # Show cache info as a table
+			  scafctl cache info -o table
+
+			  # Browse caches interactively
+			  scafctl cache info -i
 		`), settings.CliBinaryName, cliParams.BinaryName),
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			kvxOpts := flags.ToKvxOutputOptions(&options.KvxOutputFlags, kvx.WithIOStreams(ioStreams))
-			return runInfo(cmd.Context(), options, kvxOpts)
+			return runInfo(cmd.Context(), options)
 		},
 	}
 
@@ -64,12 +74,7 @@ func CommandInfo(cliParams *settings.Run, ioStreams *terminal.IOStreams, _ strin
 	return cmd
 }
 
-func runInfo(ctx context.Context, _ *InfoOptions, outputOpts *kvx.OutputOptions) error {
-	w := writer.FromContext(ctx)
-	if w == nil {
-		return fmt.Errorf("writer not initialized in context")
-	}
-
+func runInfo(ctx context.Context, opts *InfoOptions) error {
 	// Collect cache info
 	caches := []cachelib.Info{
 		cachelib.GetCacheInfo("HTTP Cache", paths.HTTPCacheDir(), "HTTP response cache"),
@@ -80,42 +85,55 @@ func runInfo(ctx context.Context, _ *InfoOptions, outputOpts *kvx.OutputOptions)
 	// Calculate totals
 	var totalSize int64
 	var totalFiles int64
-	for _, cache := range caches {
-		totalSize += cache.Size
-		totalFiles += cache.FileCount
-	}
-
-	output := cachelib.InfoOutput{
-		Caches:     caches,
-		TotalSize:  totalSize,
-		TotalHuman: format.Bytes(totalSize),
-		TotalFiles: totalFiles,
-	}
-
-	// For structured output, use kvx
-	if outputOpts.Format == kvx.OutputFormatJSON || outputOpts.Format == kvx.OutputFormatYAML {
-		return outputOpts.Write(output)
-	}
-
-	// For table/default output, print human-readable message
-	w.Infof("Cache Information")
-	w.Plain("")
-
-	// Find max name length for alignment
-	maxNameLen := 0
 	for _, c := range caches {
-		if len(c.Name) > maxNameLen {
-			maxNameLen = len(c.Name)
+		totalSize += c.Size
+		totalFiles += c.FileCount
+	}
+
+	kvxOpts := flags.ToKvxOutputOptions(&opts.KvxOutputFlags,
+		kvx.WithOutputContext(ctx),
+		kvx.WithOutputNoColor(opts.CliParams.NoColor),
+		kvx.WithOutputAppName(opts.CliParams.BinaryName+" cache info"),
+		kvx.WithOutputDisplaySchemaJSON(cacheInfoSchemaJSON),
+		kvx.WithIOStreams(opts.IOStreams),
+		kvx.WithOutputColumnOrder([]string{"name", "sizeHuman", "fileCount", "description"}),
+		kvx.WithOutputColumnHints(map[string]tui.ColumnHint{
+			"name":        {MaxWidth: 20, Priority: 10, DisplayName: "Name"},
+			"sizeHuman":   {MaxWidth: 12, Priority: 9, DisplayName: "Size"},
+			"fileCount":   {MaxWidth: 10, Priority: 8, DisplayName: "Files", Align: "right"},
+			"description": {MaxWidth: 40, Priority: 5, Flex: true, DisplayName: "Description"},
+			"path":        {Hidden: true},
+			"size":        {Hidden: true},
+		}),
+	)
+
+	// Structured formats (JSON/YAML/TOML) use the InfoOutput wrapper with totals.
+	// Visual formats (table/list/interactive) and CSV use the flat []Info array.
+	// Mermaid is routed through writeKvx by kvx.Write() regardless of this branch.
+	if kvxOpts.Format == kvx.OutputFormatJSON || kvxOpts.Format == kvx.OutputFormatYAML || kvxOpts.Format == kvx.OutputFormatTOML {
+		output := cachelib.InfoOutput{
+			Caches:     caches,
+			TotalSize:  totalSize,
+			TotalHuman: format.Bytes(totalSize),
+			TotalFiles: totalFiles,
+		}
+		return kvxOpts.Write(output)
+	}
+
+	// Capture original format before Write() potentially mutates it (non-TTY fallback).
+	originalFormat := kvxOpts.Format
+
+	if err := kvxOpts.Write(caches); err != nil {
+		return err
+	}
+
+	// Print totals summary on stderr for human-readable formats
+	if kvx.IsKvxFormat(originalFormat) || originalFormat == kvx.OutputFormatText {
+		w := writer.FromContext(ctx)
+		if w != nil {
+			w.PlainStderrf("Total: %s (%d files)\n", format.Bytes(totalSize), totalFiles)
 		}
 	}
-
-	for _, cache := range caches {
-		w.Plainf("%-*s  %s (%d files)\n", maxNameLen, cache.Name+":", cache.SizeHuman, cache.FileCount)
-		w.Plainf("%-*s  %s\n", maxNameLen, "", cache.Path)
-		w.Plain("")
-	}
-
-	w.Plainf("Total: %s (%d files)\n", output.TotalHuman, output.TotalFiles)
 
 	return nil
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -6565,6 +6565,7 @@ func TestIntegration_CacheInfo_Empty(t *testing.T) {
 	assert.Equal(t, 0, exitCode)
 	assert.Contains(t, stdout, "totalSize")
 	assert.Contains(t, stdout, "totalFiles")
+	assert.Contains(t, stdout, "HTTP Cache")
 }
 
 func TestIntegration_CacheClear_Empty(t *testing.T) {


### PR DESCRIPTION
## Description

Route table/list/interactive/text output through `kvx.Write()` with column hints and an interactive display schema, fixing formats that previously fell through to a hand-crafted text block (only JSON/YAML worked before).

- Add `cache_info_schema.json` with `x-kvx-list`/`x-kvx-detail` extensions for rich interactive TUI rendering
- Structured formats (JSON/YAML) retain the `InfoOutput` wrapper with `totalSize`/`totalHuman`/`totalFiles` for backward compatibility
- Visual formats (table/list/interactive) use the flat `[]Info`array with column order, width caps, and flex on description
- Print totals summary on stderr for human-readable formats
- Add tests for JSON, YAML, quiet, CSV, default, embedder binary name, display schema validation, and totals-on-stderr behavior
- Update tutorial with new table/CSV/interactive examples

## Related Issues

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) guide
- [x] My commits follow conventional commit format
- [x] I have added/updated tests for my changes
- [x] `go test ./...` passes
- [x] `task lint` passes
- [x] I have signed off my commits (`git commit -s -S`)
