### PR TITLE
feat(lsp): per-document parse+index cache + export refindex.NodeMap

### DIFF
--- a/pkg/lsp/diagnostics.go
+++ b/pkg/lsp/diagnostics.go
@@ -31,7 +31,14 @@ func Diagnostics(content []byte, filePath, source string, registry *provider.Reg
 	if err := sol.UnmarshalFromBytes(content); err != nil {
 		return []protocol.Diagnostic{parseErrorDiagnostic(err, source)}
 	}
+	return diagnosticsFromSolution(sol, content, filePath, source, registry)
+}
 
+// diagnosticsFromSolution runs lint on an already-parsed solution and maps the
+// findings to LSP diagnostics. It lets the server reuse the per-document cache's
+// parse instead of re-unmarshalling on every publish. content is the raw source
+// used to compute per-line squiggle ranges.
+func diagnosticsFromSolution(sol *solution.Solution, content []byte, filePath, source string, registry *provider.Registry) []protocol.Diagnostic {
 	result := lint.Solution(sol, filePath, registry)
 	lines := bytes.Split(content, []byte("\n"))
 

--- a/pkg/lsp/document.go
+++ b/pkg/lsp/document.go
@@ -1,0 +1,120 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"sync"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+	"gopkg.in/yaml.v3"
+)
+
+// DocEntry is an immutable snapshot of a single open document's parsed state. It
+// is computed once per (URI, version) by DocumentCache.Set and shared by every
+// editor feature that fires on the same keystroke (definition, references,
+// hover, completion, signature help), so the document is parsed and indexed only
+// once per edit instead of once per request.
+//
+// Every field except URI, Version, and Raw may be zero when the document fails
+// to parse: features must degrade gracefully while the user is mid-edit. ParseErr
+// is non-nil in that case and callers should fall back to raw-text behavior (or
+// no result) rather than dereferencing Sol/Index.
+type DocEntry struct {
+	URI      protocol.DocumentUri
+	Version  int32
+	Raw      []byte
+	Sol      *solution.Solution
+	Index    *refindex.Index
+	Lines    *sourcepos.LineIndex
+	Nodes    map[string]*yaml.Node // path -> value node (refindex.NodeMap)
+	ParseErr error                 // non-nil when the doc failed to parse
+}
+
+// DocumentCache stores one DocEntry per open document, keyed by URI. Entries are
+// immutable once returned; Set atomically replaces the entry for a URI under a
+// write lock, and Get returns the current snapshot under a read lock. Readers
+// never mutate the returned *DocEntry.
+type DocumentCache struct {
+	mu      sync.RWMutex
+	entries map[protocol.DocumentUri]*DocEntry
+}
+
+// NewDocumentCache constructs an empty document cache.
+func NewDocumentCache() *DocumentCache {
+	return &DocumentCache{entries: make(map[protocol.DocumentUri]*DocEntry)}
+}
+
+// Set parses and indexes text for uri at the given version, stores the resulting
+// snapshot, and returns it. Parsing is done once here; every feature reuses the
+// snapshot. A parse failure is captured in the entry's ParseErr (and the entry
+// is still stored) so the cache never panics on malformed, mid-edit content.
+func (c *DocumentCache) Set(uri protocol.DocumentUri, version int32, text string) *DocEntry {
+	entry := buildDocEntry(uri, version, text)
+	c.mu.Lock()
+	c.entries[uri] = entry
+	c.mu.Unlock()
+	return entry
+}
+
+// Get returns the current snapshot for uri, if the document is open.
+func (c *DocumentCache) Get(uri protocol.DocumentUri) (*DocEntry, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	e, ok := c.entries[uri]
+	return e, ok
+}
+
+// Delete drops the snapshot for uri (on document close).
+func (c *DocumentCache) Delete(uri protocol.DocumentUri) {
+	c.mu.Lock()
+	delete(c.entries, uri)
+	c.mu.Unlock()
+}
+
+// buildDocEntry performs the one-time parse+index for a document version. It is
+// resilient: each stage records the first error into ParseErr and continues to
+// populate whatever downstream artifacts remain computable, so features can use
+// partial information (e.g. the node map) even when the solution model fails to
+// build.
+func buildDocEntry(uri protocol.DocumentUri, version int32, text string) *DocEntry {
+	raw := []byte(text)
+	entry := &DocEntry{
+		URI:     uri,
+		Version: version,
+		Raw:     raw,
+		Lines:   sourcepos.NewLineIndex(raw, uriToPath(uri)),
+	}
+
+	// The value-node map is a pure YAML parse independent of the solution model;
+	// compute it even when the solution fails to unmarshal so cursor-context
+	// features still have something to work with.
+	if nodes, err := refindex.NodeMap(raw); err != nil {
+		entry.ParseErr = err
+	} else {
+		entry.Nodes = nodes
+	}
+
+	sol := &solution.Solution{}
+	if err := sol.UnmarshalFromBytes(raw); err != nil {
+		if entry.ParseErr == nil {
+			entry.ParseErr = err
+		}
+		return entry
+	}
+	entry.Sol = sol
+
+	idx, err := refindex.Build(sol)
+	if err != nil {
+		if entry.ParseErr == nil {
+			entry.ParseErr = err
+		}
+		return entry
+	}
+	entry.Index = idx
+
+	return entry
+}

--- a/pkg/lsp/document.go
+++ b/pkg/lsp/document.go
@@ -4,6 +4,7 @@
 package lsp
 
 import (
+	"bytes"
 	"sync"
 
 	"github.com/oakwood-commons/scafctl/pkg/refindex"
@@ -52,7 +53,27 @@ func NewDocumentCache() *DocumentCache {
 // snapshot, and returns it. Parsing is done once here; every feature reuses the
 // snapshot. A parse failure is captured in the entry's ParseErr (and the entry
 // is still stored) so the cache never panics on malformed, mid-edit content.
+//
+// Set short-circuits when the cache already holds the same (version, text)
+// snapshot for uri: it returns the existing immutable entry without re-parsing
+// or re-indexing. This honors the "computed once per (URI, version)" contract
+// for duplicate notifications -- most notably didSave, which re-sends the last
+// synced content under the cached version, but also any repeated didChange for
+// an unchanged version.
 func (c *DocumentCache) Set(uri protocol.DocumentUri, version int32, text string) *DocEntry {
+	raw := []byte(text)
+
+	// Fast path: an identical snapshot is already cached. Check under the read
+	// lock so concurrent readers are never blocked by a redundant Set.
+	c.mu.RLock()
+	existing, ok := c.entries[uri]
+	c.mu.RUnlock()
+	if ok && existing.Version == version && bytes.Equal(existing.Raw, raw) {
+		return existing
+	}
+
+	// Parse outside the write lock so concurrent Get callers keep reading the
+	// current snapshot while the new one is built; only the map swap is locked.
 	entry := buildDocEntry(uri, version, text)
 	c.mu.Lock()
 	c.entries[uri] = entry

--- a/pkg/lsp/document_benchmark_test.go
+++ b/pkg/lsp/document_benchmark_test.go
@@ -1,0 +1,35 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import "testing"
+
+// BenchmarkDocumentCache_Set measures the one-time parse+index cost paid once
+// per document version.
+func BenchmarkDocumentCache_Set(b *testing.B) {
+	c := NewDocumentCache()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; b.Loop(); i++ {
+		//nolint:gosec // benchmark counter is small and non-negative
+		c.Set(cacheURI, int32(i), validCacheSolution)
+	}
+}
+
+// BenchmarkDocumentCache_Get proves that reading a cached document at an
+// unchanged version reuses the parse: it does no UnmarshalFromBytes / refindex
+// Build work, so it is dramatically cheaper than Set. This is the win that lets
+// several features fire on one keystroke and share a single parse.
+func BenchmarkDocumentCache_Get(b *testing.B) {
+	c := NewDocumentCache()
+	c.Set(cacheURI, 1, validCacheSolution)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		entry, ok := c.Get(cacheURI)
+		if !ok || entry.Index == nil {
+			b.Fatal("expected a cached, parsed entry")
+		}
+	}
+}

--- a/pkg/lsp/document_test.go
+++ b/pkg/lsp/document_test.go
@@ -75,6 +75,37 @@ func TestDocumentCache_VersionBumpInvalidates(t *testing.T) {
 	assert.Equal(t, int32(2), got.Version)
 }
 
+// TestDocumentCache_SetDedupesIdenticalSnapshot verifies that re-Setting the
+// same (version, text) returns the already-cached entry without re-parsing --
+// the didSave case, where the last synced content is re-sent under the cached
+// version. Reusing the same pointer proves no rebuild happened.
+func TestDocumentCache_SetDedupesIdenticalSnapshot(t *testing.T) {
+	c := NewDocumentCache()
+	first := c.Set(cacheURI, 1, validCacheSolution)
+	second := c.Set(cacheURI, 1, validCacheSolution)
+
+	assert.Same(t, first, second, "an identical (version, text) snapshot reuses the cached entry")
+
+	got, ok := c.Get(cacheURI)
+	require.True(t, ok)
+	assert.Same(t, first, got)
+}
+
+// TestDocumentCache_SetSameVersionNewTextRebuilds verifies the short-circuit is
+// gated on text equality, not version alone: identical version but changed text
+// must rebuild so the cache never serves stale parsed state.
+func TestDocumentCache_SetSameVersionNewTextRebuilds(t *testing.T) {
+	c := NewDocumentCache()
+	first := c.Set(cacheURI, 1, validCacheSolution)
+	second := c.Set(cacheURI, 1, validCacheSolution+"\n# trailing edit\n")
+
+	assert.NotSame(t, first, second, "different text under the same version rebuilds the snapshot")
+
+	got, ok := c.Get(cacheURI)
+	require.True(t, ok)
+	assert.Same(t, second, got)
+}
+
 func TestDocumentCache_Delete(t *testing.T) {
 	c := NewDocumentCache()
 	c.Set(cacheURI, 1, validCacheSolution)

--- a/pkg/lsp/document_test.go
+++ b/pkg/lsp/document_test.go
@@ -1,0 +1,132 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+const cacheURI = protocol.DocumentUri("file:///cache.yaml")
+
+const validCacheSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: cache
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+`
+
+// malformedCacheSolution is not valid YAML (unclosed flow mapping), so even the
+// pure node-map parse fails.
+const malformedCacheSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata: {name: cache
+spec:
+`
+
+func TestDocumentCache_SetGetHit(t *testing.T) {
+	c := NewDocumentCache()
+	entry := c.Set(cacheURI, 1, validCacheSolution)
+
+	require.NotNil(t, entry)
+	assert.Equal(t, cacheURI, entry.URI)
+	assert.Equal(t, int32(1), entry.Version)
+	assert.Equal(t, []byte(validCacheSolution), entry.Raw)
+	assert.NoError(t, entry.ParseErr)
+	assert.NotNil(t, entry.Sol)
+	assert.NotNil(t, entry.Index)
+	assert.NotNil(t, entry.Lines)
+	assert.NotEmpty(t, entry.Nodes)
+
+	got, ok := c.Get(cacheURI)
+	require.True(t, ok)
+	assert.Same(t, entry, got, "Get returns the same cached snapshot without re-parsing")
+}
+
+func TestDocumentCache_GetMiss(t *testing.T) {
+	c := NewDocumentCache()
+	_, ok := c.Get(cacheURI)
+	assert.False(t, ok)
+}
+
+func TestDocumentCache_VersionBumpInvalidates(t *testing.T) {
+	c := NewDocumentCache()
+	first := c.Set(cacheURI, 1, validCacheSolution)
+	second := c.Set(cacheURI, 2, validCacheSolution)
+
+	assert.NotSame(t, first, second, "a new version replaces the snapshot")
+	assert.Equal(t, int32(2), second.Version)
+
+	got, ok := c.Get(cacheURI)
+	require.True(t, ok)
+	assert.Same(t, second, got)
+	assert.Equal(t, int32(2), got.Version)
+}
+
+func TestDocumentCache_Delete(t *testing.T) {
+	c := NewDocumentCache()
+	c.Set(cacheURI, 1, validCacheSolution)
+	c.Delete(cacheURI)
+
+	_, ok := c.Get(cacheURI)
+	assert.False(t, ok)
+
+	// Deleting an absent URI is a no-op.
+	assert.NotPanics(t, func() { c.Delete(cacheURI) })
+}
+
+func TestDocumentCache_ParseErrorStoredNotPanicked(t *testing.T) {
+	c := NewDocumentCache()
+	var entry *DocEntry
+	require.NotPanics(t, func() { entry = c.Set(cacheURI, 1, malformedCacheSolution) })
+
+	require.NotNil(t, entry)
+	assert.Error(t, entry.ParseErr, "a malformed document records ParseErr instead of panicking")
+	assert.Nil(t, entry.Sol)
+	assert.Nil(t, entry.Index)
+	// Raw and Lines are always populated so raw-text features still work.
+	assert.Equal(t, []byte(malformedCacheSolution), entry.Raw)
+	assert.NotNil(t, entry.Lines)
+
+	// The failed entry is still cached (features look it up and degrade).
+	got, ok := c.Get(cacheURI)
+	require.True(t, ok)
+	assert.Same(t, entry, got)
+}
+
+func TestDocumentCache_ConcurrentGetDuringSet(t *testing.T) {
+	c := NewDocumentCache()
+	c.Set(cacheURI, 1, validCacheSolution)
+
+	var wg sync.WaitGroup
+	const workers = 8
+	for i := 0; i < workers; i++ {
+		wg.Add(2)
+		go func(v int32) {
+			defer wg.Done()
+			c.Set(cacheURI, v, validCacheSolution)
+		}(int32(i + 2))
+		go func() {
+			defer wg.Done()
+			if e, ok := c.Get(cacheURI); ok {
+				_ = e.Version
+			}
+		}()
+	}
+	wg.Wait()
+
+	_, ok := c.Get(cacheURI)
+	assert.True(t, ok)
+}

--- a/pkg/lsp/navigation.go
+++ b/pkg/lsp/navigation.go
@@ -43,6 +43,13 @@ func Definition(content []byte, uri protocol.DocumentUri, pos protocol.Position)
 	if err != nil {
 		return nil
 	}
+	return definitionFromIndex(idx, uri, pos)
+}
+
+// definitionFromIndex resolves the definition location from an already-built
+// index, allowing the server to reuse the per-document cache instead of
+// re-parsing on every request.
+func definitionFromIndex(idx *refindex.Index, uri protocol.DocumentUri, pos protocol.Position) *protocol.Location {
 	ref, ok := symbolAt(idx, pos)
 	if !ok {
 		return nil
@@ -62,6 +69,11 @@ func References(content []byte, uri protocol.DocumentUri, pos protocol.Position,
 	if err != nil {
 		return []protocol.Location{}
 	}
+	return referencesFromIndex(idx, uri, pos, includeDeclaration)
+}
+
+// referencesFromIndex resolves reference locations from an already-built index.
+func referencesFromIndex(idx *refindex.Index, uri protocol.DocumentUri, pos protocol.Position, includeDeclaration bool) []protocol.Location {
 	ref, ok := symbolAt(idx, pos)
 	if !ok {
 		return []protocol.Location{}
@@ -88,6 +100,12 @@ func PrepareRename(content []byte, pos protocol.Position) *protocol.Range {
 	if err != nil {
 		return nil
 	}
+	return prepareRenameFromIndex(idx, pos)
+}
+
+// prepareRenameFromIndex resolves the renameable range from an already-built
+// index.
+func prepareRenameFromIndex(idx *refindex.Index, pos protocol.Position) *protocol.Range {
 	ref, ok := symbolAt(idx, pos)
 	if !ok {
 		return nil
@@ -105,6 +123,12 @@ func Rename(content []byte, uri protocol.DocumentUri, pos protocol.Position, new
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse solution: %w", err)
 	}
+	return renameFromIndex(sol, idx, uri, pos, newName)
+}
+
+// renameFromIndex computes the rename edit from an already-built solution and
+// index.
+func renameFromIndex(sol *solution.Solution, idx *refindex.Index, uri protocol.DocumentUri, pos protocol.Position, newName string) (*protocol.WorkspaceEdit, error) {
 	ref, ok := symbolAt(idx, pos)
 	if !ok {
 		return nil, fmt.Errorf("no renameable symbol at the cursor position")

--- a/pkg/lsp/server.go
+++ b/pkg/lsp/server.go
@@ -4,8 +4,8 @@
 package lsp
 
 import (
+	"fmt"
 	"net/url"
-	"sync"
 
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -14,15 +14,15 @@ import (
 	glspserver "github.com/tliron/glsp/server"
 )
 
-// Server is a language server for solution files. It keeps an in-memory copy of
-// each open document and republishes lint diagnostics on open/change/save.
+// Server is a language server for solution files. It keeps a per-document
+// parse+index cache for each open document and republishes lint diagnostics on
+// open/change/save.
 type Server struct {
 	binaryName string
 	version    string
 	registry   *provider.Registry
 
-	mu   sync.RWMutex
-	docs map[protocol.DocumentUri]string
+	docs *DocumentCache
 }
 
 // NewServer constructs a language server. binaryName labels diagnostics and the
@@ -36,7 +36,7 @@ func NewServer(binaryName, version string, registry *provider.Registry) *Server 
 		binaryName: binaryName,
 		version:    version,
 		registry:   registry,
-		docs:       make(map[protocol.DocumentUri]string),
+		docs:       NewDocumentCache(),
 	}
 }
 
@@ -98,7 +98,7 @@ func (s *Server) Handler() *protocol.Handler {
 }
 
 func (s *Server) didOpen(ctx *glsp.Context, params *protocol.DidOpenTextDocumentParams) error {
-	s.setDoc(params.TextDocument.URI, params.TextDocument.Text)
+	s.setDoc(params.TextDocument.URI, params.TextDocument.Version, params.TextDocument.Text)
 	s.publish(ctx, params.TextDocument.URI)
 	return nil
 }
@@ -108,13 +108,13 @@ func (s *Server) didChange(ctx *glsp.Context, params *protocol.DidChangeTextDocu
 	for _, change := range params.ContentChanges {
 		switch c := change.(type) {
 		case protocol.TextDocumentContentChangeEventWhole:
-			s.setDoc(params.TextDocument.URI, c.Text)
+			s.setDoc(params.TextDocument.URI, params.TextDocument.Version, c.Text)
 			updated = true
 		case protocol.TextDocumentContentChangeEvent:
 			// Full sync: a rangeless change carries the whole document. glsp
 			// normally maps these to the Whole type; handle the raw form too.
 			if c.Range == nil {
-				s.setDoc(params.TextDocument.URI, c.Text)
+				s.setDoc(params.TextDocument.URI, params.TextDocument.Version, c.Text)
 				updated = true
 			}
 		}
@@ -130,7 +130,13 @@ func (s *Server) didChange(ctx *glsp.Context, params *protocol.DidChangeTextDocu
 
 func (s *Server) didSave(ctx *glsp.Context, params *protocol.DidSaveTextDocumentParams) error {
 	if params.Text != nil {
-		s.setDoc(params.TextDocument.URI, *params.Text)
+		// DidSave carries no document version; reuse the version of the cached
+		// entry (the save reflects the last synced content).
+		var version int32
+		if entry, ok := s.getDoc(params.TextDocument.URI); ok {
+			version = entry.Version
+		}
+		s.setDoc(params.TextDocument.URI, version, *params.Text)
 	}
 	s.publish(ctx, params.TextDocument.URI)
 	return nil
@@ -147,73 +153,80 @@ func (s *Server) didClose(ctx *glsp.Context, params *protocol.DidCloseTextDocume
 }
 
 func (s *Server) definition(_ *glsp.Context, params *protocol.DefinitionParams) (any, error) {
-	content, ok := s.getDoc(params.TextDocument.URI)
-	if !ok {
+	entry, ok := s.getDoc(params.TextDocument.URI)
+	if !ok || entry.Index == nil {
 		return nil, nil
 	}
-	if loc := Definition([]byte(content), params.TextDocument.URI, params.Position); loc != nil {
+	if loc := definitionFromIndex(entry.Index, params.TextDocument.URI, params.Position); loc != nil {
 		return *loc, nil
 	}
 	return nil, nil
 }
 
 func (s *Server) references(_ *glsp.Context, params *protocol.ReferenceParams) ([]protocol.Location, error) {
-	content, ok := s.getDoc(params.TextDocument.URI)
-	if !ok {
+	entry, ok := s.getDoc(params.TextDocument.URI)
+	if !ok || entry.Index == nil {
 		return nil, nil
 	}
-	return References([]byte(content), params.TextDocument.URI, params.Position, params.Context.IncludeDeclaration), nil
+	return referencesFromIndex(entry.Index, params.TextDocument.URI, params.Position, params.Context.IncludeDeclaration), nil
 }
 
 func (s *Server) prepareRename(_ *glsp.Context, params *protocol.PrepareRenameParams) (any, error) {
-	content, ok := s.getDoc(params.TextDocument.URI)
-	if !ok {
+	entry, ok := s.getDoc(params.TextDocument.URI)
+	if !ok || entry.Index == nil {
 		return nil, nil
 	}
-	if rng := PrepareRename([]byte(content), params.Position); rng != nil {
+	if rng := prepareRenameFromIndex(entry.Index, params.Position); rng != nil {
 		return *rng, nil
 	}
 	return nil, nil
 }
 
 func (s *Server) rename(_ *glsp.Context, params *protocol.RenameParams) (*protocol.WorkspaceEdit, error) {
-	content, ok := s.getDoc(params.TextDocument.URI)
+	entry, ok := s.getDoc(params.TextDocument.URI)
 	if !ok {
 		return nil, nil
 	}
-	return Rename([]byte(content), params.TextDocument.URI, params.Position, params.NewName)
+	if entry.ParseErr != nil {
+		return nil, fmt.Errorf("failed to parse solution: %w", entry.ParseErr)
+	}
+	if entry.Sol == nil || entry.Index == nil {
+		return nil, fmt.Errorf("solution is not indexed")
+	}
+	return renameFromIndex(entry.Sol, entry.Index, params.TextDocument.URI, params.Position, params.NewName)
 }
 
-// publish computes and sends diagnostics for the current content of uri.
+// publish computes and sends diagnostics for the current content of uri. When
+// the document parsed cleanly it reuses the cached solution (no re-parse); a
+// parse failure falls back to the raw-content path, which reports the parse
+// error itself.
 func (s *Server) publish(ctx *glsp.Context, uri protocol.DocumentUri) {
-	content, ok := s.getDoc(uri)
+	entry, ok := s.getDoc(uri)
 	if !ok {
 		return
 	}
-	diags := Diagnostics([]byte(content), uriToPath(uri), s.binaryName, s.registry)
+	var diags []protocol.Diagnostic
+	if entry.Sol != nil {
+		diags = diagnosticsFromSolution(entry.Sol, entry.Raw, uriToPath(uri), s.binaryName, s.registry)
+	} else {
+		diags = Diagnostics(entry.Raw, uriToPath(uri), s.binaryName, s.registry)
+	}
 	ctx.Notify(protocol.ServerTextDocumentPublishDiagnostics, protocol.PublishDiagnosticsParams{
 		URI:         uri,
 		Diagnostics: diags,
 	})
 }
 
-func (s *Server) setDoc(uri protocol.DocumentUri, content string) {
-	s.mu.Lock()
-	s.docs[uri] = content
-	s.mu.Unlock()
+func (s *Server) setDoc(uri protocol.DocumentUri, version int32, content string) {
+	s.docs.Set(uri, version, content)
 }
 
-func (s *Server) getDoc(uri protocol.DocumentUri) (string, bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	c, ok := s.docs[uri]
-	return c, ok
+func (s *Server) getDoc(uri protocol.DocumentUri) (*DocEntry, bool) {
+	return s.docs.Get(uri)
 }
 
 func (s *Server) deleteDoc(uri protocol.DocumentUri) {
-	s.mu.Lock()
-	delete(s.docs, uri)
-	s.mu.Unlock()
+	s.docs.Delete(uri)
 }
 
 // uriToPath converts a file:// document URI to a filesystem path, falling back

--- a/pkg/lsp/server_test.go
+++ b/pkg/lsp/server_test.go
@@ -87,6 +87,71 @@ func TestServer_DidChangeRepublishes(t *testing.T) {
 	assert.NotEmpty(t, params.Diagnostics, "changed content should be re-linted")
 }
 
+func TestServer_DidSaveReparsesAndReusesVersion(t *testing.T) {
+	s := newTestServer(t)
+	uri := protocol.DocumentUri("file:///t.yaml")
+
+	// Open at version 3 with clean content.
+	var m string
+	var p protocol.PublishDiagnosticsParams
+	clean := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: ok\nspec:\n  resolvers:\n    a:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value: x\n"
+	require.NoError(t, s.didOpen(captureContext(&m, &p), &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{URI: uri, Version: 3, Text: clean},
+	}))
+
+	// Save carries new text but no version; the cached version is reused.
+	var method string
+	var params protocol.PublishDiagnosticsParams
+	ctx := captureContext(&method, &params)
+	saved := badSolution
+	require.NoError(t, s.didSave(ctx, &protocol.DidSaveTextDocumentParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Text:         &saved,
+	}))
+
+	assert.NotEmpty(t, params.Diagnostics, "saved content should be re-linted")
+	entry, ok := s.getDoc(uri)
+	require.True(t, ok)
+	assert.Equal(t, int32(3), entry.Version, "save reuses the last synced version")
+	assert.Equal(t, []byte(badSolution), entry.Raw)
+}
+
+func TestServer_DidSaveWithoutTextRepublishes(t *testing.T) {
+	s := newTestServer(t)
+	uri := protocol.DocumentUri("file:///t.yaml")
+
+	var m string
+	var p protocol.PublishDiagnosticsParams
+	require.NoError(t, s.didOpen(captureContext(&m, &p), &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{URI: uri, Version: 1, Text: badSolution},
+	}))
+
+	// A save without text (client did not negotiate includeText) still
+	// republishes diagnostics for the existing content.
+	var method string
+	var params protocol.PublishDiagnosticsParams
+	require.NoError(t, s.didSave(captureContext(&method, &params), &protocol.DidSaveTextDocumentParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+	}))
+	assert.NotEmpty(t, params.Diagnostics)
+}
+
+func TestServer_DidOpenMalformedDocPublishesParseError(t *testing.T) {
+	s := newTestServer(t)
+	uri := protocol.DocumentUri("file:///t.yaml")
+
+	var method string
+	var params protocol.PublishDiagnosticsParams
+	// Malformed YAML fails to parse; publish must fall back to the raw-content
+	// path and surface a parse-error diagnostic.
+	require.NoError(t, s.didOpen(captureContext(&method, &params), &protocol.DidOpenTextDocumentParams{
+		TextDocument: protocol.TextDocumentItem{URI: uri, Version: 1, Text: malformedCacheSolution},
+	}))
+	require.Len(t, params.Diagnostics, 1)
+	require.NotNil(t, params.Diagnostics[0].Code)
+	assert.Equal(t, "parse-error", params.Diagnostics[0].Code.Value)
+}
+
 func TestServer_DidChangeIgnoresRangedChangeUnderFullSync(t *testing.T) {
 	s := newTestServer(t)
 
@@ -230,6 +295,28 @@ func TestServer_NavigationHandlersOnUnknownDoc(t *testing.T) {
 	we, err := s.rename(nil, &protocol.RenameParams{TextDocumentPositionParams: tdp, NewName: "x"})
 	require.NoError(t, err)
 	assert.Nil(t, we)
+}
+
+func TestServer_RenameOnUnparseableDocReturnsWellFormedError(t *testing.T) {
+	s := newTestServer(t)
+	uri := protocol.DocumentUri("file:///t.yaml")
+
+	// Open a malformed document (fails to parse) directly into the cache.
+	s.setDoc(uri, 1, malformedCacheSolution)
+	entry, ok := s.getDoc(uri)
+	require.True(t, ok)
+	require.Error(t, entry.ParseErr, "fixture must fail to parse for this test")
+
+	tdp := protocol.TextDocumentPositionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Position:     protocol.Position{Line: 0, Character: 0},
+	}
+	we, err := s.rename(nil, &protocol.RenameParams{TextDocumentPositionParams: tdp, NewName: "whatever"})
+	require.Error(t, err)
+	assert.Nil(t, we)
+	// The message must be well-formed -- no fmt %!w(<nil>) verb leak.
+	assert.Contains(t, err.Error(), "failed to parse solution")
+	assert.NotContains(t, err.Error(), "%!w")
 }
 
 func TestServer_InitializeAdvertisesNavigationCapabilities(t *testing.T) {

--- a/pkg/refindex/nodemap_test.go
+++ b/pkg/refindex/nodemap_test.go
@@ -1,0 +1,74 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refindex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestNodeMap(t *testing.T) {
+	raw := []byte(`apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: nm
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+`)
+
+	nodes, err := NodeMap(raw)
+	require.NoError(t, err)
+	require.NotEmpty(t, nodes)
+
+	// Dotted keys resolve to the value node at that path.
+	name, ok := nodes["metadata.name"]
+	require.True(t, ok, "expected metadata.name in the node map")
+	assert.Equal(t, yaml.ScalarNode, name.Kind)
+	assert.Equal(t, "nm", name.Value)
+
+	// Sequence elements are addressed with [i].
+	provider, ok := nodes["spec.resolvers.environment.resolve.with[0].provider"]
+	require.True(t, ok, "expected the [0] sequence element path in the node map")
+	assert.Equal(t, "parameter", provider.Value)
+}
+
+func TestNodeMap_ParseError(t *testing.T) {
+	// Unclosed flow mapping is not valid YAML.
+	_, err := NodeMap([]byte("metadata: {name: x"))
+	assert.Error(t, err)
+}
+
+func TestNodeMap_Empty(t *testing.T) {
+	nodes, err := NodeMap([]byte(""))
+	require.NoError(t, err)
+	assert.Empty(t, nodes)
+}
+
+// TestNodeMap_MatchesBuildValueNodeMap guards the internal alias against drift:
+// the exported NodeMap and the internal helper must return identical maps.
+func TestNodeMap_MatchesBuildValueNodeMap(t *testing.T) {
+	raw := []byte("a:\n  b: c\n  d:\n    - e\n    - f\n")
+
+	fromExport, err := NodeMap(raw)
+	require.NoError(t, err)
+	fromInternal, err := buildValueNodeMap(raw)
+	require.NoError(t, err)
+
+	require.Equal(t, len(fromExport), len(fromInternal))
+	for path, node := range fromExport {
+		other, ok := fromInternal[path]
+		require.True(t, ok, "path %q missing from internal map", path)
+		assert.Equal(t, node.Kind, other.Kind, "path %q kind mismatch", path)
+		assert.Equal(t, node.Value, other.Value, "path %q value mismatch", path)
+	}
+}

--- a/pkg/refindex/refindex.go
+++ b/pkg/refindex/refindex.go
@@ -819,7 +819,19 @@ func lessRange(a, b sourcepos.Range) bool {
 // buildValueNodeMap parses raw YAML and returns a map from logical path to the
 // VALUE node at that path, using the same path scheme as sourcepos and walk.Walk
 // (dotted keys, [i] for sequence elements).
+//
+// It is a thin alias for the exported NodeMap, kept for readability at the
+// internal call sites.
 func buildValueNodeMap(raw []byte) (map[string]*yaml.Node, error) {
+	return NodeMap(raw)
+}
+
+// NodeMap parses raw YAML and returns a map from logical path to the VALUE node
+// at that path, using the same path scheme as sourcepos and walk.Walk (dotted
+// keys, [i] for sequence elements). It is a pure function with no dependency on
+// a built Index, so editor features (hover, completion, signature help) can ask
+// "what YAML node/path is under the cursor" directly from raw bytes.
+func NodeMap(raw []byte) (map[string]*yaml.Node, error) {
 	var doc yaml.Node
 	if err := yaml.Unmarshal(raw, &doc); err != nil {
 		return nil, fmt.Errorf("parse yaml: %w", err)


### PR DESCRIPTION
## What

Adds a per-document parse+index cache to the LSP server so the several editor
features that fire on a single keystroke (definition, references, rename,
diagnostics -- and, soon, hover/completion/signature-help) share **one** parse of
the document instead of each independently re-running
`solution.UnmarshalFromBytes` + `refindex.Build`.

This is foundation issue #766 -- it blocks every subsequent LSP feature.

## Changes

- **New `pkg/lsp/document.go`** -- `DocumentCache` / `DocEntry`, keyed by URI and
  version. `Set` parses+indexes once (atomically under a write lock) and returns
  an immutable snapshot holding the parsed `*solution.Solution`, `*refindex.Index`,
  raw bytes, a `*sourcepos.LineIndex`, the path->node map, and an explicit
  `ParseErr` so features degrade gracefully while the user is mid-edit. `Set` also
  short-circuits when the cache already holds the same `(version, text)` snapshot:
  it returns the existing entry without re-parsing, so duplicate notifications --
  most notably `didSave`, which re-sends the last synced content under the cached
  version -- honor the parse-once-per-version contract instead of re-running
  `NodeMap` + unmarshal + `refindex.Build`. The equality check is gated on the raw
  bytes (not the version alone), so a changed document under a reused version still
  rebuilds and never serves stale parsed state. `Get` reuses the snapshot; `Delete`
  drops it on close.
- **`pkg/lsp/server.go`** -- `Server.docs` migrates from `map[Uri]string` to
  `*DocumentCache`; `setDoc`/`getDoc`/`deleteDoc` delegate to it (the single,
  one-time invasive storage change, so no feature PR touches document storage
  again). `didOpen`/`didChange`/`didSave` now carry the document version.
- **`pkg/lsp/navigation.go`** -- the byte-based `Definition`/`References`/
  `PrepareRename`/`Rename` are refactored to delegate to index-based cores
  (`definitionFromIndex`, ...), and the server handlers call those cores with the
  cached `entry.Index`/`entry.Sol` -- reusing the parse.
- **`pkg/lsp/diagnostics.go`** -- adds a `diagnosticsFromSolution` core; `publish`
  reuses `entry.Sol` on the happy path (falling back to the raw-content parse only
  when the document failed to parse, which is where the parse error is reported).
- **`pkg/refindex/refindex.go`** -- exports a pure
  `NodeMap(raw []byte) (map[string]*yaml.Node, error)` (previously the private
  `buildValueNodeMap`, now a thin alias) so cursor-context features can map a
  position to a YAML node/path directly from raw bytes. MCP is unaffected.

## Tests

- Table/unit tests for the cache: hit, miss, version-bump invalidation,
  delete, parse-error-stored-not-panicked, and a `-race` concurrent Get-during-Set.
- Snapshot-dedup tests: an identical `(version, text)` `Set` reuses the cached
  entry (no rebuild), while changed text under a reused version rebuilds.
- A benchmark proving single-parse-per-version: `Set` ~49us / 665 allocs (parses)
  vs `Get` ~6ns / 0 allocs (reuses).
- `refindex.NodeMap` tests (happy path, sequence-element paths, parse error,
  empty input, drift guard vs the internal alias).
- New server tests for version-reuse on save, publishing a malformed doc, and a
  well-formed error when renaming an unparseable open doc (no `%!w(<nil>)` leak).
- Existing definition/references/rename unit + integration tests pass unchanged.

## Acceptance criteria

- [x] `server.go` no longer stores raw strings directly; all reads go through the cache.
- [x] `refindex.NodeMap` exported, pure, tested; MCP unaffected.
- [x] Existing definition/references/rename integration tests still pass.
- [x] Benchmark demonstrates single parse per version.

Closes #766
