### PR TITLE
feat(refactor): ExtractCall engine (hoist resolve block into spec.calls)

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -1110,6 +1110,26 @@ Exit codes: `0` applied (or previewed), `2` a validation error (invalid new
 name, name collision, undefined symbol, or an unlocatable reference blocked
 the rename), `4` the solution file could not be resolved, read, or parsed.
 
+### Extract Call (engine)
+
+A second source-preserving refactoring, **Extract Call**, hoists a single
+resolve/transform/validate step (a `with[i]` provider+inputs block) out of a
+resolver into a reusable `spec.calls` definition and rewrites the selected step
+to a `call: <name>` reference. Like rename, it emits byte-exact edits, so
+comments and formatting elsewhere are preserved; the extracted block's provider
+and inputs (including any inline comments) are spliced verbatim into the new
+call, re-indented to the file's style. v1 is conservative: only direct provider
+steps are extractable (a step that already uses `call:` is rejected), and no
+arguments are inferred -- the call reproduces the inputs literally (inferring
+args from near-duplicate steps with varying values is deferred). An opt-in
+variant additionally rewrites every *structurally identical* step into the same
+`call:` reference; the base extraction never mass-rewrites.
+
+The engine lives in `pkg/refactor` (domain-only, no LSP/protocol imports) and is
+designed to back a future LSP `ExtractCall` code action. **The `scafctl refactor
+extract-call` CLI subcommand is deferred to a later PR** -- this change ships the
+engine only.
+
 ---
 
 ## Language Server (LSP)

--- a/pkg/refactor/extract.go
+++ b/pkg/refactor/extract.go
@@ -120,6 +120,16 @@ func extractCall(sol *solution.Solution, blockPath, callName string, replaceIden
 		return nil, fmt.Errorf("extract call: spec.calls is present but has no entries (empty or inline); populate or remove it before extracting")
 	}
 
+	// The byte-insertion below assumes the insertion target is block-style YAML:
+	// when spec.calls already exists it APPENDS a block entry after the last one,
+	// and when it does not it inserts a new block "calls:" child of spec. A
+	// flow-style target -- an existing "calls: {a: {...}}", or a flow-style
+	// "spec: {...}" -- cannot receive that block text without producing invalid
+	// YAML. Refuse rather than emit a corrupt edit set (all-or-nothing).
+	if err := requireBlockStyleInsertion(nodes, sol.Spec.HasCalls()); err != nil {
+		return nil, fmt.Errorf("extract call: %w", err)
+	}
+
 	// The extracted block bytes (spliced, re-indented) become the call body.
 	startByte, endByte, markerIndent, err := stepBlockRange(raw, li, node)
 	if err != nil {
@@ -162,6 +172,24 @@ func extractCall(sol *solution.Solution, blockPath, callName string, replaceIden
 	edits = append(edits, insert)
 
 	return &RenameResult{OldName: blockPath, NewName: callName, Edits: edits}, nil
+}
+
+// requireBlockStyleInsertion rejects solutions whose spec.calls insertion target
+// is flow-style YAML, which the block-style byte insertion in callsInsertion
+// would corrupt. When spec.calls already exists, the target is spec.calls
+// itself (appending a block entry to a flow "calls: {a: ...}" yields invalid
+// YAML); when it does not, the target is spec (a new block "calls:" child cannot
+// be spliced into a flow-style "spec: {...}"). Either way, refuse rather than
+// emit a document that no longer parses (all-or-nothing).
+func requireBlockStyleInsertion(nodes map[string]*yaml.Node, hasCalls bool) error {
+	target := "spec"
+	if hasCalls {
+		target = "spec.calls"
+	}
+	if n, ok := nodes[target]; ok && n != nil && n.Style&yaml.FlowStyle != 0 {
+		return fmt.Errorf("%s is written in flow style; rewrite it in block style before extracting", target)
+	}
+	return nil
 }
 
 // requireProviderStep verifies node is a mapping that represents a direct

--- a/pkg/refactor/extract.go
+++ b/pkg/refactor/extract.go
@@ -1,0 +1,411 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refactor
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
+	"gopkg.in/yaml.v3"
+)
+
+// stepPathRe matches the logical path of a resolver resolve/transform/validate
+// step (a with[i] sequence element). Extract Call operates only on such steps.
+var stepPathRe = regexp.MustCompile(`\.(resolve|transform|validate)\.with\[\d+\]$`)
+
+// maxColumn is an intentionally over-long column used with LineIndex.Offset to
+// resolve the byte offset at the end of a line's visible content (the offset
+// clamps to the line end, excluding the trailing newline).
+const maxColumn = 1 << 30
+
+// ExtractCall hoists a single resolve/transform/validate step (a provider+inputs
+// block identified by blockPath, e.g. "spec.resolvers.app.resolve.with[0]") out
+// of its resolver into a reusable spec.calls definition named callName, and
+// rewrites the selected step to a "call: <callName>" reference.
+//
+// It is source-preserving: the change is expressed as byte-exact TextEdits (via
+// the shared RenameResult), so comments, key order, and formatting elsewhere in
+// the file are untouched. The extracted call reproduces the step's provider and
+// inputs verbatim (spliced from the original bytes, re-indented), preserving any
+// inline comments on the block.
+//
+// v1 scope and conservatism:
+//   - Only a DIRECT provider step is extractable. A step that already uses
+//     "call:" (or that is not a provider step) is rejected.
+//   - Argument inference is conservative: a literal block is extracted with NO
+//     args (empty Args); the call reproduces the inputs literally. Inferring
+//     arguments from near-duplicate steps with varying values is deferred.
+//   - The base ExtractCall does NOT scan for or rewrite other identical steps.
+//     Use ExtractCallReplacingIdentical for that opt-in behavior.
+//
+// Like RenameSymbol, it is all-or-nothing: any problem returns an error and NO
+// edits. Returned RenameResult has OldName set to blockPath and NewName to
+// callName (the type is shared with rename; there is no separate name pair for
+// an extraction). Callers apply the change with RenameResult.Apply.
+func ExtractCall(sol *solution.Solution, blockPath, callName string) (*RenameResult, error) {
+	return extractCall(sol, blockPath, callName, false)
+}
+
+// ExtractCallReplacingIdentical behaves exactly like ExtractCall but, in
+// addition, rewrites every OTHER resolve/transform/validate step whose
+// provider+inputs are structurally identical to the extracted block into a
+// "call: <callName>" reference. This is the opt-in, mass-rewrite variant: the
+// base ExtractCall never scans for or touches other steps.
+//
+// "Structurally identical" means the steps decode to deeply-equal YAML values
+// (same provider, same inputs, same any other step fields), independent of key
+// order and formatting. Only exact structural duplicates are replaced; steps
+// with any differing value (a near-match) are left untouched, because inferring
+// arguments to unify near-matches is deferred to a later version.
+//
+// Comments are not part of a step's decoded value, so two steps that differ
+// ONLY by an inline/leading comment are treated as identical and both rewritten
+// to "call: <callName>". The extracted call body reproduces the SELECTED
+// block's comments; a divergent comment on a rewritten duplicate is dropped
+// along with the duplicated step it annotated. This is intentional -- the steps
+// are semantically identical -- but it is the one case where a comment does not
+// survive verbatim.
+func ExtractCallReplacingIdentical(sol *solution.Solution, blockPath, callName string) (*RenameResult, error) {
+	return extractCall(sol, blockPath, callName, true)
+}
+
+// extractCall is the shared implementation behind ExtractCall (replaceIdentical
+// false) and ExtractCallReplacingIdentical (replaceIdentical true).
+func extractCall(sol *solution.Solution, blockPath, callName string, replaceIdentical bool) (*RenameResult, error) {
+	if sol == nil {
+		return nil, fmt.Errorf("extract call: nil solution")
+	}
+	if !resolverNameRe.MatchString(callName) {
+		return nil, fmt.Errorf("extract call: %q is not a valid call name (must match %s)", callName, ResolverNamePattern)
+	}
+	if _, exists := sol.Spec.Calls[callName]; exists {
+		return nil, fmt.Errorf("extract call: call %q already exists", callName)
+	}
+	if !stepPathRe.MatchString(blockPath) {
+		return nil, fmt.Errorf("extract call: %q is not a resolve/transform/validate step path (expected a ...with[i] step)", blockPath)
+	}
+
+	raw := sol.RawContent()
+	nodes, err := refindex.NodeMap(raw)
+	if err != nil {
+		return nil, fmt.Errorf("extract call: %w", err)
+	}
+	node, ok := nodes[blockPath]
+	if !ok {
+		return nil, fmt.Errorf("extract call: block path %q does not resolve to a node", blockPath)
+	}
+	if err := requireProviderStep(node); err != nil {
+		return nil, fmt.Errorf("extract call: %w", err)
+	}
+
+	li := sourcepos.NewLineIndex(raw, "")
+	sm := sol.SourceMap()
+
+	// A spec.calls key present in source but with no decodable entries (an inline
+	// "calls: {}", or a bare/comment-only "calls:") is ambiguous: HasCalls() is
+	// false, so the insertion logic below would create a SECOND "calls:" key and
+	// corrupt the file. Refuse rather than emit a broken edit set (all-or-nothing).
+	if _, present := sm.Get("spec.calls"); present && !sol.Spec.HasCalls() {
+		return nil, fmt.Errorf("extract call: spec.calls is present but has no entries (empty or inline); populate or remove it before extracting")
+	}
+
+	// The extracted block bytes (spliced, re-indented) become the call body.
+	startByte, endByte, markerIndent, err := stepBlockRange(raw, li, node)
+	if err != nil {
+		return nil, fmt.Errorf("extract call: %w", err)
+	}
+
+	callsKeyIndent, callNameIndent, targetIndent, err := callIndents(sol, sm)
+	if err != nil {
+		return nil, fmt.Errorf("extract call: %w", err)
+	}
+
+	blockText := string(raw[startByte:endByte])
+	body := reindentStepAsCall(blockText, markerIndent, targetIndent)
+	entry := strings.Repeat(" ", callNameIndent) + callName + ":\n" + body
+
+	// Which step(s) become a "call:" reference. Always the selected block; with
+	// the opt-in variant, also every structural duplicate.
+	targetPaths := []string{blockPath}
+	if replaceIdentical {
+		targetPaths = identicalStepPaths(nodes, node, blockPath)
+	}
+
+	edits := make([]TextEdit, 0, len(targetPaths)+1)
+	for _, p := range targetPaths {
+		n := nodes[p]
+		s, e, _, rerr := stepBlockRange(raw, li, n)
+		if rerr != nil {
+			return nil, fmt.Errorf("extract call: %s: %w", p, rerr)
+		}
+		edits = append(edits, TextEdit{
+			Range:   li.Range(s, e),
+			NewText: "- call: " + callName,
+		})
+	}
+
+	insert, err := callsInsertion(sol, sm, li, raw, entry, callsKeyIndent)
+	if err != nil {
+		return nil, fmt.Errorf("extract call: %w", err)
+	}
+	edits = append(edits, insert)
+
+	return &RenameResult{OldName: blockPath, NewName: callName, Edits: edits}, nil
+}
+
+// requireProviderStep verifies node is a mapping that represents a direct
+// provider step: it must declare a "provider" key and must NOT declare a "call"
+// key. Steps that already use a call, or that are not provider steps, are not
+// extractable in v1.
+func requireProviderStep(node *yaml.Node) error {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return fmt.Errorf("step is not a mapping block")
+	}
+	hasProvider, hasCall := false, false
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		switch node.Content[i].Value {
+		case "provider":
+			hasProvider = true
+		case "call":
+			hasCall = true
+		}
+	}
+	if hasCall {
+		return fmt.Errorf("step already uses a call reference; only direct provider steps are extractable")
+	}
+	if !hasProvider {
+		return fmt.Errorf("step is not a provider step (no provider key); only direct provider steps are extractable")
+	}
+	return nil
+}
+
+// stepBlockRange computes the full source byte span [startByte, endByte) of a
+// with[i] step block, plus the indentation (leading spaces) of its "- " marker.
+//
+// yaml.v3 reports only the start of a node; the mapping value node's Line points
+// at the "- provider:" line. The block's end is found by INDENTATION scanning:
+// beginning at the marker line, the block spans every following line that is
+// blank or indented MORE than the marker, stopping at the first non-blank line
+// whose indentation is <= the marker's (the next "- " sibling, or a dedent out
+// of the with: list), or at end of file. The span starts at the "- " marker
+// column and ends at the last block content line's end (excluding its trailing
+// newline, so the replacement leaves surrounding structure intact).
+func stepBlockRange(raw []byte, li *sourcepos.LineIndex, node *yaml.Node) (startByte, endByte, markerIndent int, err error) {
+	if node == nil {
+		return 0, 0, 0, fmt.Errorf("nil step node")
+	}
+	markerLine := node.Line
+	lineStart := li.Offset(sourcepos.Position{Line: markerLine, Column: 1})
+	lineEnd := li.Offset(sourcepos.Position{Line: markerLine, Column: maxColumn})
+	lineBytes := raw[lineStart:lineEnd]
+	markerIndent = leadingSpaces(lineBytes)
+	if markerIndent >= len(lineBytes) || lineBytes[markerIndent] != '-' {
+		return 0, 0, 0, fmt.Errorf("step at line %d does not begin with a %q sequence marker (only block-style steps are supported)", markerLine, "- ")
+	}
+	startByte = lineStart + markerIndent
+	lastLine := scanBlockEndLine(raw, li, markerLine, markerIndent)
+	endByte = li.Offset(sourcepos.Position{Line: lastLine, Column: maxColumn})
+	return startByte, endByte, markerIndent, nil
+}
+
+// scanBlockEndLine returns the 1-based line number of the last line belonging to
+// a block that begins at startLine and whose owning marker/key is indented
+// ownIndent spaces. A line belongs to the block if it is blank or indented more
+// than ownIndent; scanning stops at the first non-blank line indented <=
+// ownIndent, or at end of file. Trailing blank lines are excluded from the
+// returned end.
+func scanBlockEndLine(raw []byte, li *sourcepos.LineIndex, startLine, ownIndent int) int {
+	last := startLine
+	total := li.Len()
+	for l := startLine + 1; l <= total; l++ {
+		s := li.Offset(sourcepos.Position{Line: l, Column: 1})
+		e := li.Offset(sourcepos.Position{Line: l, Column: maxColumn})
+		lb := raw[s:e]
+		if isBlank(lb) {
+			continue
+		}
+		if leadingSpaces(lb) <= ownIndent {
+			break
+		}
+		last = l
+	}
+	return last
+}
+
+// reindentStepAsCall converts a step block's spliced bytes (starting at the
+// "- " marker) into the body of a spec.calls entry: the provider/inputs mapping
+// re-indented to targetIndent. The "- " marker is dropped (a call body is a
+// plain mapping, not a sequence element) and every line is shifted so the
+// mapping's top-level keys land at targetIndent, preserving relative
+// indentation, blank lines, and inline comments.
+func reindentStepAsCall(blockText string, markerIndent, targetIndent int) string {
+	// The mapping keys of a "- key:" sequence element sit two columns past the
+	// marker (the width of "- ").
+	srcIndent := markerIndent + 2
+	delta := targetIndent - srcIndent
+
+	lines := strings.Split(blockText, "\n")
+	out := make([]string, 0, len(lines))
+	for i, line := range lines {
+		if i == 0 {
+			// First line is "- provider: ..."; drop the marker, keep content.
+			content := strings.TrimLeft(strings.TrimPrefix(line, "-"), " ")
+			out = append(out, strings.Repeat(" ", targetIndent)+content)
+			continue
+		}
+		if isBlank([]byte(line)) {
+			out = append(out, "")
+			continue
+		}
+		ind := leadingSpaces([]byte(line))
+		newInd := ind + delta
+		if newInd < 0 {
+			newInd = 0
+		}
+		out = append(out, strings.Repeat(" ", newInd)+line[ind:])
+	}
+	return strings.Join(out, "\n")
+}
+
+// callIndents determines the three indentation levels used to render the calls
+// entry, matching the file's existing indentation style: the indent of the
+// "calls:" key, of each call name key, and of the call body's top-level keys.
+// When spec.calls already exists, the name/body indents are taken from a real
+// existing entry; otherwise they are derived from the spec/resolvers indent
+// unit.
+func callIndents(sol *solution.Solution, sm *sourcepos.SourceMap) (callsKeyIndent, callNameIndent, targetIndent int, err error) {
+	specPos, ok := sm.Get("spec")
+	if !ok {
+		return 0, 0, 0, fmt.Errorf("cannot locate spec block")
+	}
+	specIndent := specPos.Column - 1
+
+	unit := 2
+	if resolversPos, ok := sm.Get("spec.resolvers"); ok {
+		if u := (resolversPos.Column - 1) - specIndent; u > 0 {
+			unit = u
+		}
+	}
+
+	if sol.Spec.HasCalls() {
+		callsPos, ok := sm.Get("spec.calls")
+		if !ok {
+			return 0, 0, 0, fmt.Errorf("cannot locate existing spec.calls block")
+		}
+		callsKeyIndent = callsPos.Column - 1
+		callNameIndent = callsKeyIndent + unit
+		// Prefer a real existing entry's key indent when available.
+		for name := range sol.Spec.Calls {
+			if p, ok := sm.Get("spec.calls." + name); ok {
+				callNameIndent = p.Column - 1
+				break
+			}
+		}
+		targetIndent = callNameIndent + unit
+		return callsKeyIndent, callNameIndent, targetIndent, nil
+	}
+
+	callsKeyIndent = specIndent + unit
+	callNameIndent = callsKeyIndent + unit
+	targetIndent = callNameIndent + unit
+	return callsKeyIndent, callNameIndent, targetIndent, nil
+}
+
+// callsInsertion builds the zero-width TextEdit that inserts the rendered call
+// definition. When spec.calls already exists, the entry is appended after the
+// last existing call entry. When it does not, a new "calls:" key (holding the
+// entry) is inserted as the first child of spec, immediately after the "spec:"
+// line -- a deterministic, always-valid insertion point.
+func callsInsertion(sol *solution.Solution, sm *sourcepos.SourceMap, li *sourcepos.LineIndex, raw []byte, entry string, callsKeyIndent int) (TextEdit, error) {
+	if sol.Spec.HasCalls() {
+		callsPos, ok := sm.Get("spec.calls")
+		if !ok {
+			return TextEdit{}, fmt.Errorf("cannot locate existing spec.calls block")
+		}
+		endLine := scanBlockEndLine(raw, li, callsPos.Line, callsPos.Column-1)
+		insertByte := li.Offset(sourcepos.Position{Line: endLine, Column: maxColumn})
+		pos := li.Position(insertByte)
+		return TextEdit{
+			Range:   sourcepos.Range{Start: pos, End: pos},
+			NewText: "\n" + entry,
+		}, nil
+	}
+
+	specPos, ok := sm.Get("spec")
+	if !ok {
+		return TextEdit{}, fmt.Errorf("cannot locate spec block")
+	}
+	insertByte := li.Offset(sourcepos.Position{Line: specPos.Line + 1, Column: 1})
+	pos := li.Position(insertByte)
+	block := strings.Repeat(" ", callsKeyIndent) + "calls:\n" + entry + "\n"
+	return TextEdit{
+		Range:   sourcepos.Range{Start: pos, End: pos},
+		NewText: block,
+	}, nil
+}
+
+// identicalStepPaths returns the sorted set of with[i] step paths (including
+// blockPath) whose decoded YAML value is deeply equal to the selected block.
+// Comparison is structural (key order and formatting are irrelevant); only exact
+// duplicates match.
+func identicalStepPaths(nodes map[string]*yaml.Node, node *yaml.Node, blockPath string) []string {
+	var want any
+	if err := node.Decode(&want); err != nil {
+		// If the selected block cannot be decoded, fall back to it alone.
+		return []string{blockPath}
+	}
+	var paths []string
+	for p, n := range nodes {
+		if !stepPathRe.MatchString(p) || n.Kind != yaml.MappingNode {
+			continue
+		}
+		var got any
+		if err := n.Decode(&got); err != nil {
+			continue
+		}
+		if reflect.DeepEqual(want, got) {
+			paths = append(paths, p)
+		}
+	}
+	// Guarantee the selected block is present even if decoding oddities arise.
+	if !containsString(paths, blockPath) {
+		paths = append(paths, blockPath)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+func containsString(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// leadingSpaces counts the leading ASCII space characters of a line.
+func leadingSpaces(line []byte) int {
+	n := 0
+	for n < len(line) && line[n] == ' ' {
+		n++
+	}
+	return n
+}
+
+// isBlank reports whether a line contains only whitespace.
+func isBlank(line []byte) bool {
+	for _, b := range line {
+		if b != ' ' && b != '\t' && b != '\r' {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/refactor/extract.go
+++ b/pkg/refactor/extract.go
@@ -39,6 +39,10 @@ const maxColumn = 1 << 30
 // v1 scope and conservatism:
 //   - Only a DIRECT provider step is extractable. A step that already uses
 //     "call:" (or that is not a provider step) is rejected.
+//   - Only provider/inputs steps are extractable. A step that carries any
+//     step-level field a call definition cannot model (when, continueOnError,
+//     onError, forEach, or a validation message) is rejected rather than
+//     silently dropping that field on extraction.
 //   - Argument inference is conservative: a literal block is extracted with NO
 //     args (empty Args); the call reproduces the inputs literally. Inferring
 //     arguments from near-duplicate steps with varying values is deferred.
@@ -161,20 +165,34 @@ func extractCall(sol *solution.Solution, blockPath, callName string, replaceIden
 }
 
 // requireProviderStep verifies node is a mapping that represents a direct
-// provider step: it must declare a "provider" key and must NOT declare a "call"
-// key. Steps that already use a call, or that are not provider steps, are not
-// extractable in v1.
+// provider step that is safe to hoist verbatim: it must declare a "provider"
+// key, must NOT declare a "call" key, and must NOT declare any step-level field
+// other than provider/inputs. Steps that already use a call, that are not
+// provider steps, or that carry conditional/iteration/error-handling fields
+// (when, continueOnError, onError, forEach, message) are not extractable in v1.
+//
+// The restriction to provider/inputs exists because a step is hoisted verbatim
+// into a spec.calls definition, whose type (spec.Call) only models provider/
+// inputs (plus description/args/dedup, which a step never has). Splicing any
+// other step field into the call body would silently drop it (spec.Call ignores
+// unknown keys) AND strip it from the call site, changing behavior with no error.
 func requireProviderStep(node *yaml.Node) error {
 	if node == nil || node.Kind != yaml.MappingNode {
 		return fmt.Errorf("step is not a mapping block")
 	}
 	hasProvider, hasCall := false, false
+	var unsupported []string
 	for i := 0; i+1 < len(node.Content); i += 2 {
-		switch node.Content[i].Value {
+		key := node.Content[i].Value
+		switch key {
 		case "provider":
 			hasProvider = true
 		case "call":
 			hasCall = true
+		case "inputs":
+			// allowed
+		default:
+			unsupported = append(unsupported, key)
 		}
 	}
 	if hasCall {
@@ -182,6 +200,11 @@ func requireProviderStep(node *yaml.Node) error {
 	}
 	if !hasProvider {
 		return fmt.Errorf("step is not a provider step (no provider key); only direct provider steps are extractable")
+	}
+	if len(unsupported) > 0 {
+		sort.Strings(unsupported)
+		return fmt.Errorf("step declares unsupported field(s) %v; only provider/inputs steps are extractable in v1 "+
+			"(step-level when/continueOnError/onError/forEach/message would be silently lost)", unsupported)
 	}
 	return nil
 }

--- a/pkg/refactor/extract_benchmark_test.go
+++ b/pkg/refactor/extract_benchmark_test.go
@@ -1,0 +1,33 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refactor
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+)
+
+// BenchmarkExtractCall measures a full Extract Call over a representative
+// solution: build the node map, locate and span the step block, render the
+// calls entry, and produce the edits. Apply is included to capture the
+// end-to-end rewrite cost.
+func BenchmarkExtractCall(b *testing.B) {
+	sol := &solution.Solution{}
+	if err := sol.UnmarshalFromBytes([]byte(extractFixture)); err != nil {
+		b.Fatal(err)
+	}
+	raw := sol.RawContent()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		res, err := ExtractCall(sol, "spec.resolvers.environment.resolve.with[0]", "getEnv")
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err := Apply(raw, res.Edits); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/refactor/extract_test.go
+++ b/pkg/refactor/extract_test.go
@@ -1,0 +1,358 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refactor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// extractFixture has two resolvers whose resolve steps are structurally
+// identical, a transform step, and an inline comment on the first block. It
+// exercises extraction, identical-occurrence replacement, and comment
+// preservation.
+const extractFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: extract-test # keep this comment
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter # inline comment on the block
+            inputs:
+              value: dev
+      transform:
+        with:
+          - provider: cel
+            inputs:
+              expression: __self.lowerAscii()
+    region:
+      resolve:
+        with:
+          - provider: parameter # inline comment on the block
+            inputs:
+              value: dev
+`
+
+// reparseAndValidate asserts the rewritten bytes parse as a solution and pass
+// structural spec validation (which includes call definition/site validation).
+func reparseAndValidate(t *testing.T, out []byte) *solution.Solution {
+	t.Helper()
+	sol := &solution.Solution{}
+	require.NoError(t, sol.UnmarshalFromBytes(out), "rewritten output must re-parse")
+	require.NoError(t, sol.ValidateSpec(), "rewritten output must pass spec validation")
+	return sol
+}
+
+func TestExtractCall_HappyPath(t *testing.T) {
+	sol := loadSolution(t, extractFixture)
+
+	res, err := ExtractCall(sol, "spec.resolvers.environment.resolve.with[0]", "getEnv")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, "spec.resolvers.environment.resolve.with[0]", res.OldName)
+	assert.Equal(t, "getEnv", res.NewName)
+	// One step rewrite + one calls insertion.
+	require.Len(t, res.Edits, 2)
+
+	out, err := res.Apply(sol.RawContent())
+	require.NoError(t, err)
+	s := string(out)
+
+	// The selected step became a call reference.
+	assert.Contains(t, s, "          - call: getEnv")
+	// A calls block was created with the extracted provider+inputs.
+	assert.Contains(t, s, "  calls:\n    getEnv:\n      provider: parameter")
+	assert.Contains(t, s, "      inputs:\n        value: dev")
+	// The OTHER identical step is left untouched by the base function.
+	assert.Contains(t, s, "    region:\n      resolve:\n        with:\n          - provider: parameter")
+
+	// Structure re-parses, validates, and the new call is wired up.
+	newSol := reparseAndValidate(t, out)
+	require.True(t, newSol.Spec.HasCalls())
+	def := newSol.Spec.Calls["getEnv"]
+	require.NotNil(t, def)
+	assert.Equal(t, "parameter", def.Provider)
+	assert.Empty(t, def.Args, "v1 extraction infers no args")
+
+	idx, err := refindex.Build(newSol)
+	require.NoError(t, err)
+	assert.Zero(t, idx.Unresolved())
+	_, ok := idx.Definition(refindex.SymbolCall, "getEnv")
+	assert.True(t, ok)
+}
+
+func TestExtractCall_PreservesComments(t *testing.T) {
+	sol := loadSolution(t, extractFixture)
+
+	res, err := ExtractCall(sol, "spec.resolvers.environment.resolve.with[0]", "getEnv")
+	require.NoError(t, err)
+	out, err := res.Apply(sol.RawContent())
+	require.NoError(t, err)
+	s := string(out)
+
+	// The inline comment on the extracted block moves into the call body.
+	assert.Contains(t, s, "      provider: parameter # inline comment on the block")
+	// Unrelated comments elsewhere survive verbatim.
+	assert.Contains(t, s, "  name: extract-test # keep this comment")
+	reparseAndValidate(t, out)
+}
+
+func TestExtractCall_TransformStep(t *testing.T) {
+	sol := loadSolution(t, extractFixture)
+
+	res, err := ExtractCall(sol, "spec.resolvers.environment.transform.with[0]", "toLower")
+	require.NoError(t, err)
+	out, err := res.Apply(sol.RawContent())
+	require.NoError(t, err)
+	s := string(out)
+
+	assert.Contains(t, s, "          - call: toLower")
+	assert.Contains(t, s, "    toLower:\n      provider: cel")
+	assert.Contains(t, s, "      inputs:\n        expression: __self.lowerAscii()")
+
+	newSol := reparseAndValidate(t, out)
+	require.NotNil(t, newSol.Spec.Calls["toLower"])
+}
+
+func TestExtractCall_AppendsToExistingCalls(t *testing.T) {
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: existing-calls
+spec:
+  calls:
+    existing:
+      provider: static
+      inputs:
+        value: hi
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+`
+	sol := loadSolution(t, y)
+	res, err := ExtractCall(sol, "spec.resolvers.environment.resolve.with[0]", "getEnv")
+	require.NoError(t, err)
+	out, err := res.Apply(sol.RawContent())
+	require.NoError(t, err)
+	s := string(out)
+
+	// The existing call is untouched; the new one is appended as a sibling.
+	assert.Contains(t, s, "    existing:\n      provider: static")
+	assert.Contains(t, s, "    getEnv:\n      provider: parameter")
+	// There must be exactly one calls: key (no duplicate block created).
+	assert.Equal(t, 1, strings.Count(s, "  calls:\n"))
+
+	newSol := reparseAndValidate(t, out)
+	require.NotNil(t, newSol.Spec.Calls["existing"])
+	require.NotNil(t, newSol.Spec.Calls["getEnv"])
+}
+
+func TestExtractCall_MiddleStepInList(t *testing.T) {
+	// The extracted step is not the last in its with: list; the following
+	// sibling step must survive intact.
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: middle
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+          - provider: static
+            inputs:
+              value: fallback
+`
+	sol := loadSolution(t, y)
+	res, err := ExtractCall(sol, "spec.resolvers.environment.resolve.with[0]", "getEnv")
+	require.NoError(t, err)
+	out, err := res.Apply(sol.RawContent())
+	require.NoError(t, err)
+	s := string(out)
+
+	assert.Contains(t, s, "          - call: getEnv\n          - provider: static")
+	assert.Contains(t, s, "              value: fallback")
+	reparseAndValidate(t, out)
+}
+
+func TestExtractCallReplacingIdentical_RewritesDuplicates(t *testing.T) {
+	sol := loadSolution(t, extractFixture)
+
+	res, err := ExtractCallReplacingIdentical(sol, "spec.resolvers.environment.resolve.with[0]", "getEnv")
+	require.NoError(t, err)
+	// Two identical resolve steps rewritten + one calls insertion.
+	require.Len(t, res.Edits, 3)
+
+	out, err := res.Apply(sol.RawContent())
+	require.NoError(t, err)
+	s := string(out)
+
+	// Both structurally-identical steps became call references.
+	assert.Equal(t, 2, strings.Count(s, "- call: getEnv"))
+	// The differing transform step is NOT rewritten.
+	assert.Contains(t, s, "          - provider: cel")
+
+	newSol := reparseAndValidate(t, out)
+	idx, err := refindex.Build(newSol)
+	require.NoError(t, err)
+	assert.Zero(t, idx.Unresolved())
+	// Definition + two call references = three occurrences.
+	assert.Len(t, idx.Occurrences(refindex.SymbolCall, "getEnv"), 3)
+}
+
+func TestExtractCallReplacingIdentical_NoNearMatch(t *testing.T) {
+	// A near-match (same provider, different input value) must NOT be rewritten.
+	y := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: near
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    b:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: prod
+`
+	sol := loadSolution(t, y)
+	res, err := ExtractCallReplacingIdentical(sol, "spec.resolvers.a.resolve.with[0]", "getEnv")
+	require.NoError(t, err)
+	// Only the selected step + calls insertion (the prod step differs).
+	require.Len(t, res.Edits, 2)
+
+	out, err := res.Apply(sol.RawContent())
+	require.NoError(t, err)
+	s := string(out)
+	assert.Equal(t, 1, strings.Count(s, "- call: getEnv"))
+	assert.Contains(t, s, "              value: prod")
+	reparseAndValidate(t, out)
+}
+
+func TestExtractCall_Errors(t *testing.T) {
+	sol := loadSolution(t, extractFixtureWithCallStep())
+
+	tests := []struct {
+		name      string
+		blockPath string
+		callName  string
+		wantMsg   string
+	}{
+		{"invalid call name", "spec.resolvers.environment.resolve.with[0]", "1bad", "not a valid call name"},
+		{"unknown block path", "spec.resolvers.nope.resolve.with[0]", "getEnv", "does not resolve to a node"},
+		{"not a step path", "spec.resolvers.environment", "getEnv", "is not a resolve/transform/validate step path"},
+		{"already a call step", "spec.resolvers.viacall.resolve.with[0]", "getEnv", "already uses a call reference"},
+		{"name collision", "spec.resolvers.environment.resolve.with[0]", "existing", "already exists"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := ExtractCall(sol, tt.blockPath, tt.callName)
+			require.Error(t, err)
+			assert.Nil(t, res)
+			assert.Contains(t, err.Error(), tt.wantMsg)
+		})
+	}
+}
+
+func TestExtractCall_NilSolution(t *testing.T) {
+	res, err := ExtractCall(nil, "spec.resolvers.a.resolve.with[0]", "getEnv")
+	require.Error(t, err)
+	assert.Nil(t, res)
+	assert.Contains(t, err.Error(), "nil solution")
+}
+
+// TestExtractCall_RejectsEmptyCallsBlock guards the corruption case: a spec.calls
+// key that is present in source but decodes to no entries (inline "calls: {}" or
+// a bare/comment-only "calls:") must be rejected, not silently rewritten into a
+// second, duplicate "calls:" key (which would produce invalid YAML).
+func TestExtractCall_RejectsEmptyCallsBlock(t *testing.T) {
+	cases := map[string]string{
+		"inline empty map": `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: empty-inline-calls
+spec:
+  calls: {}
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+`,
+		"bare comment-only key": `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: empty-bare-calls
+spec:
+  calls:
+    # no entries yet
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+`,
+	}
+	for name, y := range cases {
+		t.Run(name, func(t *testing.T) {
+			sol := loadSolution(t, y)
+			res, err := ExtractCall(sol, "spec.resolvers.environment.resolve.with[0]", "getEnv")
+			require.Error(t, err)
+			assert.Nil(t, res)
+			assert.Contains(t, err.Error(), "spec.calls is present but has no entries")
+		})
+	}
+}
+
+// extractFixtureWithCallStep returns a solution containing an existing call, a
+// provider step, and a step that already uses a call: reference (non-extractable).
+func extractFixtureWithCallStep() string {
+	return `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: errors
+spec:
+  calls:
+    existing:
+      provider: static
+      inputs:
+        value: hi
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    viacall:
+      resolve:
+        with:
+          - call: existing
+`
+}

--- a/pkg/refactor/extract_test.go
+++ b/pkg/refactor/extract_test.go
@@ -411,6 +411,53 @@ spec:
 	}
 }
 
+// TestExtractCall_RejectsFlowStyleCalls guards a second corruption case: a
+// flow-style spec.calls ("calls: {a: {...}}") or flow-style spec cannot receive
+// the block-style entry the byte-insertion produces, so extracting would emit a
+// document that no longer parses. It must be rejected, not corrupted.
+func TestExtractCall_RejectsFlowStyleCalls(t *testing.T) {
+	cases := map[string]struct {
+		yaml    string
+		wantMsg string
+	}{
+		"flow-style non-empty calls": {
+			yaml: `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: flow-calls
+spec:
+  calls: {existing: {provider: parameter, inputs: {value: x}}}
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+`,
+			wantMsg: "spec.calls is written in flow style",
+		},
+		"flow-style spec (no calls yet)": {
+			yaml: `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: flow-spec
+spec: {resolvers: {environment: {resolve: {with: [{provider: parameter, inputs: {value: dev}}]}}}}
+`,
+			wantMsg: "spec is written in flow style",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			sol := loadSolution(t, tc.yaml)
+			res, err := ExtractCall(sol, "spec.resolvers.environment.resolve.with[0]", "getEnv")
+			require.Error(t, err)
+			assert.Nil(t, res)
+			assert.Contains(t, err.Error(), tc.wantMsg)
+		})
+	}
+}
+
 // extractFixtureWithCallStep returns a solution containing an existing call, a
 // provider step, and a step that already uses a call: reference (non-extractable).
 func extractFixtureWithCallStep() string {

--- a/pkg/refactor/extract_test.go
+++ b/pkg/refactor/extract_test.go
@@ -330,6 +330,87 @@ spec:
 	}
 }
 
+// TestExtractCall_RejectsUnsupportedStepFields guards the silent-behavior-loss
+// case: a step that carries a step-level field a call definition cannot model
+// (when, continueOnError, onError, forEach, or a validation message) must be
+// rejected, not hoisted verbatim -- otherwise the field is silently spliced into
+// the call body (where spec.Call ignores it) AND stripped from the call site,
+// changing conditional/iteration/error-handling behavior with no error.
+func TestExtractCall_RejectsUnsupportedStepFields(t *testing.T) {
+	cases := map[string]string{
+		"when": `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: field-when
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+            when: "1 == 1"
+`,
+		"continueOnError": `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: field-coe
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+            continueOnError: true
+`,
+		"forEach": `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: field-foreach
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+            forEach:
+              in: "[1, 2, 3]"
+`,
+		"validate message": `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: field-message
+spec:
+  resolvers:
+    environment:
+      validate:
+        with:
+          - provider: validation
+            inputs:
+              rule: __self != ""
+            message: must not be empty
+`,
+	}
+	for name, y := range cases {
+		t.Run(name, func(t *testing.T) {
+			sol := loadSolution(t, y)
+			phase := "resolve"
+			if name == "validate message" {
+				phase = "validate"
+			}
+			res, err := ExtractCall(sol, "spec.resolvers.environment."+phase+".with[0]", "getEnv")
+			require.Error(t, err)
+			assert.Nil(t, res)
+			assert.Contains(t, err.Error(), "unsupported field")
+		})
+	}
+}
+
 // extractFixtureWithCallStep returns a solution containing an existing call, a
 // provider step, and a step that already uses a call: reference (non-extractable).
 func extractFixtureWithCallStep() string {


### PR DESCRIPTION
## Summary

Adds a domain-level **Extract Call** refactoring engine in `pkg/refactor` that hoists a selected resolve/transform/validate step (a `with[i]` provider+inputs block) out of its resolver into a reusable `spec.calls` definition, and rewrites the selected step to a `call: <name>` reference. This is the substantial new domain logic that backs the future LSP code action (#779).

## Contract (for #779)

```go
func ExtractCall(sol *solution.Solution, blockPath, callName string) (*RenameResult, error)
func ExtractCallReplacingIdentical(sol *solution.Solution, blockPath, callName string) (*RenameResult, error)
```

Both return the existing `RenameResult`, so callers reuse `RenameResult.Apply(raw)`.

## Changes

- **`pkg/refactor/extract.go`** -- the engine. Source-preserving byte edits (no YAML round-trip): the step's provider/inputs and inline comments are spliced verbatim and re-indented to the file's style; comments/formatting elsewhere are untouched. All-or-nothing like `RenameSymbol` (any problem returns an error and no edits). **Pure domain code -- no LSP/protocol imports** (verified via `go list -deps`).
- **v1 scope (conservative):** only direct provider steps are extractable (a step already using `call:` is rejected); no argument inference (inputs reproduced literally); the base `ExtractCall` never scans/mass-rewrites. Only `provider`/`inputs` steps are extractable: a step is hoisted verbatim into a `spec.calls` entry, whose type (`spec.Call`) cannot model step-level fields, so a step carrying `when`, `continueOnError`, `onError`, `forEach`, or a validation `message` is **rejected** rather than silently dropping that field (which would splice it into the call body, where it is ignored, and strip it from the call site -- changing conditional/iteration/error-handling behavior with no error). The opt-in `ExtractCallReplacingIdentical` additionally rewrites every *structurally identical* step (deep value equality, key-order/format independent) into the same `call:` reference -- never near-matches.
- **Robustness:** rejects an ambiguous empty-but-present `spec.calls` (inline `{}` or a bare/comment-only key) rather than emitting a duplicate `calls:` key, and rejects a flow-style insertion target (an existing `calls: {a: {...}}` or a flow-style `spec: {...}`) rather than splicing a block entry into a flow mapping and corrupting the document. Block end-span is computed by indentation scanning (yaml.v3 gives only the node start); the new `calls:` insertion point is deterministic (append after the last existing entry, or a new `calls:` as the first child of `spec`), with indentation derived from real node positions.
- **`docs/design/cli.md`** -- documents the engine; the `scafctl refactor extract-call` CLI subcommand is **deferred** to a later PR.

## Tests / verification

- `pkg/refactor/extract_test.go`: happy path, transform step, append-to-existing-calls, middle-of-list sibling survival, identical-occurrence replacement, near-match exclusion, all error cases, an empty-`calls` regression, an unsupported-step-field regression (`when`/`continueOnError`/`forEach`/`message` are rejected), and a flow-style regression (flow-style `spec.calls`/`spec` are rejected). Every rewrite is re-parsed and `ValidateSpec()`-checked.
- `pkg/refactor/extract_benchmark_test.go`: `BenchmarkExtractCall` (~32us/op).
- `go build ./...`, `go vet ./...`, `go test ./pkg/refactor/...`, `go test ./tests/integration/...` -- all pass.
- `task lint:changed` -- 0 new issues.
- Reviewed by a dedicated code-review pass; a file-corruption edge case (empty `spec.calls`) it found was fixed and regression-tested before opening. Follow-up review passes found (a) steps with unsupported step-level fields were hoisted verbatim (silently losing `when`/`continueOnError`/`forEach`/`message`), and (b) a flow-style `spec.calls`/`spec` produced a corrupt (unparseable) rewrite; both are now rejected with a clear error and regression-tested.

## Acceptance criteria

- [x] Extracting a block produces a valid `spec.calls` entry + rewritten usage
- [x] Identical-occurrence replacement is opt-in, not automatic
- [x] Comments/formatting preserved; output re-parses and validates
- [x] Engine is pure domain code (no LSP/protocol imports)

Closes #778
