### PR TITLE
feat(lsp): cursor-context resolver for editor features

### DIFF
--- a/pkg/lsp/cursor.go
+++ b/pkg/lsp/cursor.go
@@ -154,6 +154,16 @@ func ResolveCursor(doc *DocEntry, pos protocol.Position) CursorContext {
 	key, keyStart, keyEnd, valueStart, hasValue := parseKeyLine(runes)
 
 	// 2. Cursor within the key token -> schema key context.
+	//
+	// Flow mappings that pack multiple keys on one line (e.g.
+	// "{provider: parameter, onError: fail}") are only partially supported here:
+	// the text key scanner (parseKeyLine) recognizes the first key, and value-node
+	// path selection resolves by column proximity to the nearest value span, so a
+	// cursor on a *later* key of a flow entry can fall back to a sibling's path.
+	// This is an accepted limitation of the text/column heuristic -- flow
+	// multi-key lines are rare in solutions, and block mappings (the common form,
+	// one key per line) resolve exactly. Proper per-key flow resolution would need
+	// full flow-structure parsing and is deferred until a feature requires it.
 	if key != "" && cursor >= keyStart && cursor <= keyEnd {
 		path, node := scalarLeafOnLine(doc, int(pos.Line)+1, cursor)
 		if path == "" {
@@ -202,7 +212,7 @@ func ResolveCursor(doc *DocEntry, pos protocol.Position) CursorContext {
 
 	switch {
 	case keyName == "provider":
-		return CursorContext{Kind: CursorProviderName, Path: leafPath, Node: leafNode, PartialToken: backwardIdent(line, cursor)}
+		return CursorContext{Kind: CursorProviderName, Path: leafPath, Node: leafNode, PartialToken: backwardProviderIdent(line, cursor)}
 	case isKey(enumValueKeys, keyName):
 		return CursorContext{Kind: CursorEnumValue, Path: leafPath, Node: leafNode, PartialToken: backwardIdent(line, cursor)}
 	case isKey(celValueKeys, keyName):
@@ -346,13 +356,61 @@ func blockScalarCovering(doc *DocEntry, line int) (string, *yaml.Node) {
 		if n.Style != yaml.LiteralStyle && n.Style != yaml.FoldedStyle {
 			continue
 		}
-		bodyEnd := n.Line + strings.Count(n.Value, "\n")
+		// yaml.v3 folds a ">"/">-" body's line breaks into spaces in n.Value, so
+		// strings.Count(n.Value, "\n") undercounts a folded span (often to 0) and
+		// a cursor on a folded body line would not be recognized as inside the
+		// scalar. Derive the body extent from the raw source geometry instead --
+		// this is correct for both literal (|) and folded (>) styles.
+		bodyEnd := blockBodyEnd(doc.Raw, n.Line)
 		if line > n.Line && line <= bodyEnd && len(path) > len(best) {
 			best = path
 			bestNode = n
 		}
 	}
 	return best, bestNode
+}
+
+// blockBodyEnd returns the 1-based line number of the last source line belonging
+// to a block scalar whose key/indicator is on keyLine (1-based). The body is the
+// maximal run of following lines that are blank or indented deeper than the key
+// line; the result is the last NON-blank such line, so trailing blank lines and
+// the following dedented sibling are excluded. It returns keyLine when the scalar
+// has no body lines. Deriving the span from raw geometry (rather than the scalar
+// value) makes it style-agnostic: folded scalars, whose newlines yaml.v3 collapses
+// into spaces, span correctly.
+func blockBodyEnd(raw []byte, keyLine int) int {
+	keyText, ok := lineAt(raw, keyLine-1)
+	if !ok {
+		return keyLine
+	}
+	keyIndent := leadingSpaces(keyText)
+	bodyEnd := keyLine
+	for l := keyLine + 1; ; l++ {
+		text, ok := lineAt(raw, l-1)
+		if !ok {
+			break
+		}
+		if strings.TrimSpace(text) == "" {
+			continue // blank line may be interior to the body; don't extend or stop
+		}
+		if leadingSpaces(text) <= keyIndent {
+			break // dedent to the key's level or shallower: the body has ended
+		}
+		bodyEnd = l
+	}
+	return bodyEnd
+}
+
+// leadingSpaces counts the leading space/tab runes of a line.
+func leadingSpaces(s string) int {
+	n := 0
+	for _, r := range s {
+		if r != ' ' && r != '\t' {
+			break
+		}
+		n++
+	}
+	return n
 }
 
 // firstNonSpace returns the 0-based rune index of the first non-space/tab rune,
@@ -418,6 +476,26 @@ func backwardIdent(s string, i int) string {
 	}
 	start := i
 	for start > 0 && isIdentRune(runes[start-1]) {
+		start--
+	}
+	return string(runes[start:i])
+}
+
+// backwardProviderIdent captures the partial provider token ending at rune index
+// i, treating '-' as part of the token so hyphenated provider names (e.g.
+// "go-template", "go-template-extensions") are not truncated to the suffix after
+// the last '-'. CEL/template identifiers deliberately exclude '-' (it is an
+// operator/minus there), so only provider-name completion uses this variant.
+func backwardProviderIdent(s string, i int) string {
+	runes := []rune(s)
+	if i > len(runes) {
+		i = len(runes)
+	}
+	if i < 0 {
+		i = 0
+	}
+	start := i
+	for start > 0 && (isIdentRune(runes[start-1]) || runes[start-1] == '-') {
 		start--
 	}
 	return string(runes[start:i])

--- a/pkg/lsp/cursor.go
+++ b/pkg/lsp/cursor.go
@@ -1,0 +1,507 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"bytes"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+	"gopkg.in/yaml.v3"
+)
+
+// CursorKind classifies what an editor cursor sits on in a solution document.
+// It is the shared vocabulary for hover, completion, and signature help so each
+// feature dispatches on one classification instead of growing its own fragile
+// "am I inside {{ }} / on a YAML key?" scanner.
+type CursorKind int
+
+const (
+	// CursorNone is whitespace or an unclassifiable position.
+	CursorNone CursorKind = iota
+	// CursorSymbolRef is a located reference to a resolver/action/call/function
+	// (a refindex.Reference range).
+	CursorSymbolRef
+	// CursorYAMLKey is a mapping key (schema context).
+	CursorYAMLKey
+	// CursorEnumValue is a scalar value whose schema field is a fixed enum.
+	CursorEnumValue
+	// CursorCEL is inside a CEL expression or condition value.
+	CursorCEL
+	// CursorTemplate is inside a Go-template (tmpl) value.
+	CursorTemplate
+	// CursorProviderName is a provider: value.
+	CursorProviderName
+)
+
+// String returns a short label for the cursor kind (for tests/debugging).
+func (k CursorKind) String() string {
+	switch k {
+	case CursorNone:
+		return "none"
+	case CursorSymbolRef:
+		return "symbolRef"
+	case CursorYAMLKey:
+		return "yamlKey"
+	case CursorEnumValue:
+		return "enumValue"
+	case CursorCEL:
+		return "cel"
+	case CursorTemplate:
+		return "template"
+	case CursorProviderName:
+		return "providerName"
+	default:
+		return "none"
+	}
+}
+
+// CursorContext is the resolved classification of one cursor position.
+type CursorContext struct {
+	// Kind is the classification.
+	Kind CursorKind
+	// Path is the logical YAML path at the cursor (dotted keys + [i]), when known.
+	Path string
+	// Node is the enclosing value node, when known.
+	Node *yaml.Node
+	// Ref is set when Kind == CursorSymbolRef.
+	Ref *refindex.Reference
+	// PartialToken is the text typed so far at the cursor (for completion
+	// filtering) -- the identifier fragment under/just before the cursor.
+	PartialToken string
+	// ExprPrefix is the reference prefix in a CEL/template token: "_." or
+	// "__actions." in CEL; "._.", ".__actions.", or "." in a template. Empty
+	// when the token is a bare function name or there is no prefix.
+	ExprPrefix string
+}
+
+// Reference-prefix markers captured in ExprPrefix. CEL uses the underscore data
+// root directly; Go templates dot-scope it.
+const (
+	celResolverPrefix  = "_."
+	celActionPrefix    = "__actions."
+	tmplResolverPrefix = "._."
+	tmplActionPrefix   = ".__actions."
+	tmplFieldPrefix    = "."
+)
+
+// celValueKeys are the leaf mapping keys whose scalar value holds a CEL
+// expression or condition (see pkg/spec ValueRef.Expr, pkg/spec Condition, and
+// author-function cel bodies).
+var celValueKeys = map[string]struct{}{
+	"expr":       {},
+	"expression": {},
+	"when":       {},
+	"until":      {},
+	"retryIf":    {},
+	"cel":        {},
+}
+
+// templateValueKeys are the leaf mapping keys whose scalar value holds a Go
+// template (ValueRef.Tmpl, author-function template bodies).
+var templateValueKeys = map[string]struct{}{
+	"tmpl":     {},
+	"template": {},
+}
+
+// enumValueKeys are the leaf mapping keys whose scalar value is a fixed enum in
+// the current solution schema. The classifier only needs to know a field is an
+// enum; downstream completion sources the concrete values. Keep in sync with the
+// typed string enums in pkg/spec and pkg/action (OnErrorBehavior, BackoffType,
+// ResultSchemaMode, FingerprintScope). Note onError is deprecated in favor of
+// the boolean continueOnError, but remains a functional enum field.
+var enumValueKeys = map[string]struct{}{
+	"onError":          {},
+	"backoff":          {},
+	"resultSchemaMode": {},
+	"scope":            {},
+}
+
+// ResolveCursor classifies pos against a cached document snapshot. It never
+// panics: a nil/parse-error doc or an out-of-range position yields the best
+// available classification (falling back to CursorNone), so features degrade
+// gracefully while the user is mid-edit.
+func ResolveCursor(doc *DocEntry, pos protocol.Position) CursorContext {
+	if doc == nil {
+		return CursorContext{Kind: CursorNone}
+	}
+
+	// 1. Located symbol references win: the index has exact ranges for every
+	// resolver/action/call/function occurrence. Unavailable when the solution
+	// failed to build (Index == nil), in which case we fall through to
+	// structural/text classification.
+	if doc.Index != nil {
+		if ref, ok := symbolAt(doc.Index, pos); ok {
+			r := ref
+			return CursorContext{Kind: CursorSymbolRef, Ref: &r}
+		}
+	}
+
+	line, ok := lineAt(doc.Raw, int(pos.Line))
+	if !ok {
+		return CursorContext{Kind: CursorNone}
+	}
+	runes := []rune(line)
+	cursor := int(pos.Character)
+	if cursor > len(runes) {
+		cursor = len(runes)
+	}
+
+	// Parse the "key:" structure of the current line (text-based, so it works
+	// even when the whole document failed to parse).
+	key, keyStart, keyEnd, valueStart, hasValue := parseKeyLine(runes)
+
+	// 2. Cursor within the key token -> schema key context.
+	if key != "" && cursor >= keyStart && cursor <= keyEnd {
+		path, node := scalarLeafOnLine(doc, int(pos.Line)+1, cursor)
+		if path == "" {
+			path = blockKeyPath(doc, int(pos.Line)+1, key)
+		}
+		return CursorContext{Kind: CursorYAMLKey, Path: path, Node: node, PartialToken: string(runes[keyStart:cursor])}
+	}
+
+	// 3. Value context: classify by the leaf key. Determine the key/path/value
+	// boundary from the parsed node map when available (single-line scalar or an
+	// enclosing multi-line block scalar), else fall back to the text value on the
+	// line so a mid-edit/unparsed document still classifies. Partial tokens are
+	// scanned from the RAW line, which is uniform across plain, quoted, and
+	// block-scalar values (no quote/indent offset math).
+	//
+	// Classification keys off the leaf mapping key alone (e.g. "expr" -> CEL,
+	// "provider" -> provider). This is a deliberate text heuristic per the issue:
+	// a free-form user input whose key happens to be a spec keyword (e.g. an
+	// input literally named "expr") can be misclassified. Spec-owned keys make
+	// this rare in practice.
+	leafPath, leafNode := scalarLeafOnLine(doc, int(pos.Line)+1, cursor)
+	var keyName string
+	valueStart2 := 0
+	switch {
+	case leafPath != "" && leafNode != nil:
+		keyName = lastSegment(leafPath)
+		valueStart2 = leafNode.Column - 1
+	default:
+		if bp, bn := blockScalarCovering(doc, int(pos.Line)+1); bp != "" {
+			// Cursor is inside a multi-line block-scalar body (expr:|, tmpl:|).
+			leafPath, leafNode = bp, bn
+			keyName = lastSegment(bp)
+			valueStart2 = firstNonSpace(runes)
+		} else if key != "" && hasValue {
+			keyName = key
+			valueStart2 = valueStart
+		} else {
+			return CursorContext{Kind: CursorNone}
+		}
+	}
+
+	// Cursor must be at or past where the value begins to be "in the value".
+	if cursor < valueStart2 {
+		return CursorContext{Kind: CursorNone, Path: leafPath, Node: leafNode}
+	}
+
+	switch {
+	case keyName == "provider":
+		return CursorContext{Kind: CursorProviderName, Path: leafPath, Node: leafNode, PartialToken: backwardIdent(line, cursor)}
+	case isKey(enumValueKeys, keyName):
+		return CursorContext{Kind: CursorEnumValue, Path: leafPath, Node: leafNode, PartialToken: backwardIdent(line, cursor)}
+	case isKey(celValueKeys, keyName):
+		ctx := CursorContext{Kind: CursorCEL, Path: leafPath, Node: leafNode}
+		ctx.PartialToken, ctx.ExprPrefix = celTokenAt(line, cursor)
+		return ctx
+	case isKey(templateValueKeys, keyName):
+		ctx := CursorContext{Kind: CursorTemplate, Path: leafPath, Node: leafNode}
+		ctx.PartialToken, ctx.ExprPrefix = templateTokenAt(line, cursor)
+		return ctx
+	default:
+		return CursorContext{Kind: CursorNone, Path: leafPath, Node: leafNode}
+	}
+}
+
+// lineAt returns the raw text of the 0-based line index, without its trailing
+// carriage return/newline. ok is false when the line is out of range. It scans
+// for the target line's byte span rather than splitting the whole document, so
+// it stays cheap on the per-keystroke hot path.
+func lineAt(raw []byte, line int) (string, bool) {
+	if line < 0 {
+		return "", false
+	}
+	start := 0
+	for l := 0; l < line; l++ {
+		nl := bytes.IndexByte(raw[start:], '\n')
+		if nl < 0 {
+			return "", false // fewer than line+1 lines
+		}
+		start += nl + 1
+	}
+	end := bytes.IndexByte(raw[start:], '\n')
+	if end < 0 {
+		end = len(raw)
+	} else {
+		end += start
+	}
+	return string(bytes.TrimRight(raw[start:end], "\r")), true
+}
+
+// parseKeyLine finds the "key:" separator on a YAML line, tolerating a leading
+// indent and block-sequence dashes ("- "). It returns the key text, the 0-based
+// rune columns spanning the key, the 0-based rune column where the value begins
+// (first non-space after the colon), and whether a value is present on the line.
+// All results are zero/empty when the line has no mapping key.
+func parseKeyLine(runes []rune) (key string, keyStart, keyEnd, valueStart int, hasValue bool) {
+	i := 0
+	// Skip indentation and any block-sequence "- " markers.
+	for i < len(runes) {
+		if runes[i] == ' ' || runes[i] == '\t' {
+			i++
+			continue
+		}
+		if runes[i] == '-' && i+1 < len(runes) && (runes[i+1] == ' ' || runes[i+1] == '\t') {
+			i += 2
+			continue
+		}
+		break
+	}
+	if i >= len(runes) || runes[i] == '#' {
+		return "", 0, 0, 0, false
+	}
+	keyStart = i
+	// The key ends at the first ": " or a trailing ":" (YAML's key/value
+	// separator). A colon inside the value (e.g. a CEL string) is not it.
+	sep := -1
+	for j := i; j < len(runes); j++ {
+		if runes[j] == ':' && (j+1 >= len(runes) || runes[j+1] == ' ' || runes[j+1] == '\t') {
+			sep = j
+			break
+		}
+	}
+	if sep < 0 {
+		return "", 0, 0, 0, false
+	}
+	keyEnd = sep
+	key = strings.TrimSpace(string(runes[keyStart:sep]))
+	if key == "" {
+		return "", 0, 0, 0, false
+	}
+	// Value begins at the first non-space after the colon.
+	v := sep + 1
+	for v < len(runes) && (runes[v] == ' ' || runes[v] == '\t') {
+		v++
+	}
+	valueStart = v
+	hasValue = v < len(runes) && runes[v] != '#'
+	return key, keyStart, keyEnd, valueStart, hasValue
+}
+
+// scalarLeafOnLine returns the scalar value node whose start is on the 1-based
+// line and, among several on the same line (flow mappings), the one whose value
+// span contains the cursor column; it falls back to the deepest path. Returns
+// "", nil when the document has no node map (broken YAML) or no scalar value on
+// that line.
+func scalarLeafOnLine(doc *DocEntry, line, cursor int) (string, *yaml.Node) {
+	if doc.Nodes == nil {
+		return "", nil
+	}
+	bestPath := ""
+	var bestNode *yaml.Node
+	containingPath := ""
+	var containingNode *yaml.Node
+	for path, n := range doc.Nodes {
+		if n == nil || n.Kind != yaml.ScalarNode || n.Line != line {
+			continue
+		}
+		// Prefer a node whose value span contains the cursor column.
+		start := n.Column - 1
+		end := start + len([]rune(n.Value))
+		if cursor >= start && cursor <= end && len(path) > len(containingPath) {
+			containingPath = path
+			containingNode = n
+		}
+		if len(path) > len(bestPath) {
+			bestPath = path
+			bestNode = n
+		}
+	}
+	if containingNode != nil {
+		return containingPath, containingNode
+	}
+	return bestPath, bestNode
+}
+
+// blockScalarCovering returns the block scalar (literal | or folded >) whose
+// multi-line body covers the 1-based line, and its path. yaml.v3 positions a
+// block scalar at its key line, with the body on the following lines, so a
+// cursor inside the body has no node on its own line -- this finds the enclosing
+// block instead. Returns "", nil when no block scalar covers the line.
+func blockScalarCovering(doc *DocEntry, line int) (string, *yaml.Node) {
+	if doc.Nodes == nil {
+		return "", nil
+	}
+	best := ""
+	var bestNode *yaml.Node
+	for path, n := range doc.Nodes {
+		if n == nil || n.Kind != yaml.ScalarNode {
+			continue
+		}
+		if n.Style != yaml.LiteralStyle && n.Style != yaml.FoldedStyle {
+			continue
+		}
+		bodyEnd := n.Line + strings.Count(n.Value, "\n")
+		if line > n.Line && line <= bodyEnd && len(path) > len(best) {
+			best = path
+			bestNode = n
+		}
+	}
+	return best, bestNode
+}
+
+// firstNonSpace returns the 0-based rune index of the first non-space/tab rune,
+// or len(runes) when the line is all whitespace.
+func firstNonSpace(runes []rune) int {
+	for i, r := range runes {
+		if r != ' ' && r != '\t' {
+			return i
+		}
+	}
+	return len(runes)
+}
+
+// blockKeyPath finds a best-effort logical path for a mapping key that has no
+// scalar value on its own line (a nested block). YAML positions a mapping node
+// at its first child, so the node whose leaf segment matches key and whose start
+// is nearest at/after the key line is the closest match.
+func blockKeyPath(doc *DocEntry, line int, key string) string {
+	if doc.Nodes == nil {
+		return ""
+	}
+	best := ""
+	bestLine := -1
+	for path, n := range doc.Nodes {
+		if n == nil || lastSegment(path) != key || n.Line < line {
+			continue
+		}
+		if bestLine == -1 || n.Line < bestLine {
+			best = path
+			bestLine = n.Line
+		}
+	}
+	return best
+}
+
+// lastSegment returns the final dotted/indexed path segment's key name, e.g.
+// "spec.resolvers.a.resolve.with[0].provider" -> "provider".
+func lastSegment(path string) string {
+	if i := strings.LastIndex(path, "."); i >= 0 {
+		path = path[i+1:]
+	}
+	if i := strings.IndexByte(path, '['); i >= 0 {
+		path = path[:i]
+	}
+	return path
+}
+
+func isKey(set map[string]struct{}, k string) bool {
+	_, ok := set[k]
+	return ok
+}
+
+// backwardIdent returns the identifier fragment ending at rune index i in s,
+// scanning back over identifier characters. Used to capture the partial token a
+// user has typed for a provider/enum value.
+func backwardIdent(s string, i int) string {
+	runes := []rune(s)
+	if i > len(runes) {
+		i = len(runes)
+	}
+	if i < 0 {
+		i = 0
+	}
+	start := i
+	for start > 0 && isIdentRune(runes[start-1]) {
+		start--
+	}
+	return string(runes[start:i])
+}
+
+// celTokenAt extracts the partial token and reference prefix at rune index i in
+// a CEL expression value.
+func celTokenAt(expr string, i int) (partial, prefix string) {
+	tok := backwardDotIdent(expr, i)
+	switch {
+	case strings.HasPrefix(tok, celResolverPrefix):
+		return tok[len(celResolverPrefix):], celResolverPrefix
+	case strings.HasPrefix(tok, celActionPrefix):
+		return tok[len(celActionPrefix):], celActionPrefix
+	default:
+		return tok, ""
+	}
+}
+
+// templateTokenAt extracts the partial token and reference prefix at rune index
+// i in a Go-template value. The token is only meaningful inside a {{ ... }}
+// action; outside one, prefix and partial are empty.
+func templateTokenAt(tmpl string, i int) (partial, prefix string) {
+	action, ok := enclosingAction(tmpl, i)
+	if !ok {
+		return "", ""
+	}
+	tok := backwardDotIdent(action, len([]rune(action)))
+	switch {
+	case strings.HasPrefix(tok, tmplResolverPrefix):
+		return tok[len(tmplResolverPrefix):], tmplResolverPrefix
+	case strings.HasPrefix(tok, tmplActionPrefix):
+		return tok[len(tmplActionPrefix):], tmplActionPrefix
+	case strings.HasPrefix(tok, tmplFieldPrefix):
+		return tok[len(tmplFieldPrefix):], tmplFieldPrefix
+	default:
+		return tok, ""
+	}
+}
+
+// enclosingAction returns the text of the {{ ... }} action from just after the
+// opening "{{" up to rune index i, when i is inside an open (unclosed-before-i)
+// action. ok is false when i is not inside an action.
+func enclosingAction(tmpl string, i int) (string, bool) {
+	runes := []rune(tmpl)
+	if i > len(runes) {
+		i = len(runes)
+	}
+	open := -1
+	for j := 0; j+1 < i; j++ {
+		if runes[j] == '{' && runes[j+1] == '{' {
+			open = j + 2
+		}
+		if runes[j] == '}' && runes[j+1] == '}' {
+			open = -1
+		}
+	}
+	if open < 0 || open > i {
+		return "", false
+	}
+	return string(runes[open:i]), true
+}
+
+// backwardDotIdent scans back from rune index i over identifier characters plus
+// '.', returning the dotted token (e.g. "_.env", "._.env", ".__actions.foo",
+// "toUpper").
+func backwardDotIdent(s string, i int) string {
+	runes := []rune(s)
+	if i > len(runes) {
+		i = len(runes)
+	}
+	if i < 0 {
+		i = 0
+	}
+	start := i
+	for start > 0 && (isIdentRune(runes[start-1]) || runes[start-1] == '.') {
+		start--
+	}
+	return string(runes[start:i])
+}
+
+func isIdentRune(r rune) bool {
+	return r == '_' ||
+		(r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z') ||
+		(r >= '0' && r <= '9')
+}

--- a/pkg/lsp/cursor_benchmark_test.go
+++ b/pkg/lsp/cursor_benchmark_test.go
@@ -1,0 +1,62 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// BenchmarkResolveCursor measures the hot path: ResolveCursor runs per keystroke
+// via hover/completion/signature-help, so it must stay cheap.
+func BenchmarkResolveCursor(b *testing.B) {
+	c := NewDocumentCache()
+	e := c.Set("file:///bench.yaml", 1, cursorFixture)
+	// A CEL value position (representative: node lookup + token scan).
+	pos := protocol.Position{Line: 18, Character: 30}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = ResolveCursor(e, pos)
+	}
+}
+
+// BenchmarkResolveCursor_SymbolRef measures the located-reference fast path.
+func BenchmarkResolveCursor_SymbolRef(b *testing.B) {
+	c := NewDocumentCache()
+	e := c.Set("file:///bench.yaml", 1, cursorFixture)
+	pos := protocol.Position{Line: 19, Character: 16} // on _.environment in when:
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = ResolveCursor(e, pos)
+	}
+}
+
+// BenchmarkResolveCursor_LargeDoc measures the hot path on a larger document so
+// a regression in the per-keystroke line lookup or node-map scan is visible
+// (the small fixtures hide O(document-size) costs).
+func BenchmarkResolveCursor_LargeDoc(b *testing.B) {
+	var sb strings.Builder
+	sb.WriteString("apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: big\nspec:\n  resolvers:\n")
+	for i := 0; i < 200; i++ {
+		fmt.Fprintf(&sb, "    r%d:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value:\n                expr: _.environment\n", i)
+	}
+	content := sb.String()
+	c := NewDocumentCache()
+	e := c.Set("file:///big.yaml", 1, content)
+	// A CEL position deep in the document.
+	line := uint32(strings.Count(content, "\n") - 1)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = ResolveCursor(e, protocol.Position{Line: line, Character: 24})
+	}
+}

--- a/pkg/lsp/cursor_test.go
+++ b/pkg/lsp/cursor_test.go
@@ -1,0 +1,448 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// cursorFixture exercises every cursor class. Markers in comments name the lines
+// the tests target.
+const cursorFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: cursor
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    appName:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: size(_.environment)
+        when: _.environment == "dev"
+    greeting:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              value:
+                tmpl: "{{ upper .name }}"
+            onError: fail
+`
+
+// posAt returns the LSP position of the first occurrence of token on the first
+// line containing lineHint, offset by within runes into that token.
+func posAt(t *testing.T, content, lineHint, token string, within int) protocol.Position {
+	t.Helper()
+	for i, line := range strings.Split(content, "\n") {
+		if !strings.Contains(line, lineHint) {
+			continue
+		}
+		col := strings.Index(line, token)
+		require.GreaterOrEqual(t, col, 0, "token %q not on line %q", token, lineHint)
+		// Index gives a byte offset; for the ASCII fixture that equals the rune
+		// column.
+		return protocol.Position{Line: uint32(i), Character: uint32(col + within)}
+	}
+	t.Fatalf("no line contains %q", lineHint)
+	return protocol.Position{}
+}
+
+func resolveFixture(t *testing.T, content string, pos protocol.Position) CursorContext {
+	t.Helper()
+	c := NewDocumentCache()
+	e := c.Set("file:///cursor.yaml", 1, content)
+	return ResolveCursor(e, pos)
+}
+
+func TestResolveCursor_Classes(t *testing.T) {
+	tests := []struct {
+		name         string
+		lineHint     string
+		token        string
+		within       int
+		wantKind     CursorKind
+		wantPartial  string
+		wantPrefix   string
+		wantPathTail string // suffix the resolved Path must end with (when set)
+	}{
+		{
+			name:     "symbol ref on CEL underscore reference",
+			lineHint: "expr: size(_.environment)",
+			token:    "environment)",
+			within:   2,
+			wantKind: CursorSymbolRef,
+		},
+		{
+			name:     "symbol ref on condition reference",
+			lineHint: `when: _.environment`,
+			token:    "environment ==",
+			within:   1,
+			wantKind: CursorSymbolRef,
+		},
+		{
+			name:         "yaml key on a scalar mapping key",
+			lineHint:     "provider: parameter",
+			token:        "provider",
+			within:       3,
+			wantKind:     CursorYAMLKey,
+			wantPartial:  "pro",
+			wantPathTail: ".provider",
+		},
+		{
+			name:         "yaml key on a block key",
+			lineHint:     "      resolve:",
+			token:        "resolve",
+			within:       2,
+			wantKind:     CursorYAMLKey,
+			wantPartial:  "re",
+			wantPathTail: "resolve",
+		},
+		{
+			name:         "provider name value",
+			lineHint:     "provider: parameter",
+			token:        "parameter",
+			within:       2,
+			wantKind:     CursorProviderName,
+			wantPartial:  "pa",
+			wantPathTail: ".provider",
+		},
+		{
+			name:         "enum value",
+			lineHint:     "onError: fail",
+			token:        "fail",
+			within:       4,
+			wantKind:     CursorEnumValue,
+			wantPartial:  "fail",
+			wantPathTail: ".onError",
+		},
+		{
+			name:         "cel function-name token (not a reference)",
+			lineHint:     "expr: size(_.environment)",
+			token:        "size",
+			within:       3,
+			wantKind:     CursorCEL,
+			wantPartial:  "siz",
+			wantPrefix:   "",
+			wantPathTail: ".expr",
+		},
+		{
+			name:         "template function-name token",
+			lineHint:     `tmpl: "{{ upper .name }}"`,
+			token:        "upper",
+			within:       3,
+			wantKind:     CursorTemplate,
+			wantPartial:  "upp",
+			wantPrefix:   "",
+			wantPathTail: ".tmpl",
+		},
+		{
+			name:         "template field reference token",
+			lineHint:     `tmpl: "{{ upper .name }}"`,
+			token:        ".name",
+			within:       3,
+			wantKind:     CursorTemplate,
+			wantPartial:  "na",
+			wantPrefix:   ".",
+			wantPathTail: ".tmpl",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pos := posAt(t, cursorFixture, tc.lineHint, tc.token, tc.within)
+			ctx := resolveFixture(t, cursorFixture, pos)
+			assert.Equal(t, tc.wantKind, ctx.Kind, "kind (path=%q partial=%q prefix=%q)", ctx.Path, ctx.PartialToken, ctx.ExprPrefix)
+			if tc.wantPartial != "" {
+				assert.Equal(t, tc.wantPartial, ctx.PartialToken, "partial token")
+			}
+			if tc.wantPrefix != "" || tc.wantKind == CursorCEL || tc.wantKind == CursorTemplate {
+				assert.Equal(t, tc.wantPrefix, ctx.ExprPrefix, "expr prefix")
+			}
+			if tc.wantPathTail != "" {
+				assert.True(t, strings.HasSuffix(ctx.Path, tc.wantPathTail),
+					"path %q should end with %q", ctx.Path, tc.wantPathTail)
+			}
+			if tc.wantKind == CursorSymbolRef {
+				require.NotNil(t, ctx.Ref)
+				assert.Equal(t, "environment", ctx.Ref.Symbol.Name)
+			}
+		})
+	}
+}
+
+func TestResolveCursor_CELResolverPrefixPartial(t *testing.T) {
+	// When the index is unavailable (document did not build), a resolver-prefixed
+	// CEL partial still classifies as CEL with the "_." prefix captured for
+	// completion -- exercised here by building a DocEntry with a node map but no
+	// index. (When the index IS available, a complete "_.name" is a SymbolRef,
+	// which is the right context for completing an existing resolver reference.)
+	raw := []byte(`apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.envir
+`)
+	nodes, err := refindex.NodeMap(raw)
+	require.NoError(t, err)
+	e := &DocEntry{Raw: raw, Nodes: nodes} // Index intentionally nil
+
+	pos := posAt(t, string(raw), "expr: _.envir", "_.envir", len("_.envir"))
+	ctx := ResolveCursor(e, pos)
+	assert.Equal(t, CursorCEL, ctx.Kind)
+	assert.Equal(t, celResolverPrefix, ctx.ExprPrefix)
+	assert.Equal(t, "envir", ctx.PartialToken)
+}
+
+func TestCelTokenAt(t *testing.T) {
+	tests := []struct {
+		expr        string
+		at          int
+		wantPartial string
+		wantPrefix  string
+	}{
+		{"_.env", 5, "env", "_."},
+		{"_.", 2, "", "_."},
+		{"__actions.foo", 13, "foo", "__actions."},
+		{"size(_.x)", 4, "size", ""},
+		{"toUpper", 4, "toUp", ""},
+	}
+	for _, tc := range tests {
+		partial, prefix := celTokenAt(tc.expr, tc.at)
+		assert.Equal(t, tc.wantPartial, partial, "partial for %q@%d", tc.expr, tc.at)
+		assert.Equal(t, tc.wantPrefix, prefix, "prefix for %q@%d", tc.expr, tc.at)
+	}
+}
+
+func TestTemplateTokenAt(t *testing.T) {
+	tests := []struct {
+		tmpl        string
+		at          int
+		wantPartial string
+		wantPrefix  string
+	}{
+		{"{{ ._.app }}", 9, "app", "._."},
+		{"{{ .__actions.a }}", 15, "a", ".__actions."},
+		{"{{ .name }}", 8, "name", "."},
+		{"{{ upper .x }}", 8, "upper", ""},
+		{"literal text", 5, "", ""},   // not inside an action
+		{"{{ .a }} text", 11, "", ""}, // after a closed action
+	}
+	for _, tc := range tests {
+		partial, prefix := templateTokenAt(tc.tmpl, tc.at)
+		assert.Equal(t, tc.wantPartial, partial, "partial for %q@%d", tc.tmpl, tc.at)
+		assert.Equal(t, tc.wantPrefix, prefix, "prefix for %q@%d", tc.tmpl, tc.at)
+	}
+}
+
+func TestResolveCursor_TemplateResolverPrefixPartial(t *testing.T) {
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              value:
+                tmpl: "{{ ._.ap"
+`
+	pos := posAt(t, content, `tmpl: "{{ ._.ap`, "._.ap", len("._.ap"))
+	ctx := resolveFixture(t, content, pos)
+	assert.Equal(t, CursorTemplate, ctx.Kind)
+	assert.Equal(t, tmplResolverPrefix, ctx.ExprPrefix)
+	assert.Equal(t, "ap", ctx.PartialToken)
+}
+
+func TestResolveCursor_BlockScalarCELBody(t *testing.T) {
+	// A cursor inside a multi-line literal (|) CEL body must classify as CEL --
+	// yaml positions the value node on the key line, so body lines have no node
+	// of their own; the resolver must find the enclosing block scalar.
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: |
+                  size(_.foo) && bigFunc
+`
+	pos := posAt(t, content, "size(_.foo) && bigFunc", "bigFunc", 3)
+	ctx := resolveFixture(t, content, pos)
+	assert.Equal(t, CursorCEL, ctx.Kind, "path=%q partial=%q", ctx.Path, ctx.PartialToken)
+	assert.Equal(t, "big", ctx.PartialToken)
+	assert.True(t, strings.HasSuffix(ctx.Path, ".expr"))
+}
+
+func TestResolveCursor_BlockScalarTemplateBody(t *testing.T) {
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              value:
+                tmpl: |
+                  Hello {{ upperCase .name }}
+`
+	pos := posAt(t, content, "Hello {{ upperCase", "upperCase", 5)
+	ctx := resolveFixture(t, content, pos)
+	assert.Equal(t, CursorTemplate, ctx.Kind, "path=%q partial=%q prefix=%q", ctx.Path, ctx.PartialToken, ctx.ExprPrefix)
+	assert.Equal(t, "upper", ctx.PartialToken)
+	assert.Equal(t, "", ctx.ExprPrefix)
+	assert.True(t, strings.HasSuffix(ctx.Path, ".tmpl"))
+}
+
+func TestResolveCursor_FlowMappingSelectsByColumn(t *testing.T) {
+	// Two scalars share a line in a flow mapping; the cursor column must select
+	// the right one (onError, not provider) despite provider's longer path.
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - {provider: parameter, onError: fail}
+`
+	pos := posAt(t, content, "onError: fail}", "fail", 2)
+	ctx := resolveFixture(t, content, pos)
+	assert.Equal(t, CursorEnumValue, ctx.Kind, "path=%q", ctx.Path)
+	assert.True(t, strings.HasSuffix(ctx.Path, ".onError"), "path %q", ctx.Path)
+}
+
+func TestResolveCursor_Whitespace(t *testing.T) {
+	// Cursor in leading indentation is unclassifiable.
+	pos := posAt(t, cursorFixture, "provider: parameter", "provider", -4)
+	ctx := resolveFixture(t, cursorFixture, pos)
+	assert.Equal(t, CursorNone, ctx.Kind)
+}
+
+func TestResolveCursor_NilDoc(t *testing.T) {
+	assert.Equal(t, CursorNone, ResolveCursor(nil, protocol.Position{}).Kind)
+}
+
+func TestResolveCursor_OutOfRangePosition(t *testing.T) {
+	c := NewDocumentCache()
+	e := c.Set("file:///c.yaml", 1, cursorFixture)
+	ctx := ResolveCursor(e, protocol.Position{Line: 9999, Character: 0})
+	assert.Equal(t, CursorNone, ctx.Kind)
+}
+
+func TestResolveCursor_ParseErrorDegradesGracefully(t *testing.T) {
+	// Malformed YAML: NodeMap fails, so there is no node map at all. The resolver
+	// must still classify from raw text (or return None) without panicking.
+	malformed := "spec: {resolvers: \n  provider: parameter"
+	c := NewDocumentCache()
+	e := c.Set("file:///bad.yaml", 1, malformed)
+	require.Error(t, e.ParseErr)
+
+	require.NotPanics(t, func() {
+		// On the "provider:" line, text-based classification still works.
+		pos := posAt(t, malformed, "provider: parameter", "parameter", 2)
+		ctx := ResolveCursor(e, pos)
+		assert.Equal(t, CursorProviderName, ctx.Kind)
+		assert.Equal(t, "pa", ctx.PartialToken)
+	})
+}
+
+func TestResolveCursor_PartialSolutionStillClassifies(t *testing.T) {
+	// Valid YAML but the solution fails to build (unknown provider reference in
+	// CEL). NodeMap succeeds, so classification by leaf key works even though the
+	// index is unavailable.
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.missing.deeply.nested.value.that.is.long
+`
+	c := NewDocumentCache()
+	e := c.Set("file:///c.yaml", 1, content)
+	pos := posAt(t, content, "provider: parameter", "parameter", 2)
+	ctx := ResolveCursor(e, pos)
+	assert.Equal(t, CursorProviderName, ctx.Kind)
+}
+
+func TestResolveCursor_SymbolRefWhenIndexUnavailable(t *testing.T) {
+	// A guard that classification never dereferences a nil index.
+	e := &DocEntry{Raw: []byte("name: value\n")}
+	require.NotPanics(t, func() { ResolveCursor(e, protocol.Position{Line: 0, Character: 6}) })
+}
+
+// helper visibility check: lastSegment handles indexed and dotted paths.
+func TestLastSegment(t *testing.T) {
+	assert.Equal(t, "provider", lastSegment("spec.resolvers.a.resolve.with[0].provider"))
+	assert.Equal(t, "with", lastSegment("spec.resolvers.a.resolve.with[0]"))
+	assert.Equal(t, "spec", lastSegment("spec"))
+	assert.Equal(t, "", lastSegment(""))
+}
+
+func TestCursorKind_String(t *testing.T) {
+	cases := map[CursorKind]string{
+		CursorNone:         "none",
+		CursorSymbolRef:    "symbolRef",
+		CursorYAMLKey:      "yamlKey",
+		CursorEnumValue:    "enumValue",
+		CursorCEL:          "cel",
+		CursorTemplate:     "template",
+		CursorProviderName: "providerName",
+		CursorKind(99):     "none",
+	}
+	for k, want := range cases {
+		assert.Equal(t, want, k.String())
+	}
+}
+
+func TestBackwardIdent_Guards(t *testing.T) {
+	assert.Equal(t, "", backwardIdent("abc", -1))
+	assert.Equal(t, "abc", backwardIdent("abc", 99))
+	assert.Equal(t, "", backwardDotIdent("abc", -1))
+	assert.Equal(t, "a.b", backwardDotIdent("a.b", 99))
+}

--- a/pkg/lsp/cursor_test.go
+++ b/pkg/lsp/cursor_test.go
@@ -330,6 +330,82 @@ spec:
 	assert.True(t, strings.HasSuffix(ctx.Path, ".tmpl"))
 }
 
+func TestResolveCursor_FoldedBlockScalarCELBody(t *testing.T) {
+	// A folded (>-) multi-line CEL body. yaml.v3 folds the body's line breaks
+	// into spaces in the scalar value (often yielding 0 newlines), so the block
+	// span must be derived from source geometry, not the value's newline count.
+	// A cursor on any body line must still classify as CEL.
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: >-
+                  size(_.foo) &&
+                  bigFunc(_.bar)
+`
+	pos := posAt(t, content, "bigFunc(_.bar)", "bigFunc", 3)
+	ctx := resolveFixture(t, content, pos)
+	assert.Equal(t, CursorCEL, ctx.Kind, "path=%q partial=%q", ctx.Path, ctx.PartialToken)
+	assert.Equal(t, "big", ctx.PartialToken)
+	assert.True(t, strings.HasSuffix(ctx.Path, ".expr"))
+}
+
+func TestResolveCursor_FoldedBlockScalarTemplateBody(t *testing.T) {
+	// A folded (>-) multi-line template body: the second body line must still be
+	// recognized as inside the enclosing block scalar despite yaml.v3 folding.
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              value:
+                tmpl: >-
+                  Hello world
+                  {{ upperCase .name }}
+`
+	pos := posAt(t, content, "{{ upperCase .name }}", "upperCase", 5)
+	ctx := resolveFixture(t, content, pos)
+	assert.Equal(t, CursorTemplate, ctx.Kind, "path=%q partial=%q prefix=%q", ctx.Path, ctx.PartialToken, ctx.ExprPrefix)
+	assert.Equal(t, "upper", ctx.PartialToken)
+	assert.Equal(t, "", ctx.ExprPrefix)
+	assert.True(t, strings.HasSuffix(ctx.Path, ".tmpl"))
+}
+
+func TestResolveCursor_ProviderNameHyphenPartial(t *testing.T) {
+	// Provider names commonly contain hyphens (e.g. go-template); the partial
+	// token for provider-name completion must keep the hyphen, not truncate to
+	// the suffix after the last '-'.
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: go-templ
+`
+	pos := posAt(t, content, "provider: go-templ", "go-templ", len("go-templ"))
+	ctx := resolveFixture(t, content, pos)
+	assert.Equal(t, CursorProviderName, ctx.Kind, "path=%q", ctx.Path)
+	assert.Equal(t, "go-templ", ctx.PartialToken)
+}
+
 func TestResolveCursor_FlowMappingSelectsByColumn(t *testing.T) {
 	// Two scalars share a line in a flow mapping; the cursor column must select
 	// the right one (onError, not provider) despite provider's longer path.


### PR DESCRIPTION
## What

Adds `pkg/lsp/cursor.go` with `ResolveCursor` -- the single classifier that
answers "what is under the cursor, and what kind of thing is it?" Hover,
completion, and signature help (#772/#773/#777) will dispatch on this one shared
`CursorContext` instead of each growing its own fragile "am I inside `{{ }}` / on
a YAML key?" scanner.

This is foundation issue #768 (needs #766's cache + `NodeMap`; both merged). It
is **not yet wired into any handler** -- the downstream feature PRs consume it.

## Classes

`ResolveCursor(doc *DocEntry, pos) CursorContext` classifies a position into one
of seven classes against the cached snapshot:

- **SymbolRef** -- a located resolver/action/call/function reference (delegates to
  the existing `symbolAt`). A complete `_.name` / `._.name` is a reference, which
  is the right context for completing an existing symbol.
- **YAMLKey** -- a mapping key (schema context), with the partial key typed.
- **EnumValue** -- a scalar whose leaf key is a fixed enum (`onError`/`backoff`/
  `resultSchemaMode`/`scope`).
- **CEL** -- inside a CEL expr/condition, capturing the partial token and `_.` /
  `__actions.` prefix (function-name and unresolved-token positions).
- **Template** -- inside a `{{ }}` tmpl value, capturing partial token and `._.` /
  `.__actions.` / `.` prefix.
- **ProviderName** -- a `provider:` value.
- **None** -- whitespace / unclassifiable.

## Design notes

- Reuses the cached node map (`DocEntry.Nodes`) + raw text -- **no new YAML engine**.
- Handles **multi-line block scalars** (`expr: |`, `tmpl: |`, and folded `>`/`>-`):
  yaml positions the value node on the key line, so a cursor in the body finds the
  enclosing block scalar by span. The span is derived from **raw source geometry**
  (indentation of the body relative to the key), which is style-agnostic --
  yaml.v3 folds a folded scalar's line breaks into spaces in the node value, so a
  newline count of the value would undercount the body.
- Partial-token/prefix extraction scans the **raw line**, so it is uniform across
  plain, quoted, and block-scalar values (no quote/indent offset math).
  Provider-name partial tokens keep `-`, so hyphenated providers (`go-template`,
  `go-template-extensions`) are not truncated; CEL/template identifiers still
  exclude `-` (it is an operator there).
- Flow mappings with multiple scalars on one line select the **value** by cursor
  **column**, not path length. A cursor on a *later key* of an inline flow entry
  (`{provider: ..., onError: ...}`) can still fall back to a sibling's path -- an
  accepted limitation of the text/column heuristic; block mappings (one key per
  line, the common form) resolve exactly.
- `lineAt` scans for the target line rather than splitting the whole document, to
  stay cheap on the per-keystroke hot path.
- Degrades to `CursorNone` (never panics) on a nil/parse-error doc (Nodes/Index
  may be nil) or an out-of-range position.

## Tests

- Table tests across all seven classes with position fixtures, plus block-scalar
  CEL/template bodies (literal **and folded**), a hyphenated provider partial
  token, flow-mapping column selection, resolver-prefix partials, and direct
  `celTokenAt`/`templateTokenAt` scanners.
- Degradation: nil doc, parse-error doc (text-based best effort), partial-build
  doc, out-of-range position, nil index.
- Benchmarks for the small hot path (~140ns/2 allocs) and a 200-resolver doc.

Coverage: `cursor.go` package 91.3%, `-race` clean, `lint:changed` 0 new issues.

## Acceptance criteria

- [x] All seven cursor classes correctly identified with position fixtures.
- [x] Partial token + expr prefix captured for CEL/template.
- [x] Returns `CursorNone` (no panic) on parse-error / out-of-range positions.

Closes #768
