### PR TITLE
fix(gotmpl): make author-defined functions available in tmpl ValueRefs

### DIFF
--- a/pkg/gotmpl/cache_benchmark_test.go
+++ b/pkg/gotmpl/cache_benchmark_test.go
@@ -362,3 +362,44 @@ func BenchmarkTemplateCacheMissEviction(b *testing.B) {
 		cache.Put(key, tmpl, "bench")
 	}
 }
+
+// BenchmarkServiceExecuteContextFuncs measures Execute on the cache-hit path
+// when a context func binder factory is installed (as it is in production, where
+// it supplies author-defined functions and the context cel binding). This
+// exercises the per-call getContextFuncBinder + funcMap/cache-key work added so
+// context functions are registered at parse time.
+func BenchmarkServiceExecuteContextFuncs(b *testing.B) {
+	contextFuncBinderMu.Lock()
+	orig := contextFuncBinderFactory
+	contextFuncBinderMu.Unlock()
+	defer func() {
+		contextFuncBinderMu.Lock()
+		contextFuncBinderFactory = orig
+		contextFuncBinderMu.Unlock()
+	}()
+
+	SetContextFuncBinderFactory(func(ctx context.Context) template.FuncMap {
+		return template.FuncMap{
+			"greet": func(who string) string { return "hi " + who },
+			"loud":  func(s string) string { return s + "!" },
+		}
+	})
+
+	cache := NewTemplateCache(100)
+	svc := NewServiceWithCache(nil, cache)
+	ctx := context.Background()
+	content := `{{ loud (greet .name) }}`
+	data := map[string]any{"name": "world"}
+
+	if _, err := svc.Execute(ctx, TemplateOptions{Content: content, Name: "ctxfuncs", Data: data}); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := svc.Execute(ctx, TemplateOptions{Content: content, Name: "ctxfuncs", Data: data}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/gotmpl/gotmpl.go
+++ b/pkg/gotmpl/gotmpl.go
@@ -481,8 +481,28 @@ func (s *Service) createTemplate(ctx context.Context, name, content string, opts
 		return nil, fmt.Errorf("invalid missingKey value %q: must be 'default', 'zero', or 'error'", missingKey)
 	}
 
-	// Build the effective function map keys for cache key generation
+	// Build the effective function map keys for cache key generation.
 	funcMapKeys := s.collectFuncMapKeys(opts)
+
+	// Context-bound functions (author-defined helpers, cel, ...) supplied by the
+	// registered binder factory must be known at PARSE time too -- otherwise a
+	// template that invokes them (e.g. a `tmpl:` ValueRef calling a spec.functions
+	// helper) fails to parse even though they would be bound at execution. Their
+	// implementations are (re)bound per request in executeTemplate; here only the
+	// names matter, both for parsing and for cache-key uniqueness (two solutions
+	// with different author functions must not share a cache entry).
+	ctxFuncs := getContextFuncBinder(ctx)
+	if len(ctxFuncs) > 0 {
+		present := make(map[string]struct{}, len(funcMapKeys))
+		for _, k := range funcMapKeys {
+			present[k] = struct{}{}
+		}
+		for name := range ctxFuncs {
+			if _, ok := present[name]; !ok {
+				funcMapKeys = append(funcMapKeys, name)
+			}
+		}
+	}
 
 	// Check the cache
 	cache := s.getCache()
@@ -535,6 +555,16 @@ func (s *Service) createTemplate(ctx context.Context, name, content string, opts
 				"function", k)
 		}
 		funcMap[k] = v
+	}
+
+	// Register context-bound function names (author-defined helpers, cel, ...) so
+	// templates that invoke them parse. Explicit opts.Funcs and built-in defaults
+	// take precedence; the real implementations are (re)bound with the request
+	// context in executeTemplate, so only the names matter here.
+	for k, v := range ctxFuncs {
+		if _, exists := funcMap[k]; !exists {
+			funcMap[k] = v
+		}
 	}
 
 	if len(funcMap) > 0 {

--- a/pkg/gotmpl/gotmpl_test.go
+++ b/pkg/gotmpl/gotmpl_test.go
@@ -869,6 +869,76 @@ func TestContextFuncBinder_RebindsOnCacheHit(t *testing.T) {
 	assert.Equal(t, "second", out2.Output)
 }
 
+// TestContextFuncBinder_ParsesWithoutExplicitFuncs guards the fix for
+// context-bound functions (e.g. author-defined spec.functions helpers) that are
+// supplied ONLY by the binder factory: a template invoking one must parse and
+// execute even when the caller does NOT pass it in opts.Funcs. Before the fix,
+// such a template failed to parse ("function X not defined") because context
+// funcs were bound only at execution, not registered at parse time.
+func TestContextFuncBinder_ParsesWithoutExplicitFuncs(t *testing.T) {
+	contextFuncBinderMu.Lock()
+	orig := contextFuncBinderFactory
+	contextFuncBinderMu.Unlock()
+	defer func() {
+		contextFuncBinderMu.Lock()
+		contextFuncBinderFactory = orig
+		contextFuncBinderMu.Unlock()
+	}()
+
+	SetContextFuncBinderFactory(func(ctx context.Context) template.FuncMap {
+		return template.FuncMap{"greet": func(who string) string { return "hi " + who }}
+	})
+
+	svc := NewService(nil)
+	// No opts.Funcs -- greet is available only via the context binder factory.
+	out, err := svc.Execute(context.Background(), TemplateOptions{
+		Content: `{{ greet "world" }}`,
+		Name:    "ctx-only-func",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "hi world", out.Output)
+}
+
+// TestContextFuncBinder_CacheKeyIncludesFuncNames ensures two renders of the
+// same content under different context function name sets do not collide in the
+// template cache: a name available for one render must not leak into another
+// where it is undefined.
+func TestContextFuncBinder_CacheKeyIncludesFuncNames(t *testing.T) {
+	contextFuncBinderMu.Lock()
+	orig := contextFuncBinderFactory
+	contextFuncBinderMu.Unlock()
+	defer func() {
+		contextFuncBinderMu.Lock()
+		contextFuncBinderFactory = orig
+		contextFuncBinderMu.Unlock()
+	}()
+
+	type ctxKey struct{}
+	// The available function set depends on the active context.
+	SetContextFuncBinderFactory(func(ctx context.Context) template.FuncMap {
+		if v, _ := ctx.Value(ctxKey{}).(bool); v {
+			return template.FuncMap{"greet": func() string { return "hi" }}
+		}
+		return nil
+	})
+
+	svc := NewService(nil)
+	content := `{{ greet }}`
+
+	// First render: greet is defined -> parses and executes.
+	ctxWith := context.WithValue(context.Background(), ctxKey{}, true)
+	out, err := svc.Execute(ctxWith, TemplateOptions{Content: content, Name: "cachekey"})
+	require.NoError(t, err)
+	assert.Equal(t, "hi", out.Output)
+
+	// Same content, but greet is NOT defined in this context. The cache key must
+	// differ (it includes the context func names), so this does not reuse the
+	// first parse and instead fails as an undefined function.
+	ctxWithout := context.Background()
+	_, err = svc.Execute(ctxWithout, TemplateOptions{Content: content, Name: "cachekey"})
+	require.Error(t, err)
+}
+
 func TestNewServiceRaw(t *testing.T) {
 	svc := NewServiceRaw(nil)
 	assert.NotNil(t, svc)

--- a/tests/integration/solutions/author-functions-tmpl/solution.yaml
+++ b/tests/integration/solutions/author-functions-tmpl/solution.yaml
@@ -1,0 +1,56 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+
+metadata:
+  name: author-functions-tmpl-test
+  version: 1.0.0
+  description: >-
+    Regression test: solution-author-defined functions (spec.functions) must be
+    available inside a `tmpl:` ValueRef, not only when a template is a direct
+    go-template provider input. This path previously failed to parse with
+    "function greet not defined" because context-bound functions were registered
+    only at template execution, not at parse time.
+
+spec:
+  functions:
+    greet:
+      description: Greet a name
+      params:
+        - name: who
+      template: "Hello, {{ .args.who }}!"
+
+  resolvers:
+    subject:
+      description: The name to greet
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: World
+
+    # Invokes the author function from inside a tmpl: ValueRef -- the path the
+    # fix restores.
+    greeting:
+      description: Greeting rendered via an author function in a tmpl ValueRef
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                tmpl: "{{ greet ._.subject }}"
+
+  testing:
+    cases:
+      render-author-function-in-tmpl:
+        description: The author function resolves inside the tmpl ValueRef
+        command: [run, resolver]
+        args: ["-o", "json"]
+        assertions:
+          - expression: __exitCode == 0
+          - contains: "Hello, World!"
+
+      expect-lint-clean:
+        description: The solution passes lint
+        command: [lint]
+        assertions:
+          - expression: __exitCode == 0


### PR DESCRIPTION
## Summary

Solution-author-defined functions (`spec.functions`, invoked as
`{{ myFunc .x }}`) only worked when a template was a **direct go-template
provider input**. Inside a generic `tmpl:` ValueRef -- e.g.
`inputs: { value: { tmpl: "{{ greet ._.x }}" } }`, the common form used for
resolver/action inputs, `message` text, conditions, and forEach `in` -- they
failed to parse with `function "greet" not defined`.

## Root cause

`gotmpl`'s `createTemplate` registered only the built-in default functions plus
`opts.Funcs` at **parse** time, then bound context-provided functions
(author-defined helpers and the context `cel` binding, supplied by the
registered binder factory) only at **execution**. Author functions have no
static registration, so a template invoking one via the generic path failed to
parse. The go-template provider worked only because it explicitly passes the
author functions in `opts.Funcs` + a `FuncsFingerprint`.

## Fix

In the shared `createTemplate` (so every `gotmpl.Execute` caller benefits, not
just ValueRef): register the context-bound function **names** at parse time and
include them (deduplicated) in the template cache key. A template invoking them
now parses, and two solutions with different author functions never share a
cache entry. Implementations are still (re)bound with the request context at
execution (unchanged), so a cache hit never serves a stale function body -- only
the names matter for parsing. When no binder factory is set, the cache key and
parse func map are byte-identical to before.

## Tests

- `TestContextFuncBinder_ParsesWithoutExplicitFuncs` -- a context-only function
  parses + executes without being passed in `opts.Funcs`.
- `TestContextFuncBinder_CacheKeyIncludesFuncNames` -- the cache key includes
  context function names, so two contexts with different function sets don't
  collide (a name available in one must not leak into another where it's
  undefined).
- `BenchmarkServiceExecuteContextFuncs` -- hot-path benchmark with a binder
  factory installed.
- `tests/integration/solutions/author-functions-tmpl/` -- end-to-end functional
  test invoking an author function from inside a `tmpl:` ValueRef, asserting the
  rendered output and lint-clean.
- The pre-existing `TestContextFuncBinder_RebindsOnCacheHit` (stale-binding
  cache-safety guard) still passes.

## Verification

`go build` / `gofmt` / `go vet` clean; `-race` across gotmpl + consuming
packages; the official `examples/resolvers/author-functions.yaml` still renders
correctly; `lint:solutions` 0 failed; 938 functional tests pass; full
integration suite passes; scoped `golangci-lint --new-from-merge-base` reports 0
issues.