### PR TITLE
feat(lsp): document symbols / outline

### DIFF
--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -38,6 +38,12 @@ reusing the same reference index and rename engine as `scafctl refactor rename`:
   If any reference cannot be located, the rename is refused (the editor shows the
   error) rather than applying a partial, solution-breaking change.
 
+It also provides a **document outline**. `textDocument/documentSymbol` returns a
+hierarchy -- a `spec` root whose children are the `resolvers`, `actions`,
+`calls`, and `functions` groups, each listing its symbols -- so the editor's
+Outline pane and breadcrumbs populate and **Go to Symbol in File**
+(Cmd/Ctrl+Shift+O) fuzzy-jumps to any resolver, action, call, or function.
+
 ## Trying it by hand
 
 You normally never run the server directly, but you can confirm it starts:

--- a/pkg/lsp/capabilities.go
+++ b/pkg/lsp/capabilities.go
@@ -42,6 +42,7 @@ func defaultFeatures() []feature {
 		documentSyncFeature(),
 		navigationFeature(),
 		renameFeature(),
+		symbolsFeature(),
 	}
 }
 

--- a/pkg/lsp/capabilities_test.go
+++ b/pkg/lsp/capabilities_test.go
@@ -23,7 +23,7 @@ func TestDefaultFeatures_DeterministicOrder(t *testing.T) {
 		got = append(got, f.name)
 		require.NotNil(t, f.wire, "every feature must wire a handler")
 	}
-	assert.Equal(t, []string{"documentSync", "navigation", "rename"}, got)
+	assert.Equal(t, []string{"documentSync", "navigation", "rename", "symbols"}, got)
 	assert.True(t, sort.StringsAreSorted(got), "features must be registered in alphabetical order")
 }
 

--- a/pkg/lsp/symbols.go
+++ b/pkg/lsp/symbols.go
@@ -1,0 +1,163 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"sort"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	glsp "github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// symbolsFeature wires textDocument/documentSymbol so the Outline pane,
+// breadcrumbs, and "Go to Symbol in File" list the solution's resolvers,
+// actions, calls, and functions. glsp derives the DocumentSymbolProvider
+// capability from the wired handler, so no advertise func is needed.
+func symbolsFeature() feature {
+	return feature{
+		name: "symbols",
+		wire: func(h *protocol.Handler, s *Server) {
+			h.TextDocumentDocumentSymbol = s.documentSymbol
+		},
+	}
+}
+
+// documentSymbol answers textDocument/documentSymbol from the per-document
+// cache. It returns nil (no result) when the document is unknown, not indexed,
+// or contains no symbols, so an empty or unparseable document yields an empty
+// outline rather than an error.
+func (s *Server) documentSymbol(_ *glsp.Context, params *protocol.DocumentSymbolParams) (any, error) {
+	entry, ok := s.getDoc(params.TextDocument.URI)
+	if !ok || entry.Index == nil {
+		return nil, nil
+	}
+	syms := documentSymbolsFromIndex(entry.Index)
+	if len(syms) == 0 {
+		return nil, nil
+	}
+	return syms, nil
+}
+
+// symbolGroup describes one outline group: the scafctl symbol kind it collects,
+// the label shown for the group node, and the protocol.SymbolKind used for its
+// leaf symbols. Groups are presented in this fixed order under a single "spec"
+// root.
+type symbolGroup struct {
+	label    string
+	kind     refindex.SymbolKind
+	leafKind protocol.SymbolKind
+}
+
+// symbolGroups is the fixed presentation order of outline groups. Leaf kinds are
+// chosen so editors render distinguishable icons: resolvers as fields, calls as
+// methods, actions and author functions as functions.
+var symbolGroups = []symbolGroup{
+	{label: "resolvers", kind: refindex.SymbolResolver, leafKind: protocol.SymbolKindField},
+	{label: "actions", kind: refindex.SymbolAction, leafKind: protocol.SymbolKindFunction},
+	{label: "calls", kind: refindex.SymbolCall, leafKind: protocol.SymbolKindMethod},
+	{label: "functions", kind: refindex.SymbolFunction, leafKind: protocol.SymbolKindFunction},
+}
+
+// DocumentSymbols parses solution content and returns its document-symbol
+// hierarchy. A parse error yields nil (an empty outline), never a panic.
+func DocumentSymbols(content []byte) []protocol.DocumentSymbol {
+	_, idx, err := loadIndex(content)
+	if err != nil {
+		return nil
+	}
+	return documentSymbolsFromIndex(idx)
+}
+
+// documentSymbolsFromIndex builds the document-symbol hierarchy from an
+// already-built index, allowing the server to reuse the per-document cache
+// instead of re-parsing on every request.
+//
+// The shape is a single "spec" root whose children are the non-empty groups
+// (resolvers, actions, calls, functions), each of which lists its symbols as
+// children. Empty groups are omitted; when the solution has no symbols at all,
+// the result is nil (an empty outline). Group and root ranges enclose their
+// children so cursor-in-symbol reveal works at every level.
+func documentSymbolsFromIndex(idx *refindex.Index) []protocol.DocumentSymbol {
+	if idx == nil {
+		return nil
+	}
+
+	groups := make([]protocol.DocumentSymbol, 0, len(symbolGroups))
+	for _, g := range symbolGroups {
+		names := idx.Names(g.kind)
+		leaves := make([]protocol.DocumentSymbol, 0, len(names))
+		for _, name := range names {
+			def, ok := idx.Definition(g.kind, name)
+			if !ok {
+				continue
+			}
+			r := toLSPRange(def.Range)
+			leaves = append(leaves, protocol.DocumentSymbol{
+				Name:           name,
+				Kind:           g.leafKind,
+				Range:          r,
+				SelectionRange: r,
+			})
+		}
+		if len(leaves) == 0 {
+			continue
+		}
+		// Present leaves in source order so the outline mirrors the file.
+		sort.SliceStable(leaves, func(i, j int) bool {
+			return lessLSPRange(leaves[i].Range, leaves[j].Range)
+		})
+		gr := enclosingRange(leaves)
+		groups = append(groups, protocol.DocumentSymbol{
+			Name:           g.label,
+			Kind:           protocol.SymbolKindNamespace,
+			Range:          gr,
+			SelectionRange: gr,
+			Children:       leaves,
+		})
+	}
+
+	if len(groups) == 0 {
+		return nil
+	}
+	specRange := enclosingRange(groups)
+	return []protocol.DocumentSymbol{{
+		Name:           "spec",
+		Kind:           protocol.SymbolKindNamespace,
+		Range:          specRange,
+		SelectionRange: specRange,
+		Children:       groups,
+	}}
+}
+
+// enclosingRange returns the smallest range spanning every symbol's range. It
+// assumes syms is non-empty (callers guard this).
+func enclosingRange(syms []protocol.DocumentSymbol) protocol.Range {
+	out := syms[0].Range
+	for _, s := range syms[1:] {
+		if lessLSPPosition(s.Range.Start, out.Start) {
+			out.Start = s.Range.Start
+		}
+		if lessLSPPosition(out.End, s.Range.End) {
+			out.End = s.Range.End
+		}
+	}
+	return out
+}
+
+// lessLSPRange orders ranges by start position, then end position.
+func lessLSPRange(a, b protocol.Range) bool {
+	if a.Start != b.Start {
+		return lessLSPPosition(a.Start, b.Start)
+	}
+	return lessLSPPosition(a.End, b.End)
+}
+
+// lessLSPPosition reports whether a precedes b in a document.
+func lessLSPPosition(a, b protocol.Position) bool {
+	if a.Line != b.Line {
+		return a.Line < b.Line
+	}
+	return a.Character < b.Character
+}

--- a/pkg/lsp/symbols_test.go
+++ b/pkg/lsp/symbols_test.go
@@ -1,0 +1,190 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// symbolsFixture exercises all four symbol kinds: two resolvers, a call, an
+// author function, and a workflow action.
+const symbolsFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: symbols
+spec:
+  calls:
+    fetch:
+      provider: message
+      inputs:
+        message: fetching
+  functions:
+    greet:
+      params:
+        - name: who
+      template: "hello {{ .args.who }}"
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    appName:
+      resolve:
+        with:
+          - call: fetch
+  workflow:
+    actions:
+      deploy:
+        provider: message
+        inputs:
+          message: deploying
+`
+
+// childByName returns the child symbol with the given name, failing the test if
+// absent.
+func childByName(t *testing.T, syms []protocol.DocumentSymbol, name string) protocol.DocumentSymbol {
+	t.Helper()
+	for _, s := range syms {
+		if s.Name == name {
+			return s
+		}
+	}
+	t.Fatalf("no symbol named %q in %v", name, symbolNames(syms))
+	return protocol.DocumentSymbol{}
+}
+
+func symbolNames(syms []protocol.DocumentSymbol) []string {
+	names := make([]string, 0, len(syms))
+	for _, s := range syms {
+		names = append(names, s.Name)
+	}
+	return names
+}
+
+func TestDocumentSymbols_AllKindsAndHierarchy(t *testing.T) {
+	syms := DocumentSymbols([]byte(symbolsFixture))
+	require.Len(t, syms, 1, "a single spec root")
+
+	spec := syms[0]
+	assert.Equal(t, "spec", spec.Name)
+	assert.Equal(t, protocol.SymbolKindNamespace, spec.Kind)
+
+	// Groups are present in the fixed order and only when non-empty.
+	assert.Equal(t, []string{"resolvers", "actions", "calls", "functions"}, symbolNames(spec.Children))
+
+	resolvers := childByName(t, spec.Children, "resolvers")
+	assert.Equal(t, protocol.SymbolKindNamespace, resolvers.Kind)
+	// Leaves are in source order: environment (line 15) before appName (line 20).
+	assert.Equal(t, []string{"environment", "appName"}, symbolNames(resolvers.Children))
+	for _, leaf := range resolvers.Children {
+		assert.Equal(t, protocol.SymbolKindField, leaf.Kind, "resolver leaf kind")
+	}
+
+	actions := childByName(t, spec.Children, "actions")
+	assert.Equal(t, []string{"deploy"}, symbolNames(actions.Children))
+	assert.Equal(t, protocol.SymbolKindFunction, actions.Children[0].Kind)
+
+	calls := childByName(t, spec.Children, "calls")
+	assert.Equal(t, []string{"fetch"}, symbolNames(calls.Children))
+	assert.Equal(t, protocol.SymbolKindMethod, calls.Children[0].Kind)
+
+	functions := childByName(t, spec.Children, "functions")
+	assert.Equal(t, []string{"greet"}, symbolNames(functions.Children))
+	assert.Equal(t, protocol.SymbolKindFunction, functions.Children[0].Kind)
+}
+
+func TestDocumentSymbols_RangesMatchDefinitions(t *testing.T) {
+	content := []byte(symbolsFixture)
+	_, idx, err := loadIndex(content)
+	require.NoError(t, err)
+
+	syms := DocumentSymbols(content)
+	require.Len(t, syms, 1)
+	resolvers := childByName(t, syms[0].Children, "resolvers")
+
+	// Each leaf's selection range equals the definition's positioned range.
+	env := childByName(t, resolvers.Children, "environment")
+	def, ok := idx.Definition(refindex.SymbolResolver, "environment")
+	require.True(t, ok)
+	assert.Equal(t, toLSPRange(def.Range), env.SelectionRange)
+	assert.Equal(t, toLSPRange(def.Range), env.Range)
+
+	// A group range encloses all of its children.
+	for _, leaf := range resolvers.Children {
+		assert.True(t, leaf.Range.Start.Line >= resolvers.Range.Start.Line,
+			"child starts at/after group start")
+		assert.True(t, leaf.Range.End.Line <= resolvers.Range.End.Line,
+			"child ends at/before group end")
+	}
+	// The spec root encloses every group.
+	spec := syms[0]
+	assert.True(t, resolvers.Range.Start.Line >= spec.Range.Start.Line)
+	assert.True(t, resolvers.Range.End.Line <= spec.Range.End.Line)
+}
+
+func TestDocumentSymbols_OmitsEmptyGroups(t *testing.T) {
+	// Only resolvers -- the other three groups must be absent.
+	const onlyResolvers = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: only-resolvers
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+`
+	syms := DocumentSymbols([]byte(onlyResolvers))
+	require.Len(t, syms, 1)
+	assert.Equal(t, []string{"resolvers"}, symbolNames(syms[0].Children))
+}
+
+func TestDocumentSymbols_EmptyAndParseError(t *testing.T) {
+	tests := map[string]string{
+		"empty":              "",
+		"no spec":            "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: x\n",
+		"no symbols in spec": "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: x\nspec: {}\n",
+		"invalid yaml":       "apiVersion: scafctl.io/v1\nkind: Solution\nspec:\n  resolvers:\n  - : : :\n",
+	}
+	for name, content := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				syms := DocumentSymbols([]byte(content))
+				assert.Empty(t, syms)
+			})
+		})
+	}
+}
+
+func TestDocumentSymbolsFromIndex_NilIndex(t *testing.T) {
+	assert.Nil(t, documentSymbolsFromIndex(nil))
+}
+
+func TestSymbolsFeature_Registered(t *testing.T) {
+	var found bool
+	for _, f := range defaultFeatures() {
+		if f.name == "symbols" {
+			found = true
+			require.NotNil(t, f.wire, "symbols feature must wire a handler")
+		}
+	}
+	assert.True(t, found, "symbolsFeature must be in defaultFeatures")
+
+	// Wiring the feature sets the documentSymbol handler and glsp will then
+	// advertise the provider.
+	h := &protocol.Handler{}
+	s := NewServer("scafctl", "test", nil)
+	symbolsFeature().wire(h, s)
+	assert.NotNil(t, h.TextDocumentDocumentSymbol, "documentSymbol handler wired")
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13863,6 +13863,29 @@ func TestIntegration_LspInitializeAndDiagnostics(t *testing.T) {
 	assert.Contains(t, out, "renameProvider", "rename capability")
 }
 
+func TestIntegration_LspDocumentSymbol(t *testing.T) {
+	t.Parallel()
+
+	sol := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: symbols\nspec:\n  calls:\n    fetch:\n      provider: message\n      inputs:\n        message: fetching\n  resolvers:\n    environment:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value: dev\n"
+
+	out := runLSPSession(t, sol, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "textDocument/documentSymbol", "params": map[string]any{
+			"textDocument": map[string]any{"uri": lspSessionURI},
+		},
+	})
+
+	// The provider is advertised in the initialize response.
+	assert.Contains(t, out, "documentSymbolProvider", "documentSymbol capability advertised")
+	// The response lists the spec root, both groups, and their symbols.
+	assert.Contains(t, out, `"name":"spec"`, "spec root symbol")
+	assert.Contains(t, out, `"name":"resolvers"`, "resolvers group")
+	assert.Contains(t, out, `"name":"environment"`, "resolver symbol")
+	assert.Contains(t, out, `"name":"calls"`, "calls group")
+	assert.Contains(t, out, `"name":"fetch"`, "call symbol")
+	// Hierarchy is expressed via children.
+	assert.Contains(t, out, `"children"`, "symbols nested as children")
+}
+
 func TestIntegration_LspRename(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Implements `textDocument/documentSymbol` so the editor Outline pane, breadcrumbs, and **Go to Symbol in File** (Cmd/Ctrl+Shift+O) list a solution's resolvers, actions, calls, and functions.

## Changes

- **New `pkg/lsp/symbols.go`** -- `DocumentSymbols` (pure) and `documentSymbolsFromIndex` (cache-reusing) build the hierarchy from the `refindex` already stored in the per-document cache:
  - A single `spec` root whose children are the **non-empty** groups `resolvers`, `actions`, `calls`, `functions`, each listing its symbols as children (leaves in source order).
  - Each scafctl kind maps to a distinct `protocol.SymbolKind`: resolver -> Field, action -> Function, call -> Method, function -> Function; groups/root -> Namespace.
  - Group and root ranges **enclose** their children so cursor-in-symbol reveal works at every level.
  - Registered via the `feature` seam (#767) as `symbolsFeature()`; glsp derives the `DocumentSymbolProvider` capability from the wired handler (no advertise func needed).
- **`pkg/lsp/capabilities.go`** -- one alphabetized entry (`symbolsFeature()`) added to `defaultFeatures()`.
- Reuses the cache (#766): no re-parse per request. Empty or unparseable documents yield an empty outline (nil), never a panic.

## Tests / docs

- **`pkg/lsp/symbols_test.go`** -- all four kinds + nested hierarchy, ranges match definitions and enclose children, empty-group omission, empty/no-spec/no-symbols/invalid-YAML cases, nil index, and feature registration.
- **`tests/integration/cli_test.go`** -- `TestIntegration_LspDocumentSymbol` via the `runLSPSession` harness (#769) asserts the `documentSymbol` result shape (spec root, groups, symbols, `children`) and that `documentSymbolProvider` is advertised.
- Updated `capabilities_test.go` (feature-order literal) and `docs/tutorials/lsp-tutorial.md` (outline feature). (`local/scafctl.yaml` showcase noted in the issue does not exist in the repo, so skipped.)
- `go build ./...`, `go test ./pkg/lsp/ ./tests/integration/`, `task lint:changed` (0 new issues) -- all pass.

## Acceptance criteria

- [x] Outline populates with all four symbol kinds
- [x] Go to Symbol in File jumps to symbols (hierarchy with selectionRange on each name)
- [x] `DocumentSymbolProvider` advertised via the seam

Depends on #766 (cache) and #767 (capability seam), both merged. Does not need #768.

Closes #771