### PR TITLE
feat(cli): add interactive 'explore' command via cobra-explorer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/hashicorp/go-plugin v1.8.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/mark3labs/mcp-go v0.57.0
+	github.com/oakwood-commons/cobra-explorer v0.2.0
 	github.com/oakwood-commons/httpc v0.2.0
 	github.com/oakwood-commons/kvx v0.16.0
 	github.com/oakwood-commons/oauth-helpers v0.2.0
@@ -78,8 +79,8 @@ require (
 
 require (
 	cel.dev/expr v0.25.2 // indirect
-	charm.land/bubbles/v2 v2.1.0 // indirect
-	charm.land/lipgloss/v2 v2.0.3 // indirect
+	charm.land/bubbles/v2 v2.1.1 // indirect
+	charm.land/lipgloss/v2 v2.0.5 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/AliyunContainerService/ack-ram-tool/pkg/credentials/provider v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,11 @@
 cel.dev/expr v0.25.2 h1:K6j46C81hXtZQfuX60cVWQFBJahKSE2gfRbNuvr5bFs=
 cel.dev/expr v0.25.2/go.mod h1:hrXvqGP6G6gyx8UAHSHJ5RGk//1Oj5nXQ2NI02Nrsg4=
-charm.land/bubbles/v2 v2.1.0 h1:YSnNh5cPYlYjPxRrzs5VEn3vwhtEn3jVGRBT3M7/I0g=
-charm.land/bubbles/v2 v2.1.0/go.mod h1:l97h4hym2hvWBVfmJDtrEHHCtkIKeTEb3TTJ4ZOB3wY=
+charm.land/bubbles/v2 v2.1.1 h1:7r55WzBxpo/R3z98hGmY7KKPd3ET6vsf0Fb9sDHOV60=
+charm.land/bubbles/v2 v2.1.1/go.mod h1:GE6M31gaWZVXzGw73OeuTTgy4lX+OtkH0E5ymnNsHxo=
 charm.land/bubbletea/v2 v2.0.8 h1:SxTJMhCAI3lbPmy4SgX5LWZ24AdINr4I6UEqzZvYJuY=
 charm.land/bubbletea/v2 v2.0.8/go.mod h1:2SkdgoTXluXJHOUwAoRlRXF/28vklb1rFl6GcgV1/ss=
-charm.land/lipgloss/v2 v2.0.3 h1:yM2zJ4Cf5Y51b7RHIwioil4ApI/aypFXXVHSwlM6RzU=
-charm.land/lipgloss/v2 v2.0.3/go.mod h1:7myLU9iG/3xluAWzpY/fSxYYHCgoKTie7laxk6ATwXA=
+charm.land/lipgloss/v2 v2.0.5 h1:kbNxgeeUOYv5J0YdpxFjfvf3dFvqH8Aci4zB6xqFtrY=
+charm.land/lipgloss/v2 v2.0.5/go.mod h1:9oqhxt4yxIMe6q5A4kHr44DremZk7J9UNh74GlWa5nc=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.123.0 h1:2NAUJwPR47q+E35uaJeYoNhuNEM9kM8SjgRgdeOJUSE=
 cloud.google.com/go v0.123.0/go.mod h1:xBoMV08QcqUGuPW65Qfm1o9Y4zKZBpGS+7bImXLTAZU=
@@ -626,6 +626,8 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
 github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
+github.com/oakwood-commons/cobra-explorer v0.2.0 h1:lEOTTHfbldrZU5WrOe6+jFiBB+709k3BMayVlzys9Ho=
+github.com/oakwood-commons/cobra-explorer v0.2.0/go.mod h1:y8lz6Ya1SHYbDTMMhCn0pdNZRJ6AEs/c1l8+0RbdZEE=
 github.com/oakwood-commons/httpc v0.2.0 h1:VUShxefWQJ2ONXFhe3ty5EVAmUHbZzabN7jiSpmf4a4=
 github.com/oakwood-commons/httpc v0.2.0/go.mod h1:TC9Kc/0wyjp2XlNX2BiRKxEcF4ddYy5m3rUG08gBUI4=
 github.com/oakwood-commons/kvx v0.16.0 h1:O6n5XE6ubFonZoiWc/s8o7zuMBZdf2GWYsVBr64B4c0=

--- a/pkg/cmd/scafctl/explore/explore.go
+++ b/pkg/cmd/scafctl/explore/explore.go
@@ -1,0 +1,27 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+// Package explore wires the cobra-explorer interactive TUI into scafctl as the
+// "explore" subcommand.
+package explore
+
+import (
+	explorer "github.com/oakwood-commons/cobra-explorer/explore"
+	"github.com/spf13/cobra"
+)
+
+// CommandExplore returns the "explore" subcommand: an interactive TUI for
+// browsing the command tree, inspecting flags, and building commands visually.
+//
+// It wraps github.com/oakwood-commons/cobra-explorer, wiring the resolved binary
+// name so embedders see their own CLI name in the TUI, and enabling in-process
+// execution so a command assembled in the builder can be run directly.
+//
+// root must be the fully-assembled root command; the explorer introspects it
+// read-only at run time, so it reflects every subcommand registered on root.
+func CommandExplore(root *cobra.Command, binaryName string) *cobra.Command {
+	return explorer.NewCommand(root,
+		explorer.WithBinaryName(binaryName),
+		explorer.WithExecution(true),
+	)
+}

--- a/pkg/cmd/scafctl/explore/explore_test.go
+++ b/pkg/cmd/scafctl/explore/explore_test.go
@@ -1,0 +1,38 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package explore
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommandExplore(t *testing.T) {
+	t.Parallel()
+
+	root := &cobra.Command{Use: "scafctl"}
+	cmd := CommandExplore(root, "scafctl")
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "explore", cmd.Name())
+	assert.NotEmpty(t, cmd.Short, "explore command should have a short description")
+	assert.NotNil(t, cmd.RunE, "explore command should be runnable")
+	assert.NotNil(t, cmd.Flags().Lookup("theme"), "explore command should register the --theme flag")
+}
+
+// TestCommandExplore_EmbedderBinaryName verifies the embedder contract: a
+// non-default binary name is threaded through to the explorer.
+func TestCommandExplore_EmbedderBinaryName(t *testing.T) {
+	t.Parallel()
+
+	root := &cobra.Command{Use: "mycli"}
+	cmd := CommandExplore(root, "mycli")
+
+	require.NotNil(t, cmd)
+	assert.Equal(t, "explore", cmd.Name())
+	assert.NotNil(t, cmd.RunE, "explore command should be runnable")
+}

--- a/pkg/cmd/scafctl/root.go
+++ b/pkg/cmd/scafctl/root.go
@@ -25,6 +25,7 @@ import (
 	diffcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/diff"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/eval"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/explain"
+	explorecmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/explore"
 	extractcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/extract"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/get"
 	inspectcmd "github.com/oakwood-commons/scafctl/pkg/cmd/scafctl/inspect"
@@ -958,6 +959,9 @@ func Root(opts *RootOptions) (*cobra.Command, func()) {
 	// Other Commands (no group — shown under "Additional Commands:")
 	cCmd.AddCommand(version.CommandVersion(cliParams, ioStreams, binaryName, opts.VersionExtra))
 	cCmd.AddCommand(options.CommandOptions(cliParams, ioStreams, binaryName))
+	// explore introspects the fully-assembled command tree at run time, so it is
+	// registered last with the root pointer.
+	cCmd.AddCommand(explorecmd.CommandExplore(cCmd, binaryName))
 
 	// cleanup releases auth handler plugins and telemetry. It is safe to call
 	// multiple times (idempotent via sync.Once). PersistentPostRun calls it on

--- a/pkg/cmd/scafctl/root_test.go
+++ b/pkg/cmd/scafctl/root_test.go
@@ -109,6 +109,21 @@ func TestRoot_HasOptionsSubcommand(t *testing.T) {
 	}
 }
 
+func TestRoot_HasExploreSubcommand(t *testing.T) {
+	t.Parallel()
+	cmd, _ := Root(nil)
+	found := false
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "explore" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected 'explore' subcommand to be added")
+	}
+}
+
 func TestRoot_CommandGroups(t *testing.T) {
 	t.Parallel()
 	cmd, _ := Root(nil)

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -301,6 +301,22 @@ func TestIntegration_Options(t *testing.T) {
 	assert.Contains(t, stdout, "--cwd")
 }
 
+func TestIntegration_ExploreHelp(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "explore", "--help")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "explore")
+}
+
+func TestIntegration_ExploreListThemes(t *testing.T) {
+	t.Parallel()
+	stdout, _, exitCode := runScafctl(t, "explore", "--list-themes")
+
+	assert.Equal(t, 0, exitCode)
+	assert.Contains(t, stdout, "dark")
+}
+
 func TestIntegration_RunHelp(t *testing.T) {
 	t.Parallel()
 	stdout, _, exitCode := runScafctl(t, "run", "--help")


### PR DESCRIPTION
## What

Adds a `scafctl explore` subcommand: an interactive TUI (powered by
[cobra-explorer](https://github.com/oakwood-commons/cobra-explorer)) for browsing
the full command tree, inspecting flags and documentation, and building + running
commands visually.

## Details

- **Thin wrapper** in `pkg/cmd/scafctl/explore` exposing `CommandExplore(root, binaryName)`.
- **Embedder contract honored**: the resolved binary name is threaded through via
  `explore.WithBinaryName`, so embedders see their own CLI name in the TUI (covered
  by a non-default binary-name test).
- **In-process execution enabled** (`WithExecution(true)`): pressing Enter in the
  builder runs the assembled command directly.
- **Ungrouped placement**: registered last with the root pointer so it introspects
  the fully-assembled tree; appears under "Additional Commands:" alongside
  `version` / `options`.
- Exposes cobra-explorer's `--theme` / `--list-themes` flags to end users.

## Dependency

Adds `github.com/oakwood-commons/cobra-explorer v0.2.0`, which uses
`charm.land/bubbletea/v2` -- matching scafctl's existing v2 stack. `go mod tidy`
only nudged `charm.land/bubbles/v2` (2.1.0 -> 2.1.1) and `charm.land/lipgloss/v2`
(2.0.3 -> 2.0.5); **no Bubble Tea v1 dependency is introduced.**

## Tests

- Unit: wrapper tests (incl. embedder binary-name case) + `TestRoot_HasExploreSubcommand`.
- Integration: `explore --help` and `explore --list-themes`.
- `task lint:changed`: 0 issues. `task test:e2e`: 938 passed, 0 failed.
