### PR TITLE
refactor(lsp): table-driven capability registration seam

### DIFF
--- a/pkg/lsp/capabilities.go
+++ b/pkg/lsp/capabilities.go
@@ -1,0 +1,115 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// feature is a self-contained LSP capability registered explicitly in
+// NewServer. It has two responsibilities:
+//
+//   - wire attaches the feature's glsp handler callbacks to the shared
+//     *protocol.Handler (e.g. handler.TextDocumentHover = s.hover).
+//   - advertise sets any server capability that needs a computed value beyond
+//     what glsp's CreateServerCapabilities already derives from the wired
+//     handlers (e.g. rename's PrepareProvider, a completion provider's trigger
+//     characters, the document-sync kind). It may be nil when the wired handler
+//     alone is enough for glsp to advertise the capability.
+//
+// Registration is explicit (a slice built in NewServer), NOT init()-based:
+// implicit package-level registration hides ordering and control flow. This
+// table exists only so two developers adding features rarely edit the same line
+// -- each feature contributes one alphabetized entry plus its own constructor in
+// the feature's file, instead of both editing the Handler()/Initialize wiring.
+type feature struct {
+	// name identifies the feature for tests and debugging; it does not affect
+	// wiring.
+	name string
+	// wire attaches the feature's handler callbacks. It must be non-nil.
+	wire func(h *protocol.Handler, s *Server)
+	// advertise sets computed capability values. It may be nil.
+	advertise func(c *protocol.ServerCapabilities)
+}
+
+// defaultFeatures returns the built-in feature set in a deterministic order.
+// Adding a new feature means adding ONE alphabetized entry here plus a
+// feature-returning constructor in the feature's own file -- no edits to
+// Handler() or the Initialize closure.
+func defaultFeatures() []feature {
+	return []feature{
+		documentSyncFeature(),
+		navigationFeature(),
+		renameFeature(),
+	}
+}
+
+// wireFeatures attaches every feature's handler callbacks to handler.
+func (s *Server) wireFeatures(handler *protocol.Handler) {
+	for _, f := range s.features {
+		f.wire(handler, s)
+	}
+}
+
+// advertiseFeatures applies every feature's computed capability values to caps.
+func (s *Server) advertiseFeatures(caps *protocol.ServerCapabilities) {
+	for _, f := range s.features {
+		if f.advertise != nil {
+			f.advertise(caps)
+		}
+	}
+}
+
+// documentSyncFeature wires the text-document lifecycle notifications (open,
+// change, save, close) that keep the per-document cache current and republish
+// lint diagnostics, and advertises full-document sync.
+func documentSyncFeature() feature {
+	return feature{
+		name: "documentSync",
+		wire: func(h *protocol.Handler, s *Server) {
+			h.TextDocumentDidOpen = s.didOpen
+			h.TextDocumentDidChange = s.didChange
+			h.TextDocumentDidSave = s.didSave
+			h.TextDocumentDidClose = s.didClose
+		},
+		advertise: func(c *protocol.ServerCapabilities) {
+			// Use full-document sync so each change carries the whole text; the
+			// server does not need to apply incremental patches.
+			if sync, ok := c.TextDocumentSync.(*protocol.TextDocumentSyncOptions); ok {
+				full := protocol.TextDocumentSyncKindFull
+				sync.Change = &full
+			}
+		},
+	}
+}
+
+// navigationFeature wires go-to-definition and find-references. glsp derives the
+// DefinitionProvider/ReferencesProvider capabilities from the wired handlers, so
+// no advertise func is needed.
+func navigationFeature() feature {
+	return feature{
+		name: "navigation",
+		wire: func(h *protocol.Handler, s *Server) {
+			h.TextDocumentDefinition = s.definition
+			h.TextDocumentReferences = s.references
+		},
+	}
+}
+
+// renameFeature wires prepare-rename and rename, and advertises rename with
+// prepare support so clients validate the cursor position before prompting for a
+// new name (a computed capability, not a plain flag).
+func renameFeature() feature {
+	return feature{
+		name: "rename",
+		wire: func(h *protocol.Handler, s *Server) {
+			h.TextDocumentPrepareRename = s.prepareRename
+			h.TextDocumentRename = s.rename
+		},
+		advertise: func(c *protocol.ServerCapabilities) {
+			prepare := true
+			c.RenameProvider = &protocol.RenameOptions{PrepareProvider: &prepare}
+		},
+	}
+}

--- a/pkg/lsp/capabilities_test.go
+++ b/pkg/lsp/capabilities_test.go
@@ -1,0 +1,108 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// TestDefaultFeatures_DeterministicOrder guards the registration order so the
+// seam is predictable for two developers adding entries. It also enforces the
+// documented alphabetical ordering so a mis-placed insertion is caught even if
+// the exact-literal list below is updated to match.
+func TestDefaultFeatures_DeterministicOrder(t *testing.T) {
+	features := defaultFeatures()
+	got := make([]string, 0, len(features))
+	for _, f := range features {
+		got = append(got, f.name)
+		require.NotNil(t, f.wire, "every feature must wire a handler")
+	}
+	assert.Equal(t, []string{"documentSync", "navigation", "rename"}, got)
+	assert.True(t, sort.StringsAreSorted(got), "features must be registered in alphabetical order")
+}
+
+// TestWireFeatures_WiresEveryFeature proves N registered features attach N sets
+// of handler callbacks, in order.
+func TestWireFeatures_WiresEveryFeature(t *testing.T) {
+	var order []string
+	s := &Server{features: []feature{
+		{name: "a", wire: func(_ *protocol.Handler, _ *Server) { order = append(order, "a") }},
+		{name: "b", wire: func(_ *protocol.Handler, _ *Server) { order = append(order, "b") }},
+		{name: "c", wire: func(_ *protocol.Handler, _ *Server) { order = append(order, "c") }},
+	}}
+
+	s.wireFeatures(&protocol.Handler{})
+	assert.Equal(t, []string{"a", "b", "c"}, order, "features wire in registration order")
+}
+
+// TestAdvertiseFeatures_SkipsNilAdvertise proves advertise runs for each feature
+// that has one, in order, and nil-advertise features are skipped without panic.
+func TestAdvertiseFeatures_SkipsNilAdvertise(t *testing.T) {
+	var order []string
+	s := &Server{features: []feature{
+		{name: "a", wire: noopWire, advertise: func(_ *protocol.ServerCapabilities) { order = append(order, "a") }},
+		{name: "b", wire: noopWire}, // no advertise
+		{name: "c", wire: noopWire, advertise: func(_ *protocol.ServerCapabilities) { order = append(order, "c") }},
+	}}
+
+	require.NotPanics(t, func() { s.advertiseFeatures(&protocol.ServerCapabilities{}) })
+	assert.Equal(t, []string{"a", "c"}, order, "only features with an advertise func run, in order")
+}
+
+// TestHandler_WiresDefaultFeatureCallbacks asserts the default feature set
+// attaches every existing handler callback (behavioral-parity anchor for the
+// migration to the table).
+func TestHandler_WiresDefaultFeatureCallbacks(t *testing.T) {
+	s := newTestServer(t)
+	h := s.Handler()
+
+	assert.NotNil(t, h.TextDocumentDidOpen, "documentSync: didOpen")
+	assert.NotNil(t, h.TextDocumentDidChange, "documentSync: didChange")
+	assert.NotNil(t, h.TextDocumentDidSave, "documentSync: didSave")
+	assert.NotNil(t, h.TextDocumentDidClose, "documentSync: didClose")
+	assert.NotNil(t, h.TextDocumentDefinition, "navigation: definition")
+	assert.NotNil(t, h.TextDocumentReferences, "navigation: references")
+	assert.NotNil(t, h.TextDocumentPrepareRename, "rename: prepareRename")
+	assert.NotNil(t, h.TextDocumentRename, "rename: rename")
+}
+
+// TestDocumentSyncFeature_AdvertisesFullSync checks the computed capability set
+// by the documentSync feature independent of the whole Initialize flow.
+func TestDocumentSyncFeature_AdvertisesFullSync(t *testing.T) {
+	f := documentSyncFeature()
+	require.NotNil(t, f.advertise)
+
+	full := protocol.TextDocumentSyncKindNone
+	caps := protocol.ServerCapabilities{
+		TextDocumentSync: &protocol.TextDocumentSyncOptions{Change: &full},
+	}
+	f.advertise(&caps)
+
+	sync, ok := caps.TextDocumentSync.(*protocol.TextDocumentSyncOptions)
+	require.True(t, ok)
+	require.NotNil(t, sync.Change)
+	assert.Equal(t, protocol.TextDocumentSyncKindFull, *sync.Change)
+}
+
+// TestRenameFeature_AdvertisesPrepare checks the rename feature advertises
+// prepare support as a computed RenameOptions value.
+func TestRenameFeature_AdvertisesPrepare(t *testing.T) {
+	f := renameFeature()
+	require.NotNil(t, f.advertise)
+
+	var caps protocol.ServerCapabilities
+	f.advertise(&caps)
+
+	rename, ok := caps.RenameProvider.(*protocol.RenameOptions)
+	require.True(t, ok)
+	require.NotNil(t, rename.PrepareProvider)
+	assert.True(t, *rename.PrepareProvider)
+}
+
+func noopWire(_ *protocol.Handler, _ *Server) {}

--- a/pkg/lsp/server.go
+++ b/pkg/lsp/server.go
@@ -16,13 +16,20 @@ import (
 
 // Server is a language server for solution files. It keeps a per-document
 // parse+index cache for each open document and republishes lint diagnostics on
-// open/change/save.
+// open/change/save. Editor features are registered explicitly as a table of
+// feature descriptors (see capabilities.go).
 type Server struct {
 	binaryName string
 	version    string
 	registry   *provider.Registry
 
 	docs *DocumentCache
+
+	// features is the explicit, ordered set of editor capabilities this server
+	// exposes. Handler() ranges it to wire handler callbacks; the Initialize
+	// closure ranges it to advertise capabilities. Adding a feature is one
+	// alphabetized entry in defaultFeatures().
+	features []feature
 }
 
 // NewServer constructs a language server. binaryName labels diagnostics and the
@@ -37,6 +44,7 @@ func NewServer(binaryName, version string, registry *provider.Registry) *Server 
 		version:    version,
 		registry:   registry,
 		docs:       NewDocumentCache(),
+		features:   defaultFeatures(),
 	}
 }
 
@@ -47,21 +55,17 @@ func (s *Server) Run() error {
 }
 
 // Handler builds the glsp protocol handler wired to this server's callbacks.
+// Core lifecycle methods (initialize/shutdown/cancel) are wired directly here;
+// editor features are wired from the s.features table so adding a feature does
+// not touch this function.
 func (s *Server) Handler() *protocol.Handler {
 	handler := &protocol.Handler{}
 
 	handler.Initialize = func(_ *glsp.Context, _ *protocol.InitializeParams) (any, error) {
+		// glsp derives most capabilities from which handler callbacks are set;
+		// each feature's advertise func then applies any computed values.
 		capabilities := handler.CreateServerCapabilities()
-		// Use full-document sync so each change carries the whole text; the
-		// server does not need to apply incremental patches.
-		if sync, ok := capabilities.TextDocumentSync.(*protocol.TextDocumentSyncOptions); ok {
-			full := protocol.TextDocumentSyncKindFull
-			sync.Change = &full
-		}
-		// Advertise rename with prepare support so clients validate the cursor
-		// position before prompting for a new name.
-		prepare := true
-		capabilities.RenameProvider = &protocol.RenameOptions{PrepareProvider: &prepare}
+		s.advertiseFeatures(&capabilities)
 		result := protocol.InitializeResult{
 			Capabilities: capabilities,
 			ServerInfo: &protocol.InitializeResultServerInfo{
@@ -84,15 +88,8 @@ func (s *Server) Handler() *protocol.Handler {
 	// does not cancel to simply complete the request normally.
 	handler.CancelRequest = func(_ *glsp.Context, _ *protocol.CancelParams) error { return nil }
 
-	handler.TextDocumentDidOpen = s.didOpen
-	handler.TextDocumentDidChange = s.didChange
-	handler.TextDocumentDidSave = s.didSave
-	handler.TextDocumentDidClose = s.didClose
-
-	handler.TextDocumentDefinition = s.definition
-	handler.TextDocumentReferences = s.references
-	handler.TextDocumentPrepareRename = s.prepareRename
-	handler.TextDocumentRename = s.rename
+	// Wire editor features from the explicit registration table.
+	s.wireFeatures(handler)
 
 	return handler
 }


### PR DESCRIPTION
## What

Introduces an explicit, table-driven **feature registration seam** for the LSP
server. Today every feature PR edits the same ~15 lines in `Handler()` (assign
`handler.TextDocumentX`) and in the `Initialize` closure (set a capability) --
the guaranteed two-developer merge-conflict hotspot. After this, each feature
contributes one descriptor instead of editing shared lines.

This is foundation issue #767 (does with/after #766, same `server.go` touch).

## Design

- A `feature` descriptor with two funcs:
  - `wire(h *protocol.Handler, s *Server)` -- attaches the glsp handler callbacks.
  - `advertise(c *protocol.ServerCapabilities)` -- sets any capability that needs a
    **computed** value beyond what glsp's `CreateServerCapabilities()` already
    derives from the wired handlers (may be nil).
- **No `init()` / package-level side-effect registration** (implicit ordering /
  invisible control flow). Registration is explicit: `NewServer` builds
  `s.features = defaultFeatures()`; `Handler()` ranges `wire`; the `Initialize`
  closure ranges `advertise` after `CreateServerCapabilities()`.
- The three existing wirings migrate into the table to prove parity:
  - `documentSyncFeature()` -- didOpen/didChange/didSave/didClose + full-sync kind.
  - `navigationFeature()` -- definition + references (providers derived by glsp).
  - `renameFeature()` -- prepareRename + rename, advertising `RenameOptions{PrepareProvider}`.

Adding a feature later = one alphabetized entry in `defaultFeatures()` plus a
constructor in the feature's own file.

## Changes

- New `pkg/lsp/capabilities.go` (+ `capabilities_test.go`).
- `pkg/lsp/server.go`: `Server` gains `features []feature`; `Handler()` calls
  `s.wireFeatures(handler)`; `Initialize` calls `s.advertiseFeatures(&caps)`. The
  old inline sync-kind + rename-prepare block is removed.

## Tests

- Seam mechanics: N features wire N handlers in order; advertise runs per feature
  and skips nil; deterministic + alphabetical order enforced.
- Per-feature advertise checks (full-sync kind, rename prepare) in isolation.
- Parity anchor: `Handler()` wires all 8 pre-existing callbacks; the existing
  `Initialize` capability tests and the LSP CLI integration tests pass unchanged.

## Acceptance criteria

- [x] Adding a feature requires editing only the `defaultFeatures()` literal (1 line) + a feature-owned file.
- [x] No `init()` used.
- [x] Existing LSP behavior byte-for-byte unchanged (unit + integration tests pass).

Closes #767
