### PR TITLE
feat(lsp): hover for symbols, providers, functions, and keys

### DIFF
--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -38,6 +38,25 @@ reusing the same reference index and rename engine as `scafctl refactor rename`:
   If any reference cannot be located, the rename is refused (the editor shows the
   error) rather than applying a partial, solution-breaking change.
 
+## Hover
+
+Hovering the cursor over a symbol shows contextual markdown pulled from the same
+sources the CLI already knows about -- no separate documentation to maintain:
+
+- **Resolver / action / call / function reference** -> its kind, name, and
+  `description` from the solution.
+- **Provider name** (a `provider:` value) -> the provider's description and a
+  summary of its input schema (each input's name, type, whether it is required,
+  and its doc), straight from the provider descriptor.
+- **CEL / template function** -> the function's signature (CEL), description, and
+  a usage example, from the built-in function registries (the same set the
+  `list_cel_functions` / `list_go_template_functions` MCP tools report).
+- **Mapping key** -> the schema documentation for that field, plus a related
+  concept summary when one matches.
+
+Hover degrades gracefully: on an unknown target, a parse error, or whitespace it
+simply returns nothing, so it never interrupts editing.
+
 ## Trying it by hand
 
 You normally never run the server directly, but you can confirm it starts:
@@ -86,9 +105,9 @@ needed to keep editor and CLI diagnostics consistent.
 
 ## What's next
 
-Navigation and rename currently cover resolvers. Planned additions extend the
-same reference index to actions, functions, and calls, and add hover and
-completion.
+Navigation, rename, and hover cover resolvers, actions, functions, and calls.
+Planned additions extend the same cursor-context resolver to completion and
+signature help.
 
 ## See also
 

--- a/pkg/lsp/capabilities.go
+++ b/pkg/lsp/capabilities.go
@@ -40,6 +40,7 @@ type feature struct {
 func defaultFeatures() []feature {
 	return []feature{
 		documentSyncFeature(),
+		hoverFeature(),
 		navigationFeature(),
 		renameFeature(),
 	}

--- a/pkg/lsp/capabilities_test.go
+++ b/pkg/lsp/capabilities_test.go
@@ -23,7 +23,7 @@ func TestDefaultFeatures_DeterministicOrder(t *testing.T) {
 		got = append(got, f.name)
 		require.NotNil(t, f.wire, "every feature must wire a handler")
 	}
-	assert.Equal(t, []string{"documentSync", "navigation", "rename"}, got)
+	assert.Equal(t, []string{"documentSync", "hover", "navigation", "rename"}, got)
 	assert.True(t, sort.StringsAreSorted(got), "features must be registered in alphabetical order")
 }
 

--- a/pkg/lsp/funcref.go
+++ b/pkg/lsp/funcref.go
@@ -109,18 +109,40 @@ func (i *funcIndex) add(info FuncInfo, subNames []string) {
 
 // LookupFunc returns the metadata for the function named name, searching CEL
 // functions first, then Go-template functions. ok is false when no function of
-// that name exists in either registry.
+// that name exists in either registry. The returned FuncInfo's Examples slice is
+// a copy, so callers may retain or mutate it without corrupting the shared,
+// effectively-immutable function index.
 func LookupFunc(name string) (FuncInfo, bool) {
 	info, ok := getFuncIndex().byName[name]
-	return info, ok
+	if !ok {
+		return FuncInfo{}, false
+	}
+	info.Examples = cloneExamples(info.Examples)
+	return info, true
 }
 
 // AllFuncs returns every known function's metadata (CEL first, then template),
-// de-duplicated by primary name. The returned slice is a copy the caller may
-// retain.
+// de-duplicated by primary name. The returned slice -- including each entry's
+// Examples slice -- is a copy the caller may retain or mutate without affecting
+// the shared function index.
 func AllFuncs() []FuncInfo {
 	src := getFuncIndex().all
 	out := make([]FuncInfo, len(src))
+	copy(out, src)
+	for i := range out {
+		out[i].Examples = cloneExamples(out[i].Examples)
+	}
+	return out
+}
+
+// cloneExamples returns a copy of the examples slice, or nil when empty, so
+// callers cannot mutate the function index's shared backing storage. Element
+// strings are immutable, so a shallow copy of the slice suffices.
+func cloneExamples(src []string) []string {
+	if len(src) == 0 {
+		return nil
+	}
+	out := make([]string, len(src))
 	copy(out, src)
 	return out
 }

--- a/pkg/lsp/funcref.go
+++ b/pkg/lsp/funcref.go
@@ -1,0 +1,126 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"sync"
+
+	celexpext "github.com/oakwood-commons/scafctl/pkg/celexp/ext"
+	gotmplext "github.com/oakwood-commons/scafctl/pkg/gotmpl/ext"
+)
+
+// FuncInfo is a uniform view of a CEL or Go-template function's metadata, shared
+// by hover (#772), function completion (#775), and signature help (#777) so all
+// three surface the same information from one source of truth.
+type FuncInfo struct {
+	// Name is the function name as written in an expression/template.
+	Name string
+	// Signature is the type signature (CEL functions only; empty for templates).
+	Signature string
+	// Description is the human-readable description.
+	Description string
+	// Examples are usage snippets (CEL expressions or template snippets).
+	Examples []string
+	// CEL reports whether the function is a CEL function (true) or a Go-template
+	// function (false).
+	CEL bool
+}
+
+// funcIndex is the lazily-built, immutable lookup over both function registries.
+type funcIndex struct {
+	byName map[string]FuncInfo // keyed by every invocable name
+	all    []FuncInfo          // stable, de-duplicated order (CEL first)
+}
+
+var (
+	funcIndexOnce sync.Once
+	funcIndexVal  *funcIndex
+)
+
+// getFuncIndex builds the function index once. The registries are static for the
+// life of the process, so a single build is safe and cheap on the hot path.
+func getFuncIndex() *funcIndex {
+	funcIndexOnce.Do(func() {
+		idx := &funcIndex{byName: make(map[string]FuncInfo)}
+
+		// CEL functions first, so a name present in both registries resolves to
+		// its CEL definition (CEL is the primary expression language).
+		for _, f := range celexpext.All() {
+			info := FuncInfo{
+				Name:        f.Name,
+				Signature:   f.Signature,
+				Description: f.Description,
+				CEL:         true,
+			}
+			for _, ex := range f.Examples {
+				if ex.Expression != "" {
+					info.Examples = append(info.Examples, ex.Expression)
+				}
+			}
+			idx.add(info, f.GetSubNames())
+		}
+
+		for _, f := range gotmplext.All() {
+			info := FuncInfo{
+				Name:        f.Name,
+				Description: f.Description,
+				CEL:         false,
+			}
+			for _, ex := range f.Examples {
+				if ex.Template != "" {
+					info.Examples = append(info.Examples, ex.Template)
+				}
+			}
+			idx.add(info, nil)
+		}
+
+		funcIndexVal = idx
+	})
+	return funcIndexVal
+}
+
+// add records info under its Name and any additional invocable sub-names,
+// without overwriting an already-registered name (CEL registered first wins).
+// Only the primary entry is appended to `all`; sub-names are lookup-only (they
+// resolve via LookupFunc but are not enumerated by AllFuncs), so callers that
+// list functions see one entry per function rather than every alias form.
+func (i *funcIndex) add(info FuncInfo, subNames []string) {
+	if info.Name == "" {
+		return
+	}
+	if _, exists := i.byName[info.Name]; !exists {
+		i.byName[info.Name] = info
+		i.all = append(i.all, info)
+	}
+	for _, sub := range subNames {
+		if sub == "" || sub == info.Name {
+			continue
+		}
+		if _, exists := i.byName[sub]; !exists {
+			// Sub-names (e.g. base64.encode within an "encoders" group) resolve
+			// to the group's metadata but report their own invocable name.
+			entry := info
+			entry.Name = sub
+			i.byName[sub] = entry
+		}
+	}
+}
+
+// LookupFunc returns the metadata for the function named name, searching CEL
+// functions first, then Go-template functions. ok is false when no function of
+// that name exists in either registry.
+func LookupFunc(name string) (FuncInfo, bool) {
+	info, ok := getFuncIndex().byName[name]
+	return info, ok
+}
+
+// AllFuncs returns every known function's metadata (CEL first, then template),
+// de-duplicated by primary name. The returned slice is a copy the caller may
+// retain.
+func AllFuncs() []FuncInfo {
+	src := getFuncIndex().all
+	out := make([]FuncInfo, len(src))
+	copy(out, src)
+	return out
+}

--- a/pkg/lsp/funcref_test.go
+++ b/pkg/lsp/funcref_test.go
@@ -1,0 +1,98 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"testing"
+
+	celexpext "github.com/oakwood-commons/scafctl/pkg/celexp/ext"
+	gotmplext "github.com/oakwood-commons/scafctl/pkg/gotmpl/ext"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupFunc_CEL(t *testing.T) {
+	fi, ok := LookupFunc("arrays.groupBy")
+	require.True(t, ok, "arrays.groupBy should be a known CEL function")
+	assert.True(t, fi.CEL)
+	assert.Equal(t, "arrays.groupBy", fi.Name)
+	assert.NotEmpty(t, fi.Signature, "CEL functions carry a signature")
+	assert.NotEmpty(t, fi.Description)
+}
+
+func TestLookupFunc_Template(t *testing.T) {
+	fi, ok := LookupFunc("upper")
+	require.True(t, ok, "upper should be a known template function")
+	assert.False(t, fi.CEL)
+	assert.Equal(t, "upper", fi.Name)
+	assert.Empty(t, fi.Signature, "template functions have no CEL signature")
+	assert.NotEmpty(t, fi.Description)
+}
+
+func TestLookupFunc_Unknown(t *testing.T) {
+	_, ok := LookupFunc("definitelyNotARealFunction")
+	assert.False(t, ok)
+
+	_, ok = LookupFunc("")
+	assert.False(t, ok)
+}
+
+func TestAllFuncs(t *testing.T) {
+	all := AllFuncs()
+	require.NotEmpty(t, all)
+
+	var cel, tmpl int
+	seen := map[string]bool{}
+	for _, f := range all {
+		assert.NotEmpty(t, f.Name)
+		assert.False(t, seen[f.Name], "duplicate name %q in AllFuncs", f.Name)
+		seen[f.Name] = true
+		if f.CEL {
+			cel++
+		} else {
+			tmpl++
+		}
+	}
+	assert.Positive(t, cel, "should include CEL functions")
+	assert.Positive(t, tmpl, "should include template functions")
+
+	// The returned slice is a copy; mutating it must not affect the index.
+	all[0].Name = "mutated"
+	fresh := AllFuncs()
+	assert.NotEqual(t, "mutated", fresh[0].Name)
+}
+
+func TestLookupFunc_ExamplesPopulated(t *testing.T) {
+	// arrays.groupBy ships examples; verify they are surfaced.
+	fi, ok := LookupFunc("arrays.groupBy")
+	require.True(t, ok)
+	assert.NotEmpty(t, fi.Examples)
+}
+
+func TestLookupFunc_CELFirstPrecedence(t *testing.T) {
+	// A name registered in both the CEL and template registries must resolve to
+	// its CEL definition (CEL is the primary expression language). This locks the
+	// contract that #775/#777 rely on. Find an overlapping name dynamically so
+	// the test stays valid as the registries evolve.
+	cel := map[string]bool{}
+	for _, f := range celexpext.All() {
+		cel[f.Name] = true
+		for _, sub := range f.GetSubNames() {
+			cel[sub] = true
+		}
+	}
+	overlap := ""
+	for _, f := range gotmplext.All() {
+		if cel[f.Name] {
+			overlap = f.Name
+			break
+		}
+	}
+	if overlap == "" {
+		t.Skip("no name is registered in both the CEL and template registries")
+	}
+	fi, ok := LookupFunc(overlap)
+	require.True(t, ok)
+	assert.True(t, fi.CEL, "overlapping name %q must resolve to the CEL definition", overlap)
+}

--- a/pkg/lsp/funcref_test.go
+++ b/pkg/lsp/funcref_test.go
@@ -70,6 +70,44 @@ func TestLookupFunc_ExamplesPopulated(t *testing.T) {
 	assert.NotEmpty(t, fi.Examples)
 }
 
+func TestLookupFunc_ExamplesAreACopy(t *testing.T) {
+	// The returned Examples slice must be a copy: mutating an element (or
+	// appending into spare capacity) must not corrupt the shared index that
+	// subsequent hover/completion/signature-help calls read.
+	fi, ok := LookupFunc("arrays.groupBy")
+	require.True(t, ok)
+	require.NotEmpty(t, fi.Examples)
+	orig := fi.Examples[0]
+	fi.Examples[0] = "mutated"
+
+	fresh, ok := LookupFunc("arrays.groupBy")
+	require.True(t, ok)
+	require.NotEmpty(t, fresh.Examples)
+	assert.Equal(t, orig, fresh.Examples[0], "mutating a returned example must not affect the index")
+}
+
+func TestAllFuncs_ExamplesAreACopy(t *testing.T) {
+	// AllFuncs promises a copy the caller may retain or mutate; that guarantee
+	// must extend to each entry's Examples slice, not just the outer slice.
+	all := AllFuncs()
+	idx := -1
+	for i := range all {
+		if len(all[i].Examples) > 0 {
+			idx = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, idx, 0, "expected at least one function with examples")
+	orig := all[idx].Examples[0]
+	name := all[idx].Name
+	all[idx].Examples[0] = "mutated"
+
+	fresh, ok := LookupFunc(name)
+	require.True(t, ok)
+	require.NotEmpty(t, fresh.Examples)
+	assert.Equal(t, orig, fresh.Examples[0], "mutating an AllFuncs example must not affect the index")
+}
+
 func TestLookupFunc_CELFirstPrecedence(t *testing.T) {
 	// A name registered in both the CEL and template registries must resolve to
 	// its CEL definition (CEL is the primary expression language). This locks the

--- a/pkg/lsp/hover.go
+++ b/pkg/lsp/hover.go
@@ -1,0 +1,351 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/concepts"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/oakwood-commons/scafctl/pkg/schema"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// hoverFeature registers textDocument/hover. glsp derives the HoverProvider
+// capability from the wired handler, so no advertise func is needed.
+func hoverFeature() feature {
+	return feature{
+		name: "hover",
+		wire: func(h *protocol.Handler, s *Server) {
+			h.TextDocumentHover = s.hover
+		},
+	}
+}
+
+// hover answers textDocument/hover by classifying the cursor and rendering
+// markdown from existing sources (symbol descriptions, provider descriptors,
+// function metadata, schema field docs). It returns nil (no hover) for unknown
+// targets and never panics on a parse-error/unknown document.
+func (s *Server) hover(_ *glsp.Context, params *protocol.HoverParams) (*protocol.Hover, error) {
+	entry, ok := s.getDoc(params.TextDocument.URI)
+	if !ok {
+		return nil, nil
+	}
+	cc := ResolveCursor(entry, params.Position)
+	md := s.hoverMarkdown(entry, cc, params.Position)
+	if md == "" {
+		return nil, nil
+	}
+	hov := &protocol.Hover{
+		Contents: protocol.MarkupContent{Kind: protocol.MarkupKindMarkdown, Value: md},
+	}
+	if cc.Kind == CursorSymbolRef && cc.Ref != nil {
+		rng := toLSPRange(cc.Ref.Range)
+		hov.Range = &rng
+	}
+	return hov, nil
+}
+
+// hoverMarkdown renders the hover body for a resolved cursor context, or "" when
+// there is nothing useful to show.
+func (s *Server) hoverMarkdown(entry *DocEntry, cc CursorContext, pos protocol.Position) string {
+	switch cc.Kind {
+	case CursorSymbolRef:
+		return symbolHover(entry, cc.Ref)
+	case CursorProviderName:
+		return s.providerHover(cc)
+	case CursorCEL, CursorTemplate:
+		// Only bare function-name tokens (no reference prefix) have function
+		// metadata; a prefixed token is a data/resolver reference.
+		if cc.ExprPrefix != "" {
+			return ""
+		}
+		return funcHover(fullIdentAt(entry.Raw, pos))
+	case CursorYAMLKey:
+		return keyHover(cc.Path)
+	case CursorNone, CursorEnumValue:
+		return ""
+	default:
+		return ""
+	}
+}
+
+// symbolHover renders a symbol reference's kind, name, and description (from the
+// parsed solution).
+func symbolHover(entry *DocEntry, ref *refindex.Reference) string {
+	if ref == nil {
+		return ""
+	}
+	kind := ref.Symbol.Kind
+	name := ref.Symbol.Name
+	var b strings.Builder
+	fmt.Fprintf(&b, "**%s** `%s`", kind.String(), name)
+	if desc := symbolDescription(entry.Sol, kind, name); desc != "" {
+		b.WriteString("\n\n")
+		b.WriteString(desc)
+	}
+	return b.String()
+}
+
+// symbolDescription looks up the description of a (kind, name) symbol in the
+// parsed solution. Returns "" when the solution is unavailable or the symbol has
+// no description.
+func symbolDescription(sol *solution.Solution, kind refindex.SymbolKind, name string) string {
+	if sol == nil {
+		return ""
+	}
+	switch kind {
+	case refindex.SymbolResolver:
+		if r, ok := sol.Spec.Resolvers[name]; ok && r != nil {
+			return r.Description
+		}
+	case refindex.SymbolCall:
+		if c, ok := sol.Spec.Calls[name]; ok && c != nil {
+			return c.Description
+		}
+	case refindex.SymbolFunction:
+		if f, ok := sol.Spec.Functions[name]; ok && f != nil {
+			return f.Description
+		}
+	case refindex.SymbolAction:
+		if sol.Spec.Workflow != nil {
+			if a, ok := sol.Spec.Workflow.Actions[name]; ok && a != nil {
+				return a.Description
+			}
+			if a, ok := sol.Spec.Workflow.Finally[name]; ok && a != nil {
+				return a.Description
+			}
+		}
+	}
+	return ""
+}
+
+// providerHover renders a provider descriptor's identity, description, and input
+// schema summary. Returns "" when the provider is unknown or the registry is
+// unavailable.
+func (s *Server) providerHover(cc CursorContext) string {
+	if s.registry == nil || cc.Node == nil {
+		return ""
+	}
+	name := cc.Node.Value
+	p, ok := s.registry.Get(name)
+	if !ok {
+		return ""
+	}
+	d := p.Descriptor()
+	var b strings.Builder
+	title := d.Name
+	if d.DisplayName != "" {
+		title = d.DisplayName
+	}
+	fmt.Fprintf(&b, "**provider** `%s`", title)
+	if d.Description != "" {
+		b.WriteString("\n\n")
+		b.WriteString(d.Description)
+	}
+	if summary := providerInputSummary(d); summary != "" {
+		b.WriteString("\n\n**Inputs:**\n")
+		b.WriteString(summary)
+	}
+	return b.String()
+}
+
+// providerInputSummary lists a provider's input properties (name, type, required
+// marker, description) from its JSON schema.
+func providerInputSummary(d *provider.Descriptor) string {
+	if d.Schema == nil || len(d.Schema.Properties) == 0 {
+		return ""
+	}
+	required := make(map[string]bool, len(d.Schema.Required))
+	for _, r := range d.Schema.Required {
+		required[r] = true
+	}
+	names := make([]string, 0, len(d.Schema.Properties))
+	for n := range d.Schema.Properties {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	for _, n := range names {
+		prop := d.Schema.Properties[n]
+		typ := ""
+		if prop != nil && prop.Type != "" {
+			typ = " (" + prop.Type + ")"
+		}
+		req := ""
+		if required[n] {
+			req = " *required*"
+		}
+		fmt.Fprintf(&b, "- `%s`%s%s", n, typ, req)
+		if prop != nil && prop.Description != "" {
+			fmt.Fprintf(&b, " -- %s", firstLine(prop.Description))
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// funcHover renders a CEL/template function's signature, description, and first
+// example. Returns "" when name is not a known function.
+func funcHover(name string) string {
+	if name == "" {
+		return ""
+	}
+	fi, ok := LookupFunc(name)
+	if !ok {
+		return ""
+	}
+	lang := "template"
+	if fi.CEL {
+		lang = "CEL"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "**%s function** `%s`", lang, fi.Name)
+	if fi.Signature != "" {
+		fmt.Fprintf(&b, "\n\n```\n%s\n```", fi.Signature)
+	}
+	if fi.Description != "" {
+		b.WriteString("\n\n")
+		b.WriteString(fi.Description)
+	}
+	if len(fi.Examples) > 0 {
+		fmt.Fprintf(&b, "\n\n_Example:_\n\n```\n%s\n```", fi.Examples[0])
+	}
+	return b.String()
+}
+
+// keyHover renders the schema documentation for a mapping key at a logical path,
+// plus a related concept summary when one matches the key name.
+func keyHover(path string) string {
+	var b strings.Builder
+	if fi, ok := fieldInfoForPath(path); ok && fi.Description != "" {
+		key := lastSegment(path)
+		fmt.Fprintf(&b, "**field** `%s`", key)
+		if fi.Type != "" {
+			fmt.Fprintf(&b, " (%s)", fi.Type)
+		}
+		b.WriteString("\n\n")
+		b.WriteString(fi.Description)
+	}
+	if c, ok := concepts.Get(lastSegment(path)); ok {
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		fmt.Fprintf(&b, "**concept: %s** -- %s", c.Title, c.Summary)
+	}
+	return b.String()
+}
+
+// fieldInfoForPath introspects the solution schema for the field at a logical
+// path. The path is normalized first: sequence indices ([i]) and dynamic
+// map-key segments (resolver/action/call/function/input names) are removed
+// because the schema introspector navigates struct/field and map-value types,
+// not concrete keys.
+func fieldInfoForPath(path string) (*schema.FieldInfo, bool) {
+	if path == "" {
+		return nil, false
+	}
+	fi, err := schema.IntrospectField((*solution.Solution)(nil), schemaPath(path))
+	if err != nil || fi == nil {
+		return nil, false
+	}
+	return fi, true
+}
+
+// mapContainerKeys are the fields whose values are keyed by a dynamic name; the
+// segment immediately after one of these is a concrete key, not a schema field,
+// so it is dropped when normalizing a logical path for schema introspection.
+var mapContainerKeys = map[string]struct{}{
+	"resolvers": {},
+	"calls":     {},
+	"functions": {},
+	"actions":   {},
+	"finally":   {},
+	"inputs":    {},
+	"args":      {},
+}
+
+// schemaPath normalizes a logical YAML path into the field path expected by
+// schema.IntrospectField: it strips [i] indices and the dynamic map-key segment
+// that follows any mapContainerKeys entry.
+func schemaPath(path string) string {
+	segs := strings.Split(stripIndices(path), ".")
+	out := make([]string, 0, len(segs))
+	skipNext := false
+	for _, seg := range segs {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		out = append(out, seg)
+		if _, ok := mapContainerKeys[seg]; ok {
+			skipNext = true
+		}
+	}
+	return strings.Join(out, ".")
+}
+
+// stripIndices removes [i] sequence subscripts from a logical path so it matches
+// the struct-field navigation used by schema.IntrospectField.
+func stripIndices(path string) string {
+	var b strings.Builder
+	depth := 0
+	for _, r := range path {
+		switch r {
+		case '[':
+			depth++
+		case ']':
+			if depth > 0 {
+				depth--
+			}
+		default:
+			if depth == 0 {
+				b.WriteRune(r)
+			}
+		}
+	}
+	return b.String()
+}
+
+// fullIdentAt returns the complete function identifier under pos, scanning both
+// backward and forward over identifier runes (and '.', so namespaced names like
+// "arrays.groupBy" are captured whole) on the cursor's line. Used to recover a
+// function name from a cursor that may sit mid-token.
+func fullIdentAt(raw []byte, pos protocol.Position) string {
+	line, ok := lineAt(raw, int(pos.Line))
+	if !ok {
+		return ""
+	}
+	runes := []rune(line)
+	col := int(pos.Character)
+	if col > len(runes) {
+		col = len(runes)
+	}
+	isTok := func(r rune) bool { return isIdentRune(r) || r == '.' }
+	start := col
+	for start > 0 && isTok(runes[start-1]) {
+		start--
+	}
+	end := col
+	for end < len(runes) && isTok(runes[end]) {
+		end++
+	}
+	return strings.Trim(string(runes[start:end]), ".")
+}
+
+// firstLine returns the first non-empty line of s, trimmed.
+func firstLine(s string) string {
+	for _, ln := range strings.Split(s, "\n") {
+		if t := strings.TrimSpace(ln); t != "" {
+			return t
+		}
+	}
+	return ""
+}

--- a/pkg/lsp/hover.go
+++ b/pkg/lsp/hover.go
@@ -140,11 +140,12 @@ func (s *Server) providerHover(cc CursorContext) string {
 	}
 	d := p.Descriptor()
 	var b strings.Builder
-	title := d.Name
-	if d.DisplayName != "" {
-		title = d.DisplayName
+	// Lead with the canonical registry name -- the identifier the user typed in
+	// YAML -- and fold in the friendly display name when it differs.
+	fmt.Fprintf(&b, "**provider** `%s`", d.Name)
+	if d.DisplayName != "" && d.DisplayName != d.Name {
+		fmt.Fprintf(&b, " -- %s", d.DisplayName)
 	}
-	fmt.Fprintf(&b, "**provider** `%s`", title)
 	if d.Description != "" {
 		b.WriteString("\n\n")
 		b.WriteString(d.Description)

--- a/pkg/lsp/hover.go
+++ b/pkg/lsp/hover.go
@@ -225,16 +225,23 @@ func funcHover(name string) string {
 // plus a related concept summary when one matches the key name.
 func keyHover(path string) string {
 	var b strings.Builder
+	// Derive the displayed name and concept key from the NORMALIZED path so the
+	// label matches the field actually introspected. fieldInfoForPath normalizes
+	// via schemaPath, which strips dynamic map-key segments (e.g. a resolver or
+	// input name under a mapContainerKeys parent). Labeling with the raw last
+	// segment would show the container field's doc under the wrong (instance)
+	// name -- e.g. hovering "myInput" under inputs: would display the inputs
+	// field doc labeled "myInput".
+	label := lastSegment(schemaPath(path))
 	if fi, ok := fieldInfoForPath(path); ok && fi.Description != "" {
-		key := lastSegment(path)
-		fmt.Fprintf(&b, "**field** `%s`", key)
+		fmt.Fprintf(&b, "**field** `%s`", label)
 		if fi.Type != "" {
 			fmt.Fprintf(&b, " (%s)", fi.Type)
 		}
 		b.WriteString("\n\n")
 		b.WriteString(fi.Description)
 	}
-	if c, ok := concepts.Get(lastSegment(path)); ok {
+	if c, ok := concepts.Get(label); ok {
 		if b.Len() > 0 {
 			b.WriteString("\n\n")
 		}

--- a/pkg/lsp/hover_test.go
+++ b/pkg/lsp/hover_test.go
@@ -229,3 +229,14 @@ func TestKeyHover_Concept(t *testing.T) {
 	assert.Contains(t, md, "concept")
 	assert.Contains(t, md, "Workflow")
 }
+
+func TestKeyHover_DynamicMapKeyUsesNormalizedLabel(t *testing.T) {
+	// Hovering a dynamic map-key segment (a resolver instance name under
+	// resolvers:) must label the hover with the normalized container field
+	// ("resolvers") whose doc is actually shown -- not the raw instance name,
+	// which would mislabel the container field's doc.
+	md := keyHover("spec.resolvers.myResolver")
+	assert.Contains(t, md, "**field** `resolvers`", "labels with the normalized field, not the instance name")
+	assert.Contains(t, md, "Resolver definitions keyed by name", "shows the resolvers field doc")
+	assert.NotContains(t, md, "myResolver", "must not label the container doc with the dynamic key name")
+}

--- a/pkg/lsp/hover_test.go
+++ b/pkg/lsp/hover_test.go
@@ -1,0 +1,231 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+const hoverFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: hover
+spec:
+  resolvers:
+    environment:
+      description: The target deployment environment
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    greeting:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              value:
+                tmpl: "{{ upper .name }}"
+        when: _.environment == "dev"
+`
+
+// hoverAt opens the fixture and returns the hover markdown at the position of
+// token (offset by within) on the first line containing lineHint. Empty string
+// means no hover.
+func hoverAt(t *testing.T, lineHint, token string, within int) string {
+	t.Helper()
+	s := newTestServer(t)
+	uri := protocol.DocumentUri("file:///hover.yaml")
+	s.setDoc(uri, 1, hoverFixture)
+	pos := posAt(t, hoverFixture, lineHint, token, within)
+	h, err := s.hover(nil, &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+			Position:     pos,
+		},
+	})
+	require.NoError(t, err)
+	if h == nil {
+		return ""
+	}
+	mc, ok := h.Contents.(protocol.MarkupContent)
+	require.True(t, ok, "hover contents should be MarkupContent")
+	assert.Equal(t, protocol.MarkupKindMarkdown, mc.Kind)
+	return mc.Value
+}
+
+func TestHover_SymbolRef(t *testing.T) {
+	md := hoverAt(t, `when: _.environment`, "environment ==", 1)
+	assert.Contains(t, md, "resolver")
+	assert.Contains(t, md, "environment")
+	assert.Contains(t, md, "The target deployment environment", "shows the symbol description")
+}
+
+func TestHover_ProviderName(t *testing.T) {
+	md := hoverAt(t, "provider: parameter", "parameter", 2)
+	assert.Contains(t, md, "provider")
+	assert.Contains(t, strings.ToLower(md), "parameter")
+	assert.Contains(t, md, "**Inputs:**", "provider hover lists inputs")
+}
+
+func TestHover_TemplateFunction(t *testing.T) {
+	md := hoverAt(t, `tmpl: "{{ upper .name }}"`, "upper", 2)
+	assert.Contains(t, md, "template function")
+	assert.Contains(t, md, "upper")
+}
+
+func TestHover_YAMLKey(t *testing.T) {
+	md := hoverAt(t, "      description: The target", "description", 2)
+	assert.Contains(t, md, "field")
+	assert.Contains(t, md, "description")
+	assert.Contains(t, md, "Human-readable", "shows the schema field doc")
+}
+
+func TestHover_None(t *testing.T) {
+	// Whitespace in indentation yields no hover.
+	md := hoverAt(t, "provider: parameter", "provider", -4)
+	assert.Empty(t, md)
+}
+
+func TestHover_UnknownDocument(t *testing.T) {
+	s := newTestServer(t)
+	h, err := s.hover(nil, &protocol.HoverParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///missing.yaml"},
+			Position:     protocol.Position{},
+		},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, h)
+}
+
+func TestHover_ParseErrorNoPanic(t *testing.T) {
+	s := newTestServer(t)
+	uri := protocol.DocumentUri("file:///bad.yaml")
+	s.setDoc(uri, 1, "spec: {resolvers:\n  provider: parameter")
+	require.NotPanics(t, func() {
+		_, err := s.hover(nil, &protocol.HoverParams{
+			TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+				TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+				Position:     protocol.Position{Line: 1, Character: 4},
+			},
+		})
+		require.NoError(t, err)
+	})
+}
+
+func TestHover_CELFunctionDirect(t *testing.T) {
+	// Namespaced CEL function names are captured whole.
+	md := funcHover("arrays.groupBy")
+	assert.Contains(t, md, "CEL function")
+	assert.Contains(t, md, "arrays.groupBy")
+	assert.Contains(t, md, "Example")
+}
+
+func TestHover_FeatureRegisteredAndAdvertised(t *testing.T) {
+	s := newTestServer(t)
+	h := s.Handler()
+	assert.NotNil(t, h.TextDocumentHover, "hover handler wired")
+
+	res, err := h.Initialize(nil, &protocol.InitializeParams{})
+	require.NoError(t, err)
+	init := res.(protocol.InitializeResult)
+	assert.Equal(t, true, init.Capabilities.HoverProvider, "HoverProvider advertised")
+}
+
+func TestSchemaPath(t *testing.T) {
+	cases := map[string]string{
+		"spec.resolvers.environment.description":             "spec.resolvers.description",
+		"spec.resolvers.a.resolve.with[0].provider":          "spec.resolvers.resolve.with.provider",
+		"spec.resolvers.a.resolve.with[0].inputs.value.expr": "spec.resolvers.resolve.with.inputs.expr",
+		"spec.workflow.actions.deploy.provider":              "spec.workflow.actions.provider",
+		"metadata.name":                                      "metadata.name",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, schemaPath(in), "schemaPath(%q)", in)
+	}
+}
+
+func TestStripIndices(t *testing.T) {
+	assert.Equal(t, "a.b.c", stripIndices("a.b[0].c"))
+	assert.Equal(t, "a.b.c", stripIndices("a.b[10].c[2]"))
+	assert.Equal(t, "a", stripIndices("a"))
+}
+
+func TestFullIdentAt(t *testing.T) {
+	raw := []byte("  value: arrays.groupBy(x)\n")
+	// cursor inside "groupBy"
+	got := fullIdentAt(raw, protocol.Position{Line: 0, Character: 18})
+	assert.Equal(t, "arrays.groupBy", got)
+}
+
+func TestSymbolDescription_AllKinds(t *testing.T) {
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: t
+spec:
+  resolvers:
+    myResolver:
+      description: A resolver desc
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: x
+  calls:
+    myCall:
+      description: A reusable call
+      provider: parameter
+  functions:
+    myFunc:
+      description: A helper function
+      cel: "1 + 1"
+  workflow:
+    actions:
+      myAction:
+        description: An action desc
+        provider: debug
+    finally:
+      cleanup:
+        description: A finally action
+        provider: debug
+`
+	sol := &solution.Solution{}
+	require.NoError(t, sol.UnmarshalFromBytes([]byte(content)))
+
+	assert.Equal(t, "A resolver desc", symbolDescription(sol, refindex.SymbolResolver, "myResolver"))
+	assert.Equal(t, "A reusable call", symbolDescription(sol, refindex.SymbolCall, "myCall"))
+	assert.Equal(t, "A helper function", symbolDescription(sol, refindex.SymbolFunction, "myFunc"))
+	assert.Equal(t, "An action desc", symbolDescription(sol, refindex.SymbolAction, "myAction"))
+	assert.Equal(t, "A finally action", symbolDescription(sol, refindex.SymbolAction, "cleanup"))
+
+	// Unknown name and nil solution yield empty.
+	assert.Empty(t, symbolDescription(sol, refindex.SymbolResolver, "nope"))
+	assert.Empty(t, symbolDescription(nil, refindex.SymbolResolver, "myResolver"))
+}
+
+func TestHoverMarkdown_PrefixedCELTokenIsNotAFunction(t *testing.T) {
+	// A reference-prefixed CEL/template token (e.g. "_.foo") has no function
+	// metadata; hover must return "".
+	s := newTestServer(t)
+	e := &DocEntry{Raw: []byte("expr: _.foo\n")}
+	md := s.hoverMarkdown(e, CursorContext{Kind: CursorCEL, ExprPrefix: "_.", PartialToken: "foo"}, protocol.Position{})
+	assert.Empty(t, md)
+}
+
+func TestKeyHover_Concept(t *testing.T) {
+	// The "workflow" key matches a concept, so its hover includes the concept
+	// summary alongside the schema field doc.
+	md := keyHover("spec.workflow")
+	assert.Contains(t, md, "concept")
+	assert.Contains(t, md, "Workflow")
+}

--- a/pkg/lsp/hover_test.go
+++ b/pkg/lsp/hover_test.go
@@ -4,7 +4,6 @@
 package lsp
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/refindex"
@@ -72,7 +71,8 @@ func TestHover_SymbolRef(t *testing.T) {
 func TestHover_ProviderName(t *testing.T) {
 	md := hoverAt(t, "provider: parameter", "parameter", 2)
 	assert.Contains(t, md, "provider")
-	assert.Contains(t, strings.ToLower(md), "parameter")
+	assert.Contains(t, md, "`parameter`", "leads with the canonical name the user typed")
+	assert.Contains(t, md, "CLI Parameters", "folds in the friendly display name")
 	assert.Contains(t, md, "**Inputs:**", "provider hover lists inputs")
 }
 

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13939,9 +13939,11 @@ func TestIntegration_LspHover(t *testing.T) {
 	require.NoError(t, cmd.Start())
 
 	for _, m := range msgs {
-		_, _ = stdin.Write(m)
-		time.Sleep(150 * time.Millisecond)
+		_, werr := stdin.Write(m)
+		require.NoError(t, werr, "write LSP frame to server stdin")
 	}
+	// Poll until hover contents appear instead of sleeping a fixed amount, so the
+	// test is not flaky under load (mirrors TestIntegration_LspStdioFlag).
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		if strings.Contains(out.String(), `"contents"`) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13941,6 +13941,56 @@ func TestIntegration_LspRename(t *testing.T) {
 	assert.Contains(t, out, "file:///nav.yaml", "edits target the document")
 }
 
+func TestIntegration_LspHover(t *testing.T) {
+	t.Parallel()
+
+	// "provider: parameter" is on line 9 (0-based); character 24 sits inside the
+	// value "parameter".
+	sol := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: nav\nspec:\n  resolvers:\n    environment:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value: dev\n"
+
+	msgs := [][]byte{
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": map[string]any{"capabilities": map[string]any{}}}),
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "method": "initialized", "params": map[string]any{}}),
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "method": "textDocument/didOpen", "params": map[string]any{
+			"textDocument": map[string]any{"uri": "file:///nav.yaml", "languageId": "yaml", "version": 1, "text": sol},
+		}}),
+		lspFrame(t, map[string]any{"jsonrpc": "2.0", "id": 2, "method": "textDocument/hover", "params": map[string]any{
+			"textDocument": map[string]any{"uri": "file:///nav.yaml"},
+			"position":     map[string]any{"line": 9, "character": 24},
+		}}),
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, binaryPath, "lsp")
+	cmd.Dir = findProjectRoot()
+	stdin, err := cmd.StdinPipe()
+	require.NoError(t, err)
+	out := &lockedBuffer{}
+	cmd.Stdout = out
+	require.NoError(t, cmd.Start())
+
+	for _, m := range msgs {
+		_, _ = stdin.Write(m)
+		time.Sleep(150 * time.Millisecond)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(out.String(), `"contents"`) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	_ = stdin.Close()
+	_ = cmd.Process.Kill()
+	_ = cmd.Wait()
+
+	got := out.String()
+	assert.Contains(t, got, `"contents"`, "hover returns markup contents")
+	assert.Contains(t, got, "provider", "hover describes the provider under the cursor")
+	assert.Contains(t, got, "Inputs", "provider hover lists inputs")
+}
+
 // TestIntegration_LspStdioFlag verifies that `lsp --stdio` starts the server and
 // serves the LSP protocol. Many LSP clients (and vscode-languageclient for
 // TransportKind.stdio) append `--stdio`; the server must accept it rather than


### PR DESCRIPTION
## What

Implements LSP **`textDocument/hover`** and creates the shared
**`pkg/lsp/funcref.go`** function-lookup helper. Hover dispatches on
`ResolveCursor` (#768) and renders markdown from sources the CLI already knows --
no new documentation to maintain.

This is issue #772 (needs #766 cache, #767 seam, #768 cursor -- all merged). It
also produces `funcref.go`, the shared contract that #775 (function completion)
and #777 (signature help) consume -- **S2**.

## Hover classes

- **SymbolRef** -> the resolver/action/call/function kind, name, and `description`
  from the parsed solution.
- **ProviderName** (a `provider:` value) -> the canonical provider name (the
  identifier typed in YAML, with the friendly display name folded in), its
  description, and an input-schema summary (each input's name, type, required
  flag, doc) from `registry.Get(name).Descriptor()`.
- **CEL / template function** -> the signature (CEL), description, and first
  example from the built-in function registries.
- **YAMLKey** -> the schema field doc via `schema.IntrospectField` over a
  normalized path, plus a related concept summary when one matches.

Registered via the capability seam (`hoverFeature()`); glsp advertises
`HoverProvider` from the wired handler. Hover returns nil (no panic) on unknown
targets, parse errors, and whitespace.

## funcref.go (shared contract for #775/#777)

`FuncInfo{Name, Signature, Description, Examples, CEL}` with:

- `LookupFunc(name) (FuncInfo, bool)` -- searches CEL functions first, then
  template functions (CEL-first precedence when a name exists in both).
- `AllFuncs() []FuncInfo` -- every function's metadata, de-duplicated by primary
  name (sub-names are lookup-only, not enumerated), returned as a copy.

Built lazily (`sync.Once`) over `celexpext.All()` + `gotmplext.All()` -- the same
registries the `list_cel_functions` / `list_go_template_functions` MCP tools use.

## Key design notes

- `schemaPath` normalizes a logical YAML path (dropping `[i]` indices and dynamic
  map-key segments like resolver/action/call/function/input names) into the field
  path `schema.IntrospectField` expects, e.g.
  `spec.resolvers.env.resolve.with[0].provider` -> `spec.resolvers.resolve.with.provider`.
- `fullIdentAt` captures namespaced CEL function names (`arrays.groupBy`) whole;
  `funcHover` runs only for a bare function token (`ExprPrefix == ""`), not a
  `_.`/`._.` reference.

## Tests / docs

- Table tests per hover class (symbol, provider, CEL fn, template fn, key,
  none/parse-error), plus symbol-description-all-kinds, schema-path normalization,
  and the funcref API (lookup, all, unknown, examples, CEL-first precedence).
- Integration test `TestIntegration_LspHover` (full stdio session).
- `docs/tutorials/lsp-tutorial.md` documents hover.

Package coverage 92%, `-race` clean, `lint:changed` 0 new issues.

## Acceptance criteria

- [x] Hover shows useful markdown for each class.
- [x] `funcref.go` reusable and covered.
- [x] `HoverProvider` advertised via seam; returns nil (no panic) on unknown targets.

Closes #772
