### PR TITLE
feat(cli): add lint --fix to auto-resolve fixable findings

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -1187,6 +1187,51 @@ than a hardcoded, drift-prone glob.
 
 ---
 
+## Auto-fixing Lint Findings
+
+Some lint rules are **auto-fixable**: `scafctl lint` can rewrite the solution to
+resolve them. Fixable rules are marked in `scafctl lint rules` / `scafctl lint
+rule <id>` output (a `fixable` field), and the same flag surfaces through the
+MCP `list_lint_rules` / `explain_lint_rule` tools.
+
+Three flags drive the fix workflow (modeled on `ruff`'s `--fix` / `--diff`):
+
+~~~bash
+# Preview the changes as a unified diff (no write).
+scafctl lint --fix-dry-run --diff -f ./solution.yaml
+
+# Report what would change as a summary (no write).
+scafctl lint --fix-dry-run -f ./solution.yaml
+
+# Apply the fixes in place.
+scafctl lint --fix -f ./solution.yaml
+~~~
+
+Semantics:
+
+- A file is written **only** for `--fix` **without** `--diff`. `--fix-dry-run`
+  and any `--diff` run are previews and never write.
+- `--diff` requires `--fix` or `--fix-dry-run`; `--fix` and `--fix-dry-run` are
+  mutually exclusive.
+- The diff is emitted to **stdout** (so it can be piped to `patch`); the fix
+  summary goes to **stderr** to keep structured stdout clean.
+- Fixes reuse the same reference-rewriting engine as `scafctl refactor rename`,
+  so comments and formatting are preserved. A fix that would be ambiguous or
+  collide with an existing name is **skipped** (reported, not applied) rather
+  than producing a broken solution.
+- Ambiguous auto-discovery of the solution file is an error (as with `refactor
+  rename`); pass `-f`. Reading from stdin (`-`) is not supported for `--fix`.
+- **Exit codes** follow `ruff`: `--fix` exits non-zero only when residual errors
+  remain after fixing, while the preview modes (`--fix-dry-run`, `--diff`) exit
+  non-zero (validation-failed) when there are pending fixes -- so a CI job can
+  run `scafctl lint --fix-dry-run` and fail the build when a solution needs
+  fixing. A preview exits `0` only when nothing would change.
+
+The `hyphenated-name` rule is currently auto-fixable (it renames a hyphenated
+resolver to its camelCase form and rewrites every reference).
+
+---
+
 ## Exploring Lint Rules
 
 ### List Rules

--- a/docs/tutorials/linting-tutorial.md
+++ b/docs/tutorials/linting-tutorial.md
@@ -708,6 +708,52 @@ spec:
 
 This is a **warning**-level finding (not an error) because hyphenated names are valid -- they just require bracket notation in CEL expressions.
 
+### Auto-fixing hyphenated names
+
+The `hyphenated-name` rule is **auto-fixable**. Instead of renaming by hand,
+let scafctl rewrite the definition and every reference (dependsOn entries,
+`rslvr:` values, and CEL `_["name"]` uses) in one pass, preserving comments and
+formatting:
+
+{{< tabs >}}
+{{% tab "Preview (diff)" %}}
+
+```bash
+# Show a unified diff of what would change, without writing.
+scafctl lint --fix-dry-run --diff -f ./solution.yaml
+```
+
+{{% /tab %}}
+{{% tab "Preview (summary)" %}}
+
+```bash
+# Report what would be fixed, without writing.
+scafctl lint --fix-dry-run -f ./solution.yaml
+```
+
+{{% /tab %}}
+{{% tab "Apply" %}}
+
+```bash
+# Rewrite the file in place.
+scafctl lint --fix -f ./solution.yaml
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+The `--diff` output is a standard unified diff, so it can be piped to `patch`
+or reviewed in a code review. A rename is applied only when it is unambiguous:
+if the camelCase target would collide with an existing resolver, that finding is
+**skipped** (reported, but the file is left untouched) rather than producing a
+broken solution. For finer-grained control -- renaming to a name other than the
+camelCase default, or renaming actions, calls, and functions -- use
+[`scafctl refactor rename`](refactor-tutorial.md).
+
+A runnable demo lives at `examples/lint/lint-fix-demo.yaml`: two hyphenated
+resolvers, each referenced via `dependsOn`, a CEL `expr:` value, and a `rslvr:`
+reference, so `--fix` rewrites the definition and every reference in one pass.
+
 ## 7. Redundant dependsOn
 
 The `redundant-depends-on` rule detects when a resolver's `dependsOn` entries are already auto-inferred from value references. scafctl automatically infers dependencies from `expr:`, `rslvr:`, and `tmpl:` references -- explicit `dependsOn` is only needed for pure ordering dependencies (where a resolver must wait for another without referencing its value).

--- a/examples/README.md
+++ b/examples/README.md
@@ -208,6 +208,16 @@ Source-preserving edits to a solution with `scafctl refactor`.
 
 ---
 
+## Lint Examples
+
+Auto-fixing lint findings with `scafctl lint --fix`.
+
+| Example | Description | Run |
+|---------|-------------|-----|
+| [lint/lint-fix-demo.yaml](lint/lint-fix-demo.yaml) | Two hyphenated resolvers (`app-name`, `db-host`), each referenced via dependsOn, a CEL `expr:` value, and a rslvr reference, for the auto-fixable `hyphenated-name` rule | `scafctl lint --fix-dry-run --diff -f examples/lint/lint-fix-demo.yaml` |
+
+---
+
 ## Catalog Examples
 
 Catalog build and distribution examples.

--- a/examples/lint/lint-fix-demo.yaml
+++ b/examples/lint/lint-fix-demo.yaml
@@ -1,0 +1,59 @@
+apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: lint-fix-demo
+  displayName: Lint Auto-fix Demo
+  category: solutions
+  tags:
+    - lint
+    - fix
+    - naming
+  description: >-
+    Demonstrates `scafctl lint --fix`. Two resolvers use hyphenated names
+    (`app-name`, `db-host`), which triggers the auto-fixable `hyphenated-name`
+    warning. Each is referenced several ways -- a dependsOn entry, a CEL `expr:`
+    value, and a rslvr reference -- so a single `--fix` renames the definition
+    and every reference to camelCase (`appName`, `dbHost`) while preserving
+    comments and formatting.
+spec:
+  resolvers:
+    # hyphenated-name (auto-fixable): renamed to `appName` by `lint --fix`.
+    app-name:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: billing
+
+    # hyphenated-name (auto-fixable): renamed to `dbHost` by `lint --fix`.
+    db-host:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: db.internal
+
+    connectionInfo:
+      # Reference #1: an explicit dependsOn entry (updated by the fix).
+      dependsOn:
+        - app-name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              # Reference #2: a CEL `expr:` value. A hyphenated name forces
+              # bracket notation (`_["db-host"]`); the fix updates the name
+              # inside it to `_["dbHost"]`.
+              value:
+                expr: '"host=" + _["db-host"]'
+
+    hostAlias:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              # Reference #3: a direct rslvr reference (updated by the fix).
+              value:
+                rslvr: db-host

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/oakwood-commons/scafctl-plugin-sdk v0.17.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/client_golang v1.24.1
 	github.com/sigstore/cosign/v2 v2.6.4
 	github.com/sigstore/rekor v1.5.3
@@ -251,7 +252,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect

--- a/pkg/cmd/scafctl/lint/fix.go
+++ b/pkg/cmd/scafctl/lint/fix.go
@@ -1,0 +1,213 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/fs"
+	pkglint "github.com/oakwood-commons/scafctl/pkg/lint"
+	"github.com/oakwood-commons/scafctl/pkg/logger"
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/oakwood-commons/scafctl/pkg/solution/get"
+	"github.com/oakwood-commons/scafctl/pkg/terminal/writer"
+)
+
+// runLintFix implements 'lint --fix', 'lint --fix-dry-run', and '--diff'.
+//
+// Output separation: the fix outcome summary and the unified diff are workflow
+// status, so the summary is written to stderr (never corrupting structured
+// stdout) while residual findings are rendered to stdout through the shared
+// RenderResult path (respecting -o and --severity). The diff is the primary
+// artifact of --diff and goes to stdout so it can be piped to 'patch'.
+//
+// Write policy mirrors ruff: a file is written only for --fix WITHOUT --diff.
+// --fix-dry-run and any --diff run preview without writing.
+//
+// Exit code: --fix returns non-zero only when residual errors remain after
+// fixing. The preview modes (--fix-dry-run and --diff) return validation-failed
+// (exit 2) when there are pending fixes, so they can gate CI (ruff --diff /
+// --check parity); they exit 0 only when nothing would change.
+func runLintFix(ctx context.Context, opts *Options) error {
+	if opts.BinaryName == "" {
+		opts.BinaryName = settings.CliBinaryName
+	}
+	w := writer.FromContext(ctx)
+
+	if opts.Fix && opts.FixDryRun {
+		return failFix(opts, exitcode.ValidationFailed, errors.New("--fix and --fix-dry-run are mutually exclusive"))
+	}
+	if opts.Diff && !opts.Fix && !opts.FixDryRun {
+		return failFix(opts, exitcode.ValidationFailed, errors.New("--diff requires --fix or --fix-dry-run"))
+	}
+
+	lgr := logger.FromContext(ctx)
+	getter := newLintGetter(ctx, lgr)
+
+	// Fixing mutates a file, so ambiguous auto-discovery must error (high risk)
+	// rather than silently pick one of several matches, matching 'refactor rename'.
+	resolvedPath, resolveErr := get.Resolve(ctx, getter, opts.File, "", get.ResolveOptions{
+		Risk: get.DiscoveryRiskHigh,
+	})
+	if resolveErr != nil {
+		return failFix(opts, exitcode.FileNotFound, fmt.Errorf("failed to resolve solution: %w", resolveErr))
+	}
+	if resolvedPath == "-" {
+		return failFix(opts, exitcode.ValidationFailed, errors.New("lint --fix requires a file path; stdin ('-') is not supported"))
+	}
+	opts.File = resolvedPath
+
+	raw, err := os.ReadFile(resolvedPath) //nolint:gosec // path resolved from user-provided solution reference
+	if err != nil {
+		return failFix(opts, exitcode.FileNotFound, fmt.Errorf("failed to read %s: %w", resolvedPath, err))
+	}
+
+	registry := getRegistry(ctx)
+	plan, err := pkglint.ComputeFixPlan(raw, resolvedPath, registry)
+	if err != nil {
+		return failFix(opts, exitcode.GeneralError, fmt.Errorf("failed to compute fixes: %w", err))
+	}
+
+	// --diff is a focused preview: emit only the diff (to stdout) plus the
+	// outcome summary (to stderr). No write, no residual render.
+	if opts.Diff {
+		diff, derr := plan.UnifiedDiff(resolvedPath, raw)
+		if derr != nil {
+			return failFix(opts, exitcode.GeneralError, fmt.Errorf("failed to render diff: %w", derr))
+		}
+		if w != nil && diff != "" {
+			w.Plain(diff)
+		}
+		reportFixOutcomes(w, plan, true)
+		// Preview modes gate CI: a pending fix is a non-zero exit (ruff --diff
+		// parity), so `lint --fix-dry-run` can fail a build that needs fixing.
+		return pendingFixesExit(plan)
+	}
+
+	write := opts.Fix // reaching here means --diff is not set
+	if write && plan.Changed {
+		mode := os.FileMode(0o644)
+		if fi, statErr := os.Stat(resolvedPath); statErr == nil {
+			mode = fi.Mode().Perm()
+		}
+		if werr := fs.WriteFileAtomic(resolvedPath, plan.NewContent, mode); werr != nil {
+			return failFix(opts, exitcode.GeneralError, fmt.Errorf("failed to write %s: %w", resolvedPath, werr))
+		}
+	}
+
+	reportFixOutcomes(w, plan, !write)
+
+	// Surface what still needs manual attention by linting the post-fix content
+	// (in-memory, so --fix-dry-run reflects the would-be result accurately).
+	residualErr := renderResidualFindings(ctx, opts, plan.NewContent, registry)
+	if residualErr != nil {
+		return residualErr
+	}
+	// --fix-dry-run is a preview: pending fixes gate CI even when no residual
+	// errors remain (ruff --check parity). --fix already applied them, so the
+	// plan reflects the written result and this is a no-op.
+	if !write {
+		return pendingFixesExit(plan)
+	}
+	return nil
+}
+
+// pendingFixesExit returns a validation-failed exit when a preview run still has
+// fixes to apply, so `--fix-dry-run` / `--diff` can gate CI. It returns nil when
+// nothing would change. The error carries only an exit code (root silences the
+// message), so a clean preview of pending changes is not printed as an error.
+func pendingFixesExit(plan *pkglint.FixPlan) error {
+	if plan == nil || !plan.Changed {
+		return nil
+	}
+	return exitcode.WithCode(
+		errors.New("fixable findings remain; re-run with --fix to apply"),
+		exitcode.ValidationFailed,
+	)
+}
+
+// reportFixOutcomes writes the per-finding fix summary to stderr so it never
+// corrupts structured stdout. dryRun switches the phrasing to the conditional
+// ("would fix") used by --fix-dry-run and --diff.
+func reportFixOutcomes(w *writer.Writer, plan *pkglint.FixPlan, dryRun bool) {
+	if w == nil {
+		return
+	}
+
+	applied := plan.AppliedCount()
+	skipped := plan.SkippedCount()
+
+	if applied == 0 && skipped == 0 {
+		w.SuccessStderr("No auto-fixable findings.")
+		return
+	}
+
+	fixedVerb := "fixed"
+	summaryVerb := "Fixed"
+	if dryRun {
+		fixedVerb = "would fix"
+		summaryVerb = "Would fix"
+	}
+
+	for _, o := range plan.Outcomes {
+		if o.Applied {
+			w.SuccessStderrf("  %s: %s", fixedVerb, o.Detail)
+		} else {
+			w.WarnStderrf("  skipped %s: %s", o.Location, trimNotFixable(o.Detail))
+		}
+	}
+	w.PlainStderr(fmt.Sprintf("%s %d finding(s); %d skipped.", summaryVerb, applied, skipped))
+}
+
+// trimNotFixable strips the trailing ErrNotFixable sentinel text from a skip
+// reason so the user sees the underlying cause without the internal marker.
+func trimNotFixable(detail string) string {
+	suffix := ": " + pkglint.ErrNotFixable.Error()
+	return strings.TrimSuffix(detail, suffix)
+}
+
+// renderResidualFindings lints the post-fix content and renders remaining
+// findings through the shared RenderResult path so the fix flow surfaces the
+// same output as a plain 'lint'. Findings are rendered to stdout; a non-zero
+// error count yields the ValidationFailed exit code.
+func renderResidualFindings(ctx context.Context, opts *Options, content []byte, registry *provider.Registry) error {
+	sol := &solution.Solution{}
+	if err := sol.UnmarshalFromBytes(content); err != nil {
+		writeError(opts, fmt.Sprintf("failed to re-lint fixed content: %v", err))
+		return exitcode.WithCode(err, exitcode.GeneralError)
+	}
+
+	result := pkglint.Solution(sol, opts.File, registry)
+	result = pkglint.FilterBySeverity(result, opts.Severity)
+
+	if opts.KvxOutputFlags.Output == "quiet" {
+		if result.ErrorCount > 0 {
+			return exitcode.WithCode(fmt.Errorf("found %d errors", result.ErrorCount), exitcode.ValidationFailed)
+		}
+		return nil
+	}
+
+	if renderErr := RenderResult(ctx, result, opts.BinaryName+" lint", opts.IOStreams, opts.KvxOutputFlags, opts.CliParams.NoColor); renderErr != nil {
+		writeError(opts, fmt.Sprintf("failed to write output: %v", renderErr))
+		return renderErr
+	}
+
+	if result.ErrorCount > 0 {
+		return exitcode.WithCode(fmt.Errorf("found %d errors", result.ErrorCount), exitcode.ValidationFailed)
+	}
+	return nil
+}
+
+// failFix reports err to stderr and returns it wrapped with the given exit code.
+func failFix(opts *Options, code int, err error) error {
+	writeError(opts, err.Error())
+	return exitcode.WithCode(err, code)
+}

--- a/pkg/cmd/scafctl/lint/fix_test.go
+++ b/pkg/cmd/scafctl/lint/fix_test.go
@@ -1,0 +1,278 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
+	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/settings"
+	"github.com/oakwood-commons/scafctl/pkg/terminal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const hyphenatedFixSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: fix-test
+  version: 1.0.0
+spec:
+  resolvers:
+    # hyphenated
+    my-service-name:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+    consumer:
+      dependsOn:
+        - my-service-name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                rslvr: my-service-name
+`
+
+func writeFixSolution(t *testing.T) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	solPath := filepath.Join(tmpDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solPath, []byte(hyphenatedFixSolution), 0o600))
+	return solPath
+}
+
+func fixOptions(solPath string, ioStreams *terminal.IOStreams) *Options {
+	return &Options{
+		File:           solPath,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "table"},
+		Severity:       "info",
+		CliParams:      testCliParams(),
+		IOStreams:      ioStreams,
+		BinaryName:     "scafctl",
+	}
+}
+
+func TestRunLintFix_WritesFile(t *testing.T) {
+	solPath := writeFixSolution(t)
+	ioStreams, _, errBuf := terminal.NewTestIOStreams()
+	ctx := testContext(ioStreams)
+
+	opts := fixOptions(solPath, ioStreams)
+	opts.Fix = true
+
+	require.NoError(t, runLintFix(ctx, opts))
+
+	got, err := os.ReadFile(solPath) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	content := string(got)
+	assert.Contains(t, content, "myServiceName:")
+	assert.NotContains(t, content, "my-service-name")
+	assert.Contains(t, content, "rslvr: myServiceName")
+	// Comment preserved.
+	assert.Contains(t, content, "# hyphenated")
+	// Summary goes to stderr.
+	assert.Contains(t, errBuf.String(), "fixed")
+}
+
+func TestRunLintFix_DryRunDoesNotWrite(t *testing.T) {
+	solPath := writeFixSolution(t)
+	ioStreams, _, errBuf := terminal.NewTestIOStreams()
+	ctx := testContext(ioStreams)
+
+	opts := fixOptions(solPath, ioStreams)
+	opts.FixDryRun = true
+
+	// Pending fixes gate CI: a preview with changes exits validation-failed.
+	err := runLintFix(ctx, opts)
+	require.Error(t, err)
+	assert.Equal(t, exitcode.ValidationFailed, exitcode.GetCode(err))
+
+	got, rerr := os.ReadFile(solPath) //nolint:gosec // test-controlled path
+	require.NoError(t, rerr)
+	assert.Equal(t, hyphenatedFixSolution, string(got), "--fix-dry-run must not modify the file")
+	assert.Contains(t, errBuf.String(), "would fix")
+}
+
+func TestRunLintFix_DiffDoesNotWriteAndEmitsHunks(t *testing.T) {
+	solPath := writeFixSolution(t)
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	ctx := testContext(ioStreams)
+
+	opts := fixOptions(solPath, ioStreams)
+	opts.Fix = true
+	opts.Diff = true
+
+	// --diff is a preview: pending fixes exit validation-failed (ruff parity).
+	err := runLintFix(ctx, opts)
+	require.Error(t, err)
+	assert.Equal(t, exitcode.ValidationFailed, exitcode.GetCode(err))
+
+	got, rerr := os.ReadFile(solPath) //nolint:gosec // test-controlled path
+	require.NoError(t, rerr)
+	assert.Equal(t, hyphenatedFixSolution, string(got), "--diff must not modify the file")
+
+	out := outBuf.String()
+	assert.Contains(t, out, "@@")
+	assert.Contains(t, out, "--- a/")
+	assert.Contains(t, out, "+++ b/")
+	assert.Contains(t, out, "-    my-service-name:")
+	assert.Contains(t, out, "+    myServiceName:")
+}
+
+func TestRunLintFix_DiffRequiresFixFlag(t *testing.T) {
+	solPath := writeFixSolution(t)
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	ctx := testContext(ioStreams)
+
+	opts := fixOptions(solPath, ioStreams)
+	opts.Diff = true // neither --fix nor --fix-dry-run
+
+	err := runLintFix(ctx, opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--diff requires")
+}
+
+func TestRunLintFix_FixAndDryRunMutuallyExclusive(t *testing.T) {
+	solPath := writeFixSolution(t)
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	ctx := testContext(ioStreams)
+
+	opts := fixOptions(solPath, ioStreams)
+	opts.Fix = true
+	opts.FixDryRun = true
+
+	err := runLintFix(ctx, opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+func TestRunLintFix_StdinRejected(t *testing.T) {
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	ctx := testContext(ioStreams)
+
+	opts := fixOptions("-", ioStreams)
+	opts.Fix = true
+
+	err := runLintFix(ctx, opts)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "stdin")
+}
+
+func TestRunLintFix_NonDefaultBinaryName(t *testing.T) {
+	solPath := writeFixSolution(t)
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	ctx := testContext(ioStreams)
+
+	opts := fixOptions(solPath, ioStreams)
+	opts.BinaryName = "mycli"
+	opts.Fix = true
+
+	require.NoError(t, runLintFix(ctx, opts))
+
+	got, err := os.ReadFile(solPath) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "myServiceName:")
+}
+
+func TestRunLintFix_DefaultsBinaryName(t *testing.T) {
+	solPath := writeFixSolution(t)
+	ioStreams, _, _ := terminal.NewTestIOStreams()
+	ctx := testContext(ioStreams)
+
+	opts := fixOptions(solPath, ioStreams)
+	opts.BinaryName = ""
+	opts.Fix = true
+
+	require.NoError(t, runLintFix(ctx, opts))
+	assert.Equal(t, settings.CliBinaryName, opts.BinaryName)
+}
+
+// noFixableFixSolution has no hyphenated resolvers, so a preview is a no-op.
+const noFixableFixSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: fix-clean
+  version: 1.0.0
+spec:
+  resolvers:
+    myServiceName:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+`
+
+func TestRunLintFix_DryRunNoChangesExitsZero(t *testing.T) {
+	tmpDir := t.TempDir()
+	solPath := filepath.Join(tmpDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solPath, []byte(noFixableFixSolution), 0o600))
+
+	ioStreams, _, errBuf := terminal.NewTestIOStreams()
+	ctx := testContext(ioStreams)
+
+	opts := fixOptions(solPath, ioStreams)
+	opts.FixDryRun = true
+
+	// No pending fixes -> preview exits cleanly (0).
+	require.NoError(t, runLintFix(ctx, opts))
+	assert.Contains(t, errBuf.String(), "No auto-fixable findings")
+}
+
+// collisionFixSolution renames my-service -> myService, which already exists,
+// so the fix must be skipped (reported, not applied).
+const collisionFixSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: fix-collision
+  version: 1.0.0
+spec:
+  resolvers:
+    my-service:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: a
+    myService:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: b
+`
+
+func TestRunLintFix_CollisionSkippedNoWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	solPath := filepath.Join(tmpDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solPath, []byte(collisionFixSolution), 0o600))
+
+	ioStreams, _, errBuf := terminal.NewTestIOStreams()
+	ctx := testContext(ioStreams)
+
+	opts := fixOptions(solPath, ioStreams)
+	opts.Fix = true
+
+	require.NoError(t, runLintFix(ctx, opts))
+
+	got, err := os.ReadFile(solPath) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	assert.Equal(t, collisionFixSolution, string(got), "collision must not modify the file")
+
+	stderr := errBuf.String()
+	assert.Contains(t, stderr, "skipped")
+	// The internal ErrNotFixable sentinel must be stripped from the reason.
+	assert.NotContains(t, stderr, "finding is not auto-fixable")
+}

--- a/pkg/cmd/scafctl/lint/lint.go
+++ b/pkg/cmd/scafctl/lint/lint.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/MakeNowJust/heredoc/v2"
+	"github.com/go-logr/logr"
 	"github.com/oakwood-commons/kvx/pkg/tui"
 	"github.com/oakwood-commons/scafctl/pkg/catalog"
 	"github.com/oakwood-commons/scafctl/pkg/cmd/flags"
@@ -65,6 +66,9 @@ type Options struct {
 	BinaryName     string
 	File           string
 	Severity       string
+	Fix            bool
+	FixDryRun      bool
+	Diff           bool
 	KvxOutputFlags flags.KvxOutputFlags
 	CliParams      *settings.Run
 	IOStreams      *terminal.IOStreams
@@ -107,6 +111,12 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 			# Output as JSON for CI integration
 			scafctl lint -f ./solution.yaml -o json
+
+			# Auto-fix fixable findings (rename hyphenated resolvers to camelCase)
+			scafctl lint -f ./solution.yaml --fix
+
+			# Preview the fixes as a unified diff without writing
+			scafctl lint -f ./solution.yaml --fix-dry-run --diff
 		`), settings.CliBinaryName, cliParams.BinaryName),
 		Args: cobra.MaximumNArgs(1),
 		PreRunE: func(_ *cobra.Command, args []string) error {
@@ -126,6 +136,9 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 			options.BinaryName = cliParams.BinaryName
 
+			if options.Fix || options.FixDryRun || options.Diff {
+				return runLintFix(ctx, options)
+			}
 			return runLint(ctx, options)
 		},
 		SilenceUsage: true,
@@ -133,6 +146,9 @@ func CommandLint(cliParams *settings.Run, ioStreams *terminal.IOStreams, path st
 
 	cmd.Flags().StringVarP(&options.File, "file", "f", "", "Solution file path (auto-discovered if not provided, use '-' for stdin)")
 	cmd.Flags().StringVar(&options.Severity, "severity", "info", "Minimum severity to report: error, warning, info")
+	cmd.Flags().BoolVar(&options.Fix, "fix", false, "Automatically fix fixable findings (e.g. rename hyphenated resolvers to camelCase) and write the result")
+	cmd.Flags().BoolVar(&options.FixDryRun, "fix-dry-run", false, "Report which findings would be fixed without writing any changes")
+	cmd.Flags().BoolVar(&options.Diff, "diff", false, "With --fix or --fix-dry-run, print a unified diff of the fixes instead of writing (implies no write)")
 	flags.AddKvxOutputFlagsToStruct(cmd, &options.KvxOutputFlags)
 
 	lintPath := fmt.Sprintf("%s/%s", path, cmd.Use)
@@ -160,17 +176,12 @@ func findingsColumnHints() map[string]tui.ColumnHint {
 	}
 }
 
-func runLint(ctx context.Context, opts *Options) error {
-	if opts.BinaryName == "" {
-		opts.BinaryName = settings.CliBinaryName
-	}
-
-	lgr := logger.FromContext(ctx)
-
-	// Set up getter with catalog resolver for bare name resolution.
-	// Lint loads leniently: a structural problem such as an undefined dependsOn
-	// target must surface as a finding rather than aborting the load and hiding
-	// every other issue behind the first one ("onion peeling").
+// newLintGetter builds the solution getter used by both the lint and the
+// lint --fix paths. Lint loads leniently: a structural problem such as an
+// undefined dependsOn target must surface as a finding rather than aborting the
+// load and hiding every other issue behind the first one ("onion peeling"). The
+// catalog resolver is attached when available so bare name references resolve.
+func newLintGetter(ctx context.Context, lgr *logr.Logger) *get.Getter {
 	getterOpts := []get.Option{get.WithLenientValidation()}
 	localCatalog, err := catalog.NewLocalCatalog(*lgr)
 	if err == nil {
@@ -181,8 +192,17 @@ func runLint(ctx context.Context, opts *Options) error {
 	} else {
 		lgr.V(1).Info("catalog not available for solution resolution", "error", err)
 	}
+	return get.NewGetterFromContext(ctx, getterOpts...)
+}
 
-	getter := get.NewGetterFromContext(ctx, getterOpts...)
+func runLint(ctx context.Context, opts *Options) error {
+	if opts.BinaryName == "" {
+		opts.BinaryName = settings.CliBinaryName
+	}
+
+	lgr := logger.FromContext(ctx)
+
+	getter := newLintGetter(ctx, lgr)
 
 	// Unified resolution chain: -f > positional arg > auto-discover
 	resolvedPath, resolveErr := get.Resolve(ctx, getter, opts.File, "", get.ResolveOptions{

--- a/pkg/cmd/scafctl/lint/lint_test.go
+++ b/pkg/cmd/scafctl/lint/lint_test.go
@@ -229,6 +229,43 @@ func TestRulesRun_SeverityFilter(t *testing.T) {
 	}
 }
 
+// TestRulesRun_FixableFieldSurfaces pins that the auto-fixable flag flows all
+// the way through the CLI 'lint rules' JSON surface (not just the MCP tools),
+// so the docs claim that fixable rules are marked in 'lint rules' output stays
+// honest. hyphenated-name has a registered fixer; empty-solution does not.
+func TestRulesRun_FixableFieldSurfaces(t *testing.T) {
+	t.Parallel()
+	ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+	cliParams := settings.NewCliParams()
+	ctx := testContext(ioStreams)
+
+	opts := &RulesOptions{
+		IOStreams:      ioStreams,
+		CliParams:      cliParams,
+		KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+	}
+
+	err := opts.Run(ctx)
+	require.NoError(t, err)
+
+	var rules []pkglint.RuleMeta
+	err = json.Unmarshal(outBuf.Bytes(), &rules)
+	require.NoError(t, err, "output should be valid JSON")
+
+	byName := make(map[string]pkglint.RuleMeta, len(rules))
+	for _, r := range rules {
+		byName[r.Rule] = r
+	}
+
+	fixable, ok := byName["hyphenated-name"]
+	require.True(t, ok, "hyphenated-name rule should be listed")
+	assert.True(t, fixable.Fixable, "hyphenated-name is auto-fixable")
+
+	notFixable, ok := byName["empty-solution"]
+	require.True(t, ok, "empty-solution rule should be listed")
+	assert.False(t, notFixable.Fixable, "empty-solution is not auto-fixable")
+}
+
 func TestCommandRule(t *testing.T) {
 	cliParams := settings.NewCliParams()
 	cliParams.BinaryName = "mycli"
@@ -336,6 +373,33 @@ func TestExplainRun_JSONOutput(t *testing.T) {
 	assert.NotEmpty(t, rule.Why)
 	assert.NotEmpty(t, rule.Fix)
 	assert.NotEmpty(t, rule.Examples)
+}
+
+// TestExplainRun_FixableFieldSurfaces pins that 'lint rule <id>' JSON output
+// carries the auto-fixable flag, matching the docs claim and the MCP
+// explain_lint_rule tool. hyphenated-name is fixable; empty-solution is not.
+func TestExplainRun_FixableFieldSurfaces(t *testing.T) {
+	t.Parallel()
+
+	explainJSON := func(t *testing.T, ruleName string) pkglint.RuleMeta {
+		t.Helper()
+		ioStreams, outBuf, _ := terminal.NewTestIOStreams()
+		ctx := testContext(ioStreams)
+		opts := &RuleOptions{
+			BinaryName:     "scafctl",
+			IOStreams:      ioStreams,
+			CliParams:      testCliParams(),
+			KvxOutputFlags: flags.KvxOutputFlags{Output: "json"},
+		}
+		require.NoError(t, opts.Run(ctx, ruleName))
+
+		var rule pkglint.RuleMeta
+		require.NoError(t, json.Unmarshal(outBuf.Bytes(), &rule), "output should be valid JSON")
+		return rule
+	}
+
+	assert.True(t, explainJSON(t, "hyphenated-name").Fixable, "hyphenated-name is auto-fixable")
+	assert.False(t, explainJSON(t, "empty-solution").Fixable, "empty-solution is not auto-fixable")
 }
 
 func TestExplainRun_YAMLOutput(t *testing.T) {

--- a/pkg/cmd/scafctl/refactor/rename_resolver.go
+++ b/pkg/cmd/scafctl/refactor/rename_resolver.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/oakwood-commons/scafctl/pkg/exitcode"
+	"github.com/oakwood-commons/scafctl/pkg/fs"
 	"github.com/oakwood-commons/scafctl/pkg/logger"
 	pkgrefactor "github.com/oakwood-commons/scafctl/pkg/refactor"
 	"github.com/oakwood-commons/scafctl/pkg/settings"
@@ -151,43 +152,12 @@ func runRename(ctx context.Context, opts *renameOptions, kind string, rename ren
 	if fi, statErr := os.Stat(resolvedPath); statErr == nil {
 		mode = fi.Mode().Perm()
 	}
-	if err := writeFileAtomic(resolvedPath, newContent, mode); err != nil {
+	if err := fs.WriteFileAtomic(resolvedPath, newContent, mode); err != nil {
 		return fail(w, exitcode.GeneralError, fmt.Errorf("failed to write %s: %w", resolvedPath, err))
 	}
 
 	if w != nil {
 		w.Successf("Renamed %s %q to %q (%d occurrence(s)) in %s", kind, oldName, newName, len(result.Edits), resolvedPath)
-	}
-	return nil
-}
-
-// writeFileAtomic writes data to path atomically by writing to a temporary file
-// in the same directory and renaming it over path. os.Rename is atomic on the
-// same filesystem, so a crash mid-write cannot leave the solution file
-// truncated or partially written.
-func writeFileAtomic(path string, data []byte, mode os.FileMode) error {
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*") //nolint:gosec // temp file created in the target's own directory
-	if err != nil {
-		return err
-	}
-	tmpName := tmp.Name()
-	// Best-effort cleanup if we return before a successful rename; a no-op once
-	// the temp file has been renamed away.
-	defer func() { _ = os.Remove(tmpName) }()
-
-	if _, err := tmp.Write(data); err != nil {
-		_ = tmp.Close()
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
-	if err := os.Chmod(tmpName, mode); err != nil {
-		return err
-	}
-	if err := os.Rename(tmpName, path); err != nil { //nolint:gosec // path resolved from user-provided solution reference
-		return err
 	}
 	return nil
 }

--- a/pkg/cmd/scafctl/refactor/rename_resolver_test.go
+++ b/pkg/cmd/scafctl/refactor/rename_resolver_test.go
@@ -166,24 +166,3 @@ func TestCommandRefactor_EmbedderBinaryName(t *testing.T) {
 	assert.Contains(t, resolver.Example, "mycli refactor rename resolver")
 	assert.NotContains(t, resolver.Example, "scafctl refactor rename resolver")
 }
-
-func TestWriteFileAtomic(t *testing.T) {
-	dir := t.TempDir()
-	path := filepath.Join(dir, "f.yaml")
-	require.NoError(t, os.WriteFile(path, []byte("original"), 0o640))
-
-	require.NoError(t, writeFileAtomic(path, []byte("replaced content"), 0o640))
-
-	got, err := os.ReadFile(path) //nolint:gosec // test-controlled path
-	require.NoError(t, err)
-	assert.Equal(t, "replaced content", string(got))
-
-	fi, err := os.Stat(path)
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o640), fi.Mode().Perm(), "mode preserved")
-
-	// No leftover temp files in the directory.
-	entries, err := os.ReadDir(dir)
-	require.NoError(t, err)
-	assert.Len(t, entries, 1, "no temp files left behind")
-}

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -22,6 +22,9 @@ type ReadFileFunc func(filename string) ([]byte, error)
 // in the same directory and renaming it over path. os.Rename is atomic on the
 // same filesystem, so a crash mid-write cannot leave the destination file
 // truncated or partially written. mode sets the final file's permission bits.
+//
+// On Windows, renaming over an existing destination is not permitted, so a
+// failed rename falls back to removing the destination and retrying.
 func WriteFileAtomic(path string, data []byte, mode os.FileMode) error {
 	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*") //nolint:gosec // temp file created in the target's own directory
@@ -44,6 +47,15 @@ func WriteFileAtomic(path string, data []byte, mode os.FileMode) error {
 		return err
 	}
 	if err := os.Rename(tmpName, path); err != nil { //nolint:gosec // path resolved from user-provided reference
+		// Windows does not allow rename-over-existing. Remove the destination
+		// and retry so the write is still atomic-enough on those platforms.
+		if _, statErr := os.Stat(path); statErr == nil {
+			if rmErr := os.Remove(path); rmErr == nil {
+				if retryErr := os.Rename(tmpName, path); retryErr == nil { //nolint:gosec // path resolved from user-provided reference
+					return nil
+				}
+			}
+		}
 		return err
 	}
 	return nil

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -49,12 +49,17 @@ func WriteFileAtomic(path string, data []byte, mode os.FileMode) error {
 	if err := os.Rename(tmpName, path); err != nil { //nolint:gosec // path resolved from user-provided reference
 		// Windows does not allow rename-over-existing. Remove the destination
 		// and retry so the write is still atomic-enough on those platforms.
+		// Return the final failure (remove/retry error) rather than the original
+		// rename error, so a genuine remove/retry problem is not masked by the
+		// expected rename-over-existing failure.
 		if _, statErr := os.Stat(path); statErr == nil {
-			if rmErr := os.Remove(path); rmErr == nil {
-				if retryErr := os.Rename(tmpName, path); retryErr == nil { //nolint:gosec // path resolved from user-provided reference
-					return nil
-				}
+			if rmErr := os.Remove(path); rmErr != nil {
+				return rmErr
 			}
+			if retryErr := os.Rename(tmpName, path); retryErr != nil { //nolint:gosec // path resolved from user-provided reference
+				return retryErr
+			}
+			return nil
 		}
 		return err
 	}

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -6,6 +6,7 @@ package fs
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 // StatFunc defines a function type that takes a file path as input and returns
@@ -55,11 +56,19 @@ func WriteFileAtomic(path string, data []byte, mode os.FileMode) error {
 		return err
 	}
 	if err := os.Rename(tmpName, path); err != nil { //nolint:gosec // path resolved from user-provided reference
-		// Windows does not allow rename-over-existing. Remove the destination
-		// and retry so the write is still atomic-enough on those platforms.
-		// Return the final failure (remove/retry error) rather than the original
-		// rename error, so a genuine remove/retry problem is not masked by the
-		// expected rename-over-existing failure.
+		// On POSIX, rename-over-existing is atomic and expected to succeed, so a
+		// failure here is a genuine error (permissions, cross-device link, ...).
+		// Removing the destination and retrying would destroy the existing file for
+		// no benefit, so only fall back on Windows, where rename-over-existing is
+		// not permitted.
+		if runtime.GOOS != "windows" {
+			return err
+		}
+		// Windows does not allow rename-over-existing. Remove the destination and
+		// retry so the write is still atomic-enough on that platform. Return the
+		// final failure (remove/retry error) rather than the original rename error,
+		// so a genuine remove/retry problem is not masked by the expected
+		// rename-over-existing failure.
 		if _, statErr := os.Stat(path); statErr == nil {
 			if rmErr := os.Remove(path); rmErr != nil {
 				return rmErr

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -65,11 +65,14 @@ func WriteFileAtomic(path string, data []byte, mode os.FileMode) error {
 			return err
 		}
 		// Windows does not allow rename-over-existing. Remove the destination and
-		// retry so the write is still atomic-enough on that platform. Return the
-		// final failure (remove/retry error) rather than the original rename error,
-		// so a genuine remove/retry problem is not masked by the expected
-		// rename-over-existing failure.
-		if _, statErr := os.Stat(path); statErr == nil {
+		// retry so the write is still atomic-enough on that platform. Only do this
+		// for a regular-file destination: if path is a directory, os.Remove would
+		// delete it and drop a file in its place -- surprising data loss -- so
+		// surface the original rename error instead. Return the final failure
+		// (remove/retry error) rather than the original rename error, so a genuine
+		// remove/retry problem is not masked by the expected rename-over-existing
+		// failure.
+		if fi, statErr := os.Stat(path); statErr == nil && !fi.IsDir() {
 			if rmErr := os.Remove(path); rmErr != nil {
 				return rmErr
 			}

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -40,6 +40,14 @@ func WriteFileAtomic(path string, data []byte, mode os.FileMode) error {
 		_ = tmp.Close()
 		return err
 	}
+	// Flush the file's contents to stable storage before the rename so a crash
+	// or power loss right after WriteFileAtomic returns cannot leave the renamed
+	// destination pointing at unwritten data (matches the atomic-write pattern in
+	// pkg/cache/diskcache and pkg/catalog).
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
 	if err := tmp.Close(); err != nil {
 		return err
 	}

--- a/pkg/fs/fs.go
+++ b/pkg/fs/fs.go
@@ -3,7 +3,10 @@
 
 package fs
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+)
 
 // StatFunc defines a function type that takes a file path as input and returns
 // the file's os.FileInfo and an error if the operation fails. It is typically
@@ -14,3 +17,34 @@ type StatFunc func(path string) (os.FileInfo, error)
 // It takes a filename as input and returns the file's contents as a byte slice,
 // along with an error if the operation fails.
 type ReadFileFunc func(filename string) ([]byte, error)
+
+// WriteFileAtomic writes data to path atomically by writing to a temporary file
+// in the same directory and renaming it over path. os.Rename is atomic on the
+// same filesystem, so a crash mid-write cannot leave the destination file
+// truncated or partially written. mode sets the final file's permission bits.
+func WriteFileAtomic(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*") //nolint:gosec // temp file created in the target's own directory
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	// Best-effort cleanup if we return before a successful rename; a no-op once
+	// the temp file has been renamed away.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Chmod(tmpName, mode); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, path); err != nil { //nolint:gosec // path resolved from user-provided reference
+		return err
+	}
+	return nil
+}

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -12,8 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// This package defines only function types (StatFunc, ReadFileFunc).
-// These tests verify the types compile and can be assigned real functions.
+// These tests cover the fs helpers: the function type aliases (StatFunc,
+// ReadFileFunc) compile and accept real functions, and WriteFileAtomic writes
+// content atomically.
 
 func TestStatFunc_AssignableFromOsStat(t *testing.T) {
 	var fn StatFunc = os.Stat

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -5,9 +5,11 @@ package fs
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // This package defines only function types (StatFunc, ReadFileFunc).
@@ -21,4 +23,36 @@ func TestStatFunc_AssignableFromOsStat(t *testing.T) {
 func TestReadFileFunc_AssignableFromOsReadFile(t *testing.T) {
 	var fn ReadFileFunc = os.ReadFile
 	assert.NotNil(t, fn)
+}
+
+func TestWriteFileAtomic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("original"), 0o640))
+
+	require.NoError(t, WriteFileAtomic(path, []byte("replaced content"), 0o640))
+
+	got, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	assert.Equal(t, "replaced content", string(got))
+
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o640), fi.Mode().Perm(), "mode preserved")
+
+	// No leftover temp files in the directory.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1, "no temp files left behind")
+}
+
+func TestWriteFileAtomic_CreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "new.yaml")
+
+	require.NoError(t, WriteFileAtomic(path, []byte("brand new"), 0o644))
+
+	got, err := os.ReadFile(path) //nolint:gosec // test-controlled path
+	require.NoError(t, err)
+	assert.Equal(t, "brand new", string(got))
 }

--- a/pkg/fs/fs_test.go
+++ b/pkg/fs/fs_test.go
@@ -6,6 +6,7 @@ package fs
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,4 +57,33 @@ func TestWriteFileAtomic_CreatesNewFile(t *testing.T) {
 	got, err := os.ReadFile(path) //nolint:gosec // test-controlled path
 	require.NoError(t, err)
 	assert.Equal(t, "brand new", string(got))
+}
+
+// TestWriteFileAtomic_RenameFailurePreservesDestination verifies that on
+// non-Windows platforms a failed rename returns the error without deleting the
+// existing destination. The remove+retry fallback is gated to Windows, so a
+// POSIX rename failure must never destroy the good on-disk data.
+//
+// An empty directory is used as the destination: renaming a file over a
+// directory fails on POSIX, so this exercises the rename-failure branch. Crucially,
+// os.Remove would succeed on an empty directory, so the ungated fallback would
+// delete it and retry (turning the directory into a file and returning success).
+// The gate must instead return the error and leave the directory intact.
+func TestWriteFileAtomic_RenameFailurePreservesDestination(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fallback deletes the destination on Windows; this test asserts POSIX behavior")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dest")
+	require.NoError(t, os.Mkdir(path, 0o755))
+
+	err := WriteFileAtomic(path, []byte("replaced content"), 0o640)
+	require.Error(t, err, "rename over a directory should fail without falling back to remove+retry")
+
+	// The destination must be untouched: still a directory, not deleted and
+	// replaced by the temp file via a Windows-only fallback that must not run here.
+	fi, statErr := os.Stat(path)
+	require.NoError(t, statErr, "destination must still exist after a failed rename")
+	assert.True(t, fi.IsDir(), "destination must remain a directory, not be replaced by the write")
 }

--- a/pkg/lint/fix.go
+++ b/pkg/lint/fix.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -119,11 +120,15 @@ func (p *FixPlan) UnifiedDiff(path string, original []byte) (string, error) {
 	if !p.Changed {
 		return "", nil
 	}
+	// Normalize separators to "/" so the a/ and b/ header paths are valid unified
+	// diff headers on every platform (on Windows path can contain backslashes,
+	// which produce non-standard headers that common patch tooling rejects).
+	headerPath := filepath.ToSlash(path)
 	return difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
 		A:        splitDiffLines(string(original)),
 		B:        splitDiffLines(string(p.NewContent)),
-		FromFile: "a/" + path,
-		ToFile:   "b/" + path,
+		FromFile: "a/" + headerPath,
+		ToFile:   "b/" + headerPath,
 		Context:  3,
 	})
 }

--- a/pkg/lint/fix.go
+++ b/pkg/lint/fix.go
@@ -145,12 +145,28 @@ func ComputeFixPlan(raw []byte, filePath string, registry *provider.Registry) (*
 	}
 	result := Solution(sol, filePath, registry)
 
-	current := append([]byte(nil), raw...)
+	// Findings originate from ranging over Go maps (e.g. spec.resolvers), so
+	// their order is nondeterministic across runs. Collect the fixable ones and
+	// sort by rule then location so the applied edits -- and therefore the
+	// resulting bytes and any --diff preview -- are stable and reproducible, and
+	// interacting renames (e.g. target-name collisions) resolve identically
+	// every run.
+	fixable := make([]*Finding, 0, len(result.Findings))
 	for _, f := range result.Findings {
-		fx, ok := defaultFixers[f.RuleName]
-		if !ok {
-			continue
+		if _, ok := defaultFixers[f.RuleName]; ok {
+			fixable = append(fixable, f)
 		}
+	}
+	sort.SliceStable(fixable, func(i, j int) bool {
+		if fixable[i].RuleName != fixable[j].RuleName {
+			return fixable[i].RuleName < fixable[j].RuleName
+		}
+		return fixable[i].Location < fixable[j].Location
+	})
+
+	current := append([]byte(nil), raw...)
+	for _, f := range fixable {
+		fx := defaultFixers[f.RuleName]
 
 		// Re-parse the current bytes so the fixer computes edits against
 		// up-to-date offsets after any preceding rename.

--- a/pkg/lint/fix.go
+++ b/pkg/lint/fix.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/oakwood-commons/scafctl/pkg/provider"
 	"github.com/oakwood-commons/scafctl/pkg/refactor"
@@ -119,12 +120,28 @@ func (p *FixPlan) UnifiedDiff(path string, original []byte) (string, error) {
 		return "", nil
 	}
 	return difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
-		A:        difflib.SplitLines(string(original)),
-		B:        difflib.SplitLines(string(p.NewContent)),
+		A:        splitDiffLines(string(original)),
+		B:        splitDiffLines(string(p.NewContent)),
 		FromFile: "a/" + path,
 		ToFile:   "b/" + path,
 		Context:  3,
 	})
+}
+
+// splitDiffLines splits s into newline-terminated lines for difflib. Unlike
+// difflib.SplitLines it does NOT append a trailing "\n" to the last element:
+// that helper turns a file ending in "\n" into a spurious empty final line,
+// which makes the emitted hunk claim one more line than the file actually has.
+// GNU patch(1) rejects that phantom trailing context line ("Hunk #N FAILED"),
+// even though BSD patch tolerates it -- so the extra line breaks the
+// --diff -> patch round-trip on Linux CI. Dropping the trailing empty element
+// keeps hunk line counts exact and the diff cleanly appliable.
+func splitDiffLines(s string) []string {
+	lines := strings.SplitAfter(s, "\n")
+	if n := len(lines); n > 0 && lines[n-1] == "" {
+		lines = lines[:n-1]
+	}
+	return lines
 }
 
 // ComputeFixPlan lints the solution parsed from raw and applies every registered

--- a/pkg/lint/fix.go
+++ b/pkg/lint/fix.go
@@ -1,0 +1,195 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/oakwood-commons/scafctl/pkg/refactor"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+// ErrNotFixable signals that a specific finding cannot be auto-fixed in the
+// current solution (for example, the camelCase target of a hyphenated-name
+// rename collides with an existing resolver, or a reference could not be
+// located byte-exact). A fixer wraps it so callers can distinguish a per-finding
+// skip (recorded as an un-applied FixOutcome) from a hard failure that aborts
+// the whole fix run.
+var ErrNotFixable = errors.New("finding is not auto-fixable")
+
+// Fix is the outcome a Fixer computes for a single finding: the source edits
+// that resolve it plus a short human-readable summary of what changed.
+type Fix struct {
+	// Edits are source-preserving text edits that resolve the finding. They are
+	// applied against the exact bytes the fixer was given (no YAML round-trip),
+	// so comments, key order, and formatting are preserved verbatim.
+	Edits []refactor.TextEdit
+	// Detail is a short human summary, e.g. `renamed "my-svc" -> "mySvc"`.
+	Detail string
+}
+
+// Fixer computes the edits that resolve a single finding. It returns a wrapped
+// ErrNotFixable when this specific finding cannot be auto-fixed; the caller
+// records that as a skip, not a hard failure. Any other error aborts the whole
+// fix run so a partially-fixed file is never persisted.
+//
+// IMPORTANT: implementations must treat f as an IDENTIFIER ONLY (e.g. use
+// f.RuleName / f.Location to decide what to fix) and must recompute every edit
+// offset from the passed sol. The finding's byte ranges are computed from the
+// ORIGINAL source, whereas sol is re-parsed from the already-partially-fixed
+// bytes on each iteration (see ComputeFixPlan); reusing f's offsets would
+// produce corrupt edits after a preceding fix shifts the source.
+type Fixer func(sol *solution.Solution, f *Finding) (*Fix, error)
+
+// defaultFixers maps a rule name to its Fixer. Rules opt into auto-fixing by
+// registering here (see fix_hyphenated.go). Keeping the mapping in the domain
+// layer lets CLI, MCP, and future API consumers share one source of truth for
+// which rules are fixable.
+var defaultFixers = map[string]Fixer{}
+
+// RegisterFixer attaches a fixer to a rule name. It is intended to be called
+// from package init blocks. Registering a second fixer for the same rule
+// overwrites the first.
+func RegisterFixer(ruleName string, fx Fixer) {
+	defaultFixers[ruleName] = fx
+}
+
+// Fixable reports whether the named rule has a registered auto-fixer.
+func Fixable(ruleName string) bool {
+	_, ok := defaultFixers[ruleName]
+	return ok
+}
+
+// FixableRuleNames returns the sorted names of all rules that have a registered
+// auto-fixer.
+func FixableRuleNames() []string {
+	names := make([]string, 0, len(defaultFixers))
+	for name := range defaultFixers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// FixOutcome records what happened to one fixable finding during a fix run.
+type FixOutcome struct {
+	RuleName string `json:"ruleName" yaml:"ruleName" doc:"Lint rule that produced the finding" maxLength:"128" example:"hyphenated-name"`
+	Location string `json:"location" yaml:"location" doc:"Logical path of the finding" maxLength:"512" example:"resolvers.my-svc"`
+	Applied  bool   `json:"applied" yaml:"applied" doc:"Whether the fix was applied" example:"true"`
+	Detail   string `json:"detail" yaml:"detail" doc:"Summary of the fix or skip reason" maxLength:"2048" example:"renamed \"my-svc\" -> \"mySvc\""`
+}
+
+// FixPlan is the aggregate outcome of a fix run: per-finding outcomes plus the
+// rewritten file bytes. NewContent always holds the final bytes (equal to the
+// original when nothing changed), so a diff preview and the applied write are
+// derived from the same source and can never drift.
+type FixPlan struct {
+	Outcomes   []FixOutcome `json:"outcomes" yaml:"outcomes" doc:"Per-finding fix outcomes" maxItems:"1000"`
+	NewContent []byte       `json:"-" yaml:"-"`
+	Changed    bool         `json:"changed" yaml:"changed" doc:"Whether any fix was applied" example:"true"`
+}
+
+// AppliedCount returns the number of outcomes whose fix was applied.
+func (p *FixPlan) AppliedCount() int {
+	n := 0
+	for _, o := range p.Outcomes {
+		if o.Applied {
+			n++
+		}
+	}
+	return n
+}
+
+// SkippedCount returns the number of outcomes whose fix was skipped.
+func (p *FixPlan) SkippedCount() int {
+	return len(p.Outcomes) - p.AppliedCount()
+}
+
+// UnifiedDiff renders a git-style unified diff between original and the plan's
+// rewritten content, labelled with path. It returns an empty string when
+// nothing changed.
+func (p *FixPlan) UnifiedDiff(path string, original []byte) (string, error) {
+	if !p.Changed {
+		return "", nil
+	}
+	return difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(string(original)),
+		B:        difflib.SplitLines(string(p.NewContent)),
+		FromFile: "a/" + path,
+		ToFile:   "b/" + path,
+		Context:  3,
+	})
+}
+
+// ComputeFixPlan lints the solution parsed from raw and applies every registered
+// fixer to the fixable findings, producing a FixPlan. It never writes to disk --
+// IO stays in the command layer.
+//
+// Fixes are applied iteratively: each fixer runs against a solution freshly
+// parsed from the current (already-partially-fixed) bytes, so byte offsets stay
+// valid across successive renames. A fixer's wrapped ErrNotFixable is recorded
+// as a skipped outcome and the run continues; any other error aborts the run so
+// a partially-fixed file is never returned.
+func ComputeFixPlan(raw []byte, filePath string, registry *provider.Registry) (*FixPlan, error) {
+	plan := &FixPlan{}
+
+	sol := &solution.Solution{}
+	if err := sol.UnmarshalFromBytes(raw); err != nil {
+		return nil, fmt.Errorf("parse solution: %w", err)
+	}
+	result := Solution(sol, filePath, registry)
+
+	current := append([]byte(nil), raw...)
+	for _, f := range result.Findings {
+		fx, ok := defaultFixers[f.RuleName]
+		if !ok {
+			continue
+		}
+
+		// Re-parse the current bytes so the fixer computes edits against
+		// up-to-date offsets after any preceding rename.
+		cur := &solution.Solution{}
+		if err := cur.UnmarshalFromBytes(current); err != nil {
+			return nil, fmt.Errorf("re-parse solution before fixing %s at %s: %w", f.RuleName, f.Location, err)
+		}
+
+		fix, err := fx(cur, f)
+		if err != nil {
+			if errors.Is(err, ErrNotFixable) {
+				plan.Outcomes = append(plan.Outcomes, FixOutcome{
+					RuleName: f.RuleName,
+					Location: f.Location,
+					Applied:  false,
+					Detail:   err.Error(),
+				})
+				continue
+			}
+			return nil, fmt.Errorf("compute fix for %s at %s: %w", f.RuleName, f.Location, err)
+		}
+		if fix == nil || len(fix.Edits) == 0 {
+			continue
+		}
+
+		next, err := refactor.Apply(current, fix.Edits)
+		if err != nil {
+			return nil, fmt.Errorf("apply fix for %s at %s: %w", f.RuleName, f.Location, err)
+		}
+		current = next
+		plan.Outcomes = append(plan.Outcomes, FixOutcome{
+			RuleName: f.RuleName,
+			Location: f.Location,
+			Applied:  true,
+			Detail:   fix.Detail,
+		})
+	}
+
+	plan.NewContent = current
+	plan.Changed = !bytes.Equal(raw, current)
+	return plan, nil
+}

--- a/pkg/lint/fix_hyphenated.go
+++ b/pkg/lint/fix_hyphenated.go
@@ -1,0 +1,63 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/refactor"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+)
+
+// hyphenatedNameRule is the rule whose findings this fixer resolves.
+const hyphenatedNameRule = "hyphenated-name"
+
+//nolint:gochecknoinits // Package-level registration of the auto-fixer, matching the concepts registry pattern.
+func init() {
+	RegisterFixer(hyphenatedNameRule, fixHyphenatedName)
+}
+
+// fixHyphenatedName resolves a hyphenated-name finding by renaming the resolver
+// to its camelCase form and rewriting every reference. The reference rewriting
+// is delegated wholesale to refactor.RenameResolver, which locates dependsOn
+// entries, rslvr values, CEL '_.name'/'_["name"]' uses, and explicit template
+// references byte-exact and refuses (all-or-nothing) if any reference cannot be
+// located or the target name collides. Those refusals are surfaced as a wrapped
+// ErrNotFixable so the finding is skipped rather than aborting the whole run.
+func fixHyphenatedName(sol *solution.Solution, f *Finding) (*Fix, error) {
+	name, ok := resolverNameFromLocation(f.Location)
+	if !ok {
+		return nil, fmt.Errorf("cannot determine resolver name from location %q: %w", f.Location, ErrNotFixable)
+	}
+
+	newName := hyphensToCamelCase(name)
+	res, err := refactor.RenameResolver(sol, name, newName)
+	if err != nil {
+		// RenameResolver refuses on collision, unlocatable references, or an
+		// invalid target name. Any of these means this finding is not safely
+		// auto-fixable; record the reason and move on.
+		return nil, fmt.Errorf("cannot auto-rename resolver %q to %q: %w: %w", name, newName, err, ErrNotFixable)
+	}
+
+	return &Fix{
+		Edits:  res.Edits,
+		Detail: fmt.Sprintf("renamed resolver %q -> %q (%d reference(s))", name, newName, len(res.Edits)),
+	}, nil
+}
+
+// resolverNameFromLocation extracts the resolver name from a finding location
+// of the form "resolvers.<name>". It reports false when the location is not a
+// resolver location.
+func resolverNameFromLocation(location string) (string, bool) {
+	const prefix = "resolvers."
+	if !strings.HasPrefix(location, prefix) {
+		return "", false
+	}
+	name := strings.TrimPrefix(location, prefix)
+	if name == "" || strings.Contains(name, ".") {
+		return "", false
+	}
+	return name, true
+}

--- a/pkg/lint/fix_test.go
+++ b/pkg/lint/fix_test.go
@@ -4,6 +4,9 @@
 package lint
 
 import (
+	"regexp"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/oakwood-commons/scafctl/pkg/provider"
@@ -196,6 +199,63 @@ func TestFixPlan_UnifiedDiff_NoChange(t *testing.T) {
 	diff, err := plan.UnifiedDiff("test.yaml", []byte(noFixableSolution))
 	require.NoError(t, err)
 	assert.Empty(t, diff)
+}
+
+// TestFixPlan_UnifiedDiff_HunkCountsMatch guards against the go-difflib
+// SplitLines quirk that appends a trailing "\n" to the last line: for content
+// ending in a newline that produces a phantom empty final line, making the last
+// hunk claim one more line than the file has. BSD patch tolerates the extra EOF
+// context line but GNU patch (Linux CI) rejects it, so the --diff -> patch
+// round-trip breaks. Assert every hunk's declared line counts match its body so
+// the emitted diff applies cleanly on both.
+func TestFixPlan_UnifiedDiff_HunkCountsMatch(t *testing.T) {
+	require.True(t, strings.HasSuffix(multiRefHyphenSolution, "\n"),
+		"this test is meaningful only for newline-terminated content")
+
+	plan, err := ComputeFixPlan([]byte(multiRefHyphenSolution), "test.yaml", provider.NewRegistry())
+	require.NoError(t, err)
+	require.True(t, plan.Changed)
+
+	diff, err := plan.UnifiedDiff("test.yaml", []byte(multiRefHyphenSolution))
+	require.NoError(t, err)
+	require.NotEmpty(t, diff)
+
+	hunkRe := regexp.MustCompile(`^@@ -\d+(?:,(\d+))? \+\d+(?:,(\d+))? @@`)
+	var wantA, wantB, gotA, gotB int
+	inHunk := false
+	flush := func() {
+		if inHunk {
+			assert.Equal(t, wantA, gotA, "hunk 'from' line count must match body:\n%s", diff)
+			assert.Equal(t, wantB, gotB, "hunk 'to' line count must match body:\n%s", diff)
+		}
+	}
+	for _, line := range strings.Split(diff, "\n") {
+		if m := hunkRe.FindStringSubmatch(line); m != nil {
+			flush()
+			inHunk = true
+			wantA, wantB, gotA, gotB = 1, 1, 0, 0
+			if m[1] != "" {
+				wantA, _ = strconv.Atoi(m[1])
+			}
+			if m[2] != "" {
+				wantB, _ = strconv.Atoi(m[2])
+			}
+			continue
+		}
+		if !inHunk || line == "" {
+			continue
+		}
+		switch line[0] {
+		case ' ':
+			gotA++
+			gotB++
+		case '-':
+			gotA++
+		case '+':
+			gotB++
+		}
+	}
+	flush()
 }
 
 func TestFixableRegistry(t *testing.T) {

--- a/pkg/lint/fix_test.go
+++ b/pkg/lint/fix_test.go
@@ -1,0 +1,256 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lint
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// singleHyphenSolution defines one hyphenated resolver with no references.
+const singleHyphenSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: t
+spec:
+  resolvers:
+    # a hyphenated resolver
+    my-service-name:
+      description: the service
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+`
+
+// multiRefHyphenSolution references the hyphenated resolver via dependsOn, a
+// rslvr value ref, and a CEL bracket expression (dot notation is invalid CEL
+// for hyphenated names, so bracket notation is the only in-expression form).
+const multiRefHyphenSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: t
+spec:
+  resolvers:
+    my-service-name:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+    consumer:
+      dependsOn:
+        - my-service-name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                rslvr: my-service-name
+    celuser:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                expr: '_["my-service-name"] + "x"'
+`
+
+// collisionSolution renames my-service -> myService, which already exists.
+const collisionSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: t
+spec:
+  resolvers:
+    my-service:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: a
+    myService:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: b
+`
+
+// noFixableSolution has no hyphenated resolvers.
+const noFixableSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: t
+spec:
+  resolvers:
+    myServiceName:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+`
+
+func TestComputeFixPlan_SingleHyphenated(t *testing.T) {
+	plan, err := ComputeFixPlan([]byte(singleHyphenSolution), "test.yaml", provider.NewRegistry())
+	require.NoError(t, err)
+	require.NotNil(t, plan)
+
+	assert.True(t, plan.Changed)
+	assert.Equal(t, 1, plan.AppliedCount())
+	assert.Equal(t, 0, plan.SkippedCount())
+	require.Len(t, plan.Outcomes, 1)
+	assert.Equal(t, "hyphenated-name", plan.Outcomes[0].RuleName)
+	assert.Equal(t, "resolvers.my-service-name", plan.Outcomes[0].Location)
+	assert.True(t, plan.Outcomes[0].Applied)
+
+	out := string(plan.NewContent)
+	assert.Contains(t, out, "myServiceName:")
+	assert.NotContains(t, out, "my-service-name:")
+	// Comment must be preserved (byte-exact edits, no YAML round-trip).
+	assert.Contains(t, out, "# a hyphenated resolver")
+}
+
+func TestComputeFixPlan_MultipleReferences(t *testing.T) {
+	plan, err := ComputeFixPlan([]byte(multiRefHyphenSolution), "test.yaml", provider.NewRegistry())
+	require.NoError(t, err)
+
+	assert.True(t, plan.Changed)
+	assert.Equal(t, 1, plan.AppliedCount())
+
+	out := string(plan.NewContent)
+	// Definition, dependsOn, rslvr, and CEL bracket must all be rewritten.
+	assert.NotContains(t, out, "my-service-name")
+	assert.Contains(t, out, "myServiceName:")
+	assert.Contains(t, out, "- myServiceName")
+	assert.Contains(t, out, "rslvr: myServiceName")
+	assert.Contains(t, out, `_["myServiceName"]`)
+
+	// Detail reports the reference count (definition + 3 refs == 4).
+	assert.Contains(t, plan.Outcomes[0].Detail, "4 reference(s)")
+}
+
+func TestComputeFixPlan_CollisionSkipped(t *testing.T) {
+	plan, err := ComputeFixPlan([]byte(collisionSolution), "test.yaml", provider.NewRegistry())
+	require.NoError(t, err)
+
+	assert.False(t, plan.Changed)
+	assert.Equal(t, 0, plan.AppliedCount())
+	require.Len(t, plan.Outcomes, 1)
+	assert.False(t, plan.Outcomes[0].Applied)
+	assert.Contains(t, plan.Outcomes[0].Detail, ErrNotFixable.Error())
+	// The original bytes are returned unchanged.
+	assert.Equal(t, collisionSolution, string(plan.NewContent))
+}
+
+func TestComputeFixPlan_NoFixableFindings(t *testing.T) {
+	plan, err := ComputeFixPlan([]byte(noFixableSolution), "test.yaml", provider.NewRegistry())
+	require.NoError(t, err)
+
+	assert.False(t, plan.Changed)
+	assert.Empty(t, plan.Outcomes)
+	assert.Equal(t, noFixableSolution, string(plan.NewContent))
+}
+
+func TestComputeFixPlan_Idempotent(t *testing.T) {
+	first, err := ComputeFixPlan([]byte(multiRefHyphenSolution), "test.yaml", provider.NewRegistry())
+	require.NoError(t, err)
+	require.True(t, first.Changed)
+
+	second, err := ComputeFixPlan(first.NewContent, "test.yaml", provider.NewRegistry())
+	require.NoError(t, err)
+	assert.False(t, second.Changed, "re-running fix on already-fixed content must be a no-op")
+	assert.Empty(t, second.Outcomes)
+}
+
+func TestComputeFixPlan_ParseError(t *testing.T) {
+	_, err := ComputeFixPlan([]byte("this: [is: not: valid: yaml"), "test.yaml", provider.NewRegistry())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse solution")
+}
+
+func TestFixPlan_UnifiedDiff(t *testing.T) {
+	plan, err := ComputeFixPlan([]byte(singleHyphenSolution), "test.yaml", provider.NewRegistry())
+	require.NoError(t, err)
+	require.True(t, plan.Changed)
+
+	diff, err := plan.UnifiedDiff("test.yaml", []byte(singleHyphenSolution))
+	require.NoError(t, err)
+	assert.Contains(t, diff, "--- a/test.yaml")
+	assert.Contains(t, diff, "+++ b/test.yaml")
+	assert.Contains(t, diff, "@@")
+	assert.Contains(t, diff, "-    my-service-name:")
+	assert.Contains(t, diff, "+    myServiceName:")
+}
+
+func TestFixPlan_UnifiedDiff_NoChange(t *testing.T) {
+	plan, err := ComputeFixPlan([]byte(noFixableSolution), "test.yaml", provider.NewRegistry())
+	require.NoError(t, err)
+
+	diff, err := plan.UnifiedDiff("test.yaml", []byte(noFixableSolution))
+	require.NoError(t, err)
+	assert.Empty(t, diff)
+}
+
+func TestFixableRegistry(t *testing.T) {
+	assert.True(t, Fixable("hyphenated-name"))
+	assert.False(t, Fixable("unused-resolver"))
+	assert.False(t, Fixable("nonexistent-rule"))
+
+	names := FixableRuleNames()
+	assert.Contains(t, names, "hyphenated-name")
+	// FixableRuleNames must be sorted.
+	sorted := append([]string(nil), names...)
+	require.True(t, isSorted(sorted))
+}
+
+func isSorted(s []string) bool {
+	for i := 1; i < len(s); i++ {
+		if s[i-1] > s[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestResolverNameFromLocation(t *testing.T) {
+	tests := []struct {
+		name     string
+		location string
+		wantName string
+		wantOK   bool
+	}{
+		{name: "valid", location: "resolvers.my-svc", wantName: "my-svc", wantOK: true},
+		{name: "no prefix", location: "actions.deploy", wantOK: false},
+		{name: "empty name", location: "resolvers.", wantOK: false},
+		{name: "nested path", location: "resolvers.my-svc.resolve", wantOK: false},
+		{name: "empty string", location: "", wantOK: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := resolverNameFromLocation(tt.location)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantName, got)
+			}
+		})
+	}
+}
+
+func BenchmarkComputeFixPlan(b *testing.B) {
+	raw := []byte(multiRefHyphenSolution)
+	reg := provider.NewRegistry()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := ComputeFixPlan(raw, "bench.yaml", reg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -35,8 +35,10 @@ type RuleMeta struct {
 	// Fixable reports whether findings for this rule can be resolved
 	// automatically via 'lint --fix'. It is derived from the fixer registry
 	// (see fix.go) rather than stored statically, so it never drifts from the
-	// set of rules that actually have a registered auto-fixer.
-	Fixable bool `json:"fixable,omitempty" yaml:"fixable,omitempty"`
+	// set of rules that actually have a registered auto-fixer. It is always
+	// serialized (no omitempty) so the output schema is stable (fixable:
+	// true|false) for CLI/MCP consumers.
+	Fixable bool `json:"fixable" yaml:"fixable"`
 
 	// Examples optionally provide sample YAML or commands.
 	Examples []string `json:"examples,omitempty" yaml:"examples,omitempty"`
@@ -93,7 +95,7 @@ var KnownRules = map[string]RuleMeta{
 		Category:    "naming",
 		Description: "A resolver name contains hyphens, which require bracket notation in CEL expressions.",
 		Why:         "Hyphens in resolver names require quoting in CEL: _[\"my-resolver\"] instead of _.myResolver. This is more verbose and error-prone for both humans and AI agents.",
-		Fix:         "Use camelCase for CEL-friendly access: myResolver instead of my-resolver. Run 'scafctl lint --fix' to rename hyphenated resolvers automatically (updating every reference), or 'scafctl refactor rename resolver <old> <new>' for a single rename.",
+		Fix:         "Use camelCase for CEL-friendly access: myResolver instead of my-resolver. The 'lint --fix' command renames hyphenated resolvers automatically (updating every reference); 'refactor rename resolver <old> <new>' renames a single resolver.",
 		Examples: []string{
 			"# Hyphenated (requires quoting in CEL):\nresolvers:\n  my-service:\n    ...\n# Access: _[\"my-service\"]\n\n# camelCase (direct CEL access):\nresolvers:\n  myService:\n    ...\n# Access: _.myService",
 		},

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -32,6 +32,12 @@ type RuleMeta struct {
 	// Fix gives concrete instructions for resolving a finding.
 	Fix string `json:"fix" yaml:"fix"`
 
+	// Fixable reports whether findings for this rule can be resolved
+	// automatically via 'lint --fix'. It is derived from the fixer registry
+	// (see fix.go) rather than stored statically, so it never drifts from the
+	// set of rules that actually have a registered auto-fixer.
+	Fixable bool `json:"fixable,omitempty" yaml:"fixable,omitempty"`
+
 	// Examples optionally provide sample YAML or commands.
 	Examples []string `json:"examples,omitempty" yaml:"examples,omitempty"`
 }
@@ -87,7 +93,7 @@ var KnownRules = map[string]RuleMeta{
 		Category:    "naming",
 		Description: "A resolver name contains hyphens, which require bracket notation in CEL expressions.",
 		Why:         "Hyphens in resolver names require quoting in CEL: _[\"my-resolver\"] instead of _.myResolver. This is more verbose and error-prone for both humans and AI agents.",
-		Fix:         "Use camelCase for CEL-friendly access: myResolver instead of my-resolver.",
+		Fix:         "Use camelCase for CEL-friendly access: myResolver instead of my-resolver. Run 'scafctl lint --fix' to rename hyphenated resolvers automatically (updating every reference), or 'scafctl refactor rename resolver <old> <new>' for a single rename.",
 		Examples: []string{
 			"# Hyphenated (requires quoting in CEL):\nresolvers:\n  my-service:\n    ...\n# Access: _[\"my-service\"]\n\n# camelCase (direct CEL access):\nresolvers:\n  myService:\n    ...\n# Access: _.myService",
 		},
@@ -683,6 +689,7 @@ var KnownRules = map[string]RuleMeta{
 func ListRules() []RuleMeta {
 	rules := make([]RuleMeta, 0, len(KnownRules))
 	for _, r := range KnownRules {
+		r.Fixable = Fixable(r.Rule)
 		rules = append(rules, r)
 	}
 
@@ -705,6 +712,9 @@ func ListRules() []RuleMeta {
 // GetRule looks up a rule by name. Returns the RuleMeta and true if found.
 func GetRule(name string) (RuleMeta, bool) {
 	r, ok := KnownRules[name]
+	if ok {
+		r.Fixable = Fixable(r.Rule)
+	}
 	return r, ok
 }
 

--- a/pkg/mcp/tools_lint.go
+++ b/pkg/mcp/tools_lint.go
@@ -56,6 +56,7 @@ type lintRuleSummary struct {
 	Severity    string `json:"severity"`
 	Category    string `json:"category"`
 	Description string `json:"description"`
+	Fixable     bool   `json:"fixable,omitempty"`
 }
 
 // handleListLintRules returns all known lint rules with optional filtering.
@@ -78,6 +79,7 @@ func (s *Server) handleListLintRules(_ context.Context, request mcp.CallToolRequ
 			Severity:    r.Severity,
 			Category:    r.Category,
 			Description: r.Description,
+			Fixable:     r.Fixable,
 		})
 	}
 

--- a/pkg/mcp/tools_lint.go
+++ b/pkg/mcp/tools_lint.go
@@ -56,7 +56,7 @@ type lintRuleSummary struct {
 	Severity    string `json:"severity"`
 	Category    string `json:"category"`
 	Description string `json:"description"`
-	Fixable     bool   `json:"fixable,omitempty"`
+	Fixable     bool   `json:"fixable"`
 }
 
 // handleListLintRules returns all known lint rules with optional filtering.

--- a/pkg/mcp/tools_lint_test.go
+++ b/pkg/mcp/tools_lint_test.go
@@ -73,6 +73,23 @@ func TestHandleExplainLintRule(t *testing.T) {
 			assert.NotEmpty(t, rule.Severity, "rule %q missing Severity", name)
 		}
 	})
+
+	t.Run("fixable rule surfaces fixable flag", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "explain_lint_rule"
+		request.Params.Arguments = map[string]any{
+			"rule": "hyphenated-name",
+		}
+
+		result, err := srv.handleExplainLintRule(context.Background(), request)
+		require.NoError(t, err)
+		assert.False(t, result.IsError)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+		assert.Equal(t, true, output["fixable"], "hyphenated-name is auto-fixable")
+	})
 }
 
 func TestHandleListLintRules(t *testing.T) {
@@ -129,6 +146,29 @@ func TestHandleListLintRules(t *testing.T) {
 			rule := r.(map[string]any)
 			assert.Equal(t, "error", rule["severity"])
 		}
+	})
+
+	t.Run("fixable flag surfaced in listing", func(t *testing.T) {
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "list_lint_rules"
+		request.Params.Arguments = map[string]any{}
+
+		result, err := srv.handleListLintRules(context.Background(), request)
+		require.NoError(t, err)
+
+		text := result.Content[0].(mcp.TextContent).Text
+		var output map[string]any
+		require.NoError(t, json.Unmarshal([]byte(text), &output))
+
+		var foundFixable bool
+		for _, r := range output["rules"].([]any) {
+			rule := r.(map[string]any)
+			if rule["rule"] == "hyphenated-name" {
+				assert.Equal(t, true, rule["fixable"], "hyphenated-name must be reported as fixable")
+				foundFixable = true
+			}
+		}
+		assert.True(t, foundFixable, "hyphenated-name rule should be present in listing")
 	})
 
 	t.Run("filter by category", func(t *testing.T) {

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -4557,6 +4557,127 @@ func TestIntegration_Lint_InvalidFile(t *testing.T) {
 	assert.Contains(t, stderr, "failed to load solution")
 }
 
+// lintFixHyphenatedSolution has a hyphenated resolver referenced via dependsOn,
+// a rslvr value ref, and a CEL bracket expression -- exercising every reference
+// form the hyphenated-name auto-fix must rewrite.
+const lintFixHyphenatedSolution = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: fix-integration
+  version: 1.0.0
+spec:
+  resolvers:
+    # a hyphenated resolver
+    my-service-name:
+      type: string
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: hello
+    consumer:
+      dependsOn:
+        - my-service-name
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                rslvr: my-service-name
+    celuser:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                expr: '_["my-service-name"] + "!"'
+`
+
+func TestIntegration_Lint_Fix_WritesFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solPath, []byte(lintFixHyphenatedSolution), 0o644))
+
+	_, _, exitCode := runScafctl(t, "lint", "-f", solPath, "--fix")
+	assert.Equal(t, 0, exitCode)
+
+	got, err := os.ReadFile(solPath) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	content := string(got)
+	assert.NotContains(t, content, "my-service-name")
+	assert.Contains(t, content, "myServiceName:")
+	assert.Contains(t, content, "- myServiceName")
+	assert.Contains(t, content, "rslvr: myServiceName")
+	assert.Contains(t, content, `_["myServiceName"]`)
+	// Comments are preserved (byte-exact edits, no YAML round-trip).
+	assert.Contains(t, content, "# a hyphenated resolver")
+}
+
+func TestIntegration_Lint_FixDryRun_DoesNotWrite(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solPath, []byte(lintFixHyphenatedSolution), 0o644))
+
+	_, stderr, exitCode := runScafctl(t, "lint", "-f", solPath, "--fix-dry-run")
+	// Preview with pending fixes gates CI: validation-failed exit (ruff parity).
+	assert.Equal(t, 2, exitCode)
+	assert.Contains(t, stderr, "would fix")
+
+	got, err := os.ReadFile(solPath) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	assert.Equal(t, lintFixHyphenatedSolution, string(got), "--fix-dry-run must not modify the file")
+}
+
+// TestIntegration_Lint_Fix_DiffRoundTrips proves the --diff output is a valid
+// unified diff by piping it through patch(1) and confirming the patched file
+// matches what --fix would have written.
+func TestIntegration_Lint_Fix_DiffRoundTrips(t *testing.T) {
+	t.Parallel()
+	patchBin, err := exec.LookPath("patch")
+	if err != nil {
+		t.Skip("patch(1) not available")
+	}
+
+	dir := t.TempDir()
+	solPath := filepath.Join(dir, "solution.yaml")
+	require.NoError(t, os.WriteFile(solPath, []byte(lintFixHyphenatedSolution), 0o644))
+
+	// Capture the diff (preview; file is not modified). Pending fixes gate CI,
+	// so the preview exits validation-failed (2) rather than 0.
+	diff, _, exitCode := runScafctl(t, "lint", "-f", solPath, "--fix-dry-run", "--diff")
+	require.Equal(t, 2, exitCode)
+	require.Contains(t, diff, "@@")
+
+	unchanged, err := os.ReadFile(solPath) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	require.Equal(t, lintFixHyphenatedSolution, string(unchanged), "--diff must not modify the file")
+
+	// Produce the reference output by actually fixing a copy.
+	fixDir := t.TempDir()
+	fixPath := filepath.Join(fixDir, "solution.yaml")
+	require.NoError(t, os.WriteFile(fixPath, []byte(lintFixHyphenatedSolution), 0o644))
+	_, _, exitCode = runScafctl(t, "lint", "-f", fixPath, "--fix")
+	require.Equal(t, 0, exitCode)
+	want, err := os.ReadFile(fixPath) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+
+	// Apply the diff to the original with patch -p0 and compare.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, patchBin, "-p0", solPath)
+	cmd.Dir = dir
+	cmd.Stdin = strings.NewReader(diff)
+	out, perr := cmd.CombinedOutput()
+	require.NoErrorf(t, perr, "patch failed: %s", string(out))
+
+	patched, err := os.ReadFile(solPath) //nolint:gosec // test-controlled temp path
+	require.NoError(t, err)
+	assert.Equal(t, string(want), string(patched),
+		"applying the --diff output must yield the same result as --fix")
+}
+
 func TestIntegration_Lint_YAMLOutput(t *testing.T) {
 	t.Parallel()
 	stdout, _, _ := runScafctl(t, "lint", "-f", "examples/resolver-demo.yaml", "-o", "yaml")


### PR DESCRIPTION
Add `scafctl lint --fix` to automatically rewrite a solution and resolve auto-fixable lint findings, starting with the `hyphenated-name` rule (renames hyphenated resolvers to camelCase and updates every reference: `dependsOn` entries, CEL `expr:` values, and `rslvr:` references).

## Changes

- Add `--fix`, `--fix-dry-run`, and `--diff` flags to `lint`. Preview modes (`--fix-dry-run`, `--diff`) gate CI by exiting non-zero when fixes remain (ruff `--diff`/`--check` parity); `--fix` writes and exits non-zero only if residual errors remain.
- Add a `pkg/lint` fix engine (`ComputeFixPlan`, `FixPlan`, `UnifiedDiff`) backed by a fixer registry, plus the `hyphenated-name` auto-fixer.
- Derive a `fixable` field on lint rule metadata from the fixer registry (never drifts), surfaced via `lint rules`, `lint rule <id>`, and the MCP `list_lint_rules` tool.
- Output separation: fix summary and unified diff go to stderr; residual findings render to stdout via the shared `RenderResult` path (respecting `-o`/`--severity`). Files are written only for `--fix` without `--diff`, using atomic writes.
- Share the lint getter and the rename logic with `refactor rename resolver`.
- Add an fs atomic-write helper, an example solution (`examples/lint/lint-fix-demo.yaml`), a linting tutorial section, and design docs.

## Testing

- Unit tests for the fix engine, CLI flow, and MCP tool.
- Integration tests in `tests/integration/cli_test.go`.