### PR TITLE
feat(vscode): solution snippets + drift-guard

### DIFF
--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -85,6 +85,29 @@ leave this off unless you specifically want it.
 > on the built-in `yaml`/`json` language, run **scafctl: Restart Language Server**
 > once to activate it.
 
+## Snippets
+
+Type a prefix below and press Tab (or accept the completion) in a `.yaml`/`.yml`
+file (or a file set to the `scafctl` language) to expand it, then Tab through
+the placeholders to fill in the fields.
+
+| Prefix | Expands to |
+| --- | --- |
+| `solution` | Full minimal solution scaffold (`apiVersion`, `kind`, `metadata`, `spec` with one resolver) |
+| `resolver` | A generic resolver block under `spec.resolvers` |
+| `resolver-parameter` | A resolver using the `parameter` provider |
+| `resolver-http` | A resolver using the `http` provider |
+| `resolver-static` | A resolver using the `static` provider |
+| `action` | An action block under `spec.workflow.actions` |
+| `call` | A reusable call block (`spec.calls` entry) |
+| `function` | An author-defined function block under `spec.functions` |
+| `workflow` | A `spec.workflow` block with one action |
+| `dependsOn` | A `dependsOn` key for ordering actions/resolvers |
+| `cel-ref` | A CEL reference to another resolver's value (`_.name`) |
+| `tmpl-ref` | A Go-template reference to another resolver's value (`{{ ._.name }}`) |
+| `call-ref` | A call reference (invoking a `spec.calls` definition) |
+| `rslvr-ref` | A resolver reference (`rslvr: name`) inside a value |
+
 ## Commands
 
 - **scafctl: Restart Language Server** -- restart the server (for example after

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -59,6 +59,16 @@
         "path": "./syntaxes/scafctl.tmLanguage.json"
       }
     ],
+    "snippets": [
+      {
+        "language": "yaml",
+        "path": "./snippets/scafctl.json"
+      },
+      {
+        "language": "scafctl",
+        "path": "./snippets/scafctl.json"
+      }
+    ],
     "configuration": {
       "title": "scafctl",
       "properties": {

--- a/editors/vscode/snippets/scafctl.json
+++ b/editors/vscode/snippets/scafctl.json
@@ -1,0 +1,188 @@
+{
+  "scafctl: solution scaffold": {
+    "prefix": "solution",
+    "body": [
+      "apiVersion: scafctl.io/v1",
+      "kind: Solution",
+      "",
+      "metadata:",
+      "  name: ${1:my-solution}",
+      "  version: ${2:0.1.0}",
+      "  description: ${3:A short description of what this solution does.}",
+      "",
+      "spec:",
+      "  resolvers:",
+      "    ${4:myResolver}:",
+      "      description: ${5:What this resolver produces}",
+      "      type: ${6:string}",
+      "      resolve:",
+      "        with:",
+      "          - provider: ${7:static}",
+      "            inputs:",
+      "              value: ${8:placeholder}",
+      "$0"
+    ],
+    "description": "Full minimal solution scaffold (apiVersion, kind, metadata, spec with one resolver)"
+  },
+  "scafctl: resolver": {
+    "prefix": "resolver",
+    "body": [
+      "${1:myResolver}:",
+      "  description: ${2:Describe what this resolver produces}",
+      "  type: ${3:string}",
+      "  resolve:",
+      "    with:",
+      "      - provider: ${4:static}",
+      "        inputs:",
+      "          ${5:value}: ${6:placeholder}",
+      "$0"
+    ],
+    "description": "A generic resolver block under spec.resolvers"
+  },
+  "scafctl: resolver (parameter provider)": {
+    "prefix": "resolver-parameter",
+    "body": [
+      "${1:myResolver}:",
+      "  description: ${2:A CLI-supplied parameter value}",
+      "  type: ${3:string}",
+      "  resolve:",
+      "    with:",
+      "      - provider: parameter",
+      "        inputs:",
+      "          key: ${4:paramName}",
+      "          default: ${5:defaultValue}",
+      "$0"
+    ],
+    "description": "A resolver using the parameter-type provider"
+  },
+  "scafctl: resolver (http provider)": {
+    "prefix": "resolver-http",
+    "body": [
+      "${1:myResolver}:",
+      "  description: ${2:Fetch data from an HTTP endpoint}",
+      "  type: ${3:any}",
+      "  resolve:",
+      "    with:",
+      "      - provider: http",
+      "        inputs:",
+      "          url: ${4:https://example.com/api/resource}",
+      "          method: ${5:GET}",
+      "$0"
+    ],
+    "description": "A resolver using the http-type provider"
+  },
+  "scafctl: resolver (static provider)": {
+    "prefix": "resolver-static",
+    "body": [
+      "${1:myResolver}:",
+      "  description: ${2:A fixed, hard-coded value}",
+      "  type: ${3:string}",
+      "  resolve:",
+      "    with:",
+      "      - provider: static",
+      "        inputs:",
+      "          value: ${4:placeholder}",
+      "$0"
+    ],
+    "description": "A resolver using the static-type provider"
+  },
+  "scafctl: action": {
+    "prefix": "action",
+    "body": [
+      "${1:myAction}:",
+      "  description: ${2:Describe what this action does}",
+      "  provider: ${3:message}",
+      "  inputs:",
+      "    ${4:message}:",
+      "      tmpl: \"${5:Hello}\"",
+      "$0"
+    ],
+    "description": "An action block under spec.workflow.actions"
+  },
+  "scafctl: call": {
+    "prefix": "call",
+    "body": [
+      "${1:myCall}:",
+      "  description: ${2:Describe what this reusable call does}",
+      "  provider: ${3:static}",
+      "  args:",
+      "    ${4:value}:",
+      "      type: ${5:string}",
+      "      required: ${6:true}",
+      "  inputs:",
+      "    ${7:value}:",
+      "      expr: _.args.${4:value}",
+      "$0"
+    ],
+    "description": "A call block (spec.calls entry) -- a reusable, argument-driven provider request"
+  },
+  "scafctl: function": {
+    "prefix": "function",
+    "body": [
+      "${1:myFunction}:",
+      "  description: ${2:Describe what this function does}",
+      "  params:",
+      "    - name: ${3:value}",
+      "      type: ${4:string}",
+      "      required: ${5:true}",
+      "  cel: ${6:_.args.value}",
+      "$0"
+    ],
+    "description": "A function block under spec.functions -- an author-defined template helper"
+  },
+  "scafctl: workflow": {
+    "prefix": "workflow",
+    "body": [
+      "workflow:",
+      "  actions:",
+      "    ${1:myAction}:",
+      "      description: ${2:Describe what this action does}",
+      "      provider: ${3:message}",
+      "      inputs:",
+      "        ${4:message}:",
+      "          tmpl: \"${5:Hello}\"",
+      "$0"
+    ],
+    "description": "A workflow block (spec.workflow) with one action"
+  },
+  "scafctl: dependsOn": {
+    "prefix": "dependsOn",
+    "body": [
+      "dependsOn:",
+      "  - ${1:otherAction}",
+      "$0"
+    ],
+    "description": "A dependsOn key -- ordering constraint referencing another action or resolver name"
+  },
+  "scafctl: CEL reference": {
+    "prefix": "cel-ref",
+    "body": [
+      "_.${1:name}"
+    ],
+    "description": "CEL expression reference to another resolver's value (used inside expr:)"
+  },
+  "scafctl: Go-template reference": {
+    "prefix": "tmpl-ref",
+    "body": [
+      "{{ ._.${1:name} }}"
+    ],
+    "description": "Go-template reference to another resolver's value (used inside tmpl:)"
+  },
+  "scafctl: call reference": {
+    "prefix": "call-ref",
+    "body": [
+      "call: ${1:myCall}",
+      "args:",
+      "  ${2:argName}: ${3:value}",
+      "$0"
+    ],
+    "description": "A call reference (spec.calls invocation) from a resolve/transform/validate step or action"
+  },
+  "scafctl: resolver reference": {
+    "prefix": "rslvr-ref",
+    "body": [
+      "rslvr: ${1:resolverName}"
+    ],
+    "description": "A ValueRef resolver reference -- points at another resolver by name"
+  }
+}

--- a/tests/integration/snippets_drift_test.go
+++ b/tests/integration/snippets_drift_test.go
@@ -1,0 +1,157 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+// vscodeSnippet mirrors the VS Code snippet JSON format
+// (https://code.visualstudio.com/docs/editor/userdefinedsnippets): a name ->
+// {prefix, body, description} map. body is an array of lines joined with
+// "\n" when expanded in the editor.
+type vscodeSnippet struct {
+	Prefix      string   `json:"prefix"`
+	Body        []string `json:"body"`
+	Description string   `json:"description"`
+}
+
+// snippetKeyLineRe matches a YAML "key:" at the start of a line (after
+// optional indentation and an optional leading "- " list marker), capturing
+// the indentation and the key name. It intentionally only matches a
+// *literal* leading identifier -- tab-stop placeholders like
+// "${1:myResolver}:" never match, since they don't start with a letter or
+// underscore.
+var snippetKeyLineRe = regexp.MustCompile(`^(\s*)(?:-\s*)?([A-Za-z_][A-Za-z0-9_]*):(\s|$)`)
+
+func lineIndent(s string) int {
+	n := 0
+	for _, c := range s {
+		if c != ' ' {
+			break
+		}
+		n++
+	}
+	return n
+}
+
+// extractNotableKeys returns the set of literal, schema-relevant YAML keys
+// referenced in a snippet body, in first-seen order.
+//
+// It deliberately excludes:
+//   - tab-stop placeholder "keys" (e.g. "${1:myResolver}:"), which stand in
+//     for author-chosen identifiers (resolver/action/call/function/arg
+//     names), not schema field names.
+//   - keys nested under an "inputs:" block, which are provider-specific
+//     input field names (e.g. "url", "method", "key") validated by each
+//     provider's own descriptor, not the generic solution schema.
+func extractNotableKeys(body []string) []string {
+	seen := map[string]bool{}
+	var keys []string
+	opaqueIndent := -1 // indent level of an active "inputs:" block; -1 = none
+	for _, raw := range body {
+		indent := lineIndent(raw)
+		if opaqueIndent >= 0 && indent <= opaqueIndent {
+			opaqueIndent = -1 // dedented out of the inputs: block
+		}
+		m := snippetKeyLineRe.FindStringSubmatch(raw)
+		if m == nil {
+			continue
+		}
+		key := m[2]
+		if opaqueIndent < 0 {
+			if !seen[key] {
+				seen[key] = true
+				keys = append(keys, key)
+			}
+		}
+		if key == "inputs" {
+			opaqueIndent = indent
+		}
+	}
+	return keys
+}
+
+// schemaKeySet walks the generated solution JSON schema (all $defs plus the
+// top-level document) and returns the set of every property name that
+// appears anywhere in it. This is intentionally permissive (a flat set
+// rather than a per-object check) since snippet bodies compose fragments
+// from several different schema objects (e.g. a resolver's "type" and a
+// call's "args") and re-deriving the exact nesting path for every literal
+// line is unnecessary to catch the drift this guard cares about: a snippet
+// referencing a field name that no longer exists anywhere in the schema.
+func schemaKeySet(t *testing.T) map[string]bool {
+	t.Helper()
+
+	schemaBytes, err := schema.GenerateSolutionSchema()
+	require.NoError(t, err, "generating solution schema")
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal(schemaBytes, &doc), "unmarshalling solution schema")
+
+	keys := map[string]bool{}
+	var walk func(node any)
+	walk = func(node any) {
+		switch v := node.(type) {
+		case map[string]any:
+			if props, ok := v["properties"].(map[string]any); ok {
+				for k := range props {
+					keys[k] = true
+				}
+			}
+			for _, child := range v {
+				walk(child)
+			}
+		case []any:
+			for _, child := range v {
+				walk(child)
+			}
+		}
+	}
+	walk(doc)
+	return keys
+}
+
+// TestSnippetsMatchSchema is a drift guard: every literal YAML key that a VS
+// Code snippet body hard-codes (resolver/action/call/function/spec field
+// names -- not author-chosen identifiers or provider-specific input names)
+// must still exist somewhere in the generated solution JSON schema. If the
+// schema changes a field name and the snippets are not updated to match,
+// this test fails loudly instead of the drift going unnoticed.
+func TestSnippetsMatchSchema(t *testing.T) {
+	projectRoot := findProjectRoot()
+	snippetsPath := filepath.Join(projectRoot, "editors", "vscode", "snippets", "scafctl.json")
+
+	data, err := os.ReadFile(snippetsPath)
+	require.NoError(t, err, "reading %s", snippetsPath)
+
+	var snippets map[string]vscodeSnippet
+	require.NoError(t, json.Unmarshal(data, &snippets), "parsing %s", snippetsPath)
+	require.NotEmpty(t, snippets, "expected at least one snippet in %s", snippetsPath)
+
+	validKeys := schemaKeySet(t)
+
+	for name, snip := range snippets {
+		t.Run(name, func(t *testing.T) {
+			require.NotEmpty(t, snip.Prefix, "snippet %q is missing a prefix", name)
+			require.NotEmpty(t, snip.Body, "snippet %q has an empty body", name)
+
+			for _, key := range extractNotableKeys(snip.Body) {
+				require.True(t, validKeys[key],
+					"snippet %q (prefix %q) references key %q, which no longer exists "+
+						"in the generated solution schema -- update the snippet body or, "+
+						"if the key is a provider-specific input name, ensure it is nested "+
+						"under an \"inputs:\" block so this guard skips it",
+					name, snip.Prefix, key)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a scafctl snippet set to the VS Code extension so common solution constructs expand from a prefix + Tab, plus a CI drift-guard that keeps snippet field names in sync with the generated solution schema.

## Changes

- **New `editors/vscode/snippets/scafctl.json`** -- 14 snippets covering the full set from the issue: `solution`, `resolver`, `resolver-parameter`, `resolver-http`, `resolver-static`, `action`, `call`, `function`, `workflow`, `dependsOn`, `cel-ref` (`_.name`), `tmpl-ref` (`{{ ._.name }}`), `call-ref`, `rslvr-ref`. Each has tab-stops for author-supplied fields, and bodies mirror real spec shapes (verified against real example solutions + provider input names) so an expanded snippet lints clean.
- **`editors/vscode/package.json`** -- registers `contributes.snippets` for both the `yaml` and `scafctl` language ids. The `scafctl` language mode (from #764) is opt-in, so registering both keeps snippets available out-of-the-box and in the opt-in mode.
- **New `tests/integration/snippets_drift_test.go`** -- `TestSnippetsMatchSchema` loads the snippet JSON, extracts the literal spec keys hard-coded in each body (skipping tab-stop identifiers and provider-specific `inputs:` names), and asserts each still exists in `schema.GenerateSolutionSchema`. Drift fails the test loudly. Verified with a negative test (injected a bogus key -> failed as intended).
- **`editors/vscode/README.md`** -- documents the available snippets in a table.

## Verification

- `go build ./...`, `go vet ./...` -- pass
- `go test ./tests/integration/... -run TestSnippetsMatchSchema` -- pass (14 subtests)
- `task lint:changed` -- 0 new issues
- `solution` snippet expanded to concrete values and run through `scafctl lint` -- clean (only an expected `info` unused-resolver note on the scaffold)
- `package.json` validated as JSON; `snippets/` not excluded by `.vscodeignore` (ships in the `.vsix`)

## Acceptance criteria

- [x] Snippets expand in a `solution.yaml` and lint clean
- [x] Drift-guard test fails if a snippet references a non-existent spec key
- [x] Snippets bundled in the packaged `.vsix`

Closes #770