### PR TITLE
fix(vscode): derive LSP document selector from binary discovery (fixes #764)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,7 @@ linters:
       - third_party$
       - builtin$
       - examples$
+      - node_modules
     rules:
       # Exclude some linters from running on tests files.
       - path: _test\.go
@@ -139,3 +140,4 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+      - node_modules

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -1144,7 +1144,22 @@ reusing the same positioned reference index (`refindex`) and rename engine
   is surfaced to the editor rather than a partial rewrite being applied.
 
 An editor client configures the server by pointing at the `scafctl lsp` command
-and associating it with the solution file language (YAML).
+and attaching it to solution files. To keep editor targeting in lockstep with
+CLI auto-discovery instead of hardcoding a file list, the server reports the
+exact set of file names it recognizes:
+
+~~~bash
+# Machine-readable contract consumed by editor integrations
+scafctl lsp document-selectors -o json
+~~~
+
+This prints the auto-discovered solution/action file names partitioned by editor
+language, plus the effective binary name -- covering `solution.{yaml,yml,json}`,
+`<binary>.{yaml,yml,json}`, `taskfile.{yaml,yml}`, and `actions.{yaml,yml}`.
+JSON solutions are reported separately from YAML so the client attaches them as
+JSON documents. The bundled VS Code extension queries this at startup to build
+its document selector dynamically (including any embedder binary name), rather
+than a hardcoded, drift-prone glob.
 
 ---
 

--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -57,8 +57,27 @@ The exact steps depend on the editor's LSP client, but the shape is always the
 same:
 
 1. Point the client at the `scafctl lsp` command (the server process).
-2. Associate it with the solution file language (YAML).
-3. Open a `solution.yaml` -- diagnostics appear inline as you edit.
+2. Attach it to the solution files scafctl recognizes. To avoid hardcoding a
+   file list that drifts from CLI discovery, ask the binary which files it
+   auto-discovers:
+
+   ~~~bash
+   scafctl lsp document-selectors -o json
+   ~~~
+
+   This reports the recognized file names partitioned by editor language --
+   `solution.{yaml,yml,json}`, `<binary>.{yaml,yml,json}`, `taskfile.{yaml,yml}`,
+   and `actions.{yaml,yml}` -- along with the effective binary name. JSON
+   solutions are listed separately so the client attaches them as JSON (not
+   YAML) documents.
+3. Open a `solution.yaml` (or `solution.json`, `taskfile.yaml`, ...) --
+   diagnostics appear inline as you edit.
+
+The bundled VS Code extension does this automatically: it queries
+`scafctl lsp document-selectors` at startup and builds its document selector
+from the result, so it always matches CLI auto-discovery -- including any
+embedder binary name. Users can add globs for non-standard file names via the
+`scafctl.solutionFilePatterns` setting.
 
 Because the server reuses the CLI's `lint` engine, no separate configuration is
 needed to keep editor and CLI diagnostics consistent.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -6,7 +6,7 @@ powered by the `scafctl lsp` language server.
 
 ## Features
 
-For `solution.yaml` / `scafctl.yaml` files:
+For scafctl solution and action files:
 
 - **Diagnostics** -- lint findings appear inline as you edit, matching `scafctl lint`.
 - **Go to Definition** -- jump from a resolver reference to its definition.
@@ -17,6 +17,27 @@ For `solution.yaml` / `scafctl.yaml` files:
 
 The feature set grows automatically as the language server gains capabilities --
 the extension is a thin client.
+
+### Which files get language features
+
+The extension attaches the language server to exactly the files the `scafctl`
+binary auto-discovers -- it queries the binary at startup (via
+`scafctl lsp document-selectors`) instead of hardcoding a list, so editor
+targeting never drifts from CLI discovery. Out of the box this covers, in any
+folder:
+
+- `solution.yaml` / `solution.yml` / `solution.json`
+- `<binary>.yaml` / `<binary>.yml` / `<binary>.json` (e.g. `scafctl.yaml`; for an
+  embedding CLI this is that CLI's name)
+- `taskfile.yaml` / `taskfile.yml`
+- `actions.yaml` / `actions.yml`
+
+JSON solution files are attached as JSON documents (not YAML), so language
+features work regardless of the on-disk format.
+
+For a differently named file, either **rename it to a standard name** (simplest
+-- this also enables `scafctl` CLI auto-discovery), or add a glob to
+`scafctl.solutionFilePatterns` (see Settings).
 
 ## Requirements
 
@@ -31,7 +52,37 @@ Settings; it does not download anything.
 | Setting | Default | Description |
 | --- | --- | --- |
 | `scafctl.serverPath` | `""` | Path to the `scafctl` executable. Empty resolves `scafctl` from `PATH`. |
+| `scafctl.solutionFilePatterns` | `[]` | Extra glob patterns for solution files with non-standard names (e.g. `**/my-solution.yaml`). By default these **extend** the auto-discovered set. |
+| `scafctl.solutionFilePatterns.replaceDefaults` | `false` | When `true`, the patterns above **replace** the auto-discovered defaults instead of extending them. |
+| `scafctl.language.enable` | `false` | Opt in to a dedicated `scafctl` language mode (see below). |
 | `scafctl.trace.server` | `off` | Trace LSP traffic (`off` / `messages` / `verbose`). |
+
+Changing any of these recreates the language client automatically -- no window
+reload needed.
+
+Server logs and (when `scafctl.trace.server` is `messages`/`verbose`) JSON-RPC
+traces appear in the **scafctl** Output channel; it is revealed automatically if
+the server reports an error.
+
+### The `scafctl` language mode (opt-in)
+
+By default, solution files keep their built-in `yaml` / `json` language. This is
+deliberate: it preserves other extensions' features on those files -- most
+notably the Red Hat YAML extension's schema validation, autocompletion, and
+formatting -- while the scafctl language server adds its diagnostics and
+navigation on top. This matches how tools like GitHub Actions layer over YAML.
+
+Enabling `scafctl.language.enable` contributes a dedicated `scafctl` language
+(YAML syntax highlighting, scafctl diagnostics). It does **not** re-associate
+files automatically; you opt a file in by setting its language mode to `scafctl`
+(or via `files.associations`). Note that switching a file to the `scafctl`
+language turns off the YAML/JSON extensions' schema features for that file, so
+leave this off unless you specifically want it.
+
+> Non-standard file names only receive features once the extension is active. It
+> activates when a workspace contains a standard solution file; if your workspace
+> has only custom-named files, run **scafctl: Restart Language Server** once to
+> activate it.
 
 ## Commands
 

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -80,9 +80,10 @@ language turns off the YAML/JSON extensions' schema features for that file, so
 leave this off unless you specifically want it.
 
 > Non-standard file names only receive features once the extension is active. It
-> activates when a workspace contains a standard solution file; if your workspace
-> has only custom-named files, run **scafctl: Restart Language Server** once to
-> activate it.
+> activates when a workspace contains a standard solution file, or when any file
+> is set to the `scafctl` language. If your workspace has only custom-named files
+> on the built-in `yaml`/`json` language, run **scafctl: Restart Language Server**
+> once to activate it.
 
 ## Commands
 

--- a/editors/vscode/language-configuration.json
+++ b/editors/vscode/language-configuration.json
@@ -1,0 +1,21 @@
+{
+  "comments": {
+    "lineComment": "#"
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "\"", "close": "\"" },
+    { "open": "'", "close": "'" }
+  ],
+  "surroundingPairs": [
+    ["{", "}"],
+    ["[", "]"],
+    ["\"", "\""],
+    ["'", "'"]
+  ]
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -29,7 +29,7 @@
   ],
   "main": "./out/extension.js",
   "activationEvents": [
-    "workspaceContains:**/{solution,scafctl}.{yaml,yml}",
+    "workspaceContains:**/{solution,scafctl,taskfile,actions}.{yaml,yml,json}",
     "onCommand:scafctl.restartServer"
   ],
   "contributes": {
@@ -39,6 +39,23 @@
         "title": "scafctl: Restart Language Server"
       }
     ],
+    "languages": [
+      {
+        "id": "scafctl",
+        "aliases": [
+          "scafctl",
+          "scafctl Solution"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "scafctl",
+        "scopeName": "source.scafctl",
+        "path": "./syntaxes/scafctl.tmLanguage.json"
+      }
+    ],
     "configuration": {
       "title": "scafctl",
       "properties": {
@@ -46,6 +63,24 @@
           "type": "string",
           "default": "",
           "markdownDescription": "Path to the `scafctl` executable used as the language server. When empty, `scafctl` is resolved from your `PATH`."
+        },
+        "scafctl.solutionFilePatterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "markdownDescription": "Additional glob patterns for solution files with non-standard names (e.g. `**/my-solution.yaml`). By default these **extend** the file set the `scafctl` binary auto-discovers (`solution.*`, `<binary>.*`, `taskfile.*`, `actions.*`, plus `.json` variants). Set `#scafctl.solutionFilePatterns.replaceDefaults#` to replace the discovered defaults instead."
+        },
+        "scafctl.solutionFilePatterns.replaceDefaults": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "When `true`, `#scafctl.solutionFilePatterns#` **replaces** the auto-discovered default solution file set instead of extending it. Leave `false` (recommended) to keep language features on the standard solution files."
+        },
+        "scafctl.language.enable": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Enable the dedicated `scafctl` language mode. When `false` (default, recommended), solution files stay associated with the built-in `yaml`/`json` languages, preserving other extensions' schema validation, autocompletion, and formatting (e.g. the Red Hat YAML extension). Enable this only if you want to set a file's language to `scafctl` explicitly; it does not change file associations automatically."
         },
         "scafctl.trace.server": {
           "type": "string",
@@ -66,7 +101,7 @@
     "watch": "node esbuild.js --watch",
     "check": "tsc --noEmit",
     "lint": "eslint src",
-    "test": "node --import tsx --test src/serverResolution.test.ts",
+    "test": "node --import tsx --test src/serverResolution.test.ts src/documentSelectors.test.ts",
     "package": "vsce package --no-dependencies -o scafctl.vsix",
     "publish:vsce": "vsce publish --no-dependencies --packagePath scafctl.vsix",
     "publish:ovsx": "ovsx publish scafctl.vsix"

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -29,7 +29,8 @@
   ],
   "main": "./out/extension.js",
   "activationEvents": [
-    "workspaceContains:**/{solution,scafctl,taskfile,actions}.{yaml,yml,json}",
+    "workspaceContains:**/{solution,scafctl,taskfile,actions}.{yaml,yml}",
+    "workspaceContains:**/{solution,scafctl}.json",
     "onCommand:scafctl.restartServer"
   ],
   "contributes": {

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -31,6 +31,7 @@
   "activationEvents": [
     "workspaceContains:**/{solution,scafctl,taskfile,actions}.{yaml,yml}",
     "workspaceContains:**/{solution,scafctl}.json",
+    "onLanguage:scafctl",
     "onCommand:scafctl.restartServer"
   ],
   "contributes": {

--- a/editors/vscode/src/documentSelectors.test.ts
+++ b/editors/vscode/src/documentSelectors.test.ts
@@ -1,0 +1,149 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  bracePattern,
+  buildDocumentSelector,
+  defaultRecognizedFiles,
+  DefaultBinaryName,
+  fetchRecognizedFiles,
+  parseRecognizedFiles,
+  RecognizedFiles,
+  ScafctlLanguageId,
+} from './documentSelectors';
+
+const sampleFiles: RecognizedFiles = {
+  binaryName: 'scafctl',
+  yamlNames: ['solution.yaml', 'solution.yml', 'taskfile.yaml', 'actions.yaml'],
+  jsonNames: ['solution.json'],
+};
+
+test('defaultRecognizedFiles uses the default binary name when unset', () => {
+  const files = defaultRecognizedFiles();
+  assert.equal(files.binaryName, DefaultBinaryName);
+  assert.ok(files.yamlNames.includes('solution.yaml'));
+  assert.ok(files.yamlNames.includes('taskfile.yaml'));
+  assert.ok(files.yamlNames.includes('actions.yaml'));
+  assert.ok(files.jsonNames.includes('solution.json'));
+});
+
+test('defaultRecognizedFiles honors an embedder binary name', () => {
+  const files = defaultRecognizedFiles('mycli');
+  assert.equal(files.binaryName, 'mycli');
+  assert.ok(files.yamlNames.includes('mycli.yaml'));
+  assert.ok(files.yamlNames.includes('mycli.yml'));
+  assert.ok(files.jsonNames.includes('mycli.json'));
+});
+
+test('bracePattern builds recursive globs', () => {
+  assert.equal(bracePattern([]), '');
+  assert.equal(bracePattern(['solution.yaml']), '**/solution.yaml');
+  assert.equal(bracePattern(['a.yaml', 'b.yml']), '**/{a.yaml,b.yml}');
+});
+
+test('buildDocumentSelector emits yaml and json filters by default', () => {
+  const filters = buildDocumentSelector(sampleFiles, []);
+  const yaml = filters.find((f) => f.language === 'yaml');
+  const jsonFilter = filters.find((f) => f.language === 'json');
+  assert.ok(yaml, 'expected a yaml filter');
+  assert.ok(jsonFilter, 'expected a json filter');
+  assert.equal(yaml?.pattern, '**/{solution.yaml,solution.yml,taskfile.yaml,actions.yaml}');
+  assert.equal(jsonFilter?.pattern, '**/solution.json');
+  // No scafctl language unless explicitly enabled.
+  assert.ok(!filters.some((f) => f.language === ScafctlLanguageId));
+});
+
+test('buildDocumentSelector extends defaults with user patterns', () => {
+  const filters = buildDocumentSelector(sampleFiles, ['**/custom.yaml']);
+  // Defaults still present.
+  assert.ok(filters.some((f) => f.language === 'yaml' && f.pattern?.toString().includes('solution.yaml')));
+  // User pattern added for both yaml and json.
+  assert.ok(filters.some((f) => f.language === 'yaml' && f.pattern === '**/custom.yaml'));
+  assert.ok(filters.some((f) => f.language === 'json' && f.pattern === '**/custom.yaml'));
+});
+
+test('buildDocumentSelector replaceDefaults drops the discovered set', () => {
+  const filters = buildDocumentSelector(sampleFiles, ['**/custom.yaml'], { replaceDefaults: true });
+  assert.ok(!filters.some((f) => f.pattern?.toString().includes('solution.yaml')));
+  assert.ok(filters.some((f) => f.pattern === '**/custom.yaml'));
+});
+
+test('buildDocumentSelector adds the scafctl language when enabled', () => {
+  const filters = buildDocumentSelector(sampleFiles, ['**/custom.yaml'], { languageEnabled: true });
+  const scafctlFilters = filters.filter((f) => f.language === ScafctlLanguageId);
+  // scafctl language applied to yaml defaults, json defaults, and the user pattern.
+  assert.ok(scafctlFilters.length >= 3);
+  assert.ok(scafctlFilters.some((f) => f.pattern === '**/custom.yaml'));
+});
+
+test('buildDocumentSelector ignores blank user patterns', () => {
+  const filters = buildDocumentSelector(sampleFiles, ['  ', '']);
+  assert.ok(!filters.some((f) => f.pattern === ''));
+});
+
+test('parseRecognizedFiles parses a valid payload', () => {
+  const parsed = parseRecognizedFiles(JSON.stringify(sampleFiles));
+  assert.deepEqual(parsed, sampleFiles);
+});
+
+test('parseRecognizedFiles rejects malformed or empty payloads', () => {
+  assert.equal(parseRecognizedFiles('not json'), null);
+  assert.equal(parseRecognizedFiles('null'), null);
+  assert.equal(parseRecognizedFiles('{}'), null);
+  assert.equal(parseRecognizedFiles(JSON.stringify({ yamlNames: [], jsonNames: [] })), null);
+});
+
+test('parseRecognizedFiles filters non-string entries', () => {
+  const parsed = parseRecognizedFiles(
+    JSON.stringify({ binaryName: 'scafctl', yamlNames: ['solution.yaml', 42, ''], jsonNames: 'x' }),
+  );
+  assert.deepEqual(parsed?.yamlNames, ['solution.yaml']);
+  assert.deepEqual(parsed?.jsonNames, []);
+});
+
+test('fetchRecognizedFiles falls back on a missing binary', async () => {
+  let errored = '';
+  const files = await fetchRecognizedFiles('scafctl-definitely-not-real-xyz', {
+    fallbackBinaryName: 'scafctl',
+    onError: (m) => (errored = m),
+  });
+  assert.ok(errored.length > 0, 'expected an error message');
+  assert.deepEqual(files, defaultRecognizedFiles('scafctl'));
+});
+
+test('fetchRecognizedFiles parses output from a stub binary', async () => {
+  if (process.platform === 'win32') {
+    return; // POSIX shebang script; skip on Windows
+  }
+  const dir = mkdtempSync(join(tmpdir(), 'scafctl-selectors-'));
+  const file = join(dir, 'scafctl');
+  const payload = JSON.stringify({
+    binaryName: 'mycli',
+    yamlNames: ['solution.yaml'],
+    jsonNames: ['solution.json'],
+  });
+  writeFileSync(file, `#!/bin/sh\ncat <<'EOF'\n${payload}\nEOF\n`, { mode: 0o755 });
+  chmodSync(file, 0o755);
+
+  const files = await fetchRecognizedFiles(file);
+  assert.equal(files.binaryName, 'mycli');
+  assert.deepEqual(files.yamlNames, ['solution.yaml']);
+  assert.deepEqual(files.jsonNames, ['solution.json']);
+});
+
+test('fetchRecognizedFiles falls back when the stub emits malformed JSON', async () => {
+  if (process.platform === 'win32') {
+    return;
+  }
+  const dir = mkdtempSync(join(tmpdir(), 'scafctl-selectors-bad-'));
+  const file = join(dir, 'scafctl');
+  writeFileSync(file, '#!/bin/sh\necho "not json"\n', { mode: 0o755 });
+  chmodSync(file, 0o755);
+
+  let errored = '';
+  const files = await fetchRecognizedFiles(file, { fallbackBinaryName: 'scafctl', onError: (m) => (errored = m) });
+  assert.ok(errored.length > 0);
+  assert.deepEqual(files, defaultRecognizedFiles('scafctl'));
+});

--- a/editors/vscode/src/documentSelectors.ts
+++ b/editors/vscode/src/documentSelectors.ts
@@ -1,0 +1,187 @@
+import { execFile } from 'node:child_process';
+
+/** A language+glob document filter for the LSP client's documentSelector. */
+export interface SolutionDocumentFilter {
+  language: string;
+  pattern: string;
+}
+
+/**
+ * RecognizedFiles mirrors the JSON emitted by `<binary> lsp document-selectors`.
+ * It lists the solution/action file names the CLI auto-discovers, partitioned by
+ * editor language so the client emits correct per-language document selectors.
+ */
+export interface RecognizedFiles {
+  binaryName: string;
+  yamlNames: string[];
+  jsonNames: string[];
+}
+
+/**
+ * DefaultBinaryName is the CLI binary name assumed when the server cannot be
+ * queried for its own recognized-file set.
+ */
+export const DefaultBinaryName = 'scafctl';
+
+/** The scafctl dedicated language id, contributed opt-in in package.json. */
+export const ScafctlLanguageId = 'scafctl';
+
+/**
+ * defaultRecognizedFiles returns a static fallback set used when the server
+ * binary cannot be queried (e.g. an older binary without the
+ * `lsp document-selectors` subcommand). It mirrors the CLI's default discovery
+ * set for the given binary name. This is a resilience fallback, not a
+ * compatibility contract -- the authoritative source is the running binary.
+ */
+export function defaultRecognizedFiles(binaryName?: string): RecognizedFiles {
+  const name = (binaryName ?? '').trim() || DefaultBinaryName;
+  return {
+    binaryName: name,
+    yamlNames: [
+      'solution.yaml',
+      'solution.yml',
+      `${name}.yaml`,
+      `${name}.yml`,
+      'taskfile.yaml',
+      'taskfile.yml',
+      'actions.yaml',
+      'actions.yml',
+    ],
+    jsonNames: ['solution.json', `${name}.json`],
+  };
+}
+
+/**
+ * fetchRecognizedFiles runs `<command> lsp document-selectors -o json` and
+ * parses the result. It NEVER rejects: on spawn error, non-zero exit, timeout,
+ * or malformed output it logs via onError (if provided) and returns
+ * defaultRecognizedFiles(fallbackBinaryName), so the extension always activates
+ * with a sane selector.
+ */
+export function fetchRecognizedFiles(
+  command: string,
+  opts: { timeoutMs?: number; fallbackBinaryName?: string; onError?: (message: string) => void } = {},
+): Promise<RecognizedFiles> {
+  const { timeoutMs = 5000, fallbackBinaryName, onError } = opts;
+  return new Promise((resolve) => {
+    execFile(command, ['lsp', 'document-selectors', '-o', 'json'], { timeout: timeoutMs }, (err, stdout) => {
+      if (err) {
+        onError?.(`scafctl: could not query recognized solution files ('${command} lsp document-selectors' failed: ${err.message}); using defaults.`);
+        resolve(defaultRecognizedFiles(fallbackBinaryName));
+        return;
+      }
+      const parsed = parseRecognizedFiles(stdout);
+      if (!parsed) {
+        onError?.('scafctl: could not parse recognized solution files from the server; using defaults.');
+        resolve(defaultRecognizedFiles(fallbackBinaryName));
+        return;
+      }
+      resolve(parsed);
+    });
+  });
+}
+
+/**
+ * parseRecognizedFiles validates and normalizes the JSON payload from the CLI.
+ * Returns null when the payload is missing required fields or malformed.
+ */
+export function parseRecognizedFiles(stdout: string): RecognizedFiles | null {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+  if (typeof raw !== 'object' || raw === null) {
+    return null;
+  }
+  const obj = raw as Record<string, unknown>;
+  const yamlNames = asStringArray(obj.yamlNames);
+  const jsonNames = asStringArray(obj.jsonNames);
+  // A valid payload must recognize at least one file; otherwise treat it as
+  // malformed so the caller falls back to sane defaults.
+  if (yamlNames.length === 0 && jsonNames.length === 0) {
+    return null;
+  }
+  return {
+    binaryName: typeof obj.binaryName === 'string' ? obj.binaryName : DefaultBinaryName,
+    yamlNames,
+    jsonNames,
+  };
+}
+
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((v): v is string => typeof v === 'string' && v.length > 0);
+}
+
+/**
+ * buildDocumentSelector builds the LSP documentSelector from recognized files
+ * plus user overrides.
+ *
+ * - YAML names are emitted as `{ language: 'yaml', pattern }`.
+ * - JSON names are emitted as `{ language: 'json', pattern }` (a JSON document
+ *   never matches a YAML-scoped selector).
+ * - userPatterns are custom globs whose extension is unknown, so they are
+ *   matched against yaml AND json (and scafctl when enabled). When
+ *   replaceDefaults is true they replace the discovered defaults; otherwise
+ *   they extend them.
+ * - When languageEnabled, the dedicated `scafctl` language is additionally
+ *   matched for every default pattern, so a user who sets a file's language to
+ *   `scafctl` still gets LSP features.
+ */
+export function buildDocumentSelector(
+  files: RecognizedFiles,
+  userPatterns: string[],
+  opts: { replaceDefaults?: boolean; languageEnabled?: boolean } = {},
+): SolutionDocumentFilter[] {
+  const { replaceDefaults = false, languageEnabled = false } = opts;
+  const cleanUser = userPatterns.map((p) => p.trim()).filter((p) => p.length > 0);
+
+  const filters: SolutionDocumentFilter[] = [];
+
+  if (!replaceDefaults) {
+    const yamlGlob = bracePattern(files.yamlNames);
+    if (yamlGlob) {
+      filters.push({ language: 'yaml', pattern: yamlGlob });
+      if (languageEnabled) {
+        filters.push({ language: ScafctlLanguageId, pattern: yamlGlob });
+      }
+    }
+    const jsonGlob = bracePattern(files.jsonNames);
+    if (jsonGlob) {
+      filters.push({ language: 'json', pattern: jsonGlob });
+      if (languageEnabled) {
+        filters.push({ language: ScafctlLanguageId, pattern: jsonGlob });
+      }
+    }
+  }
+
+  for (const pattern of cleanUser) {
+    filters.push({ language: 'yaml', pattern });
+    filters.push({ language: 'json', pattern });
+    if (languageEnabled) {
+      filters.push({ language: ScafctlLanguageId, pattern });
+    }
+  }
+
+  return filters;
+}
+
+/**
+ * bracePattern builds a recursive glob from a list of file names. Returns an
+ * empty string for an empty list, `**\/name` for a single name, and
+ * `**\/{a,b,c}` for multiple.
+ */
+export function bracePattern(names: string[]): string {
+  const clean = names.filter((n) => n.length > 0);
+  if (clean.length === 0) {
+    return '';
+  }
+  if (clean.length === 1) {
+    return `**/${clean[0]}`;
+  }
+  return `**/{${clean.join(',')}}`;
+}

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -2,20 +2,46 @@ import * as vscode from 'vscode';
 import {
   LanguageClient,
   LanguageClientOptions,
+  RevealOutputChannelOn,
   ServerOptions,
   TransportKind,
 } from 'vscode-languageclient/node';
-import { checkBinary, resolveCommand } from './serverResolution';
+import { binaryNameFromCommand, checkBinary, resolveCommand } from './serverResolution';
+import { buildDocumentSelector, fetchRecognizedFiles } from './documentSelectors';
 
 let client: LanguageClient | undefined;
+let output: vscode.OutputChannel | undefined;
+
+/** Config keys that require the language client to be recreated when changed. */
+const selectorConfigKeys = [
+  'scafctl.serverPath',
+  'scafctl.solutionFilePatterns',
+  'scafctl.solutionFilePatterns.replaceDefaults',
+  'scafctl.language.enable',
+];
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  output = vscode.window.createOutputChannel('scafctl');
+  context.subscriptions.push(output);
+
   context.subscriptions.push(
     vscode.commands.registerCommand('scafctl.restartServer', async () => {
       await stopClient();
       await startClient();
     }),
   );
+
+  // Recreate the client when a selector-affecting setting changes so new file
+  // patterns / language mode / server path take effect without a reload.
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(async (event) => {
+      if (selectorConfigKeys.some((key) => event.affectsConfiguration(key))) {
+        await stopClient();
+        await startClient();
+      }
+    }),
+  );
+
   await startClient();
 }
 
@@ -42,16 +68,56 @@ async function startClient(): Promise<void> {
     transport: TransportKind.stdio,
   };
 
-  // Scope the language server to solution files (scafctl auto-discovers these
-  // names), leaving other YAML documents untouched.
+  // Query the binary for the exact set of solution/action file names it
+  // auto-discovers (including .json solutions, taskfile.*, actions.*, and any
+  // embedder binary name), so editor targeting stays in lockstep with CLI
+  // discovery instead of a hardcoded, drift-prone glob. If the binary is too
+  // old to answer, fall back to defaults derived from its own file name so an
+  // embedder's <binary>.yaml still matches.
+  const recognized = await fetchRecognizedFiles(command, {
+    fallbackBinaryName: binaryNameFromCommand(command),
+    onError: (message) => output?.appendLine(message),
+  });
+
+  const userPatterns = config.get<string[]>('solutionFilePatterns') ?? [];
+  const replaceDefaults = config.get<boolean>('solutionFilePatterns.replaceDefaults') ?? false;
+  const languageEnabled = config.get<boolean>('language.enable') ?? false;
+
+  const documentSelector = buildDocumentSelector(recognized, userPatterns, {
+    replaceDefaults,
+    languageEnabled,
+  });
+
   const clientOptions: LanguageClientOptions = {
-    documentSelector: [
-      { language: 'yaml', pattern: '**/{solution,scafctl}.{yaml,yml}' },
-    ],
+    documentSelector,
+    // Route server logs and JSON-RPC traces to our output channel. The client's
+    // id ('scafctl', below) makes vscode-languageclient read the trace level
+    // from the `scafctl.trace.server` setting automatically. Surface the channel
+    // on error so a crashing/failing server is not silent.
+    outputChannel: output,
+    revealOutputChannelOn: RevealOutputChannelOn.Error,
   };
 
   client = new LanguageClient('scafctl', 'scafctl', serverOptions, clientOptions);
-  await client.start();
+
+  // client.start() rejects if the server fails to launch or the LSP handshake
+  // fails (a distinct case from a running server erroring later, which
+  // revealOutputChannelOn handles). Surface it explicitly so startup failures
+  // are not a silent unhandled rejection.
+  try {
+    await client.start();
+  } catch (err) {
+    client = undefined;
+    const message = err instanceof Error ? err.message : String(err);
+    output?.appendLine(`scafctl: language server failed to start: ${message}`);
+    const choice = await vscode.window.showErrorMessage(
+      `scafctl language server failed to start: ${message}`,
+      'Show Logs',
+    );
+    if (choice === 'Show Logs') {
+      output?.show(true);
+    }
+  }
 }
 
 async function stopClient(): Promise<void> {

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -12,6 +12,12 @@ import { buildDocumentSelector, fetchRecognizedFiles } from './documentSelectors
 let client: LanguageClient | undefined;
 let output: vscode.OutputChannel | undefined;
 
+// restartQueue serializes stop/start cycles. The restart command, config-change
+// events, and initial activation can otherwise interleave their stop/start
+// calls, leaving multiple clients or a stopped client. Chaining every cycle
+// onto a single in-flight promise makes them run strictly in order.
+let restartQueue: Promise<void> = Promise.resolve();
+
 /** Config keys that require the language client to be recreated when changed. */
 const selectorConfigKeys = [
   'scafctl.serverPath',
@@ -20,33 +26,44 @@ const selectorConfigKeys = [
   'scafctl.language.enable',
 ];
 
+/**
+ * enqueueRestart serializes client lifecycle transitions. `task` runs after any
+ * prior transition settles (success or failure), so restarts never interleave.
+ */
+function enqueueRestart(task: () => Promise<void>): Promise<void> {
+  restartQueue = restartQueue.then(task, task);
+  return restartQueue;
+}
+
+/** restartClient stops any running client and starts a fresh one. */
+async function restartClient(): Promise<void> {
+  await stopClient();
+  await startClient();
+}
+
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   output = vscode.window.createOutputChannel('scafctl');
   context.subscriptions.push(output);
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('scafctl.restartServer', async () => {
-      await stopClient();
-      await startClient();
-    }),
+    vscode.commands.registerCommand('scafctl.restartServer', () => enqueueRestart(restartClient)),
   );
 
   // Recreate the client when a selector-affecting setting changes so new file
   // patterns / language mode / server path take effect without a reload.
   context.subscriptions.push(
-    vscode.workspace.onDidChangeConfiguration(async (event) => {
+    vscode.workspace.onDidChangeConfiguration((event) => {
       if (selectorConfigKeys.some((key) => event.affectsConfiguration(key))) {
-        await stopClient();
-        await startClient();
+        void enqueueRestart(restartClient);
       }
     }),
   );
 
-  await startClient();
+  await enqueueRestart(startClient);
 }
 
 export async function deactivate(): Promise<void> {
-  await stopClient();
+  await enqueueRestart(stopClient);
 }
 
 async function startClient(): Promise<void> {
@@ -107,6 +124,14 @@ async function startClient(): Promise<void> {
   try {
     await client.start();
   } catch (err) {
+    // Attempt to stop the partially-started client so a spawned-but-unhandshaked
+    // server process is not leaked. stop() may itself reject for a client that
+    // never fully started, so guard it before clearing the reference.
+    try {
+      await client.stop();
+    } catch {
+      // Best-effort cleanup; the start error below is what matters.
+    }
     client = undefined;
     const message = err instanceof Error ? err.message : String(err);
     output?.appendLine(`scafctl: language server failed to start: ${message}`);

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -28,10 +28,20 @@ const selectorConfigKeys = [
 
 /**
  * enqueueRestart serializes client lifecycle transitions. `task` runs after any
- * prior transition settles (success or failure), so restarts never interleave.
+ * prior transition settles; its errors are logged and swallowed so a background
+ * restart (triggered via `void` from a config-change event) can never surface as
+ * an unhandled promise rejection or break the queue for later transitions.
  */
 function enqueueRestart(task: () => Promise<void>): Promise<void> {
-  restartQueue = restartQueue.then(task, task);
+  const run = async (): Promise<void> => {
+    try {
+      await task();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      output?.appendLine(`scafctl: client restart failed: ${message}`);
+    }
+  };
+  restartQueue = restartQueue.then(run);
   return restartQueue;
 }
 

--- a/editors/vscode/src/serverResolution.test.ts
+++ b/editors/vscode/src/serverResolution.test.ts
@@ -24,6 +24,18 @@ test('binaryNameFromCommand extracts the binary name from a path', () => {
   assert.equal(binaryNameFromCommand('  /opt/mycli  '), 'mycli');
 });
 
+test('binaryNameFromCommand strips non-.exe extensions (Windows launchers)', () => {
+  assert.equal(binaryNameFromCommand('mycli.cmd'), 'mycli');
+  assert.equal(binaryNameFromCommand('mycli.bat'), 'mycli');
+  assert.equal(binaryNameFromCommand('/opt/mycli.ps1'), 'mycli');
+});
+
+test('binaryNameFromCommand replaces unsafe characters', () => {
+  // Mirrors Go settings.SanitizeBinaryName (safeNameRe [^A-Za-z0-9._-]).
+  assert.equal(binaryNameFromCommand('my cli'), 'my_cli');
+  assert.equal(binaryNameFromCommand('my@cli'), 'my_cli');
+});
+
 test('binaryNameFromCommand falls back to the default for empty input', () => {
   assert.equal(binaryNameFromCommand(''), DefaultServerCommand);
   assert.equal(binaryNameFromCommand('   '), DefaultServerCommand);

--- a/editors/vscode/src/serverResolution.test.ts
+++ b/editors/vscode/src/serverResolution.test.ts
@@ -41,6 +41,13 @@ test('binaryNameFromCommand falls back to the default for empty input', () => {
   assert.equal(binaryNameFromCommand('   '), DefaultServerCommand);
 });
 
+test('binaryNameFromCommand falls back to the default for dot-only names', () => {
+  // Parity with Go settings.SanitizeBinaryName, which returns the default for
+  // '.' and '..'.
+  assert.equal(binaryNameFromCommand('.'), DefaultServerCommand);
+  assert.equal(binaryNameFromCommand('..'), DefaultServerCommand);
+});
+
 test('checkBinary reports a missing executable', async () => {
   const problem = await checkBinary('scafctl-definitely-not-real-xyz');
   assert.ok(problem, 'expected an error message');

--- a/editors/vscode/src/serverResolution.test.ts
+++ b/editors/vscode/src/serverResolution.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { checkBinary, DefaultServerCommand, resolveCommand } from './serverResolution';
+import { binaryNameFromCommand } from './serverResolution';
 
 test('resolveCommand uses the configured path when set', () => {
   assert.equal(resolveCommand('/usr/local/bin/scafctl'), '/usr/local/bin/scafctl');
@@ -14,6 +15,18 @@ test('resolveCommand falls back to the default when empty or undefined', () => {
   assert.equal(resolveCommand(''), DefaultServerCommand);
   assert.equal(resolveCommand('   '), DefaultServerCommand);
   assert.equal(resolveCommand(undefined), DefaultServerCommand);
+});
+
+test('binaryNameFromCommand extracts the binary name from a path', () => {
+  assert.equal(binaryNameFromCommand('scafctl'), 'scafctl');
+  assert.equal(binaryNameFromCommand('/opt/tools/mycli'), 'mycli');
+  assert.equal(binaryNameFromCommand('C:\\tools\\mycli.exe'.replace(/\\/g, '/')), 'mycli');
+  assert.equal(binaryNameFromCommand('  /opt/mycli  '), 'mycli');
+});
+
+test('binaryNameFromCommand falls back to the default for empty input', () => {
+  assert.equal(binaryNameFromCommand(''), DefaultServerCommand);
+  assert.equal(binaryNameFromCommand('   '), DefaultServerCommand);
 });
 
 test('checkBinary reports a missing executable', async () => {

--- a/editors/vscode/src/serverResolution.ts
+++ b/editors/vscode/src/serverResolution.ts
@@ -32,7 +32,12 @@ export function binaryNameFromCommand(command: string): string {
   // Replace unsafe characters with underscores and trim them (mirrors safeNameRe
   // [^A-Za-z0-9._-] plus a leading/trailing underscore trim).
   name = name.replace(/[^A-Za-z0-9._-]/g, '_').replace(/^_+|_+$/g, '');
-  return name.length > 0 ? name : DefaultServerCommand;
+  // Fall back to the default for empty or dot-only names, matching Go's
+  // SanitizeBinaryName (which returns the default for "", ".", and "..").
+  if (name.length === 0 || name === '.' || name === '..') {
+    return DefaultServerCommand;
+  }
+  return name;
 }
 
 /**

--- a/editors/vscode/src/serverResolution.ts
+++ b/editors/vscode/src/serverResolution.ts
@@ -16,11 +16,22 @@ export function resolveCommand(configuredPath: string | undefined): string {
 /**
  * binaryNameFromCommand derives a CLI binary name from a resolved command path
  * (e.g. `/opt/mycli` -> `mycli`, `mycli.exe` -> `mycli`, `scafctl` -> `scafctl`).
- * Used as the fallback binary name when the server cannot report its own
- * recognized files, so an embedder's `<binary>.yaml` still matches.
+ * It mirrors Go's settings.SanitizeBinaryName: strip the directory, strip the
+ * final extension (so `mycli.cmd`/`.bat`/`.ps1` don't leak into selectors),
+ * replace unsafe characters, and fall back to the default when empty. Keeping it
+ * aligned with the Go sanitizer ensures the fallback binary name matches the
+ * CLI's discovery names when the server cannot report its own recognized files.
  */
 export function binaryNameFromCommand(command: string): string {
-  const name = basename(command.trim()).replace(/\.exe$/i, '');
+  let name = basename(command.trim());
+  // Strip a single trailing extension, matching Go's filepath.Ext stripping.
+  const dot = name.lastIndexOf('.');
+  if (dot > 0) {
+    name = name.slice(0, dot);
+  }
+  // Replace unsafe characters with underscores and trim them (mirrors safeNameRe
+  // [^A-Za-z0-9._-] plus a leading/trailing underscore trim).
+  name = name.replace(/[^A-Za-z0-9._-]/g, '_').replace(/^_+|_+$/g, '');
   return name.length > 0 ? name : DefaultServerCommand;
 }
 

--- a/editors/vscode/src/serverResolution.ts
+++ b/editors/vscode/src/serverResolution.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'node:child_process';
+import { basename } from 'node:path';
 
 /** DefaultServerCommand is the command used when no explicit path is configured. */
 export const DefaultServerCommand = 'scafctl';
@@ -10,6 +11,17 @@ export const DefaultServerCommand = 'scafctl';
 export function resolveCommand(configuredPath: string | undefined): string {
   const trimmed = (configuredPath ?? '').trim();
   return trimmed.length > 0 ? trimmed : DefaultServerCommand;
+}
+
+/**
+ * binaryNameFromCommand derives a CLI binary name from a resolved command path
+ * (e.g. `/opt/mycli` -> `mycli`, `mycli.exe` -> `mycli`, `scafctl` -> `scafctl`).
+ * Used as the fallback binary name when the server cannot report its own
+ * recognized files, so an embedder's `<binary>.yaml` still matches.
+ */
+export function binaryNameFromCommand(command: string): string {
+  const name = basename(command.trim()).replace(/\.exe$/i, '');
+  return name.length > 0 ? name : DefaultServerCommand;
 }
 
 /**

--- a/editors/vscode/syntaxes/scafctl.tmLanguage.json
+++ b/editors/vscode/syntaxes/scafctl.tmLanguage.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "scafctl",
+  "scopeName": "source.scafctl",
+  "patterns": [
+    {
+      "include": "source.yaml"
+    }
+  ]
+}

--- a/pkg/cmd/scafctl/lsp/document_selectors.go
+++ b/pkg/cmd/scafctl/lsp/document_selectors.go
@@ -58,7 +58,7 @@ func commandDocumentSelectors(cliParams *settings.Run, ioStreams *terminal.IOStr
 				return fmt.Errorf("writer not initialized in context")
 			}
 
-			files := pkglsp.RecognizedFilesFor(cliParams.BinaryName)
+			files := pkglsp.RecognizedFilesFor(effectiveBinaryName)
 
 			// Build options from the populated outputFlags so --where,
 			// FormatExplicit, and AppName survive; use the effective binary

--- a/pkg/cmd/scafctl/lsp/document_selectors.go
+++ b/pkg/cmd/scafctl/lsp/document_selectors.go
@@ -1,0 +1,78 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	pkglsp "github.com/oakwood-commons/scafctl/pkg/lsp"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/kvx"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/spf13/cobra"
+)
+
+// commandDocumentSelectors creates the `lsp document-selectors` subcommand. It
+// reports the solution/action file names this binary auto-discovers, so an
+// editor (e.g. the VS Code extension) can build its LSP document selector from
+// the same source of truth as CLI discovery instead of hardcoding a list that
+// drifts. Consumed programmatically; run with `-o json` for a stable contract.
+func commandDocumentSelectors(cliParams *settings.Run, ioStreams *terminal.IOStreams) *cobra.Command {
+	var outputFlags flags.KvxOutputFlags
+
+	cmd := &cobra.Command{
+		Use:   "document-selectors",
+		Short: "Print the solution file names editors should attach the language server to",
+		Long: strings.ReplaceAll(heredoc.Doc(`
+			Print the solution and action file names that scafctl auto-discovers,
+			partitioned by editor language (YAML vs JSON), along with the effective
+			binary name.
+
+			This is a machine-readable contract for editor integrations (such as
+			the VS Code extension): the client queries this command at startup and
+			builds its LSP document selector from the result, so editor targeting
+			stays in lockstep with CLI auto-discovery -- including .json solutions,
+			taskfile.*, actions.*, and any embedder binary name -- rather than
+			hardcoding a list that drifts.
+
+			Use -o json for a stable, parseable contract:
+
+			  scafctl lsp document-selectors -o json
+		`), settings.CliBinaryName, cliParams.BinaryName),
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx := cmd.Context()
+			w := writer.FromContext(ctx)
+			if w == nil {
+				return fmt.Errorf("writer not initialized in context")
+			}
+			outputFlags.AppName = cliParams.BinaryName
+
+			files := pkglsp.RecognizedFilesFor(cliParams.BinaryName)
+
+			outputOpts := flags.NewKvxOutputOptionsFromFlags(
+				outputFlags.Output,
+				outputFlags.Interactive,
+				outputFlags.Expression,
+				kvx.WithOutputContext(ctx),
+				kvx.WithOutputNoColor(cliParams.NoColor),
+				kvx.WithOutputAppName(cliParams.BinaryName+" lsp document-selectors"),
+			)
+			outputOpts.IOStreams = ioStreams
+
+			if err := outputOpts.Write(files); err != nil {
+				return fmt.Errorf("print recognized solution files: %w", err)
+			}
+			return nil
+		},
+	}
+
+	flags.AddKvxOutputFlagsToStruct(cmd, &outputFlags)
+	return cmd
+}

--- a/pkg/cmd/scafctl/lsp/document_selectors.go
+++ b/pkg/cmd/scafctl/lsp/document_selectors.go
@@ -25,6 +25,11 @@ import (
 func commandDocumentSelectors(cliParams *settings.Run, ioStreams *terminal.IOStreams) *cobra.Command {
 	var outputFlags flags.KvxOutputFlags
 
+	// Resolve the effective binary name once (falls back to CliBinaryName when
+	// an embedder passes an empty name), so help text, discovery, and the kvx
+	// app title all use the same non-empty value.
+	effectiveBinaryName := settings.SanitizeBinaryName(cliParams.BinaryName)
+
 	cmd := &cobra.Command{
 		Use:   "document-selectors",
 		Short: "Print the solution file names editors should attach the language server to",
@@ -43,7 +48,7 @@ func commandDocumentSelectors(cliParams *settings.Run, ioStreams *terminal.IOStr
 			Use -o json for a stable, parseable contract:
 
 			  scafctl lsp document-selectors -o json
-		`), settings.CliBinaryName, cliParams.BinaryName),
+		`), settings.CliBinaryName, effectiveBinaryName),
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -52,17 +57,18 @@ func commandDocumentSelectors(cliParams *settings.Run, ioStreams *terminal.IOStr
 			if w == nil {
 				return fmt.Errorf("writer not initialized in context")
 			}
-			outputFlags.AppName = cliParams.BinaryName
 
 			files := pkglsp.RecognizedFilesFor(cliParams.BinaryName)
 
-			outputOpts := flags.NewKvxOutputOptionsFromFlags(
-				outputFlags.Output,
-				outputFlags.Interactive,
-				outputFlags.Expression,
+			// Build options from the populated outputFlags so --where,
+			// FormatExplicit, and AppName survive; use the effective binary
+			// name (files.BinaryName is already resolved with fallback) for the
+			// kvx app title.
+			outputFlags.AppName = files.BinaryName + " lsp document-selectors"
+			outputOpts := flags.ToKvxOutputOptions(
+				&outputFlags,
 				kvx.WithOutputContext(ctx),
 				kvx.WithOutputNoColor(cliParams.NoColor),
-				kvx.WithOutputAppName(cliParams.BinaryName+" lsp document-selectors"),
 			)
 			outputOpts.IOStreams = ioStreams
 

--- a/pkg/cmd/scafctl/lsp/document_selectors_test.go
+++ b/pkg/cmd/scafctl/lsp/document_selectors_test.go
@@ -81,3 +81,39 @@ func TestCommandDocumentSelectors_EmbedderBinaryName(t *testing.T) {
 	// Standard names still recognized alongside the embedder name.
 	assert.Contains(t, got.YAMLNames, "solution.yaml")
 }
+
+// TestCommandDocumentSelectors_OptionsCarryFlags verifies that output options
+// are built from the populated outputFlags struct (via ToKvxOutputOptions) so
+// FormatExplicit and AppName survive -- they were previously dropped because
+// options were built via NewKvxOutputOptionsFromFlags. The --where flag is
+// accepted (plumbed through) even though this command emits a single object.
+func TestCommandDocumentSelectors_OptionsCarryFlags(t *testing.T) {
+	// -o json is explicit here; FormatExplicit must be honored so the JSON
+	// document is emitted rather than falling back to auto/table rendering.
+	out := runDocumentSelectors(t, "", "-o", "json")
+	var got pkglsp.RecognizedFiles
+	require.NoError(t, json.Unmarshal([]byte(out), &got), "explicit -o json must produce JSON: %s", out)
+
+	// The --where flag is registered on this command and must be accepted
+	// without a parse error (it is plumbed into kvx options).
+	cmd := commandDocumentSelectors(settings.NewCliParams(), func() *terminal.IOStreams {
+		s, _, _ := terminal.NewTestIOStreams()
+		return s
+	}())
+	assert.NotNil(t, cmd.Flags().Lookup("where"), "--where flag must be registered")
+}
+
+// TestCommandDocumentSelectors_EmptyBinaryNameHelp verifies that an embedder
+// passing an empty binary name does not strip "scafctl" from the help text --
+// the replacement uses the effective (fallback) binary name instead.
+func TestCommandDocumentSelectors_EmptyBinaryNameHelp(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	cliParams.BinaryName = ""
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := commandDocumentSelectors(cliParams, ioStreams)
+
+	// With an empty binary name the effective name falls back to CliBinaryName,
+	// so the usage example must still name a real binary (not an empty string).
+	assert.Contains(t, cmd.Long, settings.CliBinaryName+" lsp document-selectors",
+		"empty binary name must fall back to the effective name in help text")
+}

--- a/pkg/cmd/scafctl/lsp/document_selectors_test.go
+++ b/pkg/cmd/scafctl/lsp/document_selectors_test.go
@@ -1,0 +1,83 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	pkglsp "github.com/oakwood-commons/scafctl/pkg/lsp"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runDocumentSelectors executes the `document-selectors` subcommand with the
+// given binary name and args, returning the captured stdout.
+func runDocumentSelectors(t *testing.T, binaryName string, args ...string) string {
+	t.Helper()
+
+	cliParams := settings.NewCliParams()
+	cliParams.ExitOnError = false
+	if binaryName != "" {
+		cliParams.BinaryName = binaryName
+	}
+
+	var out bytes.Buffer
+	ioStreams := terminal.NewIOStreams(nil, &out, &out, false)
+	w := writer.New(ioStreams, cliParams)
+	ctx := writer.WithWriter(context.Background(), w)
+	ctx = logger.WithLogger(ctx, logger.GetNoopLogger())
+
+	cmd := commandDocumentSelectors(cliParams, ioStreams)
+	cmd.SetContext(ctx)
+	cmd.SetArgs(args)
+	require.NoError(t, cmd.Execute())
+
+	return out.String()
+}
+
+func TestCommandDocumentSelectors_Construction(t *testing.T) {
+	cliParams := settings.NewCliParams()
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	cmd := commandDocumentSelectors(cliParams, ioStreams)
+
+	assert.Equal(t, "document-selectors", cmd.Name())
+	require.NotNil(t, cmd.RunE)
+	assert.NoError(t, cmd.Args(cmd, []string{}))
+	assert.Error(t, cmd.Args(cmd, []string{"unexpected"}), "takes no positional args")
+}
+
+func TestCommandDocumentSelectors_JSONOutput(t *testing.T) {
+	out := runDocumentSelectors(t, "", "-o", "json")
+
+	var got pkglsp.RecognizedFiles
+	require.NoError(t, json.Unmarshal([]byte(out), &got), "output must be valid JSON: %s", out)
+
+	assert.Equal(t, settings.CliBinaryName, got.BinaryName)
+	assert.Contains(t, got.YAMLNames, "solution.yaml")
+	assert.Contains(t, got.YAMLNames, "taskfile.yaml")
+	assert.Contains(t, got.YAMLNames, "actions.yaml")
+	assert.Contains(t, got.JSONNames, "solution.json")
+	assert.NotContains(t, got.YAMLNames, "solution.json")
+}
+
+func TestCommandDocumentSelectors_EmbedderBinaryName(t *testing.T) {
+	out := runDocumentSelectors(t, "mycli", "-o", "json")
+
+	var got pkglsp.RecognizedFiles
+	require.NoError(t, json.Unmarshal([]byte(out), &got), "output must be valid JSON: %s", out)
+
+	assert.Equal(t, "mycli", got.BinaryName)
+	assert.Contains(t, got.YAMLNames, "mycli.yaml")
+	assert.Contains(t, got.YAMLNames, "mycli.yml")
+	assert.Contains(t, got.JSONNames, "mycli.json")
+	// Standard names still recognized alongside the embedder name.
+	assert.Contains(t, got.YAMLNames, "solution.yaml")
+}

--- a/pkg/cmd/scafctl/lsp/lsp.go
+++ b/pkg/cmd/scafctl/lsp/lsp.go
@@ -19,7 +19,7 @@ import (
 )
 
 // CommandLsp creates the `lsp` command.
-func CommandLsp(cliParams *settings.Run, _ *terminal.IOStreams, path string) *cobra.Command {
+func CommandLsp(cliParams *settings.Run, ioStreams *terminal.IOStreams, path string) *cobra.Command {
 	binaryName := cliParams.BinaryName
 	if binaryName == "" {
 		binaryName = settings.CliBinaryName
@@ -57,6 +57,8 @@ func CommandLsp(cliParams *settings.Run, _ *terminal.IOStreams, path string) *co
 			return server.Run()
 		},
 	}
+
+	cmd.AddCommand(commandDocumentSelectors(cliParams, ioStreams))
 
 	return cmd
 }

--- a/pkg/lsp/selectors.go
+++ b/pkg/lsp/selectors.go
@@ -39,12 +39,17 @@ type RecognizedFiles struct {
 // given binary name, deduplicated and partitioned by extension. It unions the
 // solution discovery set with the action discovery set so editors attach to
 // every file the CLI would auto-discover (including .json solutions,
-// taskfile.*, and actions.*). An empty binaryName falls back to
-// settings.CliBinaryName.
+// taskfile.*, and actions.*). The binary name is sanitized via
+// settings.SanitizeBinaryName, so a path, extension, or empty value is
+// normalized (empty falls back to settings.CliBinaryName).
 func RecognizedFilesFor(binaryName string) RecognizedFiles {
-	if binaryName == "" {
-		binaryName = settings.CliBinaryName
-	}
+	// Normalize at the boundary: settings.SolutionFileNamesFor/ActionFileNamesFor
+	// expect an already-sanitized name, so a caller passing a path
+	// ("/opt/mycli"), an extension ("mycli.exe"), or an empty value would
+	// otherwise produce an invalid editor contract. SanitizeBinaryName strips
+	// directory/extension, replaces unsafe characters, and falls back to
+	// CliBinaryName when the result is empty.
+	binaryName = settings.SanitizeBinaryName(binaryName)
 
 	// Union solution and action discovery sets; order is preserved by first
 	// appearance so the output is deterministic and stable across releases.

--- a/pkg/lsp/selectors.go
+++ b/pkg/lsp/selectors.go
@@ -1,0 +1,70 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+)
+
+// jsonFileExtension is the suffix that marks a recognized file as a JSON
+// document (as opposed to YAML). It is used to partition recognized file names
+// into their editor language groups.
+const jsonFileExtension = ".json"
+
+// RecognizedFiles describes the solution/action file names an LSP client should
+// attach to, partitioned by document language so the client can emit correct
+// per-language document selectors. It is the editor-facing projection of the
+// CLI's discovery set (settings.SolutionFileNamesFor / ActionFileNamesFor),
+// keeping editor integrations in lockstep with CLI auto-discovery instead of
+// hardcoding a list that drifts.
+type RecognizedFiles struct {
+	// BinaryName is the effective CLI binary name these patterns are built for.
+	// For embedders this is the embedding CLI's name (e.g. "mycli"), so the
+	// editor attaches to "<mycli>.yaml" and friends automatically.
+	BinaryName string `json:"binaryName" yaml:"binaryName" doc:"Effective CLI binary name these patterns are built for" example:"scafctl" maxLength:"128"`
+	// YAMLNames are recognized solution/action file names whose editor language
+	// is YAML (e.g. "solution.yaml", "taskfile.yml", "actions.yaml").
+	YAMLNames []string `json:"yamlNames" yaml:"yamlNames" doc:"Recognized solution/action file names with a YAML language" maxItems:"64"`
+	// JSONNames are recognized solution file names whose editor language is JSON
+	// (e.g. "solution.json"). A JSON document never matches a YAML-scoped
+	// selector, so these must be surfaced separately.
+	JSONNames []string `json:"jsonNames" yaml:"jsonNames" doc:"Recognized solution file names with a JSON language" maxItems:"64"`
+}
+
+// RecognizedFilesFor returns the recognized solution/action file names for the
+// given binary name, deduplicated and partitioned by extension. It unions the
+// solution discovery set with the action discovery set so editors attach to
+// every file the CLI would auto-discover (including .json solutions,
+// taskfile.*, and actions.*). An empty binaryName falls back to
+// settings.CliBinaryName.
+func RecognizedFilesFor(binaryName string) RecognizedFiles {
+	if binaryName == "" {
+		binaryName = settings.CliBinaryName
+	}
+
+	// Union solution and action discovery sets; order is preserved by first
+	// appearance so the output is deterministic and stable across releases.
+	names := slices.Concat(
+		settings.SolutionFileNamesFor(binaryName),
+		settings.ActionFileNamesFor(binaryName),
+	)
+
+	rf := RecognizedFiles{BinaryName: binaryName}
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		if strings.HasSuffix(name, jsonFileExtension) {
+			rf.JSONNames = append(rf.JSONNames, name)
+		} else {
+			rf.YAMLNames = append(rf.YAMLNames, name)
+		}
+	}
+	return rf
+}

--- a/pkg/lsp/selectors_test.go
+++ b/pkg/lsp/selectors_test.go
@@ -51,6 +51,22 @@ func TestRecognizedFilesFor_EmptyBinaryFallsBack(t *testing.T) {
 	assert.Contains(t, rf.YAMLNames, "solution.yaml")
 }
 
+func TestRecognizedFilesFor_SanitizesUnsafeInput(t *testing.T) {
+	// A path or extension must be normalized to a bare binary name so the
+	// recognized filenames are valid (matching the CLI/embedder contract).
+	for _, raw := range []string{"/opt/tools/mycli", "mycli.exe", "./mycli"} {
+		rf := RecognizedFilesFor(raw)
+		assert.Equalf(t, "mycli", rf.BinaryName, "input %q", raw)
+		assert.Containsf(t, rf.YAMLNames, "mycli.yaml", "input %q", raw)
+		assert.Containsf(t, rf.JSONNames, "mycli.json", "input %q", raw)
+		// No path/extension debris should leak into any recognized name.
+		for _, name := range append(append([]string{}, rf.YAMLNames...), rf.JSONNames...) {
+			assert.NotContainsf(t, name, "/", "input %q produced %q", raw, name)
+			assert.NotContainsf(t, name, ".exe", "input %q produced %q", raw, name)
+		}
+	}
+}
+
 func TestRecognizedFilesFor_Deduplicates(t *testing.T) {
 	rf := RecognizedFilesFor(settings.CliBinaryName)
 

--- a/pkg/lsp/selectors_test.go
+++ b/pkg/lsp/selectors_test.go
@@ -1,0 +1,99 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRecognizedFilesFor_DefaultBinary(t *testing.T) {
+	rf := RecognizedFilesFor(settings.CliBinaryName)
+
+	assert.Equal(t, settings.CliBinaryName, rf.BinaryName)
+
+	// The standard set the extension previously missed must be present.
+	assert.Contains(t, rf.YAMLNames, "solution.yaml")
+	assert.Contains(t, rf.YAMLNames, "solution.yml")
+	assert.Contains(t, rf.YAMLNames, "taskfile.yaml")
+	assert.Contains(t, rf.YAMLNames, "taskfile.yml")
+	assert.Contains(t, rf.YAMLNames, "actions.yaml")
+	assert.Contains(t, rf.YAMLNames, "actions.yml")
+
+	// JSON solutions must be routed to JSONNames, never YAMLNames -- a JSON
+	// document does not match a YAML-scoped editor selector.
+	assert.Contains(t, rf.JSONNames, "solution.json")
+	assert.NotContains(t, rf.YAMLNames, "solution.json")
+	for _, name := range rf.YAMLNames {
+		assert.NotContains(t, name, ".json", "YAMLNames must not contain JSON files")
+	}
+}
+
+func TestRecognizedFilesFor_EmbedderBinary(t *testing.T) {
+	rf := RecognizedFilesFor("mycli")
+
+	assert.Equal(t, "mycli", rf.BinaryName)
+	// Embedder binary name flows into both YAML and JSON variants.
+	assert.Contains(t, rf.YAMLNames, "mycli.yaml")
+	assert.Contains(t, rf.YAMLNames, "mycli.yml")
+	assert.Contains(t, rf.JSONNames, "mycli.json")
+	// Standard names are still recognized alongside the embedder name.
+	assert.Contains(t, rf.YAMLNames, "solution.yaml")
+	assert.Contains(t, rf.JSONNames, "solution.json")
+}
+
+func TestRecognizedFilesFor_EmptyBinaryFallsBack(t *testing.T) {
+	rf := RecognizedFilesFor("")
+	assert.Equal(t, settings.CliBinaryName, rf.BinaryName)
+	assert.Contains(t, rf.YAMLNames, "solution.yaml")
+}
+
+func TestRecognizedFilesFor_Deduplicates(t *testing.T) {
+	rf := RecognizedFilesFor(settings.CliBinaryName)
+
+	// solution.yaml appears in both SolutionFileNamesFor and ActionFileNamesFor;
+	// the union must not duplicate it (nor any other name).
+	seen := make(map[string]int)
+	for _, n := range rf.YAMLNames {
+		seen[n]++
+	}
+	for _, n := range rf.JSONNames {
+		seen[n]++
+	}
+	for name, count := range seen {
+		assert.Equalf(t, 1, count, "%q appears %d times; expected exactly one", name, count)
+	}
+}
+
+func TestRecognizedFilesFor_IsSupersetOfCLIDiscovery(t *testing.T) {
+	// Every name the CLI would discover (solution + action modes) must be
+	// represented, so editor targeting never lags CLI auto-discovery.
+	rf := RecognizedFilesFor(settings.CliBinaryName)
+	all := make(map[string]struct{})
+	for _, n := range rf.YAMLNames {
+		all[n] = struct{}{}
+	}
+	for _, n := range rf.JSONNames {
+		all[n] = struct{}{}
+	}
+
+	for _, name := range settings.SolutionFileNamesFor(settings.CliBinaryName) {
+		_, ok := all[name]
+		assert.Truef(t, ok, "solution name %q missing from RecognizedFiles", name)
+	}
+	for _, name := range settings.ActionFileNamesFor(settings.CliBinaryName) {
+		_, ok := all[name]
+		assert.Truef(t, ok, "action name %q missing from RecognizedFiles", name)
+	}
+}
+
+func BenchmarkRecognizedFilesFor(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = RecognizedFilesFor(settings.CliBinaryName)
+	}
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13821,6 +13821,27 @@ func TestIntegration_LspHelp(t *testing.T) {
 	assert.Contains(t, stdout, "LSP")
 }
 
+func TestIntegration_LspDocumentSelectors(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "lsp", "document-selectors", "-o", "json")
+	require.Equal(t, 0, exitCode)
+
+	var got struct {
+		BinaryName string   `json:"binaryName"`
+		YAMLNames  []string `json:"yamlNames"`
+		JSONNames  []string `json:"jsonNames"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &got), "output must be valid JSON: %s", stdout)
+
+	// The full recognized set the extension previously missed must be reported.
+	assert.Contains(t, got.YAMLNames, "solution.yaml")
+	assert.Contains(t, got.YAMLNames, "taskfile.yaml")
+	assert.Contains(t, got.YAMLNames, "actions.yaml")
+	// JSON solutions are routed to jsonNames, never yamlNames.
+	assert.Contains(t, got.JSONNames, "solution.json")
+	assert.NotContains(t, got.YAMLNames, "solution.json")
+}
+
 func TestIntegration_LspInitializeAndDiagnostics(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes #764. The VS Code extension attached its language server to a hardcoded, incomplete glob (`{solution,scafctl}.{yaml,yml}`), so JSON solutions, `taskfile.*`, `actions.*`, and any embedder binary name never received LSP features -- and a JSON solution could not match a YAML-scoped selector at all.

This makes editor targeting **derive from the binary** instead of a drift-prone hardcoded list.

## What changed

**Discovery is the source of truth**

- New `pkg/lsp.RecognizedFilesFor(binaryName)` unions the solution + action discovery sets (`settings.SolutionFileNamesFor` / `ActionFileNamesFor`), dedupes, and partitions names by extension into YAML vs JSON groups (so JSON solutions attach as JSON documents).
- New `scafctl lsp document-selectors` subcommand emits that as a machine-readable JSON contract (`-o json`), also available as table/yaml for humans.
- The extension queries it at startup and builds its `documentSelector` dynamically, including any embedder binary name. If the binary is too old to answer, it degrades to defaults derived from the binary's own file name so an embedder's `<binary>.yaml` still matches.
- The VS Code activation glob is split so `.json` only activates for `solution`/`scafctl` names (matching CLI discovery; `taskfile.json`/`actions.json` are not recognized), avoiding spurious activation.
- The `document-selectors` command builds its kvx output options from the populated flags (so `--output`-explicit rendering and the app title survive) and uses the effective, fallback-resolved binary name so an embedder passing an empty name never strips `scafctl` from the help/usage text.

**Configuration (defaults chosen for safest UX)**

- `scafctl.solutionFilePatterns` -- extra globs for non-standard names. **Extends** the discovered set by default; opt-in `scafctl.solutionFilePatterns.replaceDefaults` to replace instead.
- `scafctl.language.enable` -- opt-in (default **off**) dedicated `scafctl` language embedding the YAML grammar. Off by default so other extensions' schema validation/formatting (e.g. Red Hat YAML) is preserved on solution files -- matching how GitHub Actions/Helm layer over YAML.

**Error visibility**

- Wired `scafctl.trace.server` (previously a dead setting) via an output channel with a matching client id; reveal-on-error.
- Catch `client.start()` rejections so a failed launch/handshake is reported with a "Show Logs" action instead of a silent unhandled rejection.

**Tooling**

- Exclude `node_modules` from golangci-lint so the extension's vendored JS deps (which include a stray Go file) don't break `task lint`/`test:e2e` once extension deps are installed.

**Docs**

- `docs/design/cli.md`, `docs/tutorials/lsp-tutorial.md`, and the extension README updated for the new subcommand, JSON support, and settings.

## Testing

- `pkg/lsp/selectors_test.go` -- table tests (default/embedder/empty binary, dedup, JSON partitioning, CLI-discovery superset) + `BenchmarkRecognizedFilesFor`. `selectors.go` at 100%.
- `document_selectors_test.go` + `TestIntegration_LspDocumentSelectors` -- subcommand output incl. embedder binary name.
- `documentSelectors.test.ts` / `serverResolution.test.ts` -- builder, parse, fetch fallback (missing binary, malformed JSON), extend-vs-replace, opt-in language, binary-name extraction (21 TS tests).
- `task test:e2e`: green (0 failures, 4m34s). `task lint:changed`: 0 issues.

## Notes

- Single-object output (`RecognizedFiles`), so no kvx display schema is required.
- `extension.ts` is VS Code-host glue (imports `vscode`) and has no unit tests, consistent with its prior state; its pure logic was extracted into `documentSelectors.ts` / `serverResolution.ts`, which are fully tested.
