### PR TITLE
fix(gotmpl): tolerate author-defined functions when extracting template references

### DIFF
--- a/pkg/action/validation_test.go
+++ b/pkg/action/validation_test.go
@@ -1144,6 +1144,17 @@ func TestExtractRefsFromExpression_WithActions(t *testing.T) {
 	assert.Contains(t, refs, "build")
 }
 
+// TestExtractRefsFromTemplate_AuthorFunction is a regression test: an __actions
+// reference wrapped in a call to an author-defined function must still be
+// extracted, so the action dependency graph infers the edge rather than
+// silently dropping it because the template failed to parse.
+func TestExtractRefsFromTemplate_AuthorFunction(t *testing.T) {
+	refs := make(map[string]struct{})
+	tmpl := gotmpl.GoTemplatingContent(`{{ greet .__actions.build.message }}`)
+	extractRefsFromTemplate(&tmpl, refs)
+	assert.Contains(t, refs, "build")
+}
+
 func TestValidateGlobSafety(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/gotmpl/refs.go
+++ b/pkg/gotmpl/refs.go
@@ -70,10 +70,10 @@ func (s *Service) GetReferences(ctx context.Context, opts TemplateOptions) ([]Te
 
 	// Parse the template using text/template/parse.
 	// Pass the service's function map so the parser recognises built-in and
-	// extension functions (e.g. index, printf, sprig helpers). Without this,
-	// templates that call these functions fail to parse and their variable
-	// references are silently lost.
-	trees, err := parse.Parse(opts.Name, opts.Content, leftDelim, rightDelim, s.templateFuncNamesWith(opts.DeclaredFuncs))
+	// extension functions (e.g. index, printf, sprig helpers). Unknown
+	// author-defined functions (spec.functions) are tolerated so their invoking
+	// templates still yield references rather than failing to parse.
+	trees, err := parseTemplatesTolerant(opts.Name, opts.Content, leftDelim, rightDelim, s.templateFuncNamesWith(opts.DeclaredFuncs))
 	if err != nil {
 		lgr.Error(err, "failed to parse template for reference extraction",
 			"name", opts.Name)

--- a/pkg/gotmpl/refs_position.go
+++ b/pkg/gotmpl/refs_position.go
@@ -88,7 +88,7 @@ func (s *Service) GetPositionedReferences(opts TemplateOptions) ([]PositionedRef
 		name = "unnamed-template"
 	}
 
-	trees, err := parse.Parse(name, opts.Content, leftDelim, rightDelim, s.templateFuncNamesWith(opts.DeclaredFuncs))
+	trees, err := parseTemplatesTolerant(name, opts.Content, leftDelim, rightDelim, s.templateFuncNamesWith(opts.DeclaredFuncs))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse template: %w", err)
 	}
@@ -123,7 +123,7 @@ func (s *Service) GetPositionedActionReferences(opts TemplateOptions) ([]Positio
 		return nil, fmt.Errorf("template content cannot be empty")
 	}
 
-	trees, err := parse.Parse(name, opts.Content, leftDelim, rightDelim, s.templateFuncNamesWith(opts.DeclaredFuncs))
+	trees, err := parseTemplatesTolerant(name, opts.Content, leftDelim, rightDelim, s.templateFuncNamesWith(opts.DeclaredFuncs))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse template: %w", err)
 	}

--- a/pkg/gotmpl/tolerant_parse.go
+++ b/pkg/gotmpl/tolerant_parse.go
@@ -1,0 +1,33 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gotmpl
+
+import "text/template/parse"
+
+// parseTemplatesTolerant parses a template for REFERENCE/DEPENDENCY extraction,
+// tolerating unknown functions -- typically solution-author-defined helpers
+// (spec.functions) invoked as {{ myFunc .x }}. By default text/template's parser
+// rejects a template that invokes a function it does not know, which would
+// otherwise make every reference in that template invisible to the extractor
+// (breaking dependency inference, lint, state param tracking, and `eval refs`).
+//
+// It uses the standard-library parser's parse.SkipFuncCheck mode, which disables
+// the "is this function defined" check while still reporting genuine syntax
+// errors. This is safe for reference extraction because it only affects whether
+// unknown identifiers in function position are accepted -- extraction walks the
+// resulting parse tree structurally and nothing is executed. It must NOT be used
+// for template execution or syntax validation, where an undefined function is a
+// real error the caller needs to see.
+//
+// funcs is still passed through so declared built-in/extension/author names are
+// available to the tree (harmless under SkipFuncCheck); the map is not mutated.
+func parseTemplatesTolerant(name, content, leftDelim, rightDelim string, funcs map[string]any) (map[string]*parse.Tree, error) {
+	t := parse.New(name)
+	t.Mode = parse.SkipFuncCheck
+	treeSet := make(map[string]*parse.Tree)
+	if _, err := t.Parse(content, leftDelim, rightDelim, treeSet, funcs); err != nil {
+		return nil, err
+	}
+	return treeSet, nil
+}

--- a/pkg/gotmpl/tolerant_parse_test.go
+++ b/pkg/gotmpl/tolerant_parse_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package gotmpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTemplatesTolerant(t *testing.T) {
+	base := map[string]any{"printf": true}
+
+	tests := []struct {
+		name    string
+		tmpl    string
+		wantErr bool
+	}{
+		{"no unknown functions", `{{ .x }} {{ printf "%s" .y }}`, false},
+		{"single author function", `{{ greet .x }}`, false},
+		{"multiple author functions", `{{ greet .x }}{{ shout .y }}`, false},
+		{"author function piped", `{{ .x | greet }}`, false},
+		{"author function nested", `{{ printf "%s" (greet .x) }}`, false},
+		{"genuine syntax error still fails", `{{ .x `, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			trees, err := parseTemplatesTolerant("t", tt.tmpl, "", "", base)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, trees)
+		})
+	}
+
+	// The caller's func map must not be mutated by tolerant parsing.
+	_, err := parseTemplatesTolerant("t", `{{ greet .x }}`, "", "", base)
+	require.NoError(t, err)
+	_, leaked := base["greet"]
+	assert.False(t, leaked, "tolerant parse must not mutate the caller's funcs map")
+}
+
+// TestGetGoTemplateReferences_TolerateAuthorFunctions is the regression test for
+// the core fix: reference extraction from a template that invokes an unknown
+// (author-defined) function must succeed and still return the data references,
+// rather than failing to parse and silently dropping them.
+func TestGetGoTemplateReferences_TolerateAuthorFunctions(t *testing.T) {
+	refs, err := GetGoTemplateReferences(`{{ greet ._.env }} and {{ loud ._.appName }}`, "", "")
+	require.NoError(t, err)
+
+	paths := make(map[string]bool)
+	for _, r := range refs {
+		paths[r.Path] = true
+	}
+	assert.True(t, paths["._.env"], "resolver ref ._.env must survive the author-function call")
+	assert.True(t, paths["._.appName"], "resolver ref ._.appName must survive the author-function call")
+
+	// A genuine syntax error is still reported.
+	_, err = GetGoTemplateReferences(`{{ .x `, "", "")
+	require.Error(t, err)
+}
+
+// TestPositionedExtractors_TolerateAuthorFunctions confirms the positioned
+// reference extractors also tolerate an unknown author function even when no
+// declaredFuncs are supplied (refindex passes them, but the extractors must not
+// depend on it to avoid dropping references).
+func TestPositionedExtractors_TolerateAuthorFunctions(t *testing.T) {
+	refs, err := GetGoTemplatePositionedReferences(`{{ greet ._.env }}`, "", "", nil)
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+	assert.Equal(t, "env", refs[0].Name)
+
+	aRefs, err := GetGoTemplatePositionedActionReferences(`{{ greet .__actions.build }}`, "", "", nil)
+	require.NoError(t, err)
+	require.Len(t, aRefs, 1)
+	assert.Equal(t, "build", aRefs[0].Name)
+}

--- a/pkg/lint/lint_test.go
+++ b/pkg/lint/lint_test.go
@@ -1747,6 +1747,16 @@ func TestLintTemplateUnderscorePrefix(t *testing.T) {
 			tmpl:        "{{ .__actions.build.result }}",
 			expectError: false,
 		},
+		{
+			// Regression: an underscore ref inside a call to an author-defined
+			// function must still be flagged. Before reference extraction
+			// tolerated unknown functions, the template failed to parse and the
+			// lint silently produced nothing.
+			name:        "underscore ref inside author-function call is flagged",
+			tmpl:        "{{ greet ._.config.appName }}",
+			expectError: true,
+			errorCount:  1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/resolver/refs/refs_test.go
+++ b/pkg/resolver/refs/refs_test.go
@@ -193,3 +193,15 @@ func TestExtractFromTemplate_ScopedReferences(t *testing.T) {
 		assert.NotContains(t, refs, "name")
 	})
 }
+
+// TestExtractFromTemplate_AuthorFunction is a regression test: extracting
+// resolver references from a template on stdin/a file has no solution context
+// and thus cannot know author-function names, but the extractor must still
+// tolerate the unknown function and return the resolver references rather than
+// failing to parse.
+func TestExtractFromTemplate_AuthorFunction(t *testing.T) {
+	t.Parallel()
+	refs, err := ExtractFromTemplate(`{{ greet ._.env }} and {{ loud ._.appName }}`, "{{", "}}")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"env", "appName"}, refs)
+}

--- a/pkg/spec/valueref_test.go
+++ b/pkg/spec/valueref_test.go
@@ -1289,3 +1289,16 @@ func TestValueRef_ReferencedVariables_ScopedRefs(t *testing.T) {
 	_, hasHost := vars["host"]
 	assert.False(t, hasHost, "scoped ref inside {{ with }} should be excluded")
 }
+
+// TestValueRef_ReferencedVariables_AuthorFunction is a regression test: a
+// template that invokes an author-defined function (unknown to the parser) must
+// still yield its data references rather than silently dropping them because the
+// template failed to parse.
+func TestValueRef_ReferencedVariables_AuthorFunction(t *testing.T) {
+	tmpl := gotmpl.GoTemplatingContent(`{{ greet .config }} and {{ loud .env }}`)
+	vr := ValueRef{Tmpl: &tmpl}
+	vars := vr.ReferencedVariables()
+
+	assert.Contains(t, vars, "config", "ref inside an author-function call must be captured")
+	assert.Contains(t, vars, "env", "ref inside an author-function call must be captured")
+}

--- a/pkg/state/manager_test.go
+++ b/pkg/state/manager_test.go
@@ -1386,3 +1386,15 @@ func TestLoad_MissingParamsError(t *testing.T) {
 		assert.False(t, result.Skipped)
 	})
 }
+
+// TestExtractParamRefs_AuthorFunction is a regression test: a __params
+// reference wrapped in a call to an author-defined function must still be
+// tracked, so state up-to-date checks see the param dependency rather than
+// dropping it because the template failed to parse.
+func TestExtractParamRefs_AuthorFunction(t *testing.T) {
+	tmpl := gotmpl.GoTemplatingContent(`{{ greet .__params.project }}`)
+	vr := &spec.ValueRef{Tmpl: &tmpl}
+	seen := make(map[string]struct{})
+	extractParamRefs(context.Background(), vr, seen)
+	assert.Contains(t, seen, "project")
+}


### PR DESCRIPTION
## Summary

Template **reference-extraction** in `pkg/gotmpl` (`GetGoTemplateReferences` and
the positioned extractors) parsed templates with `text/template`'s default
parser, which **rejects** a template that invokes a solution-author-defined
function (`spec.functions`, invoked as `{{ myFunc .x }}`) with
`function "myFunc" not defined`. Every data reference in such a template was
then silently dropped -- breaking:

- resolver/action **dependency inference** (a `{{ myFunc __actions.build.x }}`
  input lost the `build` edge),
- **lint** checks that scan template references,
- **state** `__params` tracking (up-to-date checks), and
- the `eval refs` command (which runs on raw template files with no solution).

## Fix

Add `parseTemplatesTolerant`, which parses for reference extraction using the
standard library's `parse.SkipFuncCheck` mode -- it disables the "is this
function defined" check (so an unknown function no longer aborts parsing) while
still reporting genuine syntax errors. The three reference-extraction parse
sites now use it.

Template **execution** and **syntax validation** are deliberately left
unchanged: there, an undefined function is a real error the caller must see.
(Author-function execution itself already works -- only extraction was broken.)

This fixes extraction for every downstream caller (`pkg/lint`, `pkg/spec`,
`pkg/state`, `pkg/action`, `pkg/resolver/refs`) with **no signature or API
changes**. It was chosen over threading author-function names through each
caller because some callers (the `resolver/refs` CLI utilities) operate on a
raw template file / stdin and have no solution context to obtain the names from.

## Tests

- `pkg/gotmpl/tolerant_parse_test.go`: `parseTemplatesTolerant` (no-unknown /
  single / multiple / piped / nested author functions, genuine syntax error,
  no caller-map mutation); `GetGoTemplateReferences` tolerance + syntax-error
  preservation; positioned extractors tolerant with no `declaredFuncs`.
- Regression tests at the affected sites: `spec.ValueRef.ReferencedVariables`
  (`pkg/spec`), `resolver/refs.ExtractFromTemplate` (`pkg/resolver/refs`),
  lint's `lintTemplateUnderscorePrefix` (`pkg/lint`), action `__actions`
  dependency extraction (`pkg/action`), and state `__params` extraction
  (`pkg/state`).

## Verification

`go build` / `gofmt` / `go vet` clean; `-race` tests pass across all affected +
consuming packages; `lint:solutions` 0 failed; full integration suite passes;
scoped `golangci-lint --new-from-merge-base` reports 0 issues.