### PR TITLE
feat(lsp): quick-fix code actions for lint diagnostics

### DIFF
--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -44,6 +44,33 @@ hierarchy -- a `spec` root whose children are the `resolvers`, `actions`,
 Outline pane and breadcrumbs populate and **Go to Symbol in File**
 (Cmd/Ctrl+Shift+O) fuzzy-jumps to any resolver, action, call, or function.
 
+Finally, it offers **quick fixes**. `textDocument/codeAction` turns certain lint
+diagnostics into one-click fixes (the editor's lightbulb), reusing the same fix
+logic (`lint.QuickFixFor`) so the applied edit always matches what the linter
+would recommend:
+
+- **deprecated field** -- replaces the deprecated `onError` field with its
+  successor `continueOnError`, translating the value (`onError: continue` becomes
+  `continueOnError: true`, and `onError: fail` becomes `continueOnError: false`).
+- **redundant dependsOn** -- removes the redundant `dependsOn` entry (or the
+  whole `dependsOn:` block when every listed dependency is already inferred from
+  value references).
+- **unused resolver** -- removes the entire unreferenced resolver block.
+
+For example, given a resolve source with the deprecated field:
+
+~~~yaml
+resolve:
+  with:
+    - provider: parameter
+      onError: continue   # deprecated-field diagnostic here
+      inputs:
+        value: dev
+~~~
+
+invoking the quick fix rewrites just that line to `continueOnError: true`,
+leaving surrounding formatting and comments untouched.
+
 ## Trying it by hand
 
 You normally never run the server directly, but you can confirm it starts:

--- a/pkg/lint/quickfix.go
+++ b/pkg/lint/quickfix.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/refactor"
 	"github.com/oakwood-commons/scafctl/pkg/refindex"
 	"github.com/oakwood-commons/scafctl/pkg/resolver"
@@ -22,6 +23,12 @@ import (
 // edits into a WorkspaceEdit rather than re-deriving fixes, so the fix stays in
 // lockstep with the lint rules that produce the findings.
 //
+// registry is the same provider registry used to produce f (may be nil). It is
+// threaded into the redundant-dependsOn fix so the redundant set is recomputed
+// with the identical provider-aware dependency extraction the lint rule used --
+// keeping the removal in exact lockstep with the finding rather than a possibly
+// divergent generic recompute.
+//
 // Supported rules: "deprecated-field" (replace the deprecated key with its
 // tagged replacement, translating the value), "redundant-depends-on" (remove the
 // redundant dependsOn entry or entries), and "unused-resolver" (remove the whole
@@ -29,7 +36,7 @@ import (
 // deterministically from sol -- yields (nil, false). It never panics on odd
 // input: a fix that cannot be built safely is reported as "no fix" rather than a
 // broken edit.
-func QuickFixFor(sol *solution.Solution, f *Finding) (edits []refactor.TextEdit, ok bool) {
+func QuickFixFor(sol *solution.Solution, f *Finding, registry *provider.Registry) (edits []refactor.TextEdit, ok bool) {
 	if sol == nil || f == nil {
 		return nil, false
 	}
@@ -42,7 +49,7 @@ func QuickFixFor(sol *solution.Solution, f *Finding) (edits []refactor.TextEdit,
 	case "deprecated-field":
 		return quickFixDeprecatedField(raw, f)
 	case "redundant-depends-on":
-		return quickFixRedundantDependsOn(sol, raw, f)
+		return quickFixRedundantDependsOn(sol, raw, f, registry)
 	case "unused-resolver":
 		return quickFixUnusedResolver(sol, raw, f)
 	default:
@@ -135,12 +142,11 @@ func translateOnErrorValue(v string) (string, bool) {
 }
 
 // quickFixRedundantDependsOn recomputes the redundant dependsOn set from sol (the
-// same way lintRedundantDependsOn does, tolerating a nil registry/lookup) and
-// builds the removal edits: remove the whole dependsOn entry when every listed
-// dependency is redundant, or remove just the redundant list elements otherwise.
-// It returns (nil,false) when nothing is actually redundant, so a stale finding
-// never yields an empty edit.
-func quickFixRedundantDependsOn(sol *solution.Solution, raw []byte, f *Finding) ([]refactor.TextEdit, bool) {
+// same way lintRedundantDependsOn does) and builds the removal edits: remove the
+// whole dependsOn entry when every listed dependency is redundant, or remove just
+// the redundant list elements otherwise. It returns (nil,false) when nothing is
+// actually redundant, so a stale finding never yields an empty edit.
+func quickFixRedundantDependsOn(sol *solution.Solution, raw []byte, f *Finding, registry *provider.Registry) ([]refactor.TextEdit, bool) {
 	name := resolverNameFromDependsOnLoc(f.Location)
 	if name == "" {
 		return nil, false
@@ -150,14 +156,18 @@ func quickFixRedundantDependsOn(sol *solution.Solution, raw []byte, f *Finding) 
 		return nil, false
 	}
 
-	// Recompute the redundant set from the solution. A nil lookup performs only
-	// generic ValueRef-based extraction; the lint rule additionally consults the
-	// registry's per-provider ExtractDependencies. For all built-in providers the
-	// two converge, so the redundant set matches the finding. A plugin provider
-	// with custom dependency extraction could diverge; if any element cannot be
-	// confirmed redundant here, the guards below decline the fix rather than
-	// remove something the finding did not flag.
-	inferred := resolver.ExtractInferredDependencies(res, nil)
+	// Recompute the redundant set with the SAME provider-aware lookup the lint
+	// rule used to produce the finding (mirroring lintRedundantDependsOn). Using
+	// the identical lookup -- rather than a nil/generic recompute -- guarantees
+	// the redundant set matches exactly what the finding flagged, even when a
+	// provider's custom ExtractDependencies diverges from generic extraction. The
+	// guards below still decline the fix for anything not confirmed redundant, so
+	// a dependency a provider considers required is never removed.
+	var lookup resolver.DescriptorLookup
+	if registry != nil {
+		lookup = registry.DescriptorLookup()
+	}
+	inferred := resolver.ExtractInferredDependencies(res, lookup)
 	inferredSet := make(map[string]bool, len(inferred))
 	for _, dep := range inferred {
 		inferredSet[dep] = true

--- a/pkg/lint/quickfix.go
+++ b/pkg/lint/quickfix.go
@@ -1,0 +1,267 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/action"
+	"github.com/oakwood-commons/scafctl/pkg/refactor"
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/oakwood-commons/scafctl/pkg/resolver"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"gopkg.in/yaml.v3"
+)
+
+// QuickFixFor returns the source edits that resolve finding f when a
+// deterministic fix exists, and ok=false when the rule has no quick fix. It is
+// the single source of quick-fix logic: the LSP code-action handler maps these
+// edits into a WorkspaceEdit rather than re-deriving fixes, so the fix stays in
+// lockstep with the lint rules that produce the findings.
+//
+// Supported rules: "deprecated-field" (replace the deprecated key with its
+// tagged replacement, translating the value), "redundant-depends-on" (remove the
+// redundant dependsOn entry or entries), and "unused-resolver" (remove the whole
+// resolver block). Any other rule -- or any finding whose fix cannot be computed
+// deterministically from sol -- yields (nil, false). It never panics on odd
+// input: a fix that cannot be built safely is reported as "no fix" rather than a
+// broken edit.
+func QuickFixFor(sol *solution.Solution, f *Finding) (edits []refactor.TextEdit, ok bool) {
+	if sol == nil || f == nil {
+		return nil, false
+	}
+	raw := sol.RawContent()
+	if len(raw) == 0 {
+		return nil, false
+	}
+
+	switch f.RuleName {
+	case "deprecated-field":
+		return quickFixDeprecatedField(raw, f)
+	case "redundant-depends-on":
+		return quickFixRedundantDependsOn(sol, raw, f)
+	case "unused-resolver":
+		return quickFixUnusedResolver(sol, raw, f)
+	default:
+		return nil, false
+	}
+}
+
+// nodeMapPath maps a finding Location to the NodeMap/SourceMap path. Lint
+// Locations omit the "spec." prefix (e.g. "resolvers.foo"), while the node/source
+// maps are spec.-prefixed. The prefixed variant is tried first, then the raw
+// location as a fallback, matching addFinding's dual lookup. It returns the
+// resolved path, or ok=false when neither form is present in nodes.
+func nodeMapPath(nodes map[string]*yaml.Node, loc string) (string, bool) {
+	if _, present := nodes["spec."+loc]; present {
+		return "spec." + loc, true
+	}
+	if _, present := nodes[loc]; present {
+		return loc, true
+	}
+	return "", false
+}
+
+// quickFixDeprecatedField builds the onError -> continueOnError replacement. The
+// replacement key name is read from the struct tag via lookupDeprecatedField on
+// the proto that matches the finding's location context, so it tracks lint
+// rather than hardcoding "continueOnError". The current value is translated
+// continue -> true / fail -> false (the only two valid onError values).
+func quickFixDeprecatedField(raw []byte, f *Finding) ([]refactor.TextEdit, bool) {
+	nodes, err := refindex.NodeMap(raw)
+	if err != nil {
+		return nil, false
+	}
+	path, ok := nodeMapPath(nodes, f.Location)
+	if !ok {
+		return nil, false
+	}
+	node := nodes[path]
+	if node == nil {
+		return nil, false
+	}
+
+	newValue, ok := translateOnErrorValue(node.Value)
+	if !ok {
+		return nil, false
+	}
+
+	meta, ok := lookupDeprecatedField(deprecatedProtoFor(f.Location), "OnError")
+	if !ok || meta.replacement == "" {
+		return nil, false
+	}
+
+	edit, err := refactor.ReplaceMappingKeyAndValue(raw, path, meta.replacement, newValue)
+	if err != nil {
+		return nil, false
+	}
+	return []refactor.TextEdit{edit}, true
+}
+
+// deprecatedProtoFor returns the struct prototype whose OnError tag describes the
+// deprecation at loc, so lookupDeprecatedField reads the correct replacement.
+// forEach is checked before the action forms because a forEach.onError lives
+// under an action location.
+func deprecatedProtoFor(loc string) any {
+	switch {
+	case strings.HasSuffix(loc, ".forEach.onError"):
+		return spec.ForEachClause{}
+	case strings.Contains(loc, ".resolve.with["):
+		return resolver.ProviderSource{}
+	case strings.Contains(loc, ".transform.with["):
+		return resolver.ProviderTransform{}
+	default:
+		// workflow.actions.<name>.onError / workflow.finally.<name>.onError
+		return action.Action{}
+	}
+}
+
+// translateOnErrorValue maps a deprecated onError value to the boolean
+// continueOnError equivalent: "continue" (keep going on error) -> "true",
+// "fail" (stop on error) -> "false". Any other value yields ok=false so no fix
+// is offered.
+func translateOnErrorValue(v string) (string, bool) {
+	switch strings.TrimSpace(v) {
+	case string(spec.OnErrorContinue):
+		return "true", true
+	case string(spec.OnErrorFail):
+		return "false", true
+	default:
+		return "", false
+	}
+}
+
+// quickFixRedundantDependsOn recomputes the redundant dependsOn set from sol (the
+// same way lintRedundantDependsOn does, tolerating a nil registry/lookup) and
+// builds the removal edits: remove the whole dependsOn entry when every listed
+// dependency is redundant, or remove just the redundant list elements otherwise.
+// It returns (nil,false) when nothing is actually redundant, so a stale finding
+// never yields an empty edit.
+func quickFixRedundantDependsOn(sol *solution.Solution, raw []byte, f *Finding) ([]refactor.TextEdit, bool) {
+	name := resolverNameFromDependsOnLoc(f.Location)
+	if name == "" {
+		return nil, false
+	}
+	res, ok := sol.Spec.Resolvers[name]
+	if !ok || res == nil || len(res.DependsOn) == 0 {
+		return nil, false
+	}
+
+	// Recompute the redundant set from the solution. A nil lookup performs only
+	// generic ValueRef-based extraction; the lint rule additionally consults the
+	// registry's per-provider ExtractDependencies. For all built-in providers the
+	// two converge, so the redundant set matches the finding. A plugin provider
+	// with custom dependency extraction could diverge; if any element cannot be
+	// confirmed redundant here, the guards below decline the fix rather than
+	// remove something the finding did not flag.
+	inferred := resolver.ExtractInferredDependencies(res, nil)
+	inferredSet := make(map[string]bool, len(inferred))
+	for _, dep := range inferred {
+		inferredSet[dep] = true
+	}
+
+	redundantIdx := make([]int, 0, len(res.DependsOn))
+	for i, dep := range res.DependsOn {
+		if inferredSet[dep] {
+			redundantIdx = append(redundantIdx, i)
+		}
+	}
+	if len(redundantIdx) == 0 {
+		return nil, false
+	}
+
+	nodes, err := refindex.NodeMap(raw)
+	if err != nil {
+		return nil, false
+	}
+	dependsOnPath, ok := nodeMapPath(nodes, f.Location)
+	if !ok {
+		return nil, false
+	}
+
+	// All redundant -> drop the whole dependsOn mapping entry (removing every
+	// element would otherwise leave an empty list).
+	if len(redundantIdx) == len(res.DependsOn) {
+		edit, err := refactor.RemoveMappingEntry(raw, dependsOnPath)
+		if err != nil {
+			return nil, false
+		}
+		return []refactor.TextEdit{edit}, true
+	}
+
+	// Partial -> remove each redundant element by its index.
+	edits := make([]refactor.TextEdit, 0, len(redundantIdx))
+	for _, i := range redundantIdx {
+		elemPath := fmt.Sprintf("%s[%d]", dependsOnPath, i)
+		edit, err := refactor.RemoveSequenceElement(raw, elemPath)
+		if err != nil {
+			return nil, false
+		}
+		edits = append(edits, edit)
+	}
+	return edits, true
+}
+
+// resolverNameFromDependsOnLoc extracts the resolver name from a
+// "resolvers.<name>.dependsOn" finding location (with or without a spec.
+// prefix). Resolver names cannot contain dots, so the fixed prefix/suffix strip
+// is unambiguous. It returns "" when loc is not that shape.
+func resolverNameFromDependsOnLoc(loc string) string {
+	loc = strings.TrimPrefix(loc, "spec.")
+	if !strings.HasPrefix(loc, "resolvers.") || !strings.HasSuffix(loc, ".dependsOn") {
+		return ""
+	}
+	name := strings.TrimSuffix(strings.TrimPrefix(loc, "resolvers."), ".dependsOn")
+	if name == "" || strings.Contains(name, ".") {
+		return ""
+	}
+	return name
+}
+
+// quickFixUnusedResolver removes the entire unused resolver mapping entry at the
+// finding's "resolvers.<name>" location. When the target is the SOLE resolver,
+// removing just its entry would leave the parent `resolvers:` key with a null
+// value -- which the JSON-schema lint reports as a fresh error (want object, got
+// null), turning a warning into an error. In that case the whole `resolvers:`
+// mapping entry is removed instead, mirroring the all-vs-partial handling in the
+// redundant-dependsOn fix.
+func quickFixUnusedResolver(sol *solution.Solution, raw []byte, f *Finding) ([]refactor.TextEdit, bool) {
+	nodes, err := refindex.NodeMap(raw)
+	if err != nil {
+		return nil, false
+	}
+	path, ok := nodeMapPath(nodes, f.Location)
+	if !ok {
+		return nil, false
+	}
+
+	// Removing the last remaining resolver would empty the parent map, so drop
+	// the parent `resolvers:` entry instead of leaving a null value behind.
+	if len(sol.Spec.Resolvers) <= 1 {
+		if parent, ok := parentPath(path); ok {
+			if edit, err := refactor.RemoveMappingEntry(raw, parent); err == nil {
+				return []refactor.TextEdit{edit}, true
+			}
+		}
+	}
+
+	edit, err := refactor.RemoveMappingEntry(raw, path)
+	if err != nil {
+		return nil, false
+	}
+	return []refactor.TextEdit{edit}, true
+}
+
+// parentPath returns the path of the mapping that contains the entry at path by
+// stripping the final ".<key>" segment (e.g. "spec.resolvers.foo" ->
+// "spec.resolvers"). It returns ok=false when path has no parent segment.
+func parentPath(path string) (string, bool) {
+	i := strings.LastIndex(path, ".")
+	if i <= 0 {
+		return "", false
+	}
+	return path[:i], true
+}

--- a/pkg/lint/quickfix_test.go
+++ b/pkg/lint/quickfix_test.go
@@ -1,0 +1,334 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/refactor"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// loadQuickFixSolution parses YAML into a Solution (retaining raw content and
+// source map, which QuickFixFor relies on).
+func loadQuickFixSolution(t *testing.T, y string) *solution.Solution {
+	t.Helper()
+	sol := &solution.Solution{}
+	require.NoError(t, sol.UnmarshalFromBytes([]byte(y)))
+	return sol
+}
+
+// findingByRule runs lint and returns the first finding for the given rule.
+func findingByRule(t *testing.T, sol *solution.Solution, rule string) *Finding {
+	t.Helper()
+	result := Solution(sol, "solution.yaml", nil)
+	for _, f := range result.Findings {
+		if f.RuleName == rule {
+			return f
+		}
+	}
+	t.Fatalf("no finding with rule %q found (findings: %v)", rule, ruleNames(result.Findings))
+	return nil
+}
+
+func ruleNames(fs []*Finding) []string {
+	out := make([]string, 0, len(fs))
+	for _, f := range fs {
+		out = append(out, f.RuleName)
+	}
+	return out
+}
+
+// applyAndValidate applies edits to the solution's raw content and asserts the
+// result still parses and passes spec validation -- the core safety guarantee of
+// a quick fix (it must never produce a broken solution).
+func applyAndValidate(t *testing.T, sol *solution.Solution, edits []refactor.TextEdit) string {
+	t.Helper()
+	out, err := refactor.Apply(sol.RawContent(), edits)
+	require.NoError(t, err, "edits must apply")
+	fixed := &solution.Solution{}
+	require.NoError(t, fixed.UnmarshalFromBytes(out), "fixed output must re-parse")
+	require.NoError(t, fixed.ValidateSpec(), "fixed output must pass spec validation")
+	return string(out)
+}
+
+func TestQuickFixFor_UnsupportedRule(t *testing.T) {
+	sol := loadQuickFixSolution(t, unusedResolverFixture)
+	edits, ok := QuickFixFor(sol, &Finding{RuleName: "some-other-rule", Location: "resolvers.x"})
+	assert.False(t, ok)
+	assert.Nil(t, edits)
+}
+
+func TestQuickFixFor_NilInputs(t *testing.T) {
+	edits, ok := QuickFixFor(nil, &Finding{RuleName: "unused-resolver"})
+	assert.False(t, ok)
+	assert.Nil(t, edits)
+
+	sol := loadQuickFixSolution(t, unusedResolverFixture)
+	edits, ok = QuickFixFor(sol, nil)
+	assert.False(t, ok)
+	assert.Nil(t, edits)
+}
+
+// ── deprecated-field ─────────────────────────────────────────────────────────
+
+const deprecatedResolveFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: dep
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: parameter
+            onError: continue
+            inputs:
+              value: dev
+    b:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.a
+`
+
+func TestQuickFixFor_DeprecatedField_ResolveContinue(t *testing.T) {
+	sol := loadQuickFixSolution(t, deprecatedResolveFixture)
+	f := findingByRule(t, sol, "deprecated-field")
+	require.Equal(t, "resolvers.a.resolve.with[0].onError", f.Location)
+
+	edits, ok := QuickFixFor(sol, f)
+	require.True(t, ok)
+	require.Len(t, edits, 1)
+
+	out := applyAndValidate(t, sol, edits)
+	assert.Contains(t, out, "continueOnError: true")
+	assert.NotContains(t, out, "onError: continue")
+}
+
+const deprecatedActionFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: dep-action
+spec:
+  workflow:
+    actions:
+      deploy:
+        provider: message
+        onError: fail
+        inputs:
+          message: go
+`
+
+func TestQuickFixFor_DeprecatedField_ActionFail(t *testing.T) {
+	sol := loadQuickFixSolution(t, deprecatedActionFixture)
+	f := findingByRule(t, sol, "deprecated-field")
+	require.Equal(t, "workflow.actions.deploy.onError", f.Location)
+
+	edits, ok := QuickFixFor(sol, f)
+	require.True(t, ok)
+	out := applyAndValidate(t, sol, edits)
+	assert.Contains(t, out, "continueOnError: false")
+	assert.NotContains(t, out, "onError: fail")
+}
+
+const deprecatedForEachFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: dep-foreach
+spec:
+  workflow:
+    actions:
+      deploy:
+        provider: message
+        forEach:
+          in:
+            expr: "['a','b']"
+          onError: continue
+        inputs:
+          message: "{{ .__item }}"
+`
+
+func TestQuickFixFor_DeprecatedField_ForEachContinue(t *testing.T) {
+	sol := loadQuickFixSolution(t, deprecatedForEachFixture)
+	f := findingByRule(t, sol, "deprecated-field")
+	require.Equal(t, "workflow.actions.deploy.forEach.onError", f.Location)
+
+	edits, ok := QuickFixFor(sol, f)
+	require.True(t, ok)
+	out := applyAndValidate(t, sol, edits)
+	assert.Contains(t, out, "continueOnError: true")
+}
+
+// ── redundant-depends-on ─────────────────────────────────────────────────────
+
+const redundantAllFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: redundant-all
+spec:
+  resolvers:
+    env:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    app:
+      dependsOn:
+        - env
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.env
+`
+
+func TestQuickFixFor_RedundantDependsOn_All(t *testing.T) {
+	sol := loadQuickFixSolution(t, redundantAllFixture)
+	f := findingByRule(t, sol, "redundant-depends-on")
+	require.Equal(t, "resolvers.app.dependsOn", f.Location)
+
+	edits, ok := QuickFixFor(sol, f)
+	require.True(t, ok)
+	out := applyAndValidate(t, sol, edits)
+	assert.NotContains(t, out, "dependsOn:", "the whole dependsOn entry is removed")
+	assert.Contains(t, out, "expr: _.env")
+}
+
+const redundantPartialFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: redundant-partial
+spec:
+  resolvers:
+    env:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    other:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: x
+    app:
+      dependsOn:
+        - env
+        - other
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.env
+`
+
+func TestQuickFixFor_RedundantDependsOn_Partial(t *testing.T) {
+	sol := loadQuickFixSolution(t, redundantPartialFixture)
+	f := findingByRule(t, sol, "redundant-depends-on")
+
+	edits, ok := QuickFixFor(sol, f)
+	require.True(t, ok)
+	// Only 'env' is inferred (via expr:), 'other' is a genuine ordering dep.
+	require.Len(t, edits, 1)
+	out := applyAndValidate(t, sol, edits)
+	assert.Contains(t, out, "dependsOn:", "the list survives")
+	assert.NotContains(t, out, "- env")
+	assert.Contains(t, out, "- other", "the non-redundant entry survives")
+}
+
+// ── unused-resolver ──────────────────────────────────────────────────────────
+
+const unusedResolverFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: unused
+spec:
+  resolvers:
+    used:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    orphan:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: x
+  workflow:
+    actions:
+      show:
+        provider: message
+        inputs:
+          message:
+            expr: _.used
+`
+
+func TestQuickFixFor_UnusedResolver(t *testing.T) {
+	sol := loadQuickFixSolution(t, unusedResolverFixture)
+	f := findingByRule(t, sol, "unused-resolver")
+	require.Equal(t, "resolvers.orphan", f.Location)
+
+	edits, ok := QuickFixFor(sol, f)
+	require.True(t, ok)
+	out := applyAndValidate(t, sol, edits)
+	assert.NotContains(t, out, "orphan:", "the orphan resolver is removed")
+	assert.Contains(t, out, "used:", "the used resolver survives")
+}
+
+// soleUnusedResolverFixture has exactly one resolver, and it is unused: removing
+// only its entry would leave `resolvers:` with a null value.
+const soleUnusedResolverFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: sole
+spec:
+  resolvers:
+    orphan:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: x
+  workflow:
+    actions:
+      show:
+        provider: message
+        inputs:
+          message: hi
+`
+
+func TestQuickFixFor_UnusedResolver_SoleResolverRemovesParent(t *testing.T) {
+	sol := loadQuickFixSolution(t, soleUnusedResolverFixture)
+	f := findingByRule(t, sol, "unused-resolver")
+	require.Equal(t, "resolvers.orphan", f.Location)
+
+	edits, ok := QuickFixFor(sol, f)
+	require.True(t, ok)
+	out := applyAndValidate(t, sol, edits)
+
+	// The whole resolvers: block is removed, not left as a null-valued key.
+	assert.NotContains(t, out, "resolvers:", "empty resolvers: key must not remain")
+	assert.NotContains(t, out, "orphan:", "the orphan resolver is removed")
+	assert.Contains(t, out, "workflow:", "the rest of the spec survives")
+
+	// Re-linting the fixed document must NOT introduce a new schema error from a
+	// null resolvers: value (the failure mode this fix guards against).
+	fixed := &solution.Solution{}
+	require.NoError(t, fixed.UnmarshalFromBytes([]byte(out)))
+	for _, nf := range Solution(fixed, "solution.yaml", nil).Findings {
+		assert.NotContains(t, nf.Message, "null",
+			"fix must not introduce a null-value finding (rule %q)", nf.RuleName)
+	}
+}

--- a/pkg/lint/quickfix_test.go
+++ b/pkg/lint/quickfix_test.go
@@ -6,6 +6,7 @@ package lint
 import (
 	"testing"
 
+	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/refactor"
 	"github.com/oakwood-commons/scafctl/pkg/solution"
 	"github.com/stretchr/testify/assert"
@@ -57,18 +58,18 @@ func applyAndValidate(t *testing.T, sol *solution.Solution, edits []refactor.Tex
 
 func TestQuickFixFor_UnsupportedRule(t *testing.T) {
 	sol := loadQuickFixSolution(t, unusedResolverFixture)
-	edits, ok := QuickFixFor(sol, &Finding{RuleName: "some-other-rule", Location: "resolvers.x"})
+	edits, ok := QuickFixFor(sol, &Finding{RuleName: "some-other-rule", Location: "resolvers.x"}, nil)
 	assert.False(t, ok)
 	assert.Nil(t, edits)
 }
 
 func TestQuickFixFor_NilInputs(t *testing.T) {
-	edits, ok := QuickFixFor(nil, &Finding{RuleName: "unused-resolver"})
+	edits, ok := QuickFixFor(nil, &Finding{RuleName: "unused-resolver"}, nil)
 	assert.False(t, ok)
 	assert.Nil(t, edits)
 
 	sol := loadQuickFixSolution(t, unusedResolverFixture)
-	edits, ok = QuickFixFor(sol, nil)
+	edits, ok = QuickFixFor(sol, nil, nil)
 	assert.False(t, ok)
 	assert.Nil(t, edits)
 }
@@ -102,7 +103,7 @@ func TestQuickFixFor_DeprecatedField_ResolveContinue(t *testing.T) {
 	f := findingByRule(t, sol, "deprecated-field")
 	require.Equal(t, "resolvers.a.resolve.with[0].onError", f.Location)
 
-	edits, ok := QuickFixFor(sol, f)
+	edits, ok := QuickFixFor(sol, f, nil)
 	require.True(t, ok)
 	require.Len(t, edits, 1)
 
@@ -130,7 +131,7 @@ func TestQuickFixFor_DeprecatedField_ActionFail(t *testing.T) {
 	f := findingByRule(t, sol, "deprecated-field")
 	require.Equal(t, "workflow.actions.deploy.onError", f.Location)
 
-	edits, ok := QuickFixFor(sol, f)
+	edits, ok := QuickFixFor(sol, f, nil)
 	require.True(t, ok)
 	out := applyAndValidate(t, sol, edits)
 	assert.Contains(t, out, "continueOnError: false")
@@ -159,7 +160,7 @@ func TestQuickFixFor_DeprecatedField_ForEachContinue(t *testing.T) {
 	f := findingByRule(t, sol, "deprecated-field")
 	require.Equal(t, "workflow.actions.deploy.forEach.onError", f.Location)
 
-	edits, ok := QuickFixFor(sol, f)
+	edits, ok := QuickFixFor(sol, f, nil)
 	require.True(t, ok)
 	out := applyAndValidate(t, sol, edits)
 	assert.Contains(t, out, "continueOnError: true")
@@ -195,7 +196,7 @@ func TestQuickFixFor_RedundantDependsOn_All(t *testing.T) {
 	f := findingByRule(t, sol, "redundant-depends-on")
 	require.Equal(t, "resolvers.app.dependsOn", f.Location)
 
-	edits, ok := QuickFixFor(sol, f)
+	edits, ok := QuickFixFor(sol, f, nil)
 	require.True(t, ok)
 	out := applyAndValidate(t, sol, edits)
 	assert.NotContains(t, out, "dependsOn:", "the whole dependsOn entry is removed")
@@ -236,7 +237,7 @@ func TestQuickFixFor_RedundantDependsOn_Partial(t *testing.T) {
 	sol := loadQuickFixSolution(t, redundantPartialFixture)
 	f := findingByRule(t, sol, "redundant-depends-on")
 
-	edits, ok := QuickFixFor(sol, f)
+	edits, ok := QuickFixFor(sol, f, nil)
 	require.True(t, ok)
 	// Only 'env' is inferred (via expr:), 'other' is a genuine ordering dep.
 	require.Len(t, edits, 1)
@@ -244,6 +245,97 @@ func TestQuickFixFor_RedundantDependsOn_Partial(t *testing.T) {
 	assert.Contains(t, out, "dependsOn:", "the list survives")
 	assert.NotContains(t, out, "- env")
 	assert.Contains(t, out, "- other", "the non-redundant entry survives")
+}
+
+// redundantDivergentFixture exercises a provider whose custom dependency
+// extraction diverges from generic extraction: resolver "app" declares
+// dependsOn [seed, extra] but references both only through the "divergent"
+// provider's inputs. Provider-aware lint (used to produce the finding) infers
+// only "seed" as redundant, leaving "extra" as a genuine ordering dependency.
+// A generic (nil-lookup) recompute would infer BOTH and delete the whole
+// dependsOn block -- removing the non-redundant "extra". The fix must keep the
+// quick fix in lockstep with the finding by using the same provider lookup.
+const redundantDivergentFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: divergent
+spec:
+  resolvers:
+    seed:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    extra:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: x
+    app:
+      dependsOn:
+        - seed
+        - extra
+      resolve:
+        with:
+          - provider: divergent
+            inputs:
+              a:
+                expr: _.seed
+              b:
+                expr: _.extra
+  workflow:
+    actions:
+      show:
+        provider: message
+        inputs:
+          message:
+            expr: _.app
+`
+
+// TestQuickFixFor_RedundantDependsOn_ProviderLookupLockstep is a regression test
+// for the quick fix removing a dependsOn entry the finding did not flag. Without
+// threading the registry into QuickFixFor, the redundant set was recomputed with
+// a nil (generic) lookup that diverged from the provider-aware finding, deleting
+// the non-redundant "extra" entry (and, since that made all entries "redundant",
+// the whole dependsOn block). With the registry threaded through, the recompute
+// matches the finding: only "seed" is removed.
+func TestQuickFixFor_RedundantDependsOn_ProviderLookupLockstep(t *testing.T) {
+	fp := newFakeProvider("divergent", nil)
+	fp.desc.ExtractDependencies = func(_ map[string]any) []string {
+		// Report only "seed"; "extra" is intentionally NOT inferred so it must
+		// survive as a genuine ordering dependency.
+		return []string{"seed"}
+	}
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(fp))
+	require.NoError(t, reg.Register(newFakeProvider("parameter", nil)))
+	require.NoError(t, reg.Register(newFakeProvider("message", nil)))
+
+	sol := loadQuickFixSolution(t, redundantDivergentFixture)
+
+	// The finding is produced with the provider registry (as the LSP does).
+	result := Solution(sol, "solution.yaml", reg)
+	var f *Finding
+	for _, ff := range result.Findings {
+		if ff.RuleName == "redundant-depends-on" {
+			f = ff
+		}
+	}
+	require.NotNil(t, f, "expected a redundant-depends-on finding; got %v", ruleNames(result.Findings))
+	require.Contains(t, f.Message, "seed")
+	require.NotContains(t, f.Message, "extra", "provider-aware lint must not flag 'extra'")
+
+	// The quick fix must use the SAME registry lookup, removing only "seed".
+	edits, ok := QuickFixFor(sol, f, reg)
+	require.True(t, ok)
+	require.Len(t, edits, 1, "only the single redundant entry is removed")
+
+	out := applyAndValidate(t, sol, edits)
+	assert.Contains(t, out, "dependsOn:", "the dependsOn block survives")
+	assert.NotContains(t, out, "- seed", "the redundant 'seed' entry is removed")
+	assert.Contains(t, out, "- extra", "the non-redundant 'extra' ordering dependency survives")
 }
 
 // ── unused-resolver ──────────────────────────────────────────────────────────
@@ -280,7 +372,7 @@ func TestQuickFixFor_UnusedResolver(t *testing.T) {
 	f := findingByRule(t, sol, "unused-resolver")
 	require.Equal(t, "resolvers.orphan", f.Location)
 
-	edits, ok := QuickFixFor(sol, f)
+	edits, ok := QuickFixFor(sol, f, nil)
 	require.True(t, ok)
 	out := applyAndValidate(t, sol, edits)
 	assert.NotContains(t, out, "orphan:", "the orphan resolver is removed")
@@ -314,7 +406,7 @@ func TestQuickFixFor_UnusedResolver_SoleResolverRemovesParent(t *testing.T) {
 	f := findingByRule(t, sol, "unused-resolver")
 	require.Equal(t, "resolvers.orphan", f.Location)
 
-	edits, ok := QuickFixFor(sol, f)
+	edits, ok := QuickFixFor(sol, f, nil)
 	require.True(t, ok)
 	out := applyAndValidate(t, sol, edits)
 

--- a/pkg/lsp/capabilities.go
+++ b/pkg/lsp/capabilities.go
@@ -39,6 +39,7 @@ type feature struct {
 // Handler() or the Initialize closure.
 func defaultFeatures() []feature {
 	return []feature{
+		codeActionFeature(),
 		documentSyncFeature(),
 		navigationFeature(),
 		renameFeature(),

--- a/pkg/lsp/capabilities_test.go
+++ b/pkg/lsp/capabilities_test.go
@@ -23,7 +23,7 @@ func TestDefaultFeatures_DeterministicOrder(t *testing.T) {
 		got = append(got, f.name)
 		require.NotNil(t, f.wire, "every feature must wire a handler")
 	}
-	assert.Equal(t, []string{"documentSync", "navigation", "rename", "symbols"}, got)
+	assert.Equal(t, []string{"codeAction", "documentSync", "navigation", "rename", "symbols"}, got)
 	assert.True(t, sort.StringsAreSorted(got), "features must be registered in alphabetical order")
 }
 

--- a/pkg/lsp/codeaction.go
+++ b/pkg/lsp/codeaction.go
@@ -1,0 +1,207 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/lint"
+	"github.com/oakwood-commons/scafctl/pkg/refactor"
+	glsp "github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// codeActionFeature wires textDocument/codeAction so editors offer one-click
+// quick fixes for lint diagnostics (deprecated onError, redundant dependsOn,
+// unused resolver). It advertises the QuickFix kind explicitly: glsp derives
+// CodeActionProvider=true from the wired handler, but the issue asks the server
+// to announce the specific kind it provides so clients can filter menus.
+func codeActionFeature() feature {
+	return feature{
+		name: "codeAction",
+		wire: func(h *protocol.Handler, s *Server) {
+			h.TextDocumentCodeAction = s.codeAction
+		},
+		advertise: func(c *protocol.ServerCapabilities) {
+			c.CodeActionProvider = &protocol.CodeActionOptions{
+				CodeActionKinds: []protocol.CodeActionKind{protocol.CodeActionKindQuickFix},
+			}
+		},
+	}
+}
+
+// codeAction answers textDocument/codeAction from the per-document cache. It
+// re-lints the cached solution (the same path diagnostics take) to obtain
+// findings with positions, keeps only those that are both fixable and relevant
+// to the request range/diagnostics, and returns each as a QuickFix code action
+// carrying the source edits from lint.QuickFixFor.
+//
+// It returns (nil, nil) -- never an error -- when the document is unknown, not
+// parsed, or has no applicable fixes, so an editor that requests actions on
+// every cursor move gets an empty result rather than a failure.
+func (s *Server) codeAction(_ *glsp.Context, params *protocol.CodeActionParams) (any, error) {
+	entry, ok := s.getDoc(params.TextDocument.URI)
+	if !ok || entry.Sol == nil {
+		return nil, nil
+	}
+
+	// Respect the client's kind filter: if it asked for kinds and none of them
+	// is quickfix, there is nothing for this server to contribute.
+	if !onlyAllowsQuickFix(params.Context.Only) {
+		return nil, nil
+	}
+
+	result := lint.Solution(entry.Sol, uriToPath(params.TextDocument.URI), s.registry)
+
+	actions := make([]protocol.CodeAction, 0)
+	for _, f := range result.Findings {
+		edits, fixable := lint.QuickFixFor(entry.Sol, f)
+		if !fixable || len(edits) == 0 {
+			continue
+		}
+		if !findingMatchesRequest(f, params) {
+			continue
+		}
+		actions = append(actions, buildCodeAction(f, edits, params))
+	}
+
+	if len(actions) == 0 {
+		return nil, nil
+	}
+	return actions, nil
+}
+
+// onlyAllowsQuickFix reports whether the request's Context.Only permits a
+// quickfix action. An empty/absent Only list means "no filter" (allow). A
+// non-empty list allows only when it contains the quickfix kind.
+func onlyAllowsQuickFix(only []protocol.CodeActionKind) bool {
+	if len(only) == 0 {
+		return true
+	}
+	for _, k := range only {
+		if k == protocol.CodeActionKindQuickFix {
+			return true
+		}
+	}
+	return false
+}
+
+// findingMatchesRequest reports whether finding f is relevant to the code-action
+// request: either its source line overlaps the requested range, or its rule name
+// matches the Code of an incoming diagnostic whose range overlaps the request.
+// Line-level overlap is intentionally coarse -- it is robust to the column
+// differences between a finding's squiggle and the client's cursor selection.
+func findingMatchesRequest(f *lint.Finding, params *protocol.CodeActionParams) bool {
+	// A finding with no resolved source position (Line 0) has no location to
+	// match; rely solely on an incoming diagnostic's rule-name match below so it
+	// is not spuriously offered on line 0 of every request.
+	if f.Line > 0 {
+		findingLine := lspLine(f.Line)
+		if lineInRange(findingLine, params.Range) {
+			return true
+		}
+		for _, d := range params.Context.Diagnostics {
+			if diagnosticCode(d) != f.RuleName {
+				continue
+			}
+			if rangesOverlapLines(d.Range, params.Range) || lineInRange(findingLine, d.Range) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, d := range params.Context.Diagnostics {
+		if diagnosticCode(d) == f.RuleName && rangesOverlapLines(d.Range, params.Range) {
+			return true
+		}
+	}
+	return false
+}
+
+// diagnosticCode returns the string form of a diagnostic's Code (the rule name
+// scafctl publishes), or "" when it is absent or not a string.
+func diagnosticCode(d protocol.Diagnostic) string {
+	if d.Code == nil {
+		return ""
+	}
+	if s, ok := d.Code.Value.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// lineInRange reports whether a 0-based line falls within an LSP range's line
+// span (inclusive).
+func lineInRange(line uint32, r protocol.Range) bool {
+	return line >= r.Start.Line && line <= r.End.Line
+}
+
+// rangesOverlapLines reports whether two LSP ranges share any line.
+func rangesOverlapLines(a, b protocol.Range) bool {
+	return a.Start.Line <= b.End.Line && b.Start.Line <= a.End.Line
+}
+
+// buildCodeAction assembles the QuickFix code action for a fixable finding: a
+// human-readable title, the quickfix kind, the incoming diagnostics it resolves,
+// the workspace edit built from lint.QuickFixFor's edits, and IsPreferred so the
+// editor's auto-fix targets it.
+func buildCodeAction(f *lint.Finding, edits []refactor.TextEdit, params *protocol.CodeActionParams) protocol.CodeAction {
+	lspEdits := make([]protocol.TextEdit, 0, len(edits))
+	for _, e := range edits {
+		lspEdits = append(lspEdits, protocol.TextEdit{Range: toLSPRange(e.Range), NewText: e.NewText})
+	}
+
+	kind := protocol.CodeActionKindQuickFix
+	preferred := true
+	return protocol.CodeAction{
+		Title:       codeActionTitle(f),
+		Kind:        &kind,
+		Diagnostics: matchingDiagnostics(f, params),
+		IsPreferred: &preferred,
+		Edit: &protocol.WorkspaceEdit{
+			Changes: map[protocol.DocumentUri][]protocol.TextEdit{
+				params.TextDocument.URI: lspEdits,
+			},
+		},
+	}
+}
+
+// matchingDiagnostics returns the subset of the request's incoming diagnostics
+// whose Code equals the finding's rule name, so the action is attached to the
+// diagnostic(s) it resolves.
+func matchingDiagnostics(f *lint.Finding, params *protocol.CodeActionParams) []protocol.Diagnostic {
+	var out []protocol.Diagnostic
+	for _, d := range params.Context.Diagnostics {
+		if diagnosticCode(d) == f.RuleName {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// codeActionTitle returns the menu title for a fixable finding, keyed by rule.
+func codeActionTitle(f *lint.Finding) string {
+	switch f.RuleName {
+	case "deprecated-field":
+		return "Replace deprecated 'onError' with 'continueOnError'"
+	case "redundant-depends-on":
+		return "Remove redundant dependsOn"
+	case "unused-resolver":
+		return fmt.Sprintf("Remove unused resolver '%s'", resolverNameFromLocation(f.Location))
+	default:
+		return "Fix lint issue"
+	}
+}
+
+// resolverNameFromLocation extracts the resolver name from a "resolvers.<name>"
+// finding location (with or without a spec. prefix) for display in the action
+// title. It returns the raw location when the shape is unexpected.
+func resolverNameFromLocation(loc string) string {
+	const prefix = "resolvers."
+	if i := strings.Index(loc, prefix); i >= 0 {
+		return loc[i+len(prefix):]
+	}
+	return loc
+}

--- a/pkg/lsp/codeaction.go
+++ b/pkg/lsp/codeaction.go
@@ -168,13 +168,26 @@ func buildCodeAction(f *lint.Finding, edits []refactor.TextEdit, params *protoco
 	}
 }
 
-// matchingDiagnostics returns the subset of the request's incoming diagnostics
-// whose Code equals the finding's rule name, so the action is attached to the
-// diagnostic(s) it resolves.
+// matchingDiagnostics returns the incoming diagnostics that THIS action actually
+// resolves: those whose Code equals the finding's rule name AND whose range
+// covers the finding's own line. Matching on rule name alone would wrongly
+// attach every same-rule diagnostic in the document (e.g. two deprecated-field
+// findings on different lines) to each action, so each action would claim to
+// resolve findings its single edit does not touch. When the finding has no
+// resolved position (Line 0), the request range is used as the fallback filter.
 func matchingDiagnostics(f *lint.Finding, params *protocol.CodeActionParams) []protocol.Diagnostic {
 	var out []protocol.Diagnostic
 	for _, d := range params.Context.Diagnostics {
-		if diagnosticCode(d) == f.RuleName {
+		if diagnosticCode(d) != f.RuleName {
+			continue
+		}
+		if f.Line > 0 {
+			if lineInRange(lspLine(f.Line), d.Range) {
+				out = append(out, d)
+			}
+			continue
+		}
+		if rangesOverlapLines(d.Range, params.Range) {
 			out = append(out, d)
 		}
 	}

--- a/pkg/lsp/codeaction.go
+++ b/pkg/lsp/codeaction.go
@@ -57,7 +57,7 @@ func (s *Server) codeAction(_ *glsp.Context, params *protocol.CodeActionParams) 
 
 	actions := make([]protocol.CodeAction, 0)
 	for _, f := range result.Findings {
-		edits, fixable := lint.QuickFixFor(entry.Sol, f)
+		edits, fixable := lint.QuickFixFor(entry.Sol, f, s.registry)
 		if !fixable || len(edits) == 0 {
 			continue
 		}

--- a/pkg/lsp/codeaction_test.go
+++ b/pkg/lsp/codeaction_test.go
@@ -113,6 +113,84 @@ func TestCodeAction_DeprecatedField_ReturnsQuickFix(t *testing.T) {
 	require.Len(t, a.Diagnostics, 1)
 }
 
+// twoDeprecatedDoc has two deprecated onError fields on different lines (line 10
+// in resolver a, line 17 in resolver b), producing two deprecated-field findings.
+// A workflow references both resolvers so neither is flagged unused.
+const twoDeprecatedDoc = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: twodep
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: parameter
+            onError: continue
+            inputs:
+              value: dev
+    b:
+      resolve:
+        with:
+          - provider: parameter
+            onError: fail
+            inputs:
+              value:
+                expr: _.a
+  workflow:
+    actions:
+      show:
+        provider: message
+        inputs:
+          message:
+            expr: _.a + _.b
+`
+
+func TestCodeAction_AttachesOnlyItsOwnDiagnostic(t *testing.T) {
+	s := newTestServer(t)
+	const uri = "file:///twodep.yaml"
+	openDoc(t, s, uri, twoDeprecatedDoc)
+
+	code := protocol.IntegerOrString{Value: "deprecated-field"}
+	diagA := protocol.Diagnostic{
+		Range: protocol.Range{Start: protocol.Position{Line: 10}, End: protocol.Position{Line: 10, Character: 30}},
+		Code:  &code,
+	}
+	diagB := protocol.Diagnostic{
+		Range: protocol.Range{Start: protocol.Position{Line: 17}, End: protocol.Position{Line: 17, Character: 30}},
+		Code:  &code,
+	}
+	// A request spanning both findings, carrying both same-rule diagnostics.
+	params := &protocol.CodeActionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Range:        protocol.Range{Start: protocol.Position{Line: 0}, End: protocol.Position{Line: 30}},
+		Context:      protocol.CodeActionContext{Diagnostics: []protocol.Diagnostic{diagA, diagB}},
+	}
+
+	res, err := s.codeAction(&glsp.Context{}, params)
+	require.NoError(t, err)
+	actions, ok := res.([]protocol.CodeAction)
+	require.True(t, ok)
+
+	// Both deprecated-field quick fixes are returned, and each attaches exactly
+	// ONE diagnostic -- the one on its own line -- not every same-rule diagnostic
+	// in the document.
+	deprecatedActions := 0
+	for _, a := range actions {
+		if a.Title != "Replace deprecated 'onError' with 'continueOnError'" {
+			continue
+		}
+		deprecatedActions++
+		require.Len(t, a.Diagnostics, 1,
+			"action must resolve only its own diagnostic")
+		attachedLine := a.Diagnostics[0].Range.Start.Line
+		editLine := a.Edit.Changes[uri][0].Range.Start.Line
+		assert.Equal(t, editLine, attachedLine,
+			"attached diagnostic line must match the action's edit line")
+	}
+	assert.Equal(t, 2, deprecatedActions, "one quick fix per deprecated-field finding")
+}
+
 func TestCodeAction_CleanDoc_ReturnsNil(t *testing.T) {
 	s := newTestServer(t)
 	const uri = "file:///clean.yaml"

--- a/pkg/lsp/codeaction_test.go
+++ b/pkg/lsp/codeaction_test.go
@@ -1,0 +1,197 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	glsp "github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+const deprecatedDoc = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: dep
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: parameter
+            onError: continue
+            inputs:
+              value: dev
+    b:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.a
+`
+
+const cleanDoc = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: clean
+spec:
+  resolvers:
+    a:
+      description: an input
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+  workflow:
+    actions:
+      show:
+        description: prints
+        provider: message
+        inputs:
+          message:
+            expr: _.a
+`
+
+// openDoc seeds the server's document cache with content at uri.
+func openDoc(t *testing.T, s *Server, uri protocol.DocumentUri, text string) {
+	t.Helper()
+	s.docs.Set(uri, 1, text)
+	entry, ok := s.getDoc(uri)
+	require.True(t, ok)
+	require.NotNil(t, entry.Sol, "test document must parse")
+}
+
+// quickFixParams builds a code-action request over the given line range with a
+// single incoming deprecated-field diagnostic (the rule used by these tests).
+func quickFixParams(uri protocol.DocumentUri, line uint32, only []protocol.CodeActionKind) *protocol.CodeActionParams {
+	rng := protocol.Range{
+		Start: protocol.Position{Line: line, Character: 0},
+		End:   protocol.Position{Line: line, Character: 20},
+	}
+	code := protocol.IntegerOrString{Value: "deprecated-field"}
+	return &protocol.CodeActionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Range:        rng,
+		Context: protocol.CodeActionContext{
+			Diagnostics: []protocol.Diagnostic{{Range: rng, Code: &code}},
+			Only:        only,
+		},
+	}
+}
+
+func TestCodeAction_DeprecatedField_ReturnsQuickFix(t *testing.T) {
+	s := newTestServer(t)
+	const uri = "file:///dep.yaml"
+	openDoc(t, s, uri, deprecatedDoc)
+
+	// The onError line is line 10 (0-based) in deprecatedDoc.
+	params := quickFixParams(uri, 10, nil)
+	res, err := s.codeAction(&glsp.Context{}, params)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	actions, ok := res.([]protocol.CodeAction)
+	require.True(t, ok)
+	require.Len(t, actions, 1)
+
+	a := actions[0]
+	assert.Equal(t, "Replace deprecated 'onError' with 'continueOnError'", a.Title)
+	require.NotNil(t, a.Kind)
+	assert.Equal(t, protocol.CodeActionKindQuickFix, *a.Kind)
+	require.NotNil(t, a.IsPreferred)
+	assert.True(t, *a.IsPreferred)
+	require.NotNil(t, a.Edit)
+	edits := a.Edit.Changes[uri]
+	require.NotEmpty(t, edits)
+	assert.Equal(t, "continueOnError: true", edits[0].NewText)
+	// The resolved diagnostic is attached.
+	require.Len(t, a.Diagnostics, 1)
+}
+
+func TestCodeAction_CleanDoc_ReturnsNil(t *testing.T) {
+	s := newTestServer(t)
+	const uri = "file:///clean.yaml"
+	openDoc(t, s, uri, cleanDoc)
+
+	params := quickFixParams(uri, 0, nil)
+	res, err := s.codeAction(&glsp.Context{}, params)
+	require.NoError(t, err)
+	assert.Nil(t, res, "a clean document offers no quick fixes")
+}
+
+func TestCodeAction_UnknownDocument_ReturnsNil(t *testing.T) {
+	s := newTestServer(t)
+	res, err := s.codeAction(&glsp.Context{}, quickFixParams("file:///missing.yaml", 0, nil))
+	require.NoError(t, err)
+	assert.Nil(t, res)
+}
+
+func TestCodeAction_RespectsOnlyFilter(t *testing.T) {
+	s := newTestServer(t)
+	const uri = "file:///dep.yaml"
+	openDoc(t, s, uri, deprecatedDoc)
+
+	// Only refactor kinds requested -> the server contributes nothing.
+	params := quickFixParams(uri, 10, []protocol.CodeActionKind{protocol.CodeActionKindRefactor})
+	res, err := s.codeAction(&glsp.Context{}, params)
+	require.NoError(t, err)
+	assert.Nil(t, res)
+
+	// Explicitly requesting quickfix -> the action is returned.
+	params = quickFixParams(uri, 10, []protocol.CodeActionKind{protocol.CodeActionKindQuickFix})
+	res, err = s.codeAction(&glsp.Context{}, params)
+	require.NoError(t, err)
+	assert.NotNil(t, res)
+}
+
+func TestCodeAction_MatchesByDiagnosticCodeOutsideRange(t *testing.T) {
+	s := newTestServer(t)
+	const uri = "file:///dep.yaml"
+	openDoc(t, s, uri, deprecatedDoc)
+
+	// Request range is far from the finding line, but an incoming diagnostic
+	// carries the matching rule Code at the finding's line -> still matched.
+	rng := protocol.Range{
+		Start: protocol.Position{Line: 0, Character: 0},
+		End:   protocol.Position{Line: 0, Character: 1},
+	}
+	code := protocol.IntegerOrString{Value: "deprecated-field"}
+	diagRange := protocol.Range{
+		Start: protocol.Position{Line: 10, Character: 0},
+		End:   protocol.Position{Line: 10, Character: 20},
+	}
+	params := &protocol.CodeActionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Range:        rng,
+		Context: protocol.CodeActionContext{
+			Diagnostics: []protocol.Diagnostic{{Range: diagRange, Code: &code}},
+		},
+	}
+	res, err := s.codeAction(&glsp.Context{}, params)
+	require.NoError(t, err)
+	assert.NotNil(t, res)
+}
+
+func TestCodeActionFeature_AdvertisesQuickFixKind(t *testing.T) {
+	f := codeActionFeature()
+	require.NotNil(t, f.advertise)
+
+	var caps protocol.ServerCapabilities
+	f.advertise(&caps)
+
+	opts, ok := caps.CodeActionProvider.(*protocol.CodeActionOptions)
+	require.True(t, ok, "CodeActionProvider must be CodeActionOptions")
+	require.Len(t, opts.CodeActionKinds, 1)
+	assert.Equal(t, protocol.CodeActionKindQuickFix, opts.CodeActionKinds[0])
+}
+
+func TestCodeActionFeature_Registered(t *testing.T) {
+	s := newTestServer(t)
+	h := s.Handler()
+	assert.NotNil(t, h.TextDocumentCodeAction, "codeAction handler must be wired")
+}

--- a/pkg/refactor/edits.go
+++ b/pkg/refactor/edits.go
@@ -108,7 +108,7 @@ func RemoveSequenceElement(raw []byte, path string) (TextEdit, error) {
 	lineEnd := ec.li.Offset(sourcepos.Position{Line: node.Line, Column: maxColumn})
 	lineBytes := raw[lineStart:lineEnd]
 	indent := leadingSpaces(lineBytes)
-	if indent >= len(lineBytes) || lineBytes[indent] != '-' {
+	if !isSequenceMarker(lineBytes, indent) {
 		return TextEdit{}, fmt.Errorf("remove sequence element: line %d does not begin with a %q sequence marker", node.Line, "- ")
 	}
 
@@ -116,6 +116,28 @@ func RemoveSequenceElement(raw []byte, path string) (TextEdit, error) {
 	endByte := ec.li.Offset(sourcepos.Position{Line: endLine + 1, Column: 1})
 
 	return TextEdit{Range: ec.li.Range(lineStart, endByte), NewText: ""}, nil
+}
+
+// isSequenceMarker reports whether line begins a block-style YAML sequence entry
+// at the given indent: a "-" followed by whitespace (a "- value" entry) or by
+// the end of the line (a bare "-" whose value is nested on the following lines).
+// It rejects a "-" fused to a non-space byte (e.g. "--foo"), which YAML parses
+// as a plain scalar rather than a sequence marker, so the guard matches the
+// documented "- " marker instead of accepting any leading hyphen.
+func isSequenceMarker(line []byte, indent int) bool {
+	if indent >= len(line) || line[indent] != '-' {
+		return false
+	}
+	next := indent + 1
+	if next >= len(line) {
+		return true // a bare "-" at end of line (value nested below)
+	}
+	switch line[next] {
+	case ' ', '\t', '\r':
+		return true
+	default:
+		return false
+	}
 }
 
 // ReplaceMappingKeyAndValue computes the TextEdit that rewrites the `key: value`

--- a/pkg/refactor/edits.go
+++ b/pkg/refactor/edits.go
@@ -1,0 +1,170 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refactor
+
+import (
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
+	"gopkg.in/yaml.v3"
+)
+
+// editContext bundles the three byte-level views a source-preserving edit needs:
+// a path->value-node map (refindex.NodeMap), a path->key-position source map
+// (sourcepos.SourceMap), and a byte<->position line index. All three use the
+// same logical-path scheme (dotted keys, [i] sequence elements, spec.-prefixed
+// roots), so a single path resolves consistently across them. It is built once
+// per edit from the raw bytes; the helpers below do not mutate the input.
+type editContext struct {
+	nodes map[string]*yaml.Node
+	sm    *sourcepos.SourceMap
+	li    *sourcepos.LineIndex
+}
+
+// newEditContext parses raw and builds the value-node map, source map, and line
+// index used by the edit builders. It returns an error when the YAML cannot be
+// parsed, so callers never operate on a partial view.
+func newEditContext(raw []byte) (*editContext, error) {
+	nodes, err := refindex.NodeMap(raw)
+	if err != nil {
+		return nil, fmt.Errorf("build node map: %w", err)
+	}
+	sm, err := sourcepos.BuildSourceMap(raw, "")
+	if err != nil {
+		return nil, fmt.Errorf("build source map: %w", err)
+	}
+	return &editContext{
+		nodes: nodes,
+		sm:    sm,
+		li:    sourcepos.NewLineIndex(raw, ""),
+	}, nil
+}
+
+// RemoveMappingEntry computes the TextEdit that deletes the whole `key: <value>`
+// mapping entry located at path (a NodeMap path that points at the entry's VALUE
+// node). The key token itself is located via the source map, which records the
+// key position for the same path.
+//
+// The removed span runs from the start of the key line (consuming the entry's
+// leading indentation) through the trailing newline of the entry's last line, so
+// no blank line is left behind and sibling entries are untouched. The value may
+// be an inline scalar, a nested block mapping, or a sequence: the block's full
+// extent is found by indentation scanning (yaml.v3 reports only a node's start),
+// identical to the technique in ExtractCall.
+//
+// It returns an error (and no edit) when path does not resolve to both a key
+// position and a value node, so a caller never applies a guessed edit.
+func RemoveMappingEntry(raw []byte, path string) (TextEdit, error) {
+	ec, err := newEditContext(raw)
+	if err != nil {
+		return TextEdit{}, fmt.Errorf("remove mapping entry: %w", err)
+	}
+	keyPos, ok := ec.sm.Get(path)
+	if !ok {
+		return TextEdit{}, fmt.Errorf("remove mapping entry: path %q has no key position", path)
+	}
+	if _, ok := ec.nodes[path]; !ok {
+		return TextEdit{}, fmt.Errorf("remove mapping entry: path %q does not resolve to a value node", path)
+	}
+
+	keyIndent := keyPos.Column - 1
+	endLine := scanBlockEndLine(raw, ec.li, keyPos.Line, keyIndent)
+
+	startByte := ec.li.Offset(sourcepos.Position{Line: keyPos.Line, Column: 1})
+	// End at the first byte of the line after the block's last line, which
+	// consumes the entry's trailing newline (clamps to EOF for the last entry).
+	endByte := ec.li.Offset(sourcepos.Position{Line: endLine + 1, Column: 1})
+
+	return TextEdit{Range: ec.li.Range(startByte, endByte), NewText: ""}, nil
+}
+
+// RemoveSequenceElement computes the TextEdit that deletes a single `- item`
+// element at a sequence-element path (e.g. "spec.resolvers.x.dependsOn[2]"). The
+// element's line plus its trailing newline are consumed, leaving the other
+// elements intact.
+//
+// Callers must decide the empty-sequence case themselves: if removing this
+// element would leave the sequence empty, prefer RemoveMappingEntry on the
+// owning key instead, so the result is not a `key:` with an empty list (which is
+// a different, still-present value rather than a removal). This helper does not
+// detect that on its own -- it only ever removes the one element at path.
+//
+// It returns an error (and no edit) when path does not resolve to a node, or the
+// element's line does not begin with a `- ` sequence marker (only block-style
+// sequences are supported).
+func RemoveSequenceElement(raw []byte, path string) (TextEdit, error) {
+	ec, err := newEditContext(raw)
+	if err != nil {
+		return TextEdit{}, fmt.Errorf("remove sequence element: %w", err)
+	}
+	node, ok := ec.nodes[path]
+	if !ok || node == nil {
+		return TextEdit{}, fmt.Errorf("remove sequence element: path %q does not resolve to a node", path)
+	}
+
+	lineStart := ec.li.Offset(sourcepos.Position{Line: node.Line, Column: 1})
+	lineEnd := ec.li.Offset(sourcepos.Position{Line: node.Line, Column: maxColumn})
+	lineBytes := raw[lineStart:lineEnd]
+	indent := leadingSpaces(lineBytes)
+	if indent >= len(lineBytes) || lineBytes[indent] != '-' {
+		return TextEdit{}, fmt.Errorf("remove sequence element: line %d does not begin with a %q sequence marker", node.Line, "- ")
+	}
+
+	endLine := scanBlockEndLine(raw, ec.li, node.Line, indent)
+	endByte := ec.li.Offset(sourcepos.Position{Line: endLine + 1, Column: 1})
+
+	return TextEdit{Range: ec.li.Range(lineStart, endByte), NewText: ""}, nil
+}
+
+// ReplaceMappingKeyAndValue computes the TextEdit that rewrites the `key: value`
+// scalar entry at path (a NodeMap path pointing at the scalar VALUE node) as
+// `newKey: newValue`. The line's leading indentation is preserved (the edit
+// starts at the key token, not the line start), and any trailing inline comment
+// after the value is preserved because the replaced span ends at the value token
+// (not the end of line). Whitespace between the key colon and the value is
+// normalized to a single space.
+//
+// It is used for the deprecated onError -> continueOnError fix. It returns an
+// error (and no edit) when path does not resolve to both a key position and a
+// scalar value node, so a caller never applies a guessed edit.
+func ReplaceMappingKeyAndValue(raw []byte, path, newKey, newValue string) (TextEdit, error) {
+	ec, err := newEditContext(raw)
+	if err != nil {
+		return TextEdit{}, fmt.Errorf("replace mapping key and value: %w", err)
+	}
+	keyPos, ok := ec.sm.Get(path)
+	if !ok {
+		return TextEdit{}, fmt.Errorf("replace mapping key and value: path %q has no key position", path)
+	}
+	valNode, ok := ec.nodes[path]
+	if !ok || valNode == nil {
+		return TextEdit{}, fmt.Errorf("replace mapping key and value: path %q does not resolve to a value node", path)
+	}
+	if valNode.Kind != yaml.ScalarNode {
+		return TextEdit{}, fmt.Errorf("replace mapping key and value: path %q is not a scalar value", path)
+	}
+
+	keyStart := ec.li.Offset(sourcepos.Position{Line: keyPos.Line, Column: keyPos.Column})
+	valStart := ec.li.Offset(sourcepos.Position{Line: valNode.Line, Column: valNode.Column})
+	valEnd := valStart + scalarRawLen(valNode)
+	if keyStart < 0 || valEnd > len(raw) || keyStart >= valEnd {
+		return TextEdit{}, fmt.Errorf("replace mapping key and value: path %q resolves to an out-of-bounds span", path)
+	}
+
+	return TextEdit{Range: ec.li.Range(keyStart, valEnd), NewText: newKey + ": " + newValue}, nil
+}
+
+// scalarRawLen returns the byte length the scalar occupies in the source,
+// accounting for surrounding quotes on quoted styles. It is exact for plain and
+// simple single/double-quoted scalars without escapes (the onError values
+// "continue"/"fail" are always in this class); block/folded scalars are not a
+// target of the replace helper and fall back to the decoded length.
+func scalarRawLen(n *yaml.Node) int {
+	l := len(n.Value)
+	if n.Style&(yaml.DoubleQuotedStyle|yaml.SingleQuotedStyle) != 0 {
+		l += 2 // opening and closing quote
+	}
+	return l
+}

--- a/pkg/refactor/edits_test.go
+++ b/pkg/refactor/edits_test.go
@@ -223,3 +223,26 @@ spec:
 		})
 	}
 }
+
+func TestIsSequenceMarker(t *testing.T) {
+	tests := []struct {
+		name   string
+		line   string
+		indent int
+		want   bool
+	}{
+		{"dash space value", "  - value", 2, true},
+		{"dash tab value", "  -\tvalue", 2, true},
+		{"bare dash at eol", "  -", 2, true},
+		{"dash CR (crlf)", "  -\r", 2, true},
+		{"double dash is scalar", "  --foo", 2, false},
+		{"dash fused to letter", "  -foo", 2, false},
+		{"not a dash", "  foo", 2, false},
+		{"indent past end", "  ", 2, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isSequenceMarker([]byte(tt.line), tt.indent))
+		})
+	}
+}

--- a/pkg/refactor/edits_test.go
+++ b/pkg/refactor/edits_test.go
@@ -1,0 +1,181 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refactor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// editFixture is a solution exercising every removal/replace shape the edit
+// builders must handle: a resolver with a dependsOn list (some redundant), a
+// deprecated onError scalar, a nested block resolver to remove wholesale, and
+// sibling entries that must survive untouched. Comments are present so
+// source-preservation can be asserted.
+const editFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: edits-test # keep this comment
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    region:
+      resolve:
+        with:
+          - provider: parameter
+            onError: continue # trailing comment
+            inputs:
+              value: us
+    appName:
+      dependsOn:
+        - environment
+        - region
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.environment
+`
+
+// reparseYAML asserts the rewritten bytes still parse as generic YAML, so a
+// removal/replacement never produces a structurally broken document.
+func reparseYAML(t *testing.T, out []byte) {
+	t.Helper()
+	var m map[string]any
+	require.NoError(t, yaml.Unmarshal(out, &m), "rewritten output must re-parse as YAML")
+}
+
+func TestRemoveMappingEntry_UnusedResolver(t *testing.T) {
+	raw := []byte(editFixture)
+
+	edit, err := RemoveMappingEntry(raw, "spec.resolvers.region")
+	require.NoError(t, err)
+
+	out, err := Apply(raw, []TextEdit{edit})
+	require.NoError(t, err)
+	s := string(out)
+
+	assert.NotContains(t, s, "region:", "the region resolver block is gone")
+	assert.NotContains(t, s, "value: us", "its nested content is gone")
+	// Siblings survive, including their comments.
+	assert.Contains(t, s, "environment:")
+	assert.Contains(t, s, "appName:")
+	assert.Contains(t, s, "# keep this comment")
+	// No blank line left where the block was removed.
+	assert.NotContains(t, s, "\n\n    appName:")
+	reparseYAML(t, out)
+}
+
+func TestRemoveMappingEntry_DependsOnWholeEntry(t *testing.T) {
+	raw := []byte(editFixture)
+
+	edit, err := RemoveMappingEntry(raw, "spec.resolvers.appName.dependsOn")
+	require.NoError(t, err)
+
+	out, err := Apply(raw, []TextEdit{edit})
+	require.NoError(t, err)
+	s := string(out)
+
+	assert.NotContains(t, s, "dependsOn:")
+	assert.NotContains(t, s, "- environment\n")
+	// The resolve block that followed dependsOn is intact.
+	assert.Contains(t, s, "expr: _.environment")
+	reparseYAML(t, out)
+}
+
+func TestRemoveMappingEntry_Errors(t *testing.T) {
+	raw := []byte(editFixture)
+	_, err := RemoveMappingEntry(raw, "spec.resolvers.doesNotExist")
+	require.Error(t, err)
+}
+
+func TestRemoveSequenceElement_MiddleAndFirst(t *testing.T) {
+	raw := []byte(editFixture)
+
+	// Remove the first dependsOn element (environment).
+	edit, err := RemoveSequenceElement(raw, "spec.resolvers.appName.dependsOn[0]")
+	require.NoError(t, err)
+	out, err := Apply(raw, []TextEdit{edit})
+	require.NoError(t, err)
+	s := string(out)
+
+	assert.NotContains(t, s, "- environment")
+	assert.Contains(t, s, "- region", "the sibling element survives")
+	assert.Contains(t, s, "dependsOn:", "the list key survives")
+	reparseYAML(t, out)
+}
+
+func TestRemoveSequenceElement_Errors(t *testing.T) {
+	raw := []byte(editFixture)
+	// A path that is not a sequence element scalar line.
+	_, err := RemoveSequenceElement(raw, "spec.resolvers.appName.dependsOn[9]")
+	require.Error(t, err)
+}
+
+func TestReplaceMappingKeyAndValue_OnErrorContinue(t *testing.T) {
+	raw := []byte(editFixture)
+
+	edit, err := ReplaceMappingKeyAndValue(raw,
+		"spec.resolvers.region.resolve.with[0].onError", "continueOnError", "true")
+	require.NoError(t, err)
+
+	out, err := Apply(raw, []TextEdit{edit})
+	require.NoError(t, err)
+	s := string(out)
+
+	assert.Contains(t, s, "continueOnError: true")
+	assert.NotContains(t, s, "onError: continue")
+	// The trailing inline comment on the value line is preserved.
+	assert.Contains(t, s, "# trailing comment")
+	// Indentation preserved (12 spaces before the key in this fixture).
+	assert.Contains(t, s, "            continueOnError: true")
+	reparseYAML(t, out)
+}
+
+func TestReplaceMappingKeyAndValue_Errors(t *testing.T) {
+	raw := []byte(editFixture)
+	// Value node that is a mapping, not a scalar.
+	_, err := ReplaceMappingKeyAndValue(raw, "spec.resolvers.environment", "x", "y")
+	require.Error(t, err)
+	// Nonexistent path.
+	_, err = ReplaceMappingKeyAndValue(raw, "spec.resolvers.nope.onError", "x", "y")
+	require.Error(t, err)
+}
+
+func TestReplaceMappingKeyAndValue_QuotedValue(t *testing.T) {
+	const quoted = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: q
+spec:
+  resolvers:
+    r:
+      resolve:
+        with:
+          - provider: parameter
+            onError: "fail"
+            inputs:
+              value: x
+`
+	raw := []byte(quoted)
+	edit, err := ReplaceMappingKeyAndValue(raw,
+		"spec.resolvers.r.resolve.with[0].onError", "continueOnError", "false")
+	require.NoError(t, err)
+	out, err := Apply(raw, []TextEdit{edit})
+	require.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, "continueOnError: false")
+	assert.NotContains(t, s, `onError: "fail"`)
+	assert.NotContains(t, s, `"fail"`)
+	reparseYAML(t, out)
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13909,6 +13909,45 @@ func TestIntegration_LspRename(t *testing.T) {
 	assert.Contains(t, out, lspSessionURI, "edits target the document")
 }
 
+// TestIntegration_LspCodeAction opens a document with a deprecated onError field
+// and sends textDocument/codeAction over the diagnostic range. The server must
+// advertise the QuickFix kind and return a quick-fix action whose edit replaces
+// onError with the continueOnError boolean equivalent.
+func TestIntegration_LspCodeAction(t *testing.T) {
+	t.Parallel()
+
+	// onError is on line 10 (0-based); "b" references "a" so "a" is not unused.
+	sol := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: dep\nspec:\n  resolvers:\n    a:\n      resolve:\n        with:\n          - provider: parameter\n            onError: continue\n            inputs:\n              value: dev\n    b:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value:\n                expr: _.a\n"
+
+	out := runLSPSession(t, sol, map[string]any{
+		"jsonrpc": "2.0", "id": 2, "method": "textDocument/codeAction", "params": map[string]any{
+			"textDocument": map[string]any{"uri": lspSessionURI},
+			"range": map[string]any{
+				"start": map[string]any{"line": 10, "character": 0},
+				"end":   map[string]any{"line": 10, "character": 30},
+			},
+			"context": map[string]any{
+				"diagnostics": []any{map[string]any{
+					"range": map[string]any{
+						"start": map[string]any{"line": 10, "character": 0},
+						"end":   map[string]any{"line": 10, "character": 30},
+					},
+					"code":    "deprecated-field",
+					"message": "field 'onError' is deprecated",
+				}},
+			},
+		},
+	})
+
+	// The provider (with the QuickFix kind) is advertised in initialize.
+	assert.Contains(t, out, "codeActionProvider", "codeAction capability advertised")
+	assert.Contains(t, out, "quickfix", "quickfix kind advertised and/or returned")
+	// The returned action carries the replacement edit.
+	assert.Contains(t, out, "Replace deprecated 'onError' with 'continueOnError'", "quick-fix title")
+	assert.Contains(t, out, "continueOnError: true", "the replacement edit")
+	assert.Contains(t, out, lspSessionURI, "edit targets the document")
+}
+
 // TestIntegration_LspStdioFlag verifies that `lsp --stdio` starts the server and
 // serves the LSP protocol. Many LSP clients (and vscode-languageclient for
 // TransportKind.stdio) append `--stdio`; the server must accept it rather than


### PR DESCRIPTION
## Summary

Implements `textDocument/codeAction` (QuickFix) that turns existing lint diagnostics into one-click editor fixes. The fix logic lives **once** in `pkg/lint` (`QuickFixFor`), so the applied edit always matches what the linter recommends -- no duplication in the LSP layer.

## Changes

- **New `pkg/lint/quickfix.go`** -- `QuickFixFor(sol, f, registry) ([]refactor.TextEdit, ok)`:
  - **deprecated-field**: replace `onError` with its tagged replacement `continueOnError`, translating `continue` -> `true` / `fail` -> `false`. The replacement name is read from the struct tag via lint's existing `lookupDeprecatedField`, so it tracks lint.
  - **redundant-depends-on**: recomputes the redundant set from the solution (not the message text) using the **same provider-aware dependency lookup the finding used**, so the removal stays in lockstep with the finding even when a provider's custom `ExtractDependencies` diverges from generic extraction; removes the whole `dependsOn:` entry when all entries are redundant, else just the redundant list elements.
  - **unused-resolver**: removes the resolver block. When it is the **sole** resolver, removes the parent `resolvers:` key instead, so no null-valued key is left behind (which would turn the warning into a schema error).
  - Guarded throughout: any odd input yields `(nil, false)`, never a broken edit.
- **New `pkg/refactor/edits.go`** -- exported, source-preserving edit builders `RemoveMappingEntry`, `RemoveSequenceElement`, `ReplaceMappingKeyAndValue`, reusing the existing byte-edit/`Apply` model and the indentation-scan span logic from `ExtractCall` (no duplication; `extract.go` untouched). No import cycle (`pkg/refactor` does not depend on `pkg/lint`).
- **New `pkg/lsp/codeaction.go`** -- `codeActionFeature()` registered via the #767 seam; advertises `CodeActionProvider{CodeActionKinds:[QuickFix]}`. The handler re-lints the cached solution (#766), keeps findings that are fixable and relevant to the request range/diagnostics (respecting `Context.Only`), and returns each as a QuickFix carrying the `WorkspaceEdit`. It passes the server's provider registry into `QuickFixFor` so the applied edit uses the identical dependency extraction the diagnostics were computed with.

## Tests / docs

- Per-rule fix tests -- every applied output **re-parses and passes `ValidateSpec`**; edit-builder table tests; handler tests (Only filter, advertise, registration); a **sole-resolver regression** (guards against the warning->error failure mode); a **provider-lockstep regression** (a provider whose custom `ExtractDependencies` diverges from generic must not cause removal of a non-redundant `dependsOn` entry); and an integration test via the `runLSPSession` harness (#769) asserting the deprecated-field quick fix and advertised capability.
- `docs/tutorials/lsp-tutorial.md` documents the quick fixes.
- `go build/vet`, `go test ./pkg/refactor/... ./pkg/lint/... ./pkg/lsp/... ./tests/integration/...`, `task lint:changed` (0 new issues) -- all pass.
- A dedicated code-review pass found a file-degrading edge case (sole-resolver removal producing a schema-error document); it was fixed + regression-tested before opening.

## Acceptance criteria

- [x] Each supported diagnostic offers a working quick fix
- [x] `lint.QuickFixFor` is the single source of fix logic (no duplication in lsp)
- [x] `CodeActionProvider` advertised via the seam

Depends on #766 (cache) and #767 (seam), both merged; not dependent on #768. This handler is reused by #779.

Closes #776
