### PR TITLE
feat: add workflow action support to find-references and rename

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -1058,12 +1058,19 @@ invalid, `4` a file was not found.
 
 ## Refactoring Solutions
 
-`refactor` applies source-preserving edits to a solution. `refactor rename
-resolver <old> <new>` renames a resolver and rewrites every reference to it --
-the definition, `dependsOn` entries, `rslvr:` values, CEL `_.name` uses, and
-explicit template `._.name` uses -- replacing only the exact bytes of each
+`refactor` applies source-preserving edits to a solution. It renames a symbol
+and rewrites every reference to it, replacing only the exact bytes of each
 occurrence, so comments, key order, and formatting are preserved (no YAML
 round-trip).
+
+`refactor rename resolver <old> <new>` renames a resolver and rewrites the
+definition, `dependsOn` entries, `rslvr:` values, CEL `_.name` uses, and
+explicit template `._.name` uses.
+
+`refactor rename action <old> <new>` renames a workflow action and rewrites the
+definition, `dependsOn` entries, CEL `__actions.name` uses, and explicit
+template `.__actions.name` uses. An action's `alias` is a separate name and is
+**not** changed by the rename.
 
 ~~~bash
 # Preview the change without writing (lists every occurrence and location)
@@ -1071,17 +1078,21 @@ scafctl refactor rename resolver environment env -f ./solution.yaml --dry-run
 
 # Apply it in place (auto-discovers the solution file if -f is omitted)
 scafctl refactor rename resolver environment env
+
+# Rename a workflow action and every reference to it
+scafctl refactor rename action deploy release
 ~~~
 
-The rename is all-or-nothing: if any reference to the target resolver cannot be
+The rename is all-or-nothing: if any reference to the target symbol cannot be
 located byte-exact -- a context-dependent bare `{{ .name }}` accessor, a
 `$`-rooted `{{ $.name }}` accessor, or a reference nested inside a literal
 value -- it aborts rather than performing a partial rewrite that would silently
-break the solution. The check is name-scoped, so an unlocatable reference to a
-*different* resolver does not block the rename.
+break the solution. The check is name- and kind-scoped, so an unlocatable
+reference to a *different* symbol (or a resolver that shares an action's name)
+does not block the rename.
 
 Exit codes: `0` applied (or previewed), `2` a validation error (invalid new
-name, name collision, undefined resolver, or an unlocatable reference blocked
+name, name collision, undefined symbol, or an unlocatable reference blocked
 the rename), `4` the solution file could not be resolved, read, or parsed.
 
 ---
@@ -1104,17 +1115,18 @@ rule name to an LSP diagnostic anchored at the finding's location. It advertises
 full-document sync and reuses the same `lint` engine as `scafctl lint`, so
 editor diagnostics match the CLI.
 
-It also provides resolver navigation and refactoring, reusing the same
-positioned reference index (`refindex`) and rename engine (`refactor`) as
-`refactor rename resolver`:
+It also provides resolver and action navigation and refactoring, reusing the
+same positioned reference index (`refindex`) and rename engine (`refactor`) as
+`refactor rename`:
 
-- **Go-to-definition** (`textDocument/definition`) -- jump from any resolver
-  reference to its definition.
-- **Find references** (`textDocument/references`) -- list every use of a resolver.
-- **Rename** (`textDocument/rename`, with `prepareRename`) -- rename a resolver
-  and every reference to it as a single `WorkspaceEdit`. The same fail-safe
-  applies: if a reference cannot be located, the rename is refused and the error
-  is surfaced to the editor rather than a partial rewrite being applied.
+- **Go-to-definition** (`textDocument/definition`) -- jump from any resolver or
+  action reference to its definition.
+- **Find references** (`textDocument/references`) -- list every use of a resolver
+  or action.
+- **Rename** (`textDocument/rename`, with `prepareRename`) -- rename a resolver or
+  action and every reference to it as a single `WorkspaceEdit`. The same
+  fail-safe applies: if a reference cannot be located, the rename is refused and
+  the error is surfaced to the editor rather than a partial rewrite being applied.
 
 An editor client configures the server by pointing at the `scafctl lsp` command
 and associating it with the solution file language (YAML).

--- a/docs/tutorials/_index.md
+++ b/docs/tutorials/_index.md
@@ -23,7 +23,7 @@ Step-by-step guides for learning scafctl features.
 - [Authentication Tutorial](auth-tutorial.md) — Set up authentication for your workflows
 - [Eval Tutorial](eval-tutorial.md) — Test CEL expressions and Go templates from the CLI
 - [Linting Tutorial](linting-tutorial.md) — Validate solutions, explore lint rules, and fix issues
-- [Refactoring Tutorial](refactor-tutorial.md) — Rename a resolver and every reference to it with `refactor rename resolver`
+- [Refactoring Tutorial](refactor-tutorial.md) — Rename a resolver or workflow action and every reference to it with `refactor rename`
 - [Language Server (LSP) Tutorial](lsp-tutorial.md) -- Run `scafctl lsp` for in-editor diagnostics
 - [CEL Expressions Tutorial](cel-tutorial.md) — Master CEL expressions and extension functions
 - [Go Templates Tutorial](go-templates-tutorial.md) — Generate files with Go template rendering

--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -27,15 +27,15 @@ the in-memory document and reports each finding (severity, message, rule name)
 at its source location, using the same engine as `scafctl lint` -- so what you
 see in the editor matches the CLI.
 
-It also supports resolver **navigation and rename**, reusing the same reference
-index and rename engine as `scafctl refactor rename resolver`:
+It also supports resolver and action **navigation and rename**, reusing the same
+reference index and rename engine as `scafctl refactor rename`:
 
-- **Go to definition** on a resolver reference jumps to where the resolver is
+- **Go to definition** on a resolver or action reference jumps to where it is
   defined.
-- **Find all references** lists every use of a resolver.
-- **Rename** a resolver updates its definition and every reference in one edit.
-  If any reference cannot be located, the rename is refused (the editor shows the
-  error) rather than applying a partial, solution-breaking change.
+- **Find all references** lists every use of a resolver or action.
+- **Rename** a resolver or action updates its definition and every reference in
+  one edit. If any reference cannot be located, the rename is refused (the editor
+  shows the error) rather than applying a partial, solution-breaking change.
 
 ## Trying it by hand
 

--- a/docs/tutorials/mcp-server-tutorial.md
+++ b/docs/tutorials/mcp-server-tutorial.md
@@ -770,6 +770,8 @@ The AI calls `inspect_solution` with `path: "solution.yaml"` and the response in
 | `extract_resolver_refs` | Find all resolver cross-references (`_.resolverName`) in a solution — shows which resolvers reference which others |
 | `find_resolver_references` | Find a resolver's definition and every reference to it in a solution (dependsOn, rslvr, CEL, template) with source locations — use before editing to see impact |
 | `rename_resolver` | Rename a resolver and every reference to it, returning the rewritten solution content (comments/formatting preserved). Refuses if the new name is invalid, collides, or a reference cannot be located |
+| `find_action_references` | Find a workflow action's definition and every reference to it in a solution (dependsOn, CEL `__actions.name`, template `.__actions.name`) with source locations — use before editing to see impact |
+| `rename_action` | Rename a workflow action and every reference to it, returning the rewritten solution content (comments/formatting preserved; the action's `alias` is unchanged). Refuses if the new name is invalid, collides, or a reference cannot be located |
 | `generate_test_scaffold` | Generate functional test case scaffolding for a solution — creates test YAML with assertions, tags, auto-populated file dependencies, and sandbox guidance |
 | `list_tests` | List functional tests defined in a solution's `spec.testing.cases` — shows test names, descriptions, assertions, and tags |
 | `show_snapshot` | Display the contents of a resolver execution snapshot file — resolver values, timing, status, and errors |

--- a/docs/tutorials/refactor-tutorial.md
+++ b/docs/tutorials/refactor-tutorial.md
@@ -6,8 +6,9 @@ weight: 46
 # Refactoring Tutorial
 
 This tutorial covers `scafctl refactor`, which applies source-preserving edits to
-a solution file. The first refactoring is `refactor rename resolver`, which
-renames a resolver and rewrites every reference to it.
+a solution file. It can rename a **resolver** (`refactor rename resolver`) or a
+**workflow action** (`refactor rename action`), rewriting every reference to the
+renamed symbol.
 
 ## Overview
 
@@ -133,18 +134,51 @@ does not block your rename. When a rename is refused, update the ambiguous
 reference to an explicit form (`._.name` in templates, `_.name` in CEL) and try
 again.
 
+## Renaming actions
+
+`refactor rename action <old> <new>` renames a workflow action defined under
+`spec.workflow.actions` (or `spec.workflow.finally`) and rewrites every
+reference to it:
+
+- the action definition (the map key)
+- `dependsOn` entries
+- CEL `__actions.name` uses (in inputs and in `when`/`until` conditions)
+- explicit Go-template `.__actions.name` uses
+
+```bash
+# Preview, then apply (see examples/refactor/action-solution.yaml)
+scafctl refactor rename action build compile \
+  -f examples/refactor/action-solution.yaml --dry-run
+scafctl refactor rename action build compile -f examples/refactor/action-solution.yaml
+```
+
+The example solution at `examples/refactor/action-solution.yaml` references the
+action `build` three ways (a `dependsOn` entry, a CEL `__actions.build` use, and
+a template `.__actions.build` use) plus its definition, so the rename reports
+four occurrences. The action also carries `alias: b`, which is left unchanged.
+
+An action's `alias` is a **separate** top-level name, not a reference to the
+action, so renaming the action leaves the `alias` untouched. The rename is
+kind-scoped: renaming an action never rewrites a resolver that happens to share
+its name (and vice versa). Every other guarantee -- byte-exact edits,
+comment/formatting preservation, and the all-or-nothing fail-safe below --
+applies identically to actions.
+
 ## Exit codes
 
 | Code | Meaning |
 | ---- | ------- |
 | 0    | Rename applied (or previewed with `--dry-run`) |
-| 2    | Validation error: invalid new name, name collision, undefined resolver, or an unlocatable reference blocked the rename |
+| 2    | Validation error: invalid new name, name collision, undefined symbol, or an unlocatable reference blocked the rename |
 | 4    | The solution file could not be resolved, read, or parsed |
 
 ## Summary
 
 - `refactor rename resolver <old> <new>` renames a resolver and every reference
   to it, preserving comments and formatting.
+- `refactor rename action <old> <new>` does the same for a workflow action
+  (rewriting `dependsOn`, CEL `__actions.name`, and template `.__actions.name`
+  uses); the action's `alias` is left unchanged.
 - Use `--dry-run` to preview; use `-f` to target a specific file.
 - The rename refuses rather than performing a partial, solution-breaking rewrite.
 

--- a/examples/refactor/action-solution.yaml
+++ b/examples/refactor/action-solution.yaml
@@ -1,0 +1,35 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: refactor-rename-action-demo
+  description: >-
+    Demonstrates `scafctl refactor rename action`. The action `build` is
+    referenced three different ways -- a dependsOn entry, a CEL `__actions.name`
+    use, and an explicit template `.__actions.name` use -- so a single rename
+    must update all of them while preserving comments and formatting. The
+    action's `alias` is a separate name and is left untouched.
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      # The action we will rename (try: refactor rename action build compile).
+      build:
+        alias: b # NOTE: an alias is independent -- renaming `build` leaves this.
+        description: Build the artifact
+        provider: message
+        inputs:
+          message: Building the artifact
+
+      # Reference #1: an explicit dependsOn entry.
+      deploy:
+        description: Deploy once the build has completed
+        dependsOn:
+          - build
+        # Reference #2: a CEL expression using the `__actions` namespace.
+        when:
+          expr: __actions.build.success
+        provider: message
+        inputs:
+          # Reference #3: an explicit Go-template `.__actions.name` reference.
+          message:
+            tmpl: "Deploying now that {{ .__actions.build.message }} completed"

--- a/pkg/celexp/refs_position.go
+++ b/pkg/celexp/refs_position.go
@@ -61,6 +61,15 @@ func (r VariableRef) End() int { return r.Offset + r.Len }
 //	refs, _ := celexp.Expression(`_.a + _.b`).UnderscoreVariableRefs(ctx)
 //	// refs == [{Name:"a", Offset:2, Len:1}, {Name:"b", Offset:8, Len:1}]
 func (e Expression) UnderscoreVariableRefs(ctx context.Context) ([]VariableRef, error) {
+	return e.PrefixedVariableRefs(ctx, "_.")
+}
+
+// PrefixedVariableRefs is the prefix-parameterized form of UnderscoreVariableRefs.
+// It returns every occurrence of a reference under the given prefix (e.g. "_." for
+// resolver data, "__actions." for action results) with its byte range within the
+// expression source. The prefix must end in "." (select-style). Semantics --
+// including the Offset == -1 "unpositioned" sentinel -- match UnderscoreVariableRefs.
+func (e Expression) PrefixedVariableRefs(ctx context.Context, prefix string) ([]VariableRef, error) {
 	env, err := NewParseEnv(ctx)
 	if err != nil {
 		return nil, err
@@ -83,7 +92,7 @@ func (e Expression) UnderscoreVariableRefs(ctx context.Context) ([]VariableRef, 
 	exprRunes := []rune(string(e))
 
 	var refs []VariableRef
-	walkVariablesWithPrefix(parsedExpr.GetExpr(), "_.", func(name string, id int64, optional bool) {
+	walkVariablesWithPrefix(parsedExpr.GetExpr(), prefix, func(name string, id int64, optional bool) {
 		anchor := int(positions[id])
 		runeOff := findIdentNear(exprRunes, []rune(name), anchor)
 		if runeOff < 0 {

--- a/pkg/celexp/refs_position_test.go
+++ b/pkg/celexp/refs_position_test.go
@@ -193,3 +193,53 @@ func TestUnderscoreVariableRefs_UnpositionableIsReportedNotDropped(t *testing.T)
 	assert.Equal(t, `a"b`, refs[0].Name)
 	assert.Equal(t, -1, refs[0].Offset, "unpositionable occurrence must be reported with Offset -1")
 }
+
+func TestPrefixedVariableRefs_ActionsPrefix(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		expr string
+		want []VariableRef
+	}{
+		{
+			name: "single action ref with trailing path",
+			expr: `__actions.build.results.exitCode`,
+			want: []VariableRef{{Name: "build", Offset: 10, Len: 5}},
+		},
+		{
+			name: "two action refs in source order",
+			expr: `__actions.a + __actions.b`,
+			want: []VariableRef{
+				{Name: "a", Offset: 10, Len: 1},
+				{Name: "b", Offset: 24, Len: 1},
+			},
+		},
+		{
+			name: "resolver refs are ignored under the actions prefix",
+			expr: `_.env + __actions.deploy`,
+			want: []VariableRef{{Name: "deploy", Offset: 18, Len: 6}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			refs, err := Expression(tt.expr).PrefixedVariableRefs(ctx, "__actions.")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, refs)
+
+			// Byte-exact invariant: each positioned range slices out its name.
+			for _, r := range refs {
+				if r.Offset < 0 {
+					continue
+				}
+				assert.Equal(t, r.Name, tt.expr[r.Offset:r.Offset+r.Len])
+			}
+		})
+	}
+}
+
+func TestPrefixedVariableRefs_ParseError(t *testing.T) {
+	_, err := Expression(`__actions.a +`).PrefixedVariableRefs(context.Background(), "__actions.")
+	require.Error(t, err)
+}

--- a/pkg/cmd/scafctl/refactor/refactor.go
+++ b/pkg/cmd/scafctl/refactor/refactor.go
@@ -31,6 +31,7 @@ func CommandRefactor(cliParams *settings.Run, ioStreams *terminal.IOStreams, pat
 			performing a partial (and potentially breaking) rewrite.
 
 			  refactor rename resolver <old> <new>   Rename a resolver everywhere
+			  refactor rename action <old> <new>     Rename a workflow action everywhere
 		`),
 		SilenceUsage: true,
 	})
@@ -48,10 +49,12 @@ func CommandRename(cliParams *settings.Run, ioStreams *terminal.IOStreams, path 
 			Rename a symbol and rewrite every reference to it in place.
 
 			  refactor rename resolver <old> <new>   Rename a resolver
+			  refactor rename action <old> <new>     Rename a workflow action
 		`),
 		SilenceUsage: true,
 	})
 
 	cCmd.AddCommand(CommandRenameResolver(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
+	cCmd.AddCommand(CommandRenameAction(cliParams, ioStreams, fmt.Sprintf("%s/%s", path, cCmd.Use)))
 	return cCmd
 }

--- a/pkg/cmd/scafctl/refactor/rename_action.go
+++ b/pkg/cmd/scafctl/refactor/rename_action.go
@@ -1,0 +1,40 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refactor
+
+import (
+	"github.com/MakeNowJust/heredoc/v2"
+	pkgrefactor "github.com/oakwood-commons/scafctl/pkg/refactor"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/spf13/cobra"
+)
+
+// CommandRenameAction creates the `refactor rename action` command.
+func CommandRenameAction(cliParams *settings.Run, _ *terminal.IOStreams, path string) *cobra.Command {
+	return newRenameCommand(cliParams, path, renameCommandConfig{
+		use:   "action <old-name> <new-name>",
+		short: "Rename a workflow action and update every reference to it",
+		long: heredoc.Doc(`
+			Rename a workflow action and rewrite every reference to it --
+			dependsOn entries, CEL '__actions.name' uses, explicit template
+			'.__actions.name' uses, and the definition itself -- preserving
+			comments, key order, and formatting.
+
+			The rename refuses to run when any reference to the target action
+			cannot be located byte-exact, so it never performs a partial rewrite
+			that would silently break the solution. Note: an action's 'alias' is
+			a separate name and is not changed by renaming the action.
+		`),
+		example: heredoc.Doc(`
+			# Rename action 'deploy' to 'release' in the discovered solution
+			scafctl refactor rename action deploy release
+
+			# Target a specific file and preview the change without writing
+			scafctl refactor rename action deploy release -f ./solution.yaml --dry-run
+		`),
+		kind:   "action",
+		rename: pkgrefactor.RenameAction,
+	})
+}

--- a/pkg/cmd/scafctl/refactor/rename_action_test.go
+++ b/pkg/cmd/scafctl/refactor/rename_action_test.go
@@ -1,0 +1,73 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refactor
+
+import (
+	"os"
+	"testing"
+
+	pkgrefactor "github.com/oakwood-commons/scafctl/pkg/refactor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const actionCmdFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: action-cmd-test # comment stays
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      build:
+        provider: shell
+        inputs:
+          command: make build
+      deploy:
+        dependsOn:
+          - build
+        provider: shell
+        when:
+          expr: __actions.build.results.exitCode == 0
+        inputs:
+          command:
+            tmpl: 'deploy {{ .__actions.build.results.stdout }}'
+`
+
+func TestRunRenameAction_HappyPath(t *testing.T) {
+	path := writeFixture(t, actionCmdFixture)
+	ctx, bufs := testContext(t)
+
+	err := runRename(ctx, &renameOptions{File: path, CliParams: testCliParams()}, "action", pkgrefactor.RenameAction, "build", "compile")
+	require.NoError(t, err)
+
+	got, readErr := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, readErr)
+	s := string(got)
+	// Every reference form is rewritten: definition, dependsOn, CEL, template.
+	assert.Contains(t, s, "compile:")
+	assert.Contains(t, s, "- compile")
+	assert.Contains(t, s, "__actions.compile.results.exitCode")
+	assert.Contains(t, s, ".__actions.compile.results.stdout")
+	// The old action name must not survive in any reference form. The literal
+	// 'command: make build' is unrelated text and is correctly left untouched.
+	assert.NotContains(t, s, "build:")
+	assert.NotContains(t, s, "- build")
+	assert.NotContains(t, s, "__actions.build")
+	assert.Contains(t, s, "# comment stays")
+	assert.Contains(t, bufs.out.String(), "Renamed action")
+}
+
+func TestRunRenameAction_DryRunLeavesFileUnchanged(t *testing.T) {
+	path := writeFixture(t, actionCmdFixture)
+	ctx, bufs := testContext(t)
+
+	err := runRename(ctx, &renameOptions{File: path, DryRun: true, CliParams: testCliParams()}, "action", pkgrefactor.RenameAction, "build", "compile")
+	require.NoError(t, err)
+
+	got, _ := os.ReadFile(path) //nolint:gosec // test-controlled path
+	assert.Equal(t, actionCmdFixture, string(got), "dry-run must not modify the file")
+	assert.Contains(t, bufs.out.String(), "Would rename action")
+	assert.Contains(t, bufs.out.String(), "build -> compile")
+}

--- a/pkg/cmd/scafctl/refactor/rename_resolver.go
+++ b/pkg/cmd/scafctl/refactor/rename_resolver.go
@@ -23,16 +23,29 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// renameResolverOptions holds flags for the rename resolver command.
-type renameResolverOptions struct {
+// renameOptions holds flags for a `refactor rename <kind>` command.
+type renameOptions struct {
 	File      string
 	DryRun    bool
 	CliParams *settings.Run
 }
 
-// CommandRenameResolver creates the `refactor rename resolver` command.
-func CommandRenameResolver(cliParams *settings.Run, _ *terminal.IOStreams, path string) *cobra.Command {
-	opts := &renameResolverOptions{CliParams: cliParams}
+// renameCommandConfig captures the kind-specific pieces of a `refactor rename
+// <kind>` subcommand; the wiring is shared by newRenameCommand.
+type renameCommandConfig struct {
+	use     string // cobra Use line, e.g. "resolver <old-name> <new-name>"
+	short   string
+	long    string
+	example string // uses settings.CliBinaryName as a placeholder for the binary name
+	kind    string // symbol label used in output ("resolver"/"action")
+	rename  renameFunc
+}
+
+// newRenameCommand builds a `refactor rename <kind>` subcommand. All rename
+// subcommands share identical flag/context wiring and differ only by the
+// kind-specific config, so the logic lives here once.
+func newRenameCommand(cliParams *settings.Run, path string, cfg renameCommandConfig) *cobra.Command {
+	opts := &renameOptions{CliParams: cliParams}
 
 	binaryName := cliParams.BinaryName
 	if binaryName == "" {
@@ -40,9 +53,32 @@ func CommandRenameResolver(cliParams *settings.Run, _ *terminal.IOStreams, path 
 	}
 
 	cmd := &cobra.Command{
-		Use:   "resolver <old-name> <new-name>",
-		Short: "Rename a resolver and update every reference to it",
-		Long: heredoc.Doc(`
+		Use:          cfg.use,
+		Short:        cfg.short,
+		Long:         cfg.long,
+		Example:      strings.ReplaceAll(cfg.example, settings.CliBinaryName, binaryName),
+		Args:         cobra.ExactArgs(2),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Name())
+			ctx := settings.IntoContext(cmd.Context(), cliParams)
+			ctx = logger.WithLogger(ctx, logger.FromContext(cmd.Context()))
+			return runRename(ctx, opts, cfg.kind, cfg.rename, args[0], args[1])
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.File, "file", "f", "", "Solution file path (auto-discovered if not provided)")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would change without modifying the file")
+
+	return cmd
+}
+
+// CommandRenameResolver creates the `refactor rename resolver` command.
+func CommandRenameResolver(cliParams *settings.Run, _ *terminal.IOStreams, path string) *cobra.Command {
+	return newRenameCommand(cliParams, path, renameCommandConfig{
+		use:   "resolver <old-name> <new-name>",
+		short: "Rename a resolver and update every reference to it",
+		long: heredoc.Doc(`
 			Rename a resolver and rewrite every reference to it -- dependsOn
 			entries, rslvr values, CEL '_.name' uses, explicit template
 			'._.name' uses, and the definition itself -- preserving comments,
@@ -54,32 +90,25 @@ func CommandRenameResolver(cliParams *settings.Run, _ *terminal.IOStreams, path 
 			inline reference nested inside a literal), so it never performs a
 			partial rewrite that would silently break the solution.
 		`),
-		Example: strings.ReplaceAll(heredoc.Doc(`
+		example: heredoc.Doc(`
 			# Rename resolver 'environment' to 'env' in the discovered solution
 			scafctl refactor rename resolver environment env
 
 			# Target a specific file and preview the change without writing
 			scafctl refactor rename resolver environment env -f ./solution.yaml --dry-run
-		`), settings.CliBinaryName, binaryName),
-		Args:         cobra.ExactArgs(2),
-		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cliParams.EntryPointSettings.Path = filepath.Join(path, cmd.Name())
-			ctx := settings.IntoContext(cmd.Context(), cliParams)
-			ctx = logger.WithLogger(ctx, logger.FromContext(cmd.Context()))
-			return runRenameResolver(ctx, opts, args[0], args[1])
-		},
-	}
-
-	cmd.Flags().StringVarP(&opts.File, "file", "f", "", "Solution file path (auto-discovered if not provided)")
-	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would change without modifying the file")
-
-	return cmd
+		`),
+		kind:   "resolver",
+		rename: pkgrefactor.RenameResolver,
+	})
 }
 
-// runRenameResolver resolves the target file, computes the rename edits via
-// pkg/refactor, and either writes the result or previews it (--dry-run).
-func runRenameResolver(ctx context.Context, opts *renameResolverOptions, oldName, newName string) error {
+// renameFunc computes rename edits for a symbol of a specific kind.
+type renameFunc func(sol *solution.Solution, oldName, newName string) (*pkgrefactor.RenameResult, error)
+
+// runRename resolves the target file, computes the rename edits via pkg/refactor,
+// and either writes the result or previews it (--dry-run). kind labels the symbol
+// ("resolver", "action") in output.
+func runRename(ctx context.Context, opts *renameOptions, kind string, rename renameFunc, oldName, newName string) error {
 	w := writer.FromContext(ctx)
 
 	getter := get.NewGetterFromContext(ctx)
@@ -103,7 +132,7 @@ func runRenameResolver(ctx context.Context, opts *renameResolverOptions, oldName
 		return fail(w, exitcode.FileNotFound, fmt.Errorf("failed to parse %s: %w", resolvedPath, err))
 	}
 
-	result, err := pkgrefactor.RenameResolver(sol, oldName, newName)
+	result, err := rename(sol, oldName, newName)
 	if err != nil {
 		return fail(w, exitcode.ValidationFailed, err)
 	}
@@ -114,7 +143,7 @@ func runRenameResolver(ctx context.Context, opts *renameResolverOptions, oldName
 	}
 
 	if opts.DryRun {
-		printRenamePreview(w, resolvedPath, result)
+		printRenamePreview(w, resolvedPath, kind, result)
 		return nil
 	}
 
@@ -127,7 +156,7 @@ func runRenameResolver(ctx context.Context, opts *renameResolverOptions, oldName
 	}
 
 	if w != nil {
-		w.Successf("Renamed resolver %q to %q (%d occurrence(s)) in %s", oldName, newName, len(result.Edits), resolvedPath)
+		w.Successf("Renamed %s %q to %q (%d occurrence(s)) in %s", kind, oldName, newName, len(result.Edits), resolvedPath)
 	}
 	return nil
 }
@@ -174,11 +203,11 @@ func fail(w *writer.Writer, code int, err error) error {
 }
 
 // printRenamePreview lists the planned edits without modifying the file.
-func printRenamePreview(w *writer.Writer, path string, res *pkgrefactor.RenameResult) {
+func printRenamePreview(w *writer.Writer, path, kind string, res *pkgrefactor.RenameResult) {
 	if w == nil {
 		return
 	}
-	w.Plainlnf("Would rename resolver %q to %q (%d occurrence(s)):", res.OldName, res.NewName, len(res.Edits))
+	w.Plainlnf("Would rename %s %q to %q (%d occurrence(s)):", kind, res.OldName, res.NewName, len(res.Edits))
 	for _, e := range res.Edits {
 		w.Plainlnf("  %s:%d:%d  %s -> %s", path, e.Range.Start.Line, e.Range.Start.Column, res.OldName, res.NewName)
 	}

--- a/pkg/cmd/scafctl/refactor/rename_resolver_test.go
+++ b/pkg/cmd/scafctl/refactor/rename_resolver_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
+	pkgrefactor "github.com/oakwood-commons/scafctl/pkg/refactor"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
 	"github.com/oakwood-commons/scafctl/pkg/terminal"
 	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
@@ -72,7 +73,7 @@ func TestRunRenameResolver_HappyPath(t *testing.T) {
 	path := writeFixture(t, cmdFixture)
 	ctx, bufs := testContext(t)
 
-	err := runRenameResolver(ctx, &renameResolverOptions{File: path, CliParams: testCliParams()}, "environment", "env")
+	err := runRename(ctx, &renameOptions{File: path, CliParams: testCliParams()}, "resolver", pkgrefactor.RenameResolver, "environment", "env")
 	require.NoError(t, err)
 
 	got, readErr := os.ReadFile(path) //nolint:gosec // test-controlled path
@@ -87,7 +88,7 @@ func TestRunRenameResolver_DryRunLeavesFileUnchanged(t *testing.T) {
 	path := writeFixture(t, cmdFixture)
 	ctx, bufs := testContext(t)
 
-	err := runRenameResolver(ctx, &renameResolverOptions{File: path, DryRun: true, CliParams: testCliParams()}, "environment", "env")
+	err := runRename(ctx, &renameOptions{File: path, DryRun: true, CliParams: testCliParams()}, "resolver", pkgrefactor.RenameResolver, "environment", "env")
 	require.NoError(t, err)
 
 	got, _ := os.ReadFile(path) //nolint:gosec // test-controlled path
@@ -113,7 +114,7 @@ func TestRunRenameResolver_Errors(t *testing.T) {
 			path := writeFixture(t, cmdFixture)
 			ctx, bufs := testContext(t)
 
-			err := runRenameResolver(ctx, &renameResolverOptions{File: path, CliParams: testCliParams()}, tt.old, tt.newName)
+			err := runRename(ctx, &renameOptions{File: path, CliParams: testCliParams()}, "resolver", pkgrefactor.RenameResolver, tt.old, tt.newName)
 			require.Error(t, err)
 			assert.Equal(t, tt.wantCode, exitcode.GetCode(err))
 			assert.Contains(t, bufs.errOut.String(), tt.wantMsg)
@@ -127,7 +128,7 @@ func TestRunRenameResolver_Errors(t *testing.T) {
 
 func TestRunRenameResolver_FileNotFound(t *testing.T) {
 	ctx, _ := testContext(t)
-	err := runRenameResolver(ctx, &renameResolverOptions{File: "/no/such/solution.yaml", CliParams: testCliParams()}, "a", "b")
+	err := runRename(ctx, &renameOptions{File: "/no/such/solution.yaml", CliParams: testCliParams()}, "resolver", pkgrefactor.RenameResolver, "a", "b")
 	require.Error(t, err)
 	assert.Equal(t, exitcode.FileNotFound, exitcode.GetCode(err))
 }

--- a/pkg/gotmpl/refs_position.go
+++ b/pkg/gotmpl/refs_position.go
@@ -20,6 +20,9 @@ const (
 	// RefKindExplicitResolver is an explicit resolver reference ({{ ._.name }}
 	// or {{ ._name }}), which always names a resolver.
 	RefKindExplicitResolver
+	// RefKindExplicitAction is an explicit action reference
+	// ({{ .__actions.name }}), which always names a workflow action.
+	RefKindExplicitAction
 )
 
 // PositionedRef is a single root-level reference occurrence in a Go template,
@@ -89,10 +92,54 @@ func (s *Service) GetPositionedReferences(opts TemplateOptions) ([]PositionedRef
 	var out []PositionedRef
 	for _, tree := range trees {
 		if tree.Root != nil {
-			walkPositioned(tree.Root, opts.Content, 0, &out)
+			walkPositioned(tree.Root, opts.Content, 0, fieldRootRange, &out)
 		}
 	}
 	return out, nil
+}
+
+// GetPositionedActionReferences extracts positioned action references
+// ({{ .__actions.name... }}) from a Go template, in source order. The name is
+// the action referenced (the segment after __actions). Scoped references
+// (inside {{ with }}/{{ range }}) are returned with Scoped set.
+func (s *Service) GetPositionedActionReferences(opts TemplateOptions) ([]PositionedRef, error) {
+	leftDelim := opts.LeftDelim
+	rightDelim := opts.RightDelim
+	if leftDelim == "" {
+		leftDelim = DefaultLeftDelim
+	}
+	if rightDelim == "" {
+		rightDelim = DefaultRightDelim
+	}
+	name := opts.Name
+	if name == "" {
+		name = "unnamed-template"
+	}
+	if opts.Content == "" {
+		return nil, fmt.Errorf("template content cannot be empty")
+	}
+
+	trees, err := parse.Parse(name, opts.Content, leftDelim, rightDelim, s.templateFuncNames())
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	var out []PositionedRef
+	for _, tree := range trees {
+		if tree.Root != nil {
+			walkPositioned(tree.Root, opts.Content, 0, fieldActionRange, &out)
+		}
+	}
+	return out, nil
+}
+
+// GetGoTemplatePositionedActionReferences is a convenience wrapper.
+func GetGoTemplatePositionedActionReferences(templateContent, leftDelim, rightDelim string) ([]PositionedRef, error) {
+	return NewService(nil).GetPositionedActionReferences(TemplateOptions{
+		Content:    templateContent,
+		LeftDelim:  leftDelim,
+		RightDelim: rightDelim,
+	})
 }
 
 // GetGoTemplatePositionedReferences is a convenience wrapper that extracts
@@ -119,44 +166,49 @@ func (s *Service) templateFuncNames() map[string]any {
 	return funcNames
 }
 
+// fieldExtractor computes a PositionedRef from a FieldNode, or reports ok=false
+// when the field is not a reference of the kind being collected.
+type fieldExtractor func(src string, fn *parse.FieldNode, scoped bool) (PositionedRef, bool)
+
 // walkPositioned recursively walks the parse tree, emitting a PositionedRef for
-// each root-level FieldNode. scopeDepth tracks {{ with }}/{{ range }} bodies
-// where dot is rebound (matching walkNodes in refs.go).
-func walkPositioned(node parse.Node, src string, scopeDepth int, out *[]PositionedRef) {
+// each root-level FieldNode that extract accepts. scopeDepth tracks
+// {{ with }}/{{ range }} bodies where dot is rebound (matching walkNodes in
+// refs.go).
+func walkPositioned(node parse.Node, src string, scopeDepth int, extract fieldExtractor, out *[]PositionedRef) {
 	switch n := node.(type) {
 	case *parse.ListNode:
 		if n == nil {
 			return
 		}
 		for _, child := range n.Nodes {
-			walkPositioned(child, src, scopeDepth, out)
+			walkPositioned(child, src, scopeDepth, extract, out)
 		}
 
 	case *parse.ActionNode:
-		walkPositionedPipe(n.Pipe, src, scopeDepth, out)
+		walkPositionedPipe(n.Pipe, src, scopeDepth, extract, out)
 
 	case *parse.IfNode:
-		walkPositionedPipe(n.Pipe, src, scopeDepth, out)
-		walkPositioned(n.List, src, scopeDepth, out)
-		walkPositioned(n.ElseList, src, scopeDepth, out)
+		walkPositionedPipe(n.Pipe, src, scopeDepth, extract, out)
+		walkPositioned(n.List, src, scopeDepth, extract, out)
+		walkPositioned(n.ElseList, src, scopeDepth, extract, out)
 
 	case *parse.RangeNode:
 		// The pipe is evaluated in the outer scope; the body rebinds dot.
-		walkPositionedPipe(n.Pipe, src, scopeDepth, out)
-		walkPositioned(n.List, src, scopeDepth+1, out)
-		walkPositioned(n.ElseList, src, scopeDepth, out)
+		walkPositionedPipe(n.Pipe, src, scopeDepth, extract, out)
+		walkPositioned(n.List, src, scopeDepth+1, extract, out)
+		walkPositioned(n.ElseList, src, scopeDepth, extract, out)
 
 	case *parse.WithNode:
-		walkPositionedPipe(n.Pipe, src, scopeDepth, out)
-		walkPositioned(n.List, src, scopeDepth+1, out)
-		walkPositioned(n.ElseList, src, scopeDepth, out)
+		walkPositionedPipe(n.Pipe, src, scopeDepth, extract, out)
+		walkPositioned(n.List, src, scopeDepth+1, extract, out)
+		walkPositioned(n.ElseList, src, scopeDepth, extract, out)
 
 	case *parse.TemplateNode:
-		walkPositionedPipe(n.Pipe, src, scopeDepth, out)
+		walkPositionedPipe(n.Pipe, src, scopeDepth, extract, out)
 	}
 }
 
-func walkPositionedPipe(p *parse.PipeNode, src string, scopeDepth int, out *[]PositionedRef) {
+func walkPositionedPipe(p *parse.PipeNode, src string, scopeDepth int, extract fieldExtractor, out *[]PositionedRef) {
 	if p == nil {
 		return
 	}
@@ -164,14 +216,33 @@ func walkPositionedPipe(p *parse.PipeNode, src string, scopeDepth int, out *[]Po
 		for _, arg := range cmd.Args {
 			switch a := arg.(type) {
 			case *parse.FieldNode:
-				if ref, ok := fieldRootRange(src, a, scopeDepth > 0); ok {
+				if ref, ok := extract(src, a, scopeDepth > 0); ok {
 					*out = append(*out, ref)
 				}
 			case *parse.PipeNode:
-				walkPositionedPipe(a, src, scopeDepth, out)
+				walkPositionedPipe(a, src, scopeDepth, extract, out)
 			}
 		}
 	}
+}
+
+// fieldActionRange computes the byte range of an action reference in a FieldNode
+// of the form {{ .__actions.name... }}. The name is the segment after __actions.
+func fieldActionRange(src string, fn *parse.FieldNode, scoped bool) (PositionedRef, bool) {
+	if len(fn.Ident) < 2 || fn.Ident[0] != actionNamespace {
+		return PositionedRef{}, false
+	}
+	fieldStart, ok := fieldStartOffset(src, fn)
+	if !ok {
+		return PositionedRef{}, false
+	}
+	name := fn.Ident[1]
+	if name == "" {
+		return PositionedRef{}, false
+	}
+	// Segment 1 starts after the leading '.', "__actions", and its trailing '.'.
+	offset := fieldStart + 1 + len(fn.Ident[0]) + 1
+	return PositionedRef{Name: name, Offset: offset, Len: len(name), Kind: RefKindExplicitAction, Scoped: scoped}, true
 }
 
 // fieldRootRange computes the byte range of the resolver-relevant root name of a

--- a/pkg/gotmpl/refs_position_action_test.go
+++ b/pkg/gotmpl/refs_position_action_test.go
@@ -1,0 +1,98 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gotmpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPositionedActionReferences(t *testing.T) {
+	tests := []struct {
+		name string
+		tmpl string
+		want []PositionedRef
+	}{
+		{
+			name: "action reference with trailing path",
+			tmpl: `{{ .__actions.build.results }}`,
+			want: []PositionedRef{{Name: "build", Offset: 14, Len: 5, Kind: RefKindExplicitAction}},
+		},
+		{
+			name: "bare __actions root is not a reference",
+			tmpl: `{{ .__actions }}`,
+			want: nil,
+		},
+		{
+			name: "plain field is not an action reference",
+			tmpl: `{{ .build }}`,
+			want: nil,
+		},
+		{
+			name: "explicit resolver ref is not an action reference",
+			tmpl: `{{ ._.build }}`,
+			want: nil,
+		},
+		{
+			name: "two action refs in source order",
+			tmpl: `{{ .__actions.a.x }} mid {{ .__actions.b }}`,
+			want: []PositionedRef{
+				{Name: "a", Offset: 14, Len: 1, Kind: RefKindExplicitAction},
+				{Name: "b", Offset: 39, Len: 1, Kind: RefKindExplicitAction},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetGoTemplatePositionedActionReferences(tt.tmpl, "", "")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+
+			// Byte-exact invariant: every range slices out exactly the name.
+			for _, r := range got {
+				require.LessOrEqual(t, r.End(), len(tt.tmpl))
+				assert.Equalf(t, r.Name, tt.tmpl[r.Offset:r.End()],
+					"range [%d:%d] must slice to %q", r.Offset, r.End(), r.Name)
+			}
+		})
+	}
+}
+
+func TestGetPositionedActionReferences_Scoped(t *testing.T) {
+	// Inside {{ with }} the dot is rebound, so the action ref is scoped.
+	tmpl := `{{ with .ctx }}{{ .__actions.deploy }}{{ end }}`
+	got, err := GetGoTemplatePositionedActionReferences(tmpl, "", "")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, "deploy", got[0].Name)
+	assert.True(t, got[0].Scoped)
+	assert.Equal(t, "deploy", tmpl[got[0].Offset:got[0].End()])
+}
+
+func TestGetPositionedActionReferences_CustomDelims(t *testing.T) {
+	got, err := GetGoTemplatePositionedActionReferences(`[[ .__actions.x ]]`, "[[", "]]")
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	assert.Equal(t, PositionedRef{Name: "x", Offset: 14, Len: 1, Kind: RefKindExplicitAction}, got[0])
+}
+
+func TestGetPositionedActionReferences_Errors(t *testing.T) {
+	_, err := GetGoTemplatePositionedActionReferences("", "", "")
+	assert.Error(t, err, "empty content")
+
+	_, err = GetGoTemplatePositionedActionReferences(`{{ .__actions.x `, "", "")
+	assert.Error(t, err, "unterminated action")
+}
+
+func BenchmarkGetPositionedActionReferences(b *testing.B) {
+	tmpl := `{{ .__actions.a.results }}-{{ .b }}{{ with .ctx }}{{ .__actions.c }}{{ end }}{{ printf "%s" .__actions.d }}`
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = GetGoTemplatePositionedActionReferences(tmpl, "", "")
+	}
+}

--- a/pkg/gotmpl/resolverdeps.go
+++ b/pkg/gotmpl/resolverdeps.go
@@ -257,3 +257,36 @@ func firstSegment(path string) string {
 	}
 	return path
 }
+
+// actionNamespace is the reserved template root identifier under which prior
+// action results are exposed, e.g. {{ .__actions.deploy.results }}.
+const actionNamespace = "__actions"
+
+// actionRefPathPrefix is the template path prefix for an action reference,
+// e.g. ".__actions.deploy.results" references action "deploy".
+const actionRefPathPrefix = "." + actionNamespace + "."
+
+// UnscopedActionRefs returns the action names referenced via {{ .__actions.name }}
+// (unscoped) in a Go template, de-duplicated in first-seen order. It is the
+// authoritative set a positioned action-reference consumer reconciles against so
+// a rename fails safe. Parse errors yield a nil slice and error.
+func UnscopedActionRefs(template, leftDelim, rightDelim string) ([]string, error) {
+	refs, err := GetGoTemplateReferences(template, leftDelim, rightDelim)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool)
+	var out []string
+	for _, ref := range refs {
+		if ref.Scoped || !strings.HasPrefix(ref.Path, actionRefPathPrefix) {
+			continue
+		}
+		name := firstSegment(strings.TrimPrefix(ref.Path, actionRefPathPrefix))
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, name)
+	}
+	return out, nil
+}

--- a/pkg/gotmpl/resolverdeps_test.go
+++ b/pkg/gotmpl/resolverdeps_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestClassifyTemplatePath(t *testing.T) {
@@ -252,5 +253,51 @@ func TestUnscopedResolverRefs(t *testing.T) {
 
 func TestUnscopedResolverRefs_ParseError(t *testing.T) {
 	_, err := UnscopedResolverRefs(`{{ .x `, "", "")
+	assert.Error(t, err)
+}
+
+func TestUnscopedActionRefs(t *testing.T) {
+	tests := []struct {
+		name string
+		tmpl string
+		want []string
+	}{
+		{
+			name: "single action ref with trailing path",
+			tmpl: `{{ .__actions.build.results }}`,
+			want: []string{"build"},
+		},
+		{
+			name: "multiple action refs de-duplicated in first-seen order",
+			tmpl: `{{ .__actions.a }}{{ .__actions.b }}{{ .__actions.a.x }}`,
+			want: []string{"a", "b"},
+		},
+		{
+			name: "bare __actions root yields nothing",
+			tmpl: `{{ .__actions }}`,
+			want: nil,
+		},
+		{
+			name: "resolver and plain refs are excluded",
+			tmpl: `{{ ._.env }}{{ .field }}{{ .__actions.deploy }}`,
+			want: []string{"deploy"},
+		},
+		{
+			name: "scoped action refs excluded",
+			tmpl: `{{ with .ctx }}{{ .__actions.inner }}{{ end }}{{ .__actions.outer }}`,
+			want: []string{"outer"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := UnscopedActionRefs(tt.tmpl, "", "")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestUnscopedActionRefs_ParseError(t *testing.T) {
+	_, err := UnscopedActionRefs(`{{ .__actions.x `, "", "")
 	assert.Error(t, err)
 }

--- a/pkg/lsp/navigation.go
+++ b/pkg/lsp/navigation.go
@@ -47,7 +47,7 @@ func Definition(content []byte, uri protocol.DocumentUri, pos protocol.Position)
 	if !ok {
 		return nil
 	}
-	def, ok := idx.Definition(ref.Symbol.Name)
+	def, ok := idx.Definition(ref.Symbol.Kind, ref.Symbol.Name)
 	if !ok {
 		return nil
 	}
@@ -69,9 +69,9 @@ func References(content []byte, uri protocol.DocumentUri, pos protocol.Position,
 
 	var refs []refindex.Reference
 	if includeDeclaration {
-		refs = idx.Occurrences(ref.Symbol.Name)
+		refs = idx.Occurrences(ref.Symbol.Kind, ref.Symbol.Name)
 	} else {
-		refs = idx.References(ref.Symbol.Name)
+		refs = idx.References(ref.Symbol.Kind, ref.Symbol.Name)
 	}
 
 	locs := make([]protocol.Location, 0, len(refs))
@@ -110,7 +110,7 @@ func Rename(content []byte, uri protocol.DocumentUri, pos protocol.Position, new
 		return nil, fmt.Errorf("no renameable symbol at the cursor position")
 	}
 
-	result, err := refactor.RenameResolver(sol, ref.Symbol.Name, newName)
+	result, err := refactor.RenameSymbol(sol, ref.Symbol.Kind, ref.Symbol.Name, newName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lsp/navigation_action_test.go
+++ b/pkg/lsp/navigation_action_test.go
@@ -1,0 +1,94 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// navActionFixture references action "build" via dependsOn, CEL, and template.
+const navActionFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: nav-action
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      build:
+        provider: shell
+        inputs:
+          command: make build
+      deploy:
+        dependsOn:
+          - build
+        provider: shell
+        when:
+          expr: __actions.build.results.exitCode == 0
+        inputs:
+          command:
+            tmpl: 'deploy {{ .__actions.build.results.stdout }}'
+`
+
+// actionCELRefPosition returns an LSP position at the start of the CEL reference
+// to action "build" in navActionFixture.
+func actionCELRefPosition(t *testing.T) protocol.Position {
+	t.Helper()
+	_, idx, err := loadIndex([]byte(navActionFixture))
+	require.NoError(t, err)
+	for _, r := range idx.References(refindex.SymbolAction, "build") {
+		if r.Origin == refindex.OriginCEL {
+			return toLSPPosition(r.Range.Start)
+		}
+	}
+	t.Fatalf("no CEL reference to action build found")
+	return protocol.Position{}
+}
+
+func TestDefinition_JumpsToActionDefinition(t *testing.T) {
+	pos := actionCELRefPosition(t)
+	loc := Definition([]byte(navActionFixture), navURI, pos)
+	require.NotNil(t, loc)
+	assert.Equal(t, navURI, loc.URI)
+	// The `build:` action key is on line 9 (0-based line 8).
+	assert.Equal(t, uint32(8), loc.Range.Start.Line)
+}
+
+func TestReferences_ActionIncludeAndExcludeDeclaration(t *testing.T) {
+	pos := actionCELRefPosition(t)
+
+	withDecl := References([]byte(navActionFixture), navURI, pos, true)
+	withoutDecl := References([]byte(navActionFixture), navURI, pos, false)
+
+	// build: definition + dependsOn + CEL + template = 4 occurrences; uses = 3.
+	assert.Len(t, withDecl, 4)
+	assert.Len(t, withoutDecl, 3)
+}
+
+func TestRename_ActionProducesWorkspaceEdit(t *testing.T) {
+	pos := actionCELRefPosition(t)
+	edit, err := Rename([]byte(navActionFixture), navURI, pos, "compile")
+	require.NoError(t, err)
+	require.NotNil(t, edit)
+
+	edits, ok := edit.Changes[navURI]
+	require.True(t, ok)
+	// definition + dependsOn + CEL + template = 4 edits, all to "compile".
+	assert.Len(t, edits, 4)
+	for _, e := range edits {
+		assert.Equal(t, "compile", e.NewText)
+	}
+}
+
+func TestRename_ActionInvalidNameErrors(t *testing.T) {
+	pos := actionCELRefPosition(t)
+	_, err := Rename([]byte(navActionFixture), navURI, pos, "1bad")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a valid action name")
+}

--- a/pkg/lsp/navigation_test.go
+++ b/pkg/lsp/navigation_test.go
@@ -52,7 +52,7 @@ func celRefPosition(t *testing.T, content string) protocol.Position {
 	t.Helper()
 	_, idx, err := loadIndex([]byte(content))
 	require.NoError(t, err)
-	for _, r := range idx.References("environment") {
+	for _, r := range idx.References(refindex.SymbolResolver, "environment") {
 		if r.Origin == refindex.OriginCEL {
 			return toLSPPosition(r.Range.Start)
 		}

--- a/pkg/mcp/tools_refactor.go
+++ b/pkg/mcp/tools_refactor.go
@@ -17,9 +17,42 @@ import (
 
 // registerRefactorTools registers positioned reference-finding and rename tools.
 func (s *Server) registerRefactorTools() {
-	findRefsTool := mcp.NewTool("find_resolver_references",
-		mcp.WithDescription("Find every reference to a resolver in a solution file -- its definition and all uses (dependsOn entries, rslvr values, CEL '_.name' expressions, and explicit template '._.name') with source locations. Use this to understand the impact of changing a resolver before editing, or to navigate a solution. Distinct from extract_resolver_refs, which analyses a single expression rather than a whole solution."),
-		mcp.WithTitleAnnotation("Find Resolver References"),
+	s.addTool(newFindReferencesTool(
+		"find_resolver_references", "Find Resolver References", "resolver",
+		"Find every reference to a resolver in a solution file -- its definition and all uses (dependsOn entries, rslvr values, CEL '_.name' expressions, and explicit template '._.name') with source locations. Use this to understand the impact of changing a resolver before editing, or to navigate a solution. Distinct from extract_resolver_refs, which analyses a single expression rather than a whole solution.",
+	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return s.handleFindReferences(ctx, request, refindex.SymbolResolver, "resolver")
+	})
+
+	s.addTool(newRenameTool(
+		"rename_resolver", "Rename Resolver", "resolver",
+		"Rename a resolver and every reference to it in a solution file, returning the rewritten content with comments and formatting preserved (only the affected identifiers change). Refuses without changes if the new name is invalid, collides with an existing resolver, or any reference cannot be located byte-exact -- so it never produces a partial, broken rename. Returns the new content for you to write back; operates on a single solution file (not composed/bundled solutions).",
+	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return s.handleRename(ctx, request, refindex.SymbolResolver, "resolver")
+	})
+
+	s.addTool(newFindReferencesTool(
+		"find_action_references", "Find Action References", "action",
+		"Find every reference to a workflow action in a solution file -- its definition and all uses (dependsOn entries, CEL '__actions.name' expressions, and explicit template '.__actions.name') with source locations. Use this to understand the impact of changing an action before editing, or to navigate a solution's workflow. Note: an action's 'alias' is a separate name and is not reported as a reference to the action.",
+	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return s.handleFindReferences(ctx, request, refindex.SymbolAction, "action")
+	})
+
+	s.addTool(newRenameTool(
+		"rename_action", "Rename Action", "action",
+		"Rename a workflow action and every reference to it in a solution file, returning the rewritten content with comments and formatting preserved (only the affected identifiers change). Rewrites dependsOn entries, CEL '__actions.name' uses, explicit template '.__actions.name' uses, and the definition. Refuses without changes if the new name is invalid, collides with an existing action, or any reference cannot be located byte-exact -- so it never produces a partial, broken rename. An action's 'alias' is independent and is not changed. Returns the new content for you to write back; operates on a single solution file (not composed/bundled solutions).",
+	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return s.handleRename(ctx, request, refindex.SymbolAction, "action")
+	})
+}
+
+// newFindReferencesTool builds a find-references tool for a given symbol kind.
+// symbolParam is both the tool's required parameter name and appears in the
+// description ("resolver"/"action").
+func newFindReferencesTool(name, title, symbolParam, description string) mcp.Tool {
+	return mcp.NewTool(name,
+		mcp.WithDescription(description),
+		mcp.WithTitleAnnotation(title),
 		mcp.WithToolIcons(toolIcons["refs"]),
 		mcp.WithDeferLoading(true),
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -30,19 +63,22 @@ func (s *Server) registerRefactorTools() {
 			mcp.Description("Path to the solution YAML file"),
 			mcp.Required(),
 		),
-		mcp.WithString("resolver",
-			mcp.Description("Name of the resolver to find references for"),
+		mcp.WithString(symbolParam,
+			mcp.Description(fmt.Sprintf("Name of the %s to find references for", symbolParam)),
 			mcp.Required(),
 		),
 		mcp.WithString("cwd",
 			mcp.Description(cwdDescFilePaths),
 		),
 	)
-	s.addTool(findRefsTool, s.handleFindResolverReferences)
+}
 
-	renameTool := mcp.NewTool("rename_resolver",
-		mcp.WithDescription("Rename a resolver and every reference to it in a solution file, returning the rewritten content with comments and formatting preserved (only the affected identifiers change). Refuses without changes if the new name is invalid, collides with an existing resolver, or any reference cannot be located byte-exact -- so it never produces a partial, broken rename. Returns the new content for you to write back; operates on a single solution file (not composed/bundled solutions)."),
-		mcp.WithTitleAnnotation("Rename Resolver"),
+// newRenameTool builds a rename tool for a given symbol kind. symbolLabel
+// ("resolver"/"action") appears only in parameter descriptions.
+func newRenameTool(name, title, symbolLabel, description string) mcp.Tool {
+	return mcp.NewTool(name,
+		mcp.WithDescription(description),
+		mcp.WithTitleAnnotation(title),
 		mcp.WithToolIcons(toolIcons["refs"]),
 		mcp.WithDeferLoading(true),
 		mcp.WithReadOnlyHintAnnotation(true),
@@ -54,32 +90,32 @@ func (s *Server) registerRefactorTools() {
 			mcp.Required(),
 		),
 		mcp.WithString("old_name",
-			mcp.Description("Current resolver name"),
+			mcp.Description(fmt.Sprintf("Current %s name", symbolLabel)),
 			mcp.Required(),
 		),
 		mcp.WithString("new_name",
-			mcp.Description("New resolver name"),
+			mcp.Description(fmt.Sprintf("New %s name", symbolLabel)),
 			mcp.Required(),
 		),
 		mcp.WithString("cwd",
 			mcp.Description(cwdDescFilePaths),
 		),
 	)
-	s.addTool(renameTool, s.handleRenameResolver)
 }
 
-// handleFindResolverReferences returns the definition and all references of a
-// resolver within a solution file.
-func (s *Server) handleFindResolverReferences(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// handleFindReferences returns the definition and all references of a symbol of
+// the given kind within a solution file. symbolParam names the request field and
+// the primary key in the JSON result ("resolver"/"action").
+func (s *Server) handleFindReferences(_ context.Context, request mcp.CallToolRequest, kind refindex.SymbolKind, symbolParam string) (*mcp.CallToolResult, error) {
 	file, err := request.RequireString("file")
 	if err != nil {
 		return newStructuredError(ErrCodeInvalidInput, err.Error(), WithField("file"),
 			WithSuggestion("Provide the path to a solution YAML file")), nil
 	}
-	name, err := request.RequireString("resolver")
+	name, err := request.RequireString(symbolParam)
 	if err != nil {
-		return newStructuredError(ErrCodeInvalidInput, err.Error(), WithField("resolver"),
-			WithSuggestion("Provide the resolver name to find references for")), nil
+		return newStructuredError(ErrCodeInvalidInput, err.Error(), WithField(symbolParam),
+			WithSuggestion(fmt.Sprintf("Provide the %s name to find references for", symbolParam))), nil
 	}
 	cwd := request.GetString("cwd", "")
 
@@ -94,12 +130,12 @@ func (s *Server) handleFindResolverReferences(_ context.Context, request mcp.Cal
 		return newStructuredError(ErrCodeExecFailed, fmt.Sprintf("indexing solution: %v", err), WithField("file")), nil
 	}
 
-	def, defined := idx.Definition(name)
+	def, defined := idx.Definition(kind, name)
 	result := map[string]any{
-		"resolver":   name,
+		symbolParam:  name,
 		"defined":    defined,
-		"references": referencesJSON(idx.References(name)),
-		"unresolved": idx.UnresolvedFor(name),
+		"references": referencesJSON(idx.References(kind, name)),
+		"unresolved": idx.UnresolvedFor(kind, name),
 	}
 	if defined {
 		result["definition"] = locationJSON(def)
@@ -107,9 +143,9 @@ func (s *Server) handleFindResolverReferences(_ context.Context, request mcp.Cal
 	return mcp.NewToolResultJSON(result)
 }
 
-// handleRenameResolver computes the rewritten solution content for a resolver
-// rename, or a structured error explaining why the rename was refused.
-func (s *Server) handleRenameResolver(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+// handleRename computes the rewritten solution content for a rename of the given
+// symbol kind, or a structured error explaining why the rename was refused.
+func (s *Server) handleRename(_ context.Context, request mcp.CallToolRequest, kind refindex.SymbolKind, symbolLabel string) (*mcp.CallToolResult, error) {
 	file, err := request.RequireString("file")
 	if err != nil {
 		return newStructuredError(ErrCodeInvalidInput, err.Error(), WithField("file"),
@@ -131,11 +167,15 @@ func (s *Server) handleRenameResolver(_ context.Context, request mcp.CallToolReq
 			WithField("file"), WithSuggestion("Check the file exists and contains valid solution YAML")), nil
 	}
 
-	renameResult, err := refactor.RenameResolver(sol, oldName, newName)
+	renameResult, err := refactor.RenameSymbol(sol, kind, oldName, newName)
 	if err != nil {
+		relatedTool := "find_resolver_references"
+		if kind == refindex.SymbolAction {
+			relatedTool = "find_action_references"
+		}
 		return newStructuredError(ErrCodeValidationError, err.Error(),
-			WithSuggestion("Fix the new name, resolve the collision, or make ambiguous references explicit (_.name in CEL, ._.name in templates), then retry"),
-			WithRelatedTools("find_resolver_references")), nil
+			WithSuggestion(fmt.Sprintf("Fix the new name, resolve the collision, or make ambiguous %s references explicit, then retry", symbolLabel)),
+			WithRelatedTools(relatedTool)), nil
 	}
 
 	newContent, err := renameResult.Apply(sol.RawContent())

--- a/pkg/mcp/tools_refactor_test.go
+++ b/pkg/mcp/tools_refactor_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -68,6 +69,20 @@ func callTool(t *testing.T, name string, args map[string]any, handler func(conte
 	return result, data
 }
 
+// findResolverRefs and renameResolver bind the generic kind-aware handlers to
+// the resolver kind for the resolver-focused tests below.
+func findResolverRefs(srv *Server) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return srv.handleFindReferences(ctx, request, refindex.SymbolResolver, "resolver")
+	}
+}
+
+func renameResolver(srv *Server) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return srv.handleRename(ctx, request, refindex.SymbolResolver, "resolver")
+	}
+}
+
 func TestHandleFindResolverReferences(t *testing.T) {
 	srv, err := NewServer(WithServerVersion("test"))
 	require.NoError(t, err)
@@ -75,7 +90,7 @@ func TestHandleFindResolverReferences(t *testing.T) {
 
 	_, data := callTool(t, "find_resolver_references",
 		map[string]any{"file": path, "resolver": "environment"},
-		srv.handleFindResolverReferences)
+		findResolverRefs(srv))
 
 	assert.Equal(t, true, data["defined"])
 	assert.NotNil(t, data["definition"])
@@ -101,7 +116,7 @@ func TestHandleFindResolverReferences_Undefined(t *testing.T) {
 
 	_, data := callTool(t, "find_resolver_references",
 		map[string]any{"file": path, "resolver": "nope"},
-		srv.handleFindResolverReferences)
+		findResolverRefs(srv))
 
 	assert.Equal(t, false, data["defined"])
 	refs, _ := data["references"].([]any)
@@ -114,7 +129,7 @@ func TestHandleRenameResolver(t *testing.T) {
 
 	_, data := callTool(t, "rename_resolver",
 		map[string]any{"file": path, "old_name": "environment", "new_name": "env"},
-		srv.handleRenameResolver)
+		renameResolver(srv))
 
 	assert.Equal(t, "environment", data["oldName"])
 	assert.Equal(t, "env", data["newName"])
@@ -137,7 +152,7 @@ func TestHandleRenameResolver_InvalidName(t *testing.T) {
 
 	result, _ := callTool(t, "rename_resolver",
 		map[string]any{"file": path, "old_name": "environment", "new_name": "1bad"},
-		srv.handleRenameResolver)
+		renameResolver(srv))
 	assert.True(t, result.IsError)
 	assert.Contains(t, extractText(t, result), "not a valid resolver name")
 
@@ -215,7 +230,7 @@ spec:
 
 	result, _ := callTool(t, "rename_resolver",
 		map[string]any{"file": path, "old_name": "environment", "new_name": "env"},
-		srv.handleRenameResolver)
+		renameResolver(srv))
 	assert.True(t, result.IsError)
 	assert.Contains(t, extractText(t, result), "could not be located")
 }
@@ -224,7 +239,7 @@ func TestHandleRenameResolver_FileNotFound(t *testing.T) {
 	srv, _ := NewServer(WithServerVersion("test"))
 	result, _ := callTool(t, "rename_resolver",
 		map[string]any{"file": "/no/such/solution.yaml", "old_name": "a", "new_name": "b"},
-		srv.handleRenameResolver)
+		renameResolver(srv))
 	assert.True(t, result.IsError)
 	assert.Contains(t, extractText(t, result), "loading solution")
 }
@@ -232,10 +247,10 @@ func TestHandleRenameResolver_FileNotFound(t *testing.T) {
 func TestHandleRefactor_MissingArgs(t *testing.T) {
 	srv, _ := NewServer(WithServerVersion("test"))
 
-	r1, _ := callTool(t, "find_resolver_references", map[string]any{"file": "x.yaml"}, srv.handleFindResolverReferences)
+	r1, _ := callTool(t, "find_resolver_references", map[string]any{"file": "x.yaml"}, findResolverRefs(srv))
 	assert.True(t, r1.IsError, "missing 'resolver' should error")
 
-	r2, _ := callTool(t, "rename_resolver", map[string]any{"file": "x.yaml", "old_name": "a"}, srv.handleRenameResolver)
+	r2, _ := callTool(t, "rename_resolver", map[string]any{"file": "x.yaml", "old_name": "a"}, renameResolver(srv))
 	assert.True(t, r2.IsError, "missing 'new_name' should error")
 }
 
@@ -247,6 +262,111 @@ func TestHandleFindResolverReferences_CwdRelativePath(t *testing.T) {
 	// Relative file resolved against cwd.
 	_, data := callTool(t, "find_resolver_references",
 		map[string]any{"file": "solution.yaml", "resolver": "environment", "cwd": dir},
-		srv.handleFindResolverReferences)
+		findResolverRefs(srv))
 	assert.Equal(t, true, data["defined"])
+}
+
+// actionRefactorFixture references action "build" via dependsOn, CEL, and
+// template forms; "make build" is unrelated literal text left untouched.
+const actionRefactorFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: mcp-refactor-action
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      build:
+        provider: shell
+        inputs:
+          command: make build
+      deploy:
+        dependsOn:
+          - build
+        provider: shell
+        when:
+          expr: __actions.build.results.exitCode == 0
+        inputs:
+          command:
+            tmpl: 'deploy {{ .__actions.build.results.stdout }}'
+`
+
+func findActionRefs(srv *Server) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return srv.handleFindReferences(ctx, request, refindex.SymbolAction, "action")
+	}
+}
+
+func renameAction(srv *Server) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return srv.handleRename(ctx, request, refindex.SymbolAction, "action")
+	}
+}
+
+func TestHandleFindActionReferences(t *testing.T) {
+	srv, err := NewServer(WithServerVersion("test"))
+	require.NoError(t, err)
+	path := writeRefactorFixture(t, actionRefactorFixture)
+
+	_, data := callTool(t, "find_action_references",
+		map[string]any{"file": path, "action": "build"},
+		findActionRefs(srv))
+
+	assert.Equal(t, true, data["defined"])
+	assert.NotNil(t, data["definition"])
+	assert.EqualValues(t, 0, data["unresolved"])
+
+	refs, ok := data["references"].([]any)
+	require.True(t, ok)
+	// dependsOn + CEL + template = 3 uses.
+	assert.Len(t, refs, 3)
+
+	origins := map[string]bool{}
+	for _, r := range refs {
+		origins[r.(map[string]any)["origin"].(string)] = true
+	}
+	assert.True(t, origins["dependsOn"])
+	assert.True(t, origins["cel"])
+	assert.True(t, origins["template"])
+}
+
+func TestHandleRenameAction(t *testing.T) {
+	srv, _ := NewServer(WithServerVersion("test"))
+	path := writeRefactorFixture(t, actionRefactorFixture)
+
+	_, data := callTool(t, "rename_action",
+		map[string]any{"file": path, "old_name": "build", "new_name": "compile"},
+		renameAction(srv))
+
+	assert.Equal(t, "build", data["oldName"])
+	assert.Equal(t, "compile", data["newName"])
+
+	occ, ok := data["occurrences"].([]any)
+	require.True(t, ok)
+	// definition + dependsOn + CEL + template = 4.
+	assert.Len(t, occ, 4)
+
+	content, ok := data["content"].(string)
+	require.True(t, ok)
+	assert.Contains(t, content, "compile:")
+	assert.Contains(t, content, "__actions.compile.results.exitCode")
+	assert.NotContains(t, content, "__actions.build")
+	// Unrelated literal text is preserved.
+	assert.Contains(t, content, "make build")
+}
+
+func TestHandleRenameAction_InvalidName(t *testing.T) {
+	srv, _ := NewServer(WithServerVersion("test"))
+	path := writeRefactorFixture(t, actionRefactorFixture)
+
+	result, _ := callTool(t, "rename_action",
+		map[string]any{"file": path, "old_name": "build", "new_name": "1bad"},
+		renameAction(srv))
+	assert.True(t, result.IsError)
+
+	var te struct {
+		Code string `json:"code"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(extractText(t, result)), &te))
+	assert.Equal(t, ErrCodeValidationError, te.Code)
 }

--- a/pkg/refactor/refactor.go
+++ b/pkg/refactor/refactor.go
@@ -56,47 +56,60 @@ func (r *RenameResult) Apply(raw []byte) ([]byte, error) {
 
 // RenameResolver computes the edits to rename a resolver and every reference to
 // it (dependsOn entries, rslvr values, CEL _.name uses, explicit template
-// ._.name uses, and the definition key).
-//
-// It returns an error, producing NO edits, when:
-//   - newName is not a valid resolver name;
+// ._.name uses, and the definition key). It is RenameSymbol for resolvers; see
+// RenameSymbol for the refusal conditions.
+func RenameResolver(sol *solution.Solution, oldName, newName string) (*RenameResult, error) {
+	return RenameSymbol(sol, refindex.SymbolResolver, oldName, newName)
+}
+
+// RenameAction computes the edits to rename an action and every reference to it
+// (dependsOn entries, __actions.name CEL uses, and .__actions.name template
+// uses, plus the definition). It refuses (producing no edits) under the same
+// conditions as RenameResolver.
+func RenameAction(sol *solution.Solution, oldName, newName string) (*RenameResult, error) {
+	return RenameSymbol(sol, refindex.SymbolAction, oldName, newName)
+}
+
+// RenameSymbol computes the edits to rename a symbol of the given kind and every
+// reference to it. It returns an error, producing NO edits, when:
+//   - newName is not a valid name;
 //   - newName equals oldName;
 //   - oldName is not defined in the solution;
-//   - newName already names a resolver (collision); or
-//   - the reference index is incomplete (some references could not be located),
-//     which would make a rename partial and unsafe.
-func RenameResolver(sol *solution.Solution, oldName, newName string) (*RenameResult, error) {
+//   - newName already names a symbol of the same kind (collision); or
+//   - the reference index is incomplete for oldName (some references could not be
+//     located), which would make a rename partial and unsafe.
+func RenameSymbol(sol *solution.Solution, kind refindex.SymbolKind, oldName, newName string) (*RenameResult, error) {
 	if sol == nil {
-		return nil, fmt.Errorf("rename resolver: nil solution")
+		return nil, fmt.Errorf("rename %s: nil solution", kind)
 	}
 	if !resolverNameRe.MatchString(newName) {
-		return nil, fmt.Errorf("rename resolver: %q is not a valid resolver name (must match %s)", newName, ResolverNamePattern)
+		return nil, fmt.Errorf("rename %s: %q is not a valid %s name (must match %s)", kind, newName, kind, ResolverNamePattern)
 	}
 	if oldName == newName {
-		return nil, fmt.Errorf("rename resolver: new name equals old name %q", oldName)
+		return nil, fmt.Errorf("rename %s: new name equals old name %q", kind, oldName)
 	}
 
 	idx, err := refindex.Build(sol)
 	if err != nil {
-		return nil, fmt.Errorf("rename resolver: %w", err)
+		return nil, fmt.Errorf("rename %s: %w", kind, err)
 	}
 
-	if _, ok := idx.Definition(oldName); !ok {
-		return nil, fmt.Errorf("rename resolver: resolver %q is not defined", oldName)
+	if _, ok := idx.Definition(kind, oldName); !ok {
+		return nil, fmt.Errorf("rename %s: %s %q is not defined", kind, kind, oldName)
 	}
-	if _, ok := idx.Definition(newName); ok {
-		return nil, fmt.Errorf("rename resolver: resolver %q already exists", newName)
+	if _, ok := idx.Definition(kind, newName); ok {
+		return nil, fmt.Errorf("rename %s: %s %q already exists", kind, kind, newName)
 	}
 
 	// Refuse a partial rewrite: if any reference to oldName could not be located
 	// byte-exact, a rename might miss it and silently break the solution. This is
-	// name-scoped -- unlocatable references to OTHER resolvers do not block this
+	// symbol-scoped -- unlocatable references to OTHER symbols do not block this
 	// rename, but references whose target could not be determined at all do.
-	if n := idx.UnresolvedFor(oldName); n > 0 {
-		return nil, fmt.Errorf("rename resolver: %d reference(s) to %q could not be located; aborting to avoid a partial rename", n, oldName)
+	if n := idx.UnresolvedFor(kind, oldName); n > 0 {
+		return nil, fmt.Errorf("rename %s: %d reference(s) to %q could not be located; aborting to avoid a partial rename", kind, n, oldName)
 	}
 
-	occ := idx.Occurrences(oldName)
+	occ := idx.Occurrences(kind, oldName)
 	edits := make([]TextEdit, 0, len(occ))
 	for _, r := range occ {
 		edits = append(edits, TextEdit{Range: r.Range, NewText: newName})

--- a/pkg/refactor/refactor_action_test.go
+++ b/pkg/refactor/refactor_action_test.go
@@ -1,0 +1,155 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refactor
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// renameActionFixture references action "build" via dependsOn, CEL, and
+// template. "make build" is unrelated literal text. "build" also carries an
+// alias "b" that must be left untouched by the rename.
+const renameActionFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: rename-action-test # keep this comment
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      build:
+        alias: b
+        provider: shell
+        inputs:
+          command: make build
+      deploy:
+        dependsOn:
+          - build
+        provider: shell
+        when:
+          expr: __actions.build.results.exitCode == 0
+        inputs:
+          command:
+            tmpl: 'deploy {{ .__actions.build.results.stdout }}'
+`
+
+func TestRenameAction_HappyPath(t *testing.T) {
+	sol := loadSolution(t, renameActionFixture)
+
+	res, err := RenameAction(sol, "build", "compile")
+	require.NoError(t, err)
+	require.Equal(t, "build", res.OldName)
+	require.Equal(t, "compile", res.NewName)
+	// definition + dependsOn + CEL + template = 4 occurrences (alias excluded).
+	require.Len(t, res.Edits, 4)
+
+	raw := sol.RawContent()
+	out, err := res.Apply(raw)
+	require.NoError(t, err)
+	s := string(out)
+
+	// Comments and unrelated literal text are preserved.
+	assert.Contains(t, s, "# keep this comment")
+	assert.Contains(t, s, "command: make build")
+	// The alias is independent and must not be rewritten.
+	assert.Contains(t, s, "alias: b")
+
+	// The rewritten content re-parses and the rename is complete and consistent.
+	newSol := loadSolution(t, s)
+	idx, err := refindex.Build(newSol)
+	require.NoError(t, err)
+	assert.Zero(t, idx.Unresolved())
+	def, ok := idx.Definition(refindex.SymbolAction, "compile")
+	require.True(t, ok)
+	assert.True(t, def.IsDef)
+	assert.Len(t, idx.Occurrences(refindex.SymbolAction, "compile"), 4)
+	_, stillThere := idx.Definition(refindex.SymbolAction, "build")
+	assert.False(t, stillThere)
+}
+
+func TestRenameAction_Guards(t *testing.T) {
+	sol := loadSolution(t, renameActionFixture)
+
+	tests := []struct {
+		name    string
+		old     string
+		newName string
+		wantMsg string
+	}{
+		{"invalid new name", "build", "1bad", "not a valid action name"},
+		{"equal names", "build", "build", "equals old name"},
+		{"undefined old", "missing", "whatever", "is not defined"},
+		{"collision", "build", "deploy", "already exists"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := RenameAction(sol, tt.old, tt.newName)
+			require.Error(t, err)
+			assert.Nil(t, res)
+			assert.Contains(t, err.Error(), tt.wantMsg)
+		})
+	}
+}
+
+func TestRenameAction_NilSolution(t *testing.T) {
+	res, err := RenameAction(nil, "a", "b")
+	require.Error(t, err)
+	assert.Nil(t, res)
+}
+
+// TestRenameAction_DoesNotTouchResolvers verifies kind isolation: renaming an
+// action never rewrites a resolver of the same name, and vice versa.
+func TestRenameAction_DoesNotTouchResolvers(t *testing.T) {
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: mixed
+spec:
+  resolvers:
+    build:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: from-resolver
+  workflow:
+    actions:
+      build:
+        provider: shell
+        inputs:
+          command: make
+      deploy:
+        dependsOn:
+          - build
+        provider: shell
+        inputs:
+          value:
+            expr: _.build
+`
+	sol := loadSolution(t, y)
+
+	// Renaming the action "build" must rewrite only the action definition and
+	// its dependsOn use (2 edits) -- never the resolver "build" or the CEL
+	// resolver ref _.build.
+	res, err := RenameAction(sol, "build", "compile")
+	require.NoError(t, err)
+	assert.Len(t, res.Edits, 2)
+
+	out, err := res.Apply(sol.RawContent())
+	require.NoError(t, err)
+
+	newSol := loadSolution(t, string(out))
+	idx, err := refindex.Build(newSol)
+	require.NoError(t, err)
+	// Resolver "build" is untouched; action is now "compile".
+	_, resolverStillThere := idx.Definition(refindex.SymbolResolver, "build")
+	assert.True(t, resolverStillThere, "resolver build must be untouched")
+	_, actionRenamed := idx.Definition(refindex.SymbolAction, "compile")
+	assert.True(t, actionRenamed, "action build must be renamed to compile")
+}

--- a/pkg/refactor/refactor_test.go
+++ b/pkg/refactor/refactor_test.go
@@ -77,11 +77,11 @@ func TestRenameResolver_HappyPath(t *testing.T) {
 	idx, err := refindex.Build(newSol)
 	require.NoError(t, err)
 	assert.Zero(t, idx.Unresolved())
-	def, ok := idx.Definition("env")
+	def, ok := idx.Definition(refindex.SymbolResolver, "env")
 	require.True(t, ok)
 	assert.True(t, def.IsDef)
-	assert.Len(t, idx.Occurrences("env"), 4)
-	_, stillThere := idx.Definition("environment")
+	assert.Len(t, idx.Occurrences(refindex.SymbolResolver, "env"), 4)
+	_, stillThere := idx.Definition(refindex.SymbolResolver, "environment")
 	assert.False(t, stillThere)
 }
 

--- a/pkg/refindex/refindex.go
+++ b/pkg/refindex/refindex.go
@@ -29,6 +29,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/oakwood-commons/scafctl/pkg/action"
 	"github.com/oakwood-commons/scafctl/pkg/celexp"
 	"github.com/oakwood-commons/scafctl/pkg/gotmpl"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
@@ -45,6 +46,8 @@ type SymbolKind int
 const (
 	// SymbolResolver is a resolver defined under spec.resolvers.
 	SymbolResolver SymbolKind = iota
+	// SymbolAction is an action defined under spec.workflow.actions or finally.
+	SymbolAction
 )
 
 // String returns the lowercase kind name.
@@ -52,6 +55,8 @@ func (k SymbolKind) String() string {
 	switch k {
 	case SymbolResolver:
 		return "resolver"
+	case SymbolAction:
+		return "action"
 	default:
 		return "unknown"
 	}
@@ -106,19 +111,26 @@ type Reference struct {
 	IsDef bool
 }
 
+// symbolKey identifies a symbol by kind and name; resolvers and actions may
+// share a name, so references are indexed per (kind, name).
+type symbolKey struct {
+	kind SymbolKind
+	name string
+}
+
 // Index is a queryable set of positioned references over one solution.
 type Index struct {
-	file   string
-	refs   []Reference
-	byName map[string][]Reference
-	// unresolvedByName counts references that were identified semantically but
-	// could not be located byte-exact, attributed to the resolver name they
-	// target. This makes the fail-safe name-scoped: a rename of X is blocked
+	file  string
+	refs  []Reference
+	byKey map[symbolKey][]Reference
+	// unresolvedByKey counts references that were identified semantically but
+	// could not be located byte-exact, attributed to the (kind, name) they
+	// target. This makes the fail-safe symbol-scoped: a rename of X is blocked
 	// only by unlocatable references to X, not by unrelated ones.
-	unresolvedByName map[string]int
-	// unresolvedOther counts unlocatable references whose target name could not
-	// be determined (e.g. an expression/template that failed to parse). These
-	// conservatively block every rename, since they might reference any name.
+	unresolvedByKey map[symbolKey]int
+	// unresolvedOther counts unlocatable references whose target could not be
+	// determined (e.g. an expression/template that failed to parse). These
+	// conservatively block every rename, since they might reference any symbol.
 	unresolvedOther int
 }
 
@@ -129,19 +141,19 @@ func (i *Index) All() []Reference {
 	return out
 }
 
-// Occurrences returns every occurrence of name (definition and uses), sorted by
-// position. This is the set a rename must rewrite.
-func (i *Index) Occurrences(name string) []Reference {
-	src := i.byName[name]
+// Occurrences returns every occurrence of the (kind, name) symbol (definition
+// and uses), sorted by position. This is the set a rename must rewrite.
+func (i *Index) Occurrences(kind SymbolKind, name string) []Reference {
+	src := i.byKey[symbolKey{kind, name}]
 	out := make([]Reference, len(src))
 	copy(out, src)
 	return out
 }
 
-// References returns the non-definition uses of name, sorted by position.
-func (i *Index) References(name string) []Reference {
+// References returns the non-definition uses of the (kind, name) symbol.
+func (i *Index) References(kind SymbolKind, name string) []Reference {
 	var out []Reference
-	for _, r := range i.byName[name] {
+	for _, r := range i.byKey[symbolKey{kind, name}] {
 		if !r.IsDef {
 			out = append(out, r)
 		}
@@ -149,9 +161,10 @@ func (i *Index) References(name string) []Reference {
 	return out
 }
 
-// Definition returns the defining occurrence of name, if one exists.
-func (i *Index) Definition(name string) (Reference, bool) {
-	for _, r := range i.byName[name] {
+// Definition returns the defining occurrence of the (kind, name) symbol, if one
+// exists.
+func (i *Index) Definition(kind SymbolKind, name string) (Reference, bool) {
+	for _, r := range i.byKey[symbolKey{kind, name}] {
 		if r.IsDef {
 			return r, true
 		}
@@ -159,11 +172,13 @@ func (i *Index) Definition(name string) (Reference, bool) {
 	return Reference{}, false
 }
 
-// Names returns the sorted set of symbol names known to the index.
-func (i *Index) Names() []string {
-	out := make([]string, 0, len(i.byName))
-	for n := range i.byName {
-		out = append(out, n)
+// Names returns the sorted set of symbol names of the given kind.
+func (i *Index) Names(kind SymbolKind) []string {
+	var out []string
+	for k := range i.byKey {
+		if k.kind == kind {
+			out = append(out, k.name)
+		}
 	}
 	sort.Strings(out)
 	return out
@@ -174,24 +189,24 @@ func (i *Index) Names() []string {
 // value means the index is not a complete picture of every reference.
 func (i *Index) Unresolved() int {
 	total := i.unresolvedOther
-	for _, n := range i.unresolvedByName {
+	for _, n := range i.unresolvedByKey {
 		total += n
 	}
 	return total
 }
 
 // UnresolvedFor returns the number of unlocatable references that could affect a
-// rename of name: those attributed to name plus any whose target could not be
-// determined. A rename of name must refuse when this is non-zero, or it risks a
-// partial (solution-breaking) rewrite.
-func (i *Index) UnresolvedFor(name string) int {
-	return i.unresolvedByName[name] + i.unresolvedOther
+// rename of the (kind, name) symbol: those attributed to it plus any whose
+// target could not be determined. A rename must refuse when this is non-zero, or
+// it risks a partial (solution-breaking) rewrite.
+func (i *Index) UnresolvedFor(kind SymbolKind, name string) int {
+	return i.unresolvedByKey[symbolKey{kind, name}] + i.unresolvedOther
 }
 
 // Build constructs a positioned reference index for the solution. It returns an
 // empty (non-nil) index when sol is nil.
 func Build(sol *solution.Solution) (*Index, error) {
-	idx := &Index{byName: map[string][]Reference{}, unresolvedByName: map[string]int{}}
+	idx := &Index{byKey: map[symbolKey][]Reference{}, unresolvedByKey: map[symbolKey]int{}}
 	if sol == nil {
 		return idx, nil
 	}
@@ -214,9 +229,16 @@ func Build(sol *solution.Solution) (*Index, error) {
 
 	v := &walk.Visitor{
 		Resolver: func(path, name string, r *resolver.Resolver) error {
-			b.addDefinition(path, name)
+			b.addDefinition(path, name, SymbolResolver)
 			for i, dep := range r.DependsOn {
-				b.addWholeScalarRef(fmt.Sprintf("%s.dependsOn[%d]", path, i), dep, OriginDependsOn)
+				b.addWholeScalarRef(fmt.Sprintf("%s.dependsOn[%d]", path, i), dep, SymbolResolver, OriginDependsOn)
+			}
+			return nil
+		},
+		Action: func(path, name, _ string, act *action.Action) error {
+			b.addDefinition(path, name, SymbolAction)
+			for i, dep := range act.DependsOn {
+				b.addWholeScalarRef(fmt.Sprintf("%s.dependsOn[%d]", path, i), dep, SymbolAction, OriginDependsOn)
 			}
 			return nil
 		},
@@ -227,7 +249,7 @@ func Build(sol *solution.Solution) (*Index, error) {
 		ValueRef: func(path string, vr *spec.ValueRef) error {
 			switch {
 			case vr.Resolver != nil:
-				b.addWholeScalarRef(path+".rslvr", *vr.Resolver, OriginResolverRef)
+				b.addWholeScalarRef(path+".rslvr", *vr.Resolver, SymbolResolver, OriginResolverRef)
 			case vr.Expr != nil:
 				b.addCELRefs(path, vr.Expr)
 			case vr.Tmpl != nil:
@@ -236,7 +258,7 @@ func Build(sol *solution.Solution) (*Index, error) {
 				// walk.Walk does not descend into literal maps/arrays, but scafctl
 				// resolves inline ValueRefs ({rslvr}/{expr}/{tmpl}) nested inside
 				// them. Those references are not positioned here, so record their
-				// target names as unresolved to keep rename fail-safe (C1).
+				// target names as unresolved to keep rename fail-safe.
 				b.markLiteralResolverRefs(vr.Literal)
 			}
 			return nil
@@ -260,174 +282,228 @@ type builder struct {
 	nodes map[string]*yaml.Node
 }
 
-// markUnresolved records that a reference to name could not be located.
-func (b *builder) markUnresolved(name string) { b.idx.unresolvedByName[name]++ }
+// markUnresolved records that a reference to the (kind, name) symbol could not
+// be located.
+func (b *builder) markUnresolved(kind SymbolKind, name string) {
+	b.idx.unresolvedByKey[symbolKey{kind, name}]++
+}
 
-// markUnresolvedUnknown records an unlocatable reference whose target name could
-// not be determined (e.g. a parse failure). It conservatively blocks every
-// rename.
+// markUnresolvedUnknown records an unlocatable reference whose target could not
+// be determined (e.g. a parse failure). It conservatively blocks every rename.
 func (b *builder) markUnresolvedUnknown() { b.idx.unresolvedOther++ }
 
-// addDefinition records the defining site of a resolver, located at its map key.
-func (b *builder) addDefinition(path, name string) {
+// addDefinition records the defining site of a symbol, located at its map key.
+func (b *builder) addDefinition(path, name string, kind SymbolKind) {
 	pos, ok := b.sm.Get(path)
 	if !ok {
-		b.markUnresolved(name)
+		b.markUnresolved(kind, name)
 		return
 	}
 	start := b.li.Offset(pos)
-	b.emitAt(start, name, OriginDefinition, true)
+	b.emitAt(start, name, kind, OriginDefinition, true)
 }
 
 // addWholeScalarRef records a reference whose entire scalar value is the name
 // (dependsOn entries, rslvr values).
-func (b *builder) addWholeScalarRef(path, name string, origin Origin) {
+func (b *builder) addWholeScalarRef(path, name string, kind SymbolKind, origin Origin) {
 	node, ok := b.scalarAt(path)
 	if !ok {
-		b.markUnresolved(name)
+		b.markUnresolved(kind, name)
 		return
 	}
 	start, ok := b.contentStart(node)
 	if !ok {
-		b.markUnresolved(name)
+		b.markUnresolved(kind, name)
 		return
 	}
-	b.emitAt(start, name, origin, false)
+	b.emitAt(start, name, kind, origin, false)
 }
 
-// addCELRefs records every _.name reference inside a CEL expression. basePath is
-// the ValueRef or condition path; the scalar is at basePath.expr (object form)
-// or basePath itself (condition scalar shorthand).
+// celPrefixes are the CEL namespaces this index tracks, each mapped to the
+// symbol kind its references target: "_." for resolver data, "__actions." for
+// action results.
+var celPrefixes = []struct {
+	prefix string
+	kind   SymbolKind
+}{
+	{"_.", SymbolResolver},
+	{celexp.VarActions + ".", SymbolAction},
+}
+
+// addCELRefs records every namespaced reference inside a CEL expression, for
+// each tracked prefix. basePath is the ValueRef or condition path; the scalar is
+// at basePath.expr (object form) or basePath itself (condition scalar shorthand).
 //
-// It reconciles the positioned references against the authoritative underscore
-// variable set: any resolver name the parser reports that a positioned ref did
-// not cover is recorded as unresolved, so a rename fails safe.
+// It reconciles positioned references against the authoritative variable set for
+// each prefix: any name the parser reports that a positioned ref did not cover
+// is recorded as unresolved, so a rename fails safe.
 func (b *builder) addCELRefs(basePath string, expr *celexp.Expression) {
 	if expr == nil {
 		return
 	}
 	node := b.celScalar(basePath)
-	if node == nil {
-		// No scalar to position against; treat all underscore vars as unresolved.
-		if names, err := expr.GetUnderscoreVariables(context.Background()); err == nil {
-			for _, name := range names {
-				b.markUnresolved(name)
-			}
-		} else {
-			b.markUnresolvedUnknown()
+	start := -1
+	if node != nil {
+		if s, ok := b.contentStart(node); ok {
+			start = s
 		}
-		return
 	}
 
-	refs, err := expr.UnderscoreVariableRefs(context.Background())
+	for _, p := range celPrefixes {
+		if start < 0 {
+			b.markCELNamesUnresolved(expr, p.prefix, p.kind)
+			continue
+		}
+		b.addCELPrefixRefs(start, expr, p.prefix, p.kind)
+	}
+}
+
+// markCELNamesUnresolved records all of an expression's names under prefix as
+// unresolved (used when there is no scalar to position against).
+func (b *builder) markCELNamesUnresolved(expr *celexp.Expression, prefix string, kind SymbolKind) {
+	names, err := expr.GetVariablesWithPrefix(context.Background(), prefix)
 	if err != nil {
 		b.markUnresolvedUnknown()
 		return
 	}
-	start, ok := b.contentStart(node)
-	if !ok {
-		for _, r := range refs {
-			b.markUnresolved(r.Name)
-		}
+	for _, name := range names {
+		b.markUnresolved(kind, name)
+	}
+}
+
+// addCELPrefixRefs positions and reconciles the references of one prefix.
+func (b *builder) addCELPrefixRefs(start int, expr *celexp.Expression, prefix string, kind SymbolKind) {
+	refs, err := expr.PrefixedVariableRefs(context.Background(), prefix)
+	if err != nil {
+		b.markUnresolvedUnknown()
 		return
 	}
-
 	attempted := make(map[string]bool, len(refs))
 	for _, r := range refs {
 		attempted[r.Name] = true
 		if r.Offset < 0 {
-			// The occurrence exists but could not be positioned; treat it as
-			// unlocatable so a rename of this name fails safe.
-			b.markUnresolved(r.Name)
+			b.markUnresolved(kind, r.Name)
 			continue
 		}
-		b.emitAt(start+r.Offset, r.Name, OriginCEL, false)
+		b.emitAt(start+r.Offset, r.Name, kind, OriginCEL, false)
 	}
-	// Cross-check: any authoritative underscore variable that the positioned
-	// walker never returned (e.g. an occurrence it could not anchor) is unlocatable.
-	if auth, err := expr.GetUnderscoreVariables(context.Background()); err == nil {
+	// Cross-check against the authoritative name set for this prefix.
+	if auth, err := expr.GetVariablesWithPrefix(context.Background(), prefix); err == nil {
 		for _, name := range auth {
 			if !attempted[name] {
-				b.markUnresolved(name)
+				b.markUnresolved(kind, name)
 			}
 		}
 	}
 }
 
-// addTemplateRefs records explicit ._.name resolver references inside a Go
-// template, and reconciles against the authoritative unscoped reference set so
-// that references it cannot position -- bare {{ .field }}, $-rooted {{ $.name }},
-// or an explicit ref whose bytes do not validate -- are recorded as unresolved
-// (C2). Bare/$ references are conservatively attributed by name: they only block
-// renaming a resolver that shares that exact name.
+// addTemplateRefs records both explicit resolver references ({{ ._.name }}) and
+// action references ({{ .__actions.name }}) inside a Go template, reconciling
+// each against its authoritative unscoped set so unpositionable references are
+// recorded as unresolved (fail-safe).
 func (b *builder) addTemplateRefs(path string, tmpl *gotmpl.GoTemplatingContent) {
 	if tmpl == nil {
 		return
 	}
 	tmplStr := string(*tmpl)
+	node, nodeOk := b.scalarAt(path)
+	start := -1
+	if nodeOk {
+		if s, ok := b.contentStart(node); ok {
+			start = s
+		}
+	}
+	b.addTemplateResolverRefs(tmplStr, start)
+	b.addTemplateActionRefs(tmplStr, start)
+}
 
+// addTemplateResolverRefs handles the resolver forms ({{ ._.name }}, and
+// context-dependent bare/$-rooted fields which are conservatively marked).
+func (b *builder) addTemplateResolverRefs(tmplStr string, start int) {
 	candidates, cerr := gotmpl.UnscopedResolverRefs(tmplStr, "", "")
 	if cerr != nil {
 		b.markUnresolvedUnknown()
 		return
 	}
-
-	node, ok := b.scalarAt(path)
-	if !ok {
+	if start < 0 {
 		for _, c := range candidates {
-			b.markUnresolved(c.Name)
+			b.markUnresolved(SymbolResolver, c.Name)
 		}
 		return
 	}
-	start, ok := b.contentStart(node)
-	if !ok {
-		for _, c := range candidates {
-			b.markUnresolved(c.Name)
-		}
-		return
-	}
-
 	refs, err := gotmpl.GetGoTemplatePositionedReferences(tmplStr, "", "")
 	if err != nil {
 		b.markUnresolvedUnknown()
 		return
 	}
-
-	// Emit the explicit resolver references we can position byte-exact.
 	positionedExplicit := make(map[string]bool)
 	for _, r := range refs {
 		if r.Scoped || r.Kind != gotmpl.RefKindExplicitResolver {
 			continue
 		}
-		if b.emitAt(start+r.Offset, r.Name, OriginTemplate, false) {
+		if b.emitAt(start+r.Offset, r.Name, SymbolResolver, OriginTemplate, false) {
 			positionedExplicit[r.Name] = true
 		}
 	}
-
-	// Reconcile against the authoritative candidate set.
 	for _, c := range candidates {
 		if c.Explicit {
 			if !positionedExplicit[c.Name] {
-				b.markUnresolved(c.Name)
+				b.markUnresolved(SymbolResolver, c.Name)
 			}
 			continue
 		}
-		// Bare or $-rooted reference: cannot be safely positioned.
-		b.markUnresolved(c.Name)
+		b.markUnresolved(SymbolResolver, c.Name)
+	}
+}
+
+// addTemplateActionRefs handles the action form ({{ .__actions.name }}).
+func (b *builder) addTemplateActionRefs(tmplStr string, start int) {
+	names, err := gotmpl.UnscopedActionRefs(tmplStr, "", "")
+	if err != nil {
+		b.markUnresolvedUnknown()
+		return
+	}
+	if len(names) == 0 {
+		return
+	}
+	if start < 0 {
+		for _, n := range names {
+			b.markUnresolved(SymbolAction, n)
+		}
+		return
+	}
+	refs, err := gotmpl.GetGoTemplatePositionedActionReferences(tmplStr, "", "")
+	if err != nil {
+		b.markUnresolvedUnknown()
+		return
+	}
+	positioned := make(map[string]bool)
+	for _, r := range refs {
+		if r.Scoped {
+			continue
+		}
+		if b.emitAt(start+r.Offset, r.Name, SymbolAction, OriginTemplate, false) {
+			positioned[r.Name] = true
+		}
+	}
+	for _, n := range names {
+		if !positioned[n] {
+			b.markUnresolved(SymbolAction, n)
+		}
 	}
 }
 
 // emitAt validates that the bytes at [start, start+len(name)) equal name and, if
 // so, records the reference and returns true. A mismatch (or out-of-range span)
-// is attributed to name as unresolved and returns false.
-func (b *builder) emitAt(start int, name string, origin Origin, isDef bool) bool {
+// is attributed to the (kind, name) symbol as unresolved and returns false.
+func (b *builder) emitAt(start int, name string, kind SymbolKind, origin Origin, isDef bool) bool {
 	end := start + len(name)
 	if start < 0 || end > len(b.raw) || string(b.raw[start:end]) != name {
-		b.markUnresolved(name)
+		b.markUnresolved(kind, name)
 		return false
 	}
 	b.idx.record(Reference{
-		Symbol: Symbol{Kind: SymbolResolver, Name: name},
+		Symbol: Symbol{Kind: kind, Name: name},
 		Range:  b.li.Range(start, end),
 		Origin: origin,
 		IsDef:  isDef,
@@ -468,25 +544,36 @@ func (b *builder) markLiteralResolverRefsDepth(v any, depth int) {
 	}
 }
 
-// markLiteralValueRef records the resolver names referenced by a single nested
-// inline ValueRef as unresolved.
+// markLiteralValueRef records the symbol names referenced by a single nested
+// inline ValueRef as unresolved (both resolver and action namespaces).
 func (b *builder) markLiteralValueRef(payload, kind string) {
 	switch kind {
 	case "rslvr":
-		b.markUnresolved(payload)
+		b.markUnresolved(SymbolResolver, payload)
 	case "expr":
 		expr := celexp.Expression(payload)
-		if names, err := expr.GetUnderscoreVariables(context.Background()); err == nil {
-			for _, n := range names {
-				b.markUnresolved(n)
+		for _, p := range celPrefixes {
+			names, err := expr.GetVariablesWithPrefix(context.Background(), p.prefix)
+			if err != nil {
+				b.markUnresolvedUnknown()
+				return
 			}
-		} else {
-			b.markUnresolvedUnknown()
+			for _, n := range names {
+				b.markUnresolved(p.kind, n)
+			}
 		}
 	case "tmpl":
 		if cands, err := gotmpl.UnscopedResolverRefs(payload, "", ""); err == nil {
 			for _, c := range cands {
-				b.markUnresolved(c.Name)
+				b.markUnresolved(SymbolResolver, c.Name)
+			}
+		} else {
+			b.markUnresolvedUnknown()
+			return
+		}
+		if names, err := gotmpl.UnscopedActionRefs(payload, "", ""); err == nil {
+			for _, n := range names {
+				b.markUnresolved(SymbolAction, n)
 			}
 		} else {
 			b.markUnresolvedUnknown()
@@ -561,16 +648,17 @@ func (b *builder) contentStart(n *yaml.Node) (int, bool) {
 // finalize sorts references by position for deterministic output.
 func (i *Index) finalize() {
 	sort.SliceStable(i.refs, func(a, c int) bool { return lessRange(i.refs[a].Range, i.refs[c].Range) })
-	for name := range i.byName {
-		refs := i.byName[name]
+	for key := range i.byKey {
+		refs := i.byKey[key]
 		sort.SliceStable(refs, func(a, c int) bool { return lessRange(refs[a].Range, refs[c].Range) })
-		i.byName[name] = refs
+		i.byKey[key] = refs
 	}
 }
 
 func (i *Index) record(r Reference) {
+	key := symbolKey{r.Symbol.Kind, r.Symbol.Name}
 	i.refs = append(i.refs, r)
-	i.byName[r.Symbol.Name] = append(i.byName[r.Symbol.Name], r)
+	i.byKey[key] = append(i.byKey[key], r)
 }
 
 func lessRange(a, b sourcepos.Range) bool {

--- a/pkg/refindex/refindex_action_test.go
+++ b/pkg/refindex/refindex_action_test.go
@@ -1,0 +1,178 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refindex
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/celexp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// actionFixtureYAML references action "build" via dependsOn, CEL
+// (__actions.build) and template (.__actions.build). "make build" is unrelated
+// literal text. "deploy" carries an alias that must NOT be treated as a
+// reference to the action it names. A finally action references a regular one.
+const actionFixtureYAML = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: refindex-action-test
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      build:
+        alias: b
+        provider: shell
+        inputs:
+          command: make build
+      deploy:
+        dependsOn:
+          - build
+        provider: shell
+        when:
+          expr: __actions.build.results.exitCode == 0
+        inputs:
+          command:
+            tmpl: 'deploy {{ .__actions.build.results.stdout }}'
+    finally:
+      cleanup:
+        provider: shell
+        inputs:
+          note:
+            expr: __actions.deploy.results.exitCode
+`
+
+func TestBuild_ActionNamesAndDefinitions(t *testing.T) {
+	idx, raw, li := buildFixture(t, actionFixtureYAML)
+
+	assert.Equal(t, []string{"build", "cleanup", "deploy"}, idx.Names(SymbolAction))
+	assert.Zero(t, idx.Unresolved(), "clean action fixture should have no unresolved refs")
+
+	for _, name := range idx.Names(SymbolAction) {
+		def, ok := idx.Definition(SymbolAction, name)
+		require.Truef(t, ok, "definition for action %q", name)
+		assert.True(t, def.IsDef)
+		assert.Equal(t, OriginDefinition, def.Origin)
+		assert.Equal(t, SymbolAction, def.Symbol.Kind)
+		assertByteExact(t, raw, li, def)
+	}
+}
+
+func TestBuild_ActionReferencesByOrigin(t *testing.T) {
+	idx, raw, li := buildFixture(t, actionFixtureYAML)
+
+	// "build" is referenced three ways: dependsOn, CEL (when expr), template.
+	buildRefs := idx.References(SymbolAction, "build")
+	origins := map[Origin]int{}
+	for _, r := range buildRefs {
+		origins[r.Origin]++
+		assert.False(t, r.IsDef)
+		assert.Equal(t, SymbolAction, r.Symbol.Kind)
+		assertByteExact(t, raw, li, r)
+	}
+	assert.Equal(t, 1, origins[OriginDependsOn], "dependsOn ref")
+	assert.Equal(t, 1, origins[OriginCEL], "when expr CEL ref")
+	assert.Equal(t, 1, origins[OriginTemplate], "template ref")
+	assert.Len(t, buildRefs, 3)
+
+	// "deploy" is referenced once, from the finally action's CEL expression.
+	deployRefs := idx.References(SymbolAction, "deploy")
+	assert.Len(t, deployRefs, 1)
+	assert.Equal(t, OriginCEL, deployRefs[0].Origin)
+	assertByteExact(t, raw, li, deployRefs[0])
+}
+
+func TestBuild_ActionAliasIsNotAReference(t *testing.T) {
+	idx := mustBuild(t, actionFixtureYAML)
+
+	// The alias "b" on action "build" is an independent name, not a reference to
+	// any action -- renaming an action must not touch it.
+	assert.Empty(t, idx.References(SymbolAction, "b"), "alias must not be a reference")
+	_, defined := idx.Definition(SymbolAction, "b")
+	assert.False(t, defined, "alias must not be an action definition")
+	assert.NotContains(t, idx.Names(SymbolAction), "b")
+}
+
+func TestBuild_ActionOccurrencesIncludeDefinition(t *testing.T) {
+	idx, raw, li := buildFixture(t, actionFixtureYAML)
+
+	occ := idx.Occurrences(SymbolAction, "build")
+	// 1 definition + 3 uses.
+	assert.Len(t, occ, 4)
+
+	defCount := 0
+	for _, r := range occ {
+		if r.IsDef {
+			defCount++
+		}
+		assertByteExact(t, raw, li, r)
+	}
+	assert.Equal(t, 1, defCount)
+	assert.True(t, occ[0].IsDef, "first occurrence is the definition")
+}
+
+func TestBuild_ActionAndResolverKindsAreIsolated(t *testing.T) {
+	idx := mustBuild(t, actionFixtureYAML)
+
+	// This fixture defines actions but no resolvers -- action names must not
+	// leak into the resolver kind and vice versa.
+	assert.Empty(t, idx.Names(SymbolResolver))
+	assert.Empty(t, idx.References(SymbolResolver, "build"))
+	_, defined := idx.Definition(SymbolResolver, "build")
+	assert.False(t, defined)
+}
+
+// mustBuild builds an index from YAML, failing the test on error.
+func mustBuild(t *testing.T, y string) *Index {
+	t.Helper()
+	idx, _, _ := buildFixture(t, y)
+	return idx
+}
+
+// TestMarkCELNamesUnresolved_ActionFailSafe white-box tests the defensive branch
+// taken when a CEL scalar cannot be positioned at all: every action name in the
+// expression must be attributed to the unresolved set so the rename fails safe.
+func TestMarkCELNamesUnresolved_ActionFailSafe(t *testing.T) {
+	b := &builder{idx: &Index{byKey: map[symbolKey][]Reference{}, unresolvedByKey: map[symbolKey]int{}}}
+	expr := celexp.Expression(`__actions.build.results + __actions.deploy.status`)
+	b.markCELNamesUnresolved(&expr, "__actions.", SymbolAction)
+
+	assert.Positive(t, b.idx.UnresolvedFor(SymbolAction, "build"))
+	assert.Positive(t, b.idx.UnresolvedFor(SymbolAction, "deploy"))
+}
+
+func TestBuild_UnpositionableActionCELRefIsUnresolved(t *testing.T) {
+	// An action CEL reference nested inside a literal array has no positionable
+	// scalar node, so it must be recorded as unresolved (attributed to that
+	// action name) rather than silently dropped -- exercising the
+	// markCELNamesUnresolved fail-safe for the action kind. This blocks a rename
+	// of that action, which is the safe behavior.
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: unpositionable-action
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      build:
+        provider: message
+        inputs:
+          message: building
+      deploy:
+        provider: message
+        inputs:
+          value:
+            items:
+              - expr: __actions.build.results
+`
+	idx := mustBuild(t, y)
+	assert.Positive(t, idx.Unresolved())
+	assert.Positive(t, idx.UnresolvedFor(SymbolAction, "build"),
+		"a nested (unpositionable) action CEL ref must count against that action")
+	// Name-scoped: an unrelated action is not blocked.
+	assert.Zero(t, idx.UnresolvedFor(SymbolAction, "deploy"))
+}

--- a/pkg/refindex/refindex_test.go
+++ b/pkg/refindex/refindex_test.go
@@ -75,11 +75,11 @@ func assertByteExact(t *testing.T, raw []byte, li *sourcepos.LineIndex, r Refere
 func TestBuild_NamesAndDefinitions(t *testing.T) {
 	idx, raw, li := buildFixture(t, fixtureYAML)
 
-	assert.Equal(t, []string{"aliasRef", "appName", "environment", "greeting"}, idx.Names())
+	assert.Equal(t, []string{"aliasRef", "appName", "environment", "greeting"}, idx.Names(SymbolResolver))
 	assert.Zero(t, idx.Unresolved(), "clean fixture should have no unresolved refs")
 
-	for _, name := range idx.Names() {
-		def, ok := idx.Definition(name)
+	for _, name := range idx.Names(SymbolResolver) {
+		def, ok := idx.Definition(SymbolResolver, name)
 		require.Truef(t, ok, "definition for %q", name)
 		assert.True(t, def.IsDef)
 		assert.Equal(t, OriginDefinition, def.Origin)
@@ -93,7 +93,7 @@ func TestBuild_ReferencesByOrigin(t *testing.T) {
 
 	// "environment" is referenced four ways: dependsOn, CEL (when), CEL (expr),
 	// and template.
-	envRefs := idx.References("environment")
+	envRefs := idx.References(SymbolResolver, "environment")
 	origins := map[Origin]int{}
 	for _, r := range envRefs {
 		origins[r.Origin]++
@@ -106,7 +106,7 @@ func TestBuild_ReferencesByOrigin(t *testing.T) {
 	assert.Len(t, envRefs, 4)
 
 	// "appName" is referenced by a template (._.appName) and a rslvr.
-	appRefs := idx.References("appName")
+	appRefs := idx.References(SymbolResolver, "appName")
 	appOrigins := map[Origin]int{}
 	for _, r := range appRefs {
 		appOrigins[r.Origin]++
@@ -120,7 +120,7 @@ func TestBuild_ReferencesByOrigin(t *testing.T) {
 func TestBuild_Occurrences_IncludesDefinition(t *testing.T) {
 	idx, raw, li := buildFixture(t, fixtureYAML)
 
-	occ := idx.Occurrences("environment")
+	occ := idx.Occurrences(SymbolResolver, "environment")
 	// 1 definition + 4 uses.
 	assert.Len(t, occ, 5)
 
@@ -179,7 +179,7 @@ spec:
               value: yes
 `
 	idx, raw, li := buildFixture(t, y)
-	refs := idx.References("environment")
+	refs := idx.References(SymbolResolver, "environment")
 	require.Len(t, refs, 1)
 	assert.Equal(t, OriginCEL, refs[0].Origin)
 	assertByteExact(t, raw, li, refs[0])
@@ -207,7 +207,7 @@ spec:
                 expr: '_.environment'
 `
 	idx, raw, li := buildFixture(t, y)
-	refs := idx.References("environment")
+	refs := idx.References(SymbolResolver, "environment")
 	require.Len(t, refs, 1)
 	assert.Equal(t, OriginCEL, refs[0].Origin)
 	assertByteExact(t, raw, li, refs[0])
@@ -257,7 +257,7 @@ spec:
 	idx, raw, li := buildFixture(t, y)
 
 	// Line-1 explicit ref in the block resolves byte-exact.
-	appRefs := idx.References("appName")
+	appRefs := idx.References(SymbolResolver, "appName")
 	require.Len(t, appRefs, 1)
 	assert.Equal(t, OriginTemplate, appRefs[0].Origin)
 	assertByteExact(t, raw, li, appRefs[0])
@@ -270,15 +270,15 @@ func TestBuild_Nil(t *testing.T) {
 	idx, err := Build(nil)
 	require.NoError(t, err)
 	assert.Empty(t, idx.All())
-	assert.Empty(t, idx.Names())
-	_, ok := idx.Definition("x")
+	assert.Empty(t, idx.Names(SymbolResolver))
+	_, ok := idx.Definition(SymbolResolver, "x")
 	assert.False(t, ok)
 }
 
 func TestBuild_EmptyReferencesForUnknown(t *testing.T) {
 	idx, _, _ := buildFixture(t, fixtureYAML)
-	assert.Empty(t, idx.References("does-not-exist"))
-	assert.Empty(t, idx.Occurrences("does-not-exist"))
+	assert.Empty(t, idx.References(SymbolResolver, "does-not-exist"))
+	assert.Empty(t, idx.Occurrences(SymbolResolver, "does-not-exist"))
 }
 
 func TestBuild_MalformedExpressionsAreSkipped(t *testing.T) {
@@ -304,9 +304,9 @@ spec:
 	require.NoError(t, sol.UnmarshalFromBytes([]byte(y)))
 	idx, err := Build(sol)
 	require.NoError(t, err)
-	assert.Empty(t, idx.References("a"))
-	assert.Empty(t, idx.References("x"))
-	_, ok := idx.Definition("broken")
+	assert.Empty(t, idx.References(SymbolResolver, "a"))
+	assert.Empty(t, idx.References(SymbolResolver, "x"))
+	_, ok := idx.Definition(SymbolResolver, "broken")
 	assert.True(t, ok)
 }
 
@@ -392,18 +392,18 @@ spec:
 	idx, _, _ := buildFixture(t, y)
 
 	// Every reference above targets "environment" and is unpositioned.
-	assert.GreaterOrEqual(t, idx.UnresolvedFor("environment"), 3,
+	assert.GreaterOrEqual(t, idx.UnresolvedFor(SymbolResolver, "environment"), 3,
 		"nested rslvr + nested expr + $-template must all count against environment")
 
 	// The fail-safe is name-scoped: renaming an unrelated resolver is not blocked.
-	assert.Zero(t, idx.UnresolvedFor("other"))
-	assert.Zero(t, idx.UnresolvedFor("nestedRslvr"))
+	assert.Zero(t, idx.UnresolvedFor(SymbolResolver, "other"))
+	assert.Zero(t, idx.UnresolvedFor(SymbolResolver, "nestedRslvr"))
 }
 
 func TestBuild_CleanFixtureHasNoPerNameUnresolved(t *testing.T) {
 	idx, _, _ := buildFixture(t, fixtureYAML)
-	for _, name := range idx.Names() {
-		assert.Zerof(t, idx.UnresolvedFor(name), "resolver %q should have no unresolved refs", name)
+	for _, name := range idx.Names(SymbolResolver) {
+		assert.Zerof(t, idx.UnresolvedFor(SymbolResolver, name), "resolver %q should have no unresolved refs", name)
 	}
 }
 
@@ -432,7 +432,7 @@ spec:
                   - tmpl: "{{ ._.environment }}"
 `
 	idx, _, _ := buildFixture(t, y)
-	assert.GreaterOrEqual(t, idx.UnresolvedFor("environment"), 1)
+	assert.GreaterOrEqual(t, idx.UnresolvedFor(SymbolResolver, "environment"), 1)
 }
 
 func TestBuild_MalformedNestedExprBlocksAllRenames(t *testing.T) {
@@ -456,8 +456,8 @@ spec:
 	idx, _, _ := buildFixture(t, y)
 	assert.Positive(t, idx.Unresolved())
 	// unresolvedOther is included for every name.
-	assert.Positive(t, idx.UnresolvedFor("environment"))
-	assert.Positive(t, idx.UnresolvedFor("anything-at-all"))
+	assert.Positive(t, idx.UnresolvedFor(SymbolResolver, "environment"))
+	assert.Positive(t, idx.UnresolvedFor(SymbolResolver, "anything-at-all"))
 }
 
 func TestBuild_UnpositionableCELRefIsUnresolved(t *testing.T) {
@@ -480,5 +480,5 @@ spec:
 `
 	idx, _, _ := buildFixture(t, y)
 	assert.Positive(t, idx.Unresolved())
-	assert.Positive(t, idx.UnresolvedFor(`a"b`))
+	assert.Positive(t, idx.UnresolvedFor(SymbolResolver, `a"b`))
 }

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13705,6 +13705,85 @@ func TestIntegration_RefactorHelp(t *testing.T) {
 	assert.Contains(t, stdout, "rename")
 }
 
+// ── refactor rename action ───────────────────────────────────────────────────
+
+const refactorRenameActionFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: refactor-action-int # keep this comment
+spec:
+  resolvers: {}
+  workflow:
+    actions:
+      build:
+        alias: b
+        provider: message
+        inputs:
+          message: make build
+      deploy:
+        dependsOn:
+          - build
+        provider: message
+        when:
+          expr: __actions.build.success
+        inputs:
+          message:
+            tmpl: 'deploy {{ .__actions.build.message }}'
+`
+
+func writeRefactorActionFixture(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "solution.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(refactorRenameActionFixture), 0o600))
+	return path
+}
+
+func TestIntegration_RefactorRenameActionDryRun(t *testing.T) {
+	t.Parallel()
+	path := writeRefactorActionFixture(t)
+
+	stdout, _, exitCode := runScafctl(t, "refactor", "rename", "action", "build", "compile", "-f", path, "--dry-run")
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Would rename action")
+	assert.Contains(t, stdout, "build -> compile")
+
+	// Dry-run must not modify the file.
+	got, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	assert.Equal(t, refactorRenameActionFixture, string(got))
+}
+
+func TestIntegration_RefactorRenameActionApply(t *testing.T) {
+	t.Parallel()
+	path := writeRefactorActionFixture(t)
+
+	stdout, _, exitCode := runScafctl(t, "refactor", "rename", "action", "build", "compile", "-f", path)
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "Renamed action")
+
+	got, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	s := string(got)
+	assert.Contains(t, s, "compile:")
+	assert.Contains(t, s, "- compile")
+	assert.Contains(t, s, "__actions.compile.success")
+	assert.Contains(t, s, ".__actions.compile.message")
+	// The action's alias is a separate name and must be left untouched.
+	assert.Contains(t, s, "alias: b")
+	// Unrelated literal text is preserved.
+	assert.Contains(t, s, "message: make build")
+	assert.Contains(t, s, "# keep this comment")
+}
+
+func TestIntegration_RefactorRenameActionCollision(t *testing.T) {
+	t.Parallel()
+	path := writeRefactorActionFixture(t)
+
+	_, stderr, exitCode := runScafctl(t, "refactor", "rename", "action", "build", "deploy", "-f", path)
+	assert.Equal(t, exitcode.ValidationFailed, exitCode)
+	assert.Contains(t, stderr, "already exists")
+}
+
 // ── lsp (language server over stdio) ─────────────────────────────────────────
 
 // lspFrame wraps a JSON-RPC message in an LSP Content-Length frame.


### PR DESCRIPTION
## Summary

Extends the positioned reference-finding and rename framework -- previously
resolver-only (added in #752/#753/#756/#758) -- to also cover **workflow
actions**, across every consuming layer (CLI, LSP, MCP), with no AST round-trip.

The reference index (`pkg/refindex`) is now **kind-aware**: symbols are keyed by
`(SymbolKind, name)` and every query/builder method takes a `SymbolKind`, so
resolvers and actions never collide. Action references are extracted from:

- `dependsOn` entries
- CEL `__actions.<name>` expressions
- explicit template `.__actions.<name>` uses
- the definition (the action's map key under `spec.workflow.actions` / `finally`)

## New user-facing surface

| Layer | Addition |
|-------|----------|
| CLI | `scafctl refactor rename action <old> <new>` (`--dry-run`, `-f`), sharing a new `newRenameCommand` builder with the resolver command |
| LSP | go-to-definition, find-references, and rename now operate on actions as well as resolvers |
| MCP | `find_action_references` and `rename_action` tools, built from shared kind-generic handlers |

## Internals

- Positioned extractors: `celexp.Expression.PrefixedVariableRefs`,
  `gotmpl.GetPositionedActionReferences`, `gotmpl.UnscopedActionRefs`.
- Refactor engine: generic `RenameSymbol(kind, ...)` with `RenameResolver` /
  `RenameAction` wrappers.
- New `RefKindExplicitAction`; `__actions` namespace centralized in constants
  (`celexp.VarActions`, `gotmpl` `actionNamespace`).

## Invariants (tested)

Renaming an action never rewrites:
- a same-named **resolver** (kind isolation),
- the action's independent **`alias`**, or
- unrelated **literal text** (e.g. `command: make build`).

Any reference that cannot be located byte-exact **aborts** the rename rather than
producing a partial, solution-breaking rewrite (name- and kind-scoped fail-safe).

## Tests & docs

- Unit tests for the new extractors (`gotmpl`, `celexp`) plus a benchmark for the
  action extractor; kind-isolation, alias-independence, and fail-safe tests in
  `refindex`/`refactor`; a white-box test for the `markCELNamesUnresolved`
  fail-safe branch.
- LSP action navigation/rename tests; CLI unit + integration tests
  (`tests/integration/cli_test.go`); MCP action tool tests.
- Docs: `docs/design/cli.md`, refactor/lsp/mcp tutorials, MCP tool table, and
  `examples/refactor/action-solution.yaml`.

## Verification

`go build` / `gofmt` / `go vet` clean; `-race` tests green across all affected
packages; **933 integration tests pass**; solution lint clean; scoped
`golangci-lint --new-from-merge-base` reports 0 issues.