### PR TITLE
test(integration): reusable LSP stdio session harness

### DIFF
--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13848,44 +13848,11 @@ func TestIntegration_LspInitializeAndDiagnostics(t *testing.T) {
 
 	badSolution := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: bad\nspec:\n  resolvers:\n    appName:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value:\n                expr: _.doesNotExist\n"
 
-	msgs := [][]byte{
-		lspFrame(t, map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{"capabilities": map[string]any{}}}),
-		lspFrame(t, map[string]any{"jsonrpc": "2.0", "method": "initialized", "params": map[string]any{}}),
-		lspFrame(t, map[string]any{"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": map[string]any{
-			"textDocument": map[string]any{"uri": "file:///tmp/bad.yaml", "languageId": "yaml", "version": 1, "text": badSolution},
-		}}),
-	}
+	// Migrated to the runLSPSession harness: this test sends no requests beyond
+	// the handshake + didOpen, so it exercises the harness's "diagnostics only"
+	// path (the server publishes diagnostics for the opened document on its own).
+	out := runLSPSession(t, badSolution)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, binaryPath, "lsp")
-	cmd.Dir = findProjectRoot()
-	stdin, err := cmd.StdinPipe()
-	require.NoError(t, err)
-	var outBuf lockedBuffer
-	cmd.Stdout = &outBuf
-	require.NoError(t, cmd.Start())
-
-	for _, m := range msgs {
-		_, werr := stdin.Write(m)
-		require.NoError(t, werr, "write LSP frame to server stdin")
-	}
-
-	// Wait until the diagnostics notification for the bad solution appears
-	// instead of sleeping a fixed amount, so the test is not flaky under load.
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if strings.Contains(outBuf.String(), "publishDiagnostics") &&
-			strings.Contains(outBuf.String(), "doesNotExist") {
-			break
-		}
-		time.Sleep(20 * time.Millisecond)
-	}
-	_ = stdin.Close()
-	_ = cmd.Process.Kill()
-	_ = cmd.Wait()
-
-	out := outBuf.String()
 	assert.Contains(t, out, `"capabilities"`, "initialize response")
 	assert.Contains(t, out, "scafctl lsp", "server info")
 	assert.Contains(t, out, "publishDiagnostics", "diagnostics notification")
@@ -13903,42 +13870,20 @@ func TestIntegration_LspRename(t *testing.T) {
 	// sits inside that identifier.
 	sol := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: nav\nspec:\n  resolvers:\n    environment:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value: dev\n    appName:\n      dependsOn:\n        - environment\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value:\n                expr: _.environment\n"
 
-	msgs := [][]byte{
-		lspFrame(t, map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{"capabilities": map[string]any{}}}),
-		lspFrame(t, map[string]any{"jsonrpc": "2.0", "method": "initialized", "params": map[string]any{}}),
-		lspFrame(t, map[string]any{"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": map[string]any{
-			"textDocument": map[string]any{"uri": "file:///nav.yaml", "languageId": "yaml", "version": 1, "text": sol},
-		}}),
-		lspFrame(t, map[string]any{"jsonrpc": "2.0", "id": 2, "method": "textDocument/rename", "params": map[string]any{
-			"textDocument": map[string]any{"uri": "file:///nav.yaml"},
+	// Migrated to the reusable runLSPSession harness: initialize + didOpen + the
+	// rename request + teardown are all handled by the helper. The request
+	// targets lspSessionURI (the URI the harness opens the document under).
+	out := runLSPSession(t, sol, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "textDocument/rename", "params": map[string]any{
+			"textDocument": map[string]any{"uri": lspSessionURI},
 			"position":     map[string]any{"line": 6, "character": 6},
 			"newName":      "env",
-		}}),
-	}
+		},
+	})
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, binaryPath, "lsp")
-	cmd.Dir = findProjectRoot()
-	stdin, err := cmd.StdinPipe()
-	require.NoError(t, err)
-	var outBuf bytes.Buffer
-	cmd.Stdout = &outBuf
-	require.NoError(t, cmd.Start())
-
-	for _, m := range msgs {
-		_, _ = stdin.Write(m)
-		time.Sleep(150 * time.Millisecond)
-	}
-	time.Sleep(700 * time.Millisecond)
-	_ = stdin.Close()
-	_ = cmd.Process.Kill()
-	_ = cmd.Wait()
-
-	out := outBuf.String()
 	assert.Contains(t, out, `"changes"`, "rename returns a workspace edit")
 	assert.Contains(t, out, `"newText":"env"`, "edits rename to env")
-	assert.Contains(t, out, "file:///nav.yaml", "edits target the document")
+	assert.Contains(t, out, lspSessionURI, "edits target the document")
 }
 
 // TestIntegration_LspStdioFlag verifies that `lsp --stdio` starts the server and

--- a/tests/integration/lsp_harness_test.go
+++ b/tests/integration/lsp_harness_test.go
@@ -1,0 +1,92 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// lspSessionURI is the document URI that runLSPSession opens docText under.
+// Requests passed to the harness (rename, hover, definition, ...) must target
+// this same URI in their params so they resolve against the opened document.
+const lspSessionURI = "file:///session.yaml"
+
+// runLSPSession spawns `scafctl lsp`, performs the standard LSP handshake
+// (initialize + initialized), opens docText via textDocument/didOpen at
+// lspSessionURI, then sends each request in order and returns the accumulated
+// server stdout.
+//
+// Each request is an already-shaped JSON-RPC payload (a map like
+// {"jsonrpc":"2.0","id":2,"method":"textDocument/rename","params":{...}}); the
+// harness frames it with lspFrame. The initialize request uses id 1, so give
+// request payloads ids >= 2 to avoid collisions.
+//
+// The helper returns once the server's stdout has been quiet for a short
+// settle window (or a max deadline elapses), rather than requiring each caller
+// to hard-code a stop condition. This lets one harness serve very different
+// request types. Callers assert on the returned stdout; because the transport
+// is line-delimited JSON-RPC frames, assertions typically use substring or
+// JSON checks against the accumulated output.
+func runLSPSession(t *testing.T, docText string, requests ...map[string]any) string {
+	t.Helper()
+
+	frames := make([][]byte, 0, 3+len(requests))
+	frames = append(frames,
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{"capabilities": map[string]any{}}}),
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "method": "initialized", "params": map[string]any{}}),
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": map[string]any{
+			"textDocument": map[string]any{"uri": lspSessionURI, "languageId": "yaml", "version": 1, "text": docText},
+		}}),
+	)
+	for _, r := range requests {
+		frames = append(frames, lspFrame(t, r))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binaryPath, "lsp")
+	cmd.Dir = findProjectRoot()
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	out := &lockedBuffer{}
+	cmd.Stdout = out
+	require.NoError(t, cmd.Start())
+
+	for _, m := range frames {
+		_, werr := stdin.Write(m)
+		require.NoError(t, werr, "write LSP frame to server stdin")
+	}
+
+	// Return once stdout has stopped growing for `quiet`, or after `maxWait`.
+	// Polling for a settle window (rather than a fixed sleep) keeps the helper
+	// fast in the common case and non-flaky under load.
+	const (
+		quiet   = 400 * time.Millisecond
+		maxWait = 8 * time.Second
+		tick    = 20 * time.Millisecond
+	)
+	start := time.Now()
+	lastLen := -1
+	lastChange := time.Now()
+	for time.Since(start) < maxWait {
+		cur := len(out.String())
+		if cur != lastLen {
+			lastLen = cur
+			lastChange = time.Now()
+		} else if cur > 0 && time.Since(lastChange) >= quiet {
+			break
+		}
+		time.Sleep(tick)
+	}
+
+	_ = stdin.Close()
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+	return out.String()
+}


### PR DESCRIPTION
## Summary

Extracts the ~40-line setup that every LSP integration test copy-pastes (spawn `scafctl lsp`, build JSON-RPC frames, handshake, `didOpen`, poll stdout, teardown) into a single reusable driver, so each feature test -- there are 8+ coming -- is a few lines instead of ~40, and the duplication can't drift.

## Contract

```go
func runLSPSession(t *testing.T, docText string, requests ...map[string]any) string
```

Spawns `scafctl lsp`, performs `initialize` + `initialized`, opens `docText` via `textDocument/didOpen` at the shared `lspSessionURI`, sends each already-shaped JSON-RPC request in order, and returns accumulated stdout. It returns once stdout has been quiet for a short settle window (or a max deadline), so one helper serves diagnostics, rename, hover, and future request types without each caller hard-coding a stop condition.

## Changes

- **New `tests/integration/lsp_harness_test.go`** -- `runLSPSession` + the `lspSessionURI` constant. Reuses the existing `lspFrame()` and `lockedBuffer` helpers unchanged.
- **`tests/integration/cli_test.go`** -- migrates two existing tests to the harness with identical assertions, proving parity across both usage shapes:
  - `TestIntegration_LspRename` -- handshake + `didOpen` + a request.
  - `TestIntegration_LspInitializeAndDiagnostics` -- diagnostics-only (no extra requests).
  - `TestIntegration_LspStdioFlag` is intentionally left as-is: it needs `--stdio` and stderr assertions that fall outside the harness's scope.

## Verification

- `go build ./...`, `go vet ./tests/integration/` -- pass.
- `go test ./tests/integration/ -run TestIntegration_Lsp` -- all 5 LSP tests pass (migrated ones green with unchanged assertions).
- `task lint:changed` -- 0 new issues.
- Test-only: **no server behavior change.**

## Acceptance criteria

- [x] Existing LSP integration tests migrated to `runLSPSession` and green (two migrated)
- [x] Helper handles initialize + didOpen + N requests + teardown
- [x] No behavior change to the server; test-only PR

Closes #769