### PR TITLE
feat: add find_resolver_references and rename_resolver MCP tools

### DIFF
--- a/docs/tutorials/mcp-server-tutorial.md
+++ b/docs/tutorials/mcp-server-tutorial.md
@@ -38,14 +38,18 @@ Run the `--info` flag to confirm the server is built and can list its tools:
 
 {{< tabs "mcp-server-tutorial-cmd-1" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl mcp serve --info
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl mcp serve --info
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -95,14 +99,18 @@ You can start the server interactively for testing:
 
 {{< tabs "mcp-server-tutorial-cmd-2" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl mcp serve
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl mcp serve
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -430,7 +438,7 @@ No files needed — you provide the expression and data inline.
 
 > [!NOTE]
 > **You:** "Evaluate this CEL expression with sample data: `_.items.filter(i, i.enabled).map(i, i.name)`"
-> 
+>
 > Use this data: `{"items": [{"name": "alpha", "enabled": true}, {"name": "beta", "enabled": false}, {"name": "gamma", "enabled": true}]}`
 
 The AI calls `evaluate_cel` with the expression and data, and returns something like:
@@ -760,6 +768,8 @@ The AI calls `inspect_solution` with `path: "solution.yaml"` and the response in
 | `validate_expression` | Syntax-check a CEL expression or Go template without executing it — returns validity, errors, and referenced fields |
 | `catalog_inspect` | Get detailed metadata for a specific catalog artifact — version, kind, digest, created timestamp, and dependency list |
 | `extract_resolver_refs` | Find all resolver cross-references (`_.resolverName`) in a solution — shows which resolvers reference which others |
+| `find_resolver_references` | Find a resolver's definition and every reference to it in a solution (dependsOn, rslvr, CEL, template) with source locations — use before editing to see impact |
+| `rename_resolver` | Rename a resolver and every reference to it, returning the rewritten solution content (comments/formatting preserved). Refuses if the new name is invalid, collides, or a reference cannot be located |
 | `generate_test_scaffold` | Generate functional test case scaffolding for a solution — creates test YAML with assertions, tags, auto-populated file dependencies, and sandbox guidance |
 | `list_tests` | List functional tests defined in a solution's `spec.testing.cases` — shows test names, descriptions, assertions, and tags |
 | `show_snapshot` | Display the contents of a resolver execution snapshot file — resolver values, timing, status, and errors |
@@ -819,6 +829,7 @@ MCP prompts are predefined templates that guide AI agents through common workflo
 In most AI clients, prompts appear as suggested conversation starters or can be invoked explicitly. For example, in VS Code with Copilot, you might see a prompt suggestion like "Create a new scafctl solution" that fills in the context automatically.
 
 The prompts instruct the AI to:
+
 1. **Fetch the schema first** — ensuring it uses correct field names and structure
 2. **Check available providers** — so it picks real providers, not invented ones
 3. **Reference examples** — for practical patterns and best practices
@@ -832,14 +843,18 @@ Print the full tool list and verify the server starts correctly:
 
 {{< tabs "mcp-server-tutorial-cmd-3" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl mcp serve --info
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl mcp serve --info
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -849,14 +864,18 @@ When the MCP server runs over stdio, application logs go to stderr by default. F
 
 {{< tabs "mcp-server-tutorial-cmd-4" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl mcp serve --log-file /tmp/scafctl-mcp.log
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl mcp serve --log-file /tmp/scafctl-mcp.log
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -864,14 +883,18 @@ Then tail the log in another terminal:
 
 {{< tabs "mcp-server-tutorial-cmd-5" >}}
 {{% tab "Bash" %}}
+
 ```bash
 tail -f /tmp/scafctl-mcp.log
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 tail -f /tmp/scafctl-mcp.log
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -881,14 +904,18 @@ You can test the server manually by sending JSON-RPC messages:
 
 {{< tabs "mcp-server-tutorial-cmd-6" >}}
 {{% tab "Bash" %}}
+
 ```bash
 echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | scafctl mcp serve
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 Write-Output '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | scafctl mcp serve
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -898,14 +925,18 @@ Enable verbose logging to see tool calls and responses:
 
 {{< tabs "mcp-server-tutorial-cmd-7" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl mcp serve --log-level debug --log-file /tmp/scafctl-mcp-debug.log
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl mcp serve --log-level debug --log-file /tmp/scafctl-mcp-debug.log
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -917,14 +948,18 @@ The AI client cannot find the `scafctl` binary. Ensure it's on your `$PATH`:
 
 {{< tabs "mcp-server-tutorial-cmd-8" >}}
 {{% tab "Bash" %}}
+
 ```bash
 which scafctl
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 which scafctl
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -961,6 +996,7 @@ This means the solution contains only resolvers and no `spec.workflow` section. 
 
 {{< tabs "mcp-server-tutorial-cmd-9" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # For solutions with ONLY resolvers (no spec.workflow):
 scafctl run resolver -f ./my-solution.yaml -r key=value
@@ -968,8 +1004,10 @@ scafctl run resolver -f ./my-solution.yaml -r key=value
 # For solutions WITH actions (spec.workflow.actions):
 scafctl run solution -f ./my-solution.yaml -r key=value
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 # For solutions with ONLY resolvers (no spec.workflow):
 scafctl run resolver -f ./my-solution.yaml -r key=value
@@ -977,6 +1015,7 @@ scafctl run resolver -f ./my-solution.yaml -r key=value
 # For solutions WITH actions (spec.workflow.actions):
 scafctl run solution -f ./my-solution.yaml -r key=value
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -988,6 +1027,7 @@ If a tool returns an auth error, set up authentication before starting the serve
 
 {{< tabs "mcp-server-tutorial-cmd-10" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # Authenticate first
 scafctl auth login <provider>
@@ -995,8 +1035,10 @@ scafctl auth login <provider>
 # Then start the server (or let the AI client start it)
 scafctl mcp serve
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 # Authenticate first
 scafctl auth login <provider>
@@ -1004,6 +1046,7 @@ scafctl auth login <provider>
 # Then start the server (or let the AI client start it)
 scafctl mcp serve
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1054,6 +1097,7 @@ The MCP server supports three transport protocols:
 
 {{< tabs "mcp-server-tutorial-cmd-11" >}}
 {{% tab "Bash" %}}
+
 ```bash
 # Default: stdio (JSON-RPC 2.0 over stdin/stdout)
 scafctl mcp serve
@@ -1064,8 +1108,10 @@ scafctl mcp serve --transport sse --addr :8080
 # HTTP: Streamable HTTP transport
 scafctl mcp serve --transport http --addr :8080
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 # Default: stdio (JSON-RPC 2.0 over stdin/stdout)
 scafctl mcp serve
@@ -1076,6 +1122,7 @@ scafctl mcp serve --transport sse --addr :8080
 # HTTP: Streamable HTTP transport
 scafctl mcp serve --transport http --addr :8080
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1096,6 +1143,7 @@ All tool errors return structured JSON with machine-readable context:
 ```
 
 Error codes include:
+
 - `INVALID_INPUT` — Bad or missing input arguments
 - `NOT_FOUND` — Requested resource doesn't exist
 - `VALIDATION_ERROR` — Content failed validation
@@ -1116,14 +1164,18 @@ Enable detailed logging with:
 
 {{< tabs "mcp-server-tutorial-cmd-12" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl mcp serve --log-file /tmp/scafctl-mcp.log
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl mcp serve --log-file /tmp/scafctl-mcp.log
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1184,14 +1236,18 @@ For high-throughput scenarios, you can tune the stdio transport:
 
 {{< tabs "mcp-server-tutorial-cmd-13" >}}
 {{% tab "Bash" %}}
+
 ```bash
 scafctl mcp serve --worker-pool-size 4 --queue-size 200
 ```
+
 {{% /tab %}}
 {{% tab "PowerShell" %}}
+
 ```powershell
 scafctl mcp serve --worker-pool-size 4 --queue-size 200
 ```
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -1214,6 +1270,7 @@ Key tools declare their output JSON Schema via `outputSchema`, enabling clients 
 ### ResourceLink in Results
 
 Tool results include `ResourceLink` items that point to related MCP resources:
+
 - `inspect_solution` → links to the solution's YAML, schema, and dependency graph resources
 - `list_providers` → link to the provider quick reference resource
 - `preview_resolvers` → links to the solution and its dependency graph

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -983,6 +983,9 @@ func (s *Server) registerTools() {
 	// Lint explanation tools
 	s.registerLintTools()
 
+	// Refactoring tools (positioned find-references and rename)
+	s.registerRefactorTools()
+
 	// Error explanation tools
 	s.registerErrorTools()
 

--- a/pkg/mcp/tools_refactor.go
+++ b/pkg/mcp/tools_refactor.go
@@ -47,7 +47,7 @@ func (s *Server) registerRefactorTools() {
 		mcp.WithDeferLoading(true),
 		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithDestructiveHintAnnotation(false),
-		mcp.WithIdempotentHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
 		mcp.WithOpenWorldHintAnnotation(false),
 		mcp.WithString("file",
 			mcp.Description("Path to the solution YAML file"),
@@ -133,7 +133,7 @@ func (s *Server) handleRenameResolver(_ context.Context, request mcp.CallToolReq
 
 	renameResult, err := refactor.RenameResolver(sol, oldName, newName)
 	if err != nil {
-		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+		return newStructuredError(ErrCodeValidationError, err.Error(),
 			WithSuggestion("Fix the new name, resolve the collision, or make ambiguous references explicit (_.name in CEL, ._.name in templates), then retry"),
 			WithRelatedTools("find_resolver_references")), nil
 	}
@@ -173,6 +173,10 @@ func (s *Server) loadSolutionRaw(file, cwd string) (*solution.Solution, error) {
 		return nil, err
 	}
 	sol := &solution.Solution{}
+	// Set the path before unmarshalling so the SourceMap/Range positions built
+	// during FromYAML carry a non-empty file, keeping positioned outputs and
+	// refindex metadata accurate.
+	sol.SetPath(path)
 	if err := sol.UnmarshalFromBytes(raw); err != nil {
 		return nil, err
 	}

--- a/pkg/mcp/tools_refactor.go
+++ b/pkg/mcp/tools_refactor.go
@@ -1,0 +1,198 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/refactor"
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+)
+
+// registerRefactorTools registers positioned reference-finding and rename tools.
+func (s *Server) registerRefactorTools() {
+	findRefsTool := mcp.NewTool("find_resolver_references",
+		mcp.WithDescription("Find every reference to a resolver in a solution file -- its definition and all uses (dependsOn entries, rslvr values, CEL '_.name' expressions, and explicit template '._.name') with source locations. Use this to understand the impact of changing a resolver before editing, or to navigate a solution. Distinct from extract_resolver_refs, which analyses a single expression rather than a whole solution."),
+		mcp.WithTitleAnnotation("Find Resolver References"),
+		mcp.WithToolIcons(toolIcons["refs"]),
+		mcp.WithDeferLoading(true),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("file",
+			mcp.Description("Path to the solution YAML file"),
+			mcp.Required(),
+		),
+		mcp.WithString("resolver",
+			mcp.Description("Name of the resolver to find references for"),
+			mcp.Required(),
+		),
+		mcp.WithString("cwd",
+			mcp.Description(cwdDescFilePaths),
+		),
+	)
+	s.addTool(findRefsTool, s.handleFindResolverReferences)
+
+	renameTool := mcp.NewTool("rename_resolver",
+		mcp.WithDescription("Rename a resolver and every reference to it in a solution file, returning the rewritten content with comments and formatting preserved (only the affected identifiers change). Refuses without changes if the new name is invalid, collides with an existing resolver, or any reference cannot be located byte-exact -- so it never produces a partial, broken rename. Returns the new content for you to write back; operates on a single solution file (not composed/bundled solutions)."),
+		mcp.WithTitleAnnotation("Rename Resolver"),
+		mcp.WithToolIcons(toolIcons["refs"]),
+		mcp.WithDeferLoading(true),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(false),
+		mcp.WithOpenWorldHintAnnotation(false),
+		mcp.WithString("file",
+			mcp.Description("Path to the solution YAML file"),
+			mcp.Required(),
+		),
+		mcp.WithString("old_name",
+			mcp.Description("Current resolver name"),
+			mcp.Required(),
+		),
+		mcp.WithString("new_name",
+			mcp.Description("New resolver name"),
+			mcp.Required(),
+		),
+		mcp.WithString("cwd",
+			mcp.Description(cwdDescFilePaths),
+		),
+	)
+	s.addTool(renameTool, s.handleRenameResolver)
+}
+
+// handleFindResolverReferences returns the definition and all references of a
+// resolver within a solution file.
+func (s *Server) handleFindResolverReferences(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	file, err := request.RequireString("file")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(), WithField("file"),
+			WithSuggestion("Provide the path to a solution YAML file")), nil
+	}
+	name, err := request.RequireString("resolver")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(), WithField("resolver"),
+			WithSuggestion("Provide the resolver name to find references for")), nil
+	}
+	cwd := request.GetString("cwd", "")
+
+	sol, loadErr := s.loadSolutionRaw(file, cwd)
+	if loadErr != nil {
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", loadErr),
+			WithField("file"), WithSuggestion("Check the file exists and contains valid solution YAML")), nil
+	}
+
+	idx, err := refindex.Build(sol)
+	if err != nil {
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("indexing solution: %v", err), WithField("file")), nil
+	}
+
+	def, defined := idx.Definition(name)
+	result := map[string]any{
+		"resolver":   name,
+		"defined":    defined,
+		"references": referencesJSON(idx.References(name)),
+		"unresolved": idx.UnresolvedFor(name),
+	}
+	if defined {
+		result["definition"] = locationJSON(def)
+	}
+	return mcp.NewToolResultJSON(result)
+}
+
+// handleRenameResolver computes the rewritten solution content for a resolver
+// rename, or a structured error explaining why the rename was refused.
+func (s *Server) handleRenameResolver(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	file, err := request.RequireString("file")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(), WithField("file"),
+			WithSuggestion("Provide the path to a solution YAML file")), nil
+	}
+	oldName, err := request.RequireString("old_name")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(), WithField("old_name")), nil
+	}
+	newName, err := request.RequireString("new_name")
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(), WithField("new_name")), nil
+	}
+	cwd := request.GetString("cwd", "")
+
+	sol, loadErr := s.loadSolutionRaw(file, cwd)
+	if loadErr != nil {
+		return newStructuredError(ErrCodeLoadFailed, fmt.Sprintf("loading solution: %v", loadErr),
+			WithField("file"), WithSuggestion("Check the file exists and contains valid solution YAML")), nil
+	}
+
+	renameResult, err := refactor.RenameResolver(sol, oldName, newName)
+	if err != nil {
+		return newStructuredError(ErrCodeInvalidInput, err.Error(),
+			WithSuggestion("Fix the new name, resolve the collision, or make ambiguous references explicit (_.name in CEL, ._.name in templates), then retry"),
+			WithRelatedTools("find_resolver_references")), nil
+	}
+
+	newContent, err := renameResult.Apply(sol.RawContent())
+	if err != nil {
+		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("applying rename: %v", err), WithField("file")), nil
+	}
+
+	occurrences := make([]map[string]any, 0, len(renameResult.Edits))
+	for _, e := range renameResult.Edits {
+		occurrences = append(occurrences, map[string]any{
+			"line":   e.Range.Start.Line,
+			"column": e.Range.Start.Column,
+		})
+	}
+
+	return mcp.NewToolResultJSON(map[string]any{
+		"oldName":     oldName,
+		"newName":     newName,
+		"occurrences": occurrences,
+		"content":     string(newContent),
+	})
+}
+
+// loadSolutionRaw reads the raw solution file (resolved relative to cwd when the
+// path is relative) and unmarshals it, preserving RawContent for byte-exact
+// positions. It intentionally reads the file directly -- like the CLI rename
+// command -- so edits align with the on-disk bytes.
+func (s *Server) loadSolutionRaw(file, cwd string) (*solution.Solution, error) {
+	path := file
+	if cwd != "" && !filepath.IsAbs(path) {
+		path = filepath.Join(cwd, path)
+	}
+	raw, err := os.ReadFile(path) //nolint:gosec // path is a user-provided solution reference
+	if err != nil {
+		return nil, err
+	}
+	sol := &solution.Solution{}
+	if err := sol.UnmarshalFromBytes(raw); err != nil {
+		return nil, err
+	}
+	return sol, nil
+}
+
+// referencesJSON converts positioned references to a JSON-friendly slice.
+func referencesJSON(refs []refindex.Reference) []map[string]any {
+	out := make([]map[string]any, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, locationJSON(r))
+	}
+	return out
+}
+
+// locationJSON renders a reference as a location with its origin.
+func locationJSON(r refindex.Reference) map[string]any {
+	return map[string]any{
+		"line":   r.Range.Start.Line,
+		"column": r.Range.Start.Column,
+		"origin": r.Origin.String(),
+	}
+}

--- a/pkg/mcp/tools_refactor_test.go
+++ b/pkg/mcp/tools_refactor_test.go
@@ -1,0 +1,207 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const refactorFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: mcp-refactor
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    appName:
+      dependsOn:
+        - environment
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.environment
+    greeting:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              template:
+                tmpl: "{{ ._.appName }}-{{ ._.environment }}"
+`
+
+func writeRefactorFixture(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return path
+}
+
+func callTool(t *testing.T, name string, args map[string]any, handler func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)) (*mcp.CallToolResult, map[string]any) {
+	t.Helper()
+	request := mcp.CallToolRequest{}
+	request.Params.Name = name
+	request.Params.Arguments = args
+	result, err := handler(context.Background(), request)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	if result.IsError {
+		return result, nil
+	}
+	var data map[string]any
+	require.NoError(t, json.Unmarshal([]byte(extractText(t, result)), &data))
+	return result, data
+}
+
+func TestHandleFindResolverReferences(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+	path := writeRefactorFixture(t, refactorFixture)
+
+	_, data := callTool(t, "find_resolver_references",
+		map[string]any{"file": path, "resolver": "environment"},
+		srv.handleFindResolverReferences)
+
+	assert.Equal(t, true, data["defined"])
+	assert.NotNil(t, data["definition"])
+	assert.EqualValues(t, 0, data["unresolved"])
+
+	refs, ok := data["references"].([]any)
+	require.True(t, ok)
+	// dependsOn + CEL + template = 3 uses.
+	assert.Len(t, refs, 3)
+
+	origins := map[string]bool{}
+	for _, r := range refs {
+		origins[r.(map[string]any)["origin"].(string)] = true
+	}
+	assert.True(t, origins["dependsOn"])
+	assert.True(t, origins["cel"])
+	assert.True(t, origins["template"])
+}
+
+func TestHandleFindResolverReferences_Undefined(t *testing.T) {
+	srv, _ := NewServer(WithServerVersion("test"))
+	path := writeRefactorFixture(t, refactorFixture)
+
+	_, data := callTool(t, "find_resolver_references",
+		map[string]any{"file": path, "resolver": "nope"},
+		srv.handleFindResolverReferences)
+
+	assert.Equal(t, false, data["defined"])
+	refs, _ := data["references"].([]any)
+	assert.Empty(t, refs)
+}
+
+func TestHandleRenameResolver(t *testing.T) {
+	srv, _ := NewServer(WithServerVersion("test"))
+	path := writeRefactorFixture(t, refactorFixture)
+
+	_, data := callTool(t, "rename_resolver",
+		map[string]any{"file": path, "old_name": "environment", "new_name": "env"},
+		srv.handleRenameResolver)
+
+	assert.Equal(t, "environment", data["oldName"])
+	assert.Equal(t, "env", data["newName"])
+
+	occ, ok := data["occurrences"].([]any)
+	require.True(t, ok)
+	// definition + dependsOn + CEL + template = 4.
+	assert.Len(t, occ, 4)
+
+	content, ok := data["content"].(string)
+	require.True(t, ok)
+	assert.NotContains(t, content, "environment")
+	assert.Contains(t, content, "env:")
+	assert.Contains(t, content, "expr: _.env")
+}
+
+func TestHandleRenameResolver_InvalidName(t *testing.T) {
+	srv, _ := NewServer(WithServerVersion("test"))
+	path := writeRefactorFixture(t, refactorFixture)
+
+	result, _ := callTool(t, "rename_resolver",
+		map[string]any{"file": path, "old_name": "environment", "new_name": "1bad"},
+		srv.handleRenameResolver)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractText(t, result), "not a valid resolver name")
+}
+
+func TestHandleRenameResolver_RefusesWhenUnresolved(t *testing.T) {
+	// A $-rooted template reference to environment is unpositionable, so the
+	// rename must refuse.
+	fixture := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: unresolved
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    greet:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              template:
+                tmpl: "{{ $.environment }}"
+`
+	srv, _ := NewServer(WithServerVersion("test"))
+	path := writeRefactorFixture(t, fixture)
+
+	result, _ := callTool(t, "rename_resolver",
+		map[string]any{"file": path, "old_name": "environment", "new_name": "env"},
+		srv.handleRenameResolver)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractText(t, result), "could not be located")
+}
+
+func TestHandleRenameResolver_FileNotFound(t *testing.T) {
+	srv, _ := NewServer(WithServerVersion("test"))
+	result, _ := callTool(t, "rename_resolver",
+		map[string]any{"file": "/no/such/solution.yaml", "old_name": "a", "new_name": "b"},
+		srv.handleRenameResolver)
+	assert.True(t, result.IsError)
+	assert.Contains(t, extractText(t, result), "loading solution")
+}
+
+func TestHandleRefactor_MissingArgs(t *testing.T) {
+	srv, _ := NewServer(WithServerVersion("test"))
+
+	r1, _ := callTool(t, "find_resolver_references", map[string]any{"file": "x.yaml"}, srv.handleFindResolverReferences)
+	assert.True(t, r1.IsError, "missing 'resolver' should error")
+
+	r2, _ := callTool(t, "rename_resolver", map[string]any{"file": "x.yaml", "old_name": "a"}, srv.handleRenameResolver)
+	assert.True(t, r2.IsError, "missing 'new_name' should error")
+}
+
+func TestHandleFindResolverReferences_CwdRelativePath(t *testing.T) {
+	srv, _ := NewServer(WithServerVersion("test"))
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "solution.yaml"), []byte(refactorFixture), 0o600))
+
+	// Relative file resolved against cwd.
+	_, data := callTool(t, "find_resolver_references",
+		map[string]any{"file": "solution.yaml", "resolver": "environment", "cwd": dir},
+		srv.handleFindResolverReferences)
+	assert.Equal(t, true, data["defined"])
+}

--- a/pkg/mcp/tools_refactor_test.go
+++ b/pkg/mcp/tools_refactor_test.go
@@ -140,6 +140,51 @@ func TestHandleRenameResolver_InvalidName(t *testing.T) {
 		srv.handleRenameResolver)
 	assert.True(t, result.IsError)
 	assert.Contains(t, extractText(t, result), "not a valid resolver name")
+
+	// A refused rename on valid arguments is a semantic validation error, not a
+	// bad-request-shape INVALID_INPUT -- lock down the code so clients can
+	// distinguish the two.
+	var te struct {
+		Code string `json:"code"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(extractText(t, result)), &te))
+	assert.Equal(t, ErrCodeValidationError, te.Code)
+}
+
+func TestLoadSolutionRaw_SetsPath(t *testing.T) {
+	srv, _ := NewServer(WithServerVersion("test"))
+	path := writeRefactorFixture(t, refactorFixture)
+
+	// The loaded solution must carry its path so SourceMap/Range positions built
+	// during parsing get a non-empty file (empty otherwise).
+	sol, err := srv.loadSolutionRaw(path, "")
+	require.NoError(t, err)
+	assert.Equal(t, path, sol.GetPath())
+
+	// A cwd-relative file resolves to the joined path.
+	dir := filepath.Dir(path)
+	solRel, err := srv.loadSolutionRaw("solution.yaml", dir)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "solution.yaml"), solRel.GetPath())
+}
+
+func TestRenameResolver_IdempotentAnnotation(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+
+	// rename_resolver is read-only with no side effects (it only returns
+	// rewritten content), so repeated calls with the same inputs are safe --
+	// it must advertise the idempotent hint so clients may cache/retry.
+	var found bool
+	for _, st := range srv.mcpServer.ListTools() {
+		if st.Tool.Name != "rename_resolver" {
+			continue
+		}
+		found = true
+		require.NotNil(t, st.Tool.Annotations.IdempotentHint)
+		assert.True(t, *st.Tool.Annotations.IdempotentHint)
+	}
+	assert.True(t, found, "rename_resolver tool must be registered")
 }
 
 func TestHandleRenameResolver_RefusesWhenUnresolved(t *testing.T) {


### PR DESCRIPTION
## Summary

Expose the positioned reference index (refindex) and rename engine (refactor) to
AI agents via two MCP tools:

- `find_resolver_references` (read-only): given a solution file and a resolver
  name, returns the resolver's definition and every reference to it -- dependsOn
  entries, rslvr values, CEL `_.name` uses, and explicit template `._.name` --
  each with a source location and origin, plus an unresolved count.
- `rename_resolver` (read-only, idempotent): renames a resolver and every
  reference to it, returning the rewritten solution content with comments and
  formatting preserved. It has no side effects (returns content for the agent to
  write), so repeated calls with the same inputs are safe. Refuses without
  changes -- via a structured `VALIDATION_ERROR` -- if the new name is invalid,
  collides with an existing resolver, or any reference cannot be located
  byte-exact, so it never produces a partial, breaking rename.

These complement the existing `extract_resolver_refs` tool, which analyses a
single expression; the new tools operate over a whole solution with positions.

## Design

- Thin MCP handlers (`pkg/mcp/tools_refactor.go`) -- all logic lives in the
  shared refindex/refactor packages. Loads the raw solution file directly (like
  the CLI rename command) for byte-exact positions; single-file scope. The
  loader sets the solution path before unmarshalling so SourceMap/Range
  positions carry a non-empty file, keeping positioned outputs and refindex
  metadata accurate.
- `rename_resolver` returns the new content for the agent to write (read-only, no
  file mutation) and is marked idempotent accordingly.
- Error codes distinguish request-shape problems (`INVALID_INPUT`, e.g. missing
  arguments) from semantic rename refusals on valid inputs (`VALIDATION_ERROR`),
  so clients/agents can tell a bad request from a refused-but-valid rename.

## Testing

- Unit tests: find (defined/undefined, origins, unresolved count, cwd-relative
  path), rename (occurrences + rewritten content), refusal cases (invalid name,
  $-rooted unpositionable reference, missing file, missing args), the
  `VALIDATION_ERROR` code on refusal, the idempotent tool annotation, and that
  the loader sets the solution path (absolute and cwd-relative).
- Full `pkg/mcp` suite passes with `-race`; gofmt/vet clean; golangci-lint 0 new
  issues. MCP tutorial tool reference updated.

## Follow-up

- Extend to actions/functions/calls once the index gains those symbol kinds.
