### PR TITLE
feat(lsp): schema-driven structural completion

### DIFF
--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -63,6 +63,24 @@ sources the CLI already knows about -- no separate documentation to maintain:
 Hover degrades gracefully: on an unknown target, a parse error, or whitespace it
 simply returns nothing, so it never interrupts editing.
 
+## Completion
+
+As you type, the server offers **schema-driven structural completions**:
+
+- **Keys** -- typing a key under a known path offers the valid child keys from the
+  generated solution schema (e.g. under a resolver: `description`, `resolve`,
+  `dependsOn`, ...; under a provider entry: `provider`, `inputs`, `onError`, ...),
+  filtered by what you have typed. Each suggestion carries its type and field
+  documentation.
+- **Enum values** -- an enum-valued field (`onError`, `backoff`,
+  `resultSchemaMode`, `scope`) offers its allowed values.
+
+Completion is triggered on `.`, `:`, and space, and works mid-edit even while the
+document does not yet parse (the container is inferred from indentation).
+Structural key and enum-value completion are available today; symbol completion
+(after `_.` / `call:` / `dependsOn`) and CEL/template function completion extend
+the same dispatch.
+
 ## Trying it by hand
 
 You normally never run the server directly, but you can confirm it starts:
@@ -111,9 +129,10 @@ needed to keep editor and CLI diagnostics consistent.
 
 ## What's next
 
-Navigation, rename, and hover cover resolvers, actions, functions, and calls.
-Planned additions extend the same cursor-context resolver to completion and
-signature help.
+Navigation, rename, hover, and structural completion cover resolvers, actions,
+functions, and calls. Planned additions extend the same completion dispatch to
+symbol references (after `_.` / `call:` / `dependsOn`) and CEL/template function
+names.
 
 ## See also
 

--- a/pkg/lsp/capabilities.go
+++ b/pkg/lsp/capabilities.go
@@ -39,6 +39,7 @@ type feature struct {
 // Handler() or the Initialize closure.
 func defaultFeatures() []feature {
 	return []feature{
+		completionFeature(),
 		documentSyncFeature(),
 		hoverFeature(),
 		navigationFeature(),

--- a/pkg/lsp/capabilities_test.go
+++ b/pkg/lsp/capabilities_test.go
@@ -23,7 +23,7 @@ func TestDefaultFeatures_DeterministicOrder(t *testing.T) {
 		got = append(got, f.name)
 		require.NotNil(t, f.wire, "every feature must wire a handler")
 	}
-	assert.Equal(t, []string{"documentSync", "hover", "navigation", "rename", "symbols"}, got)
+	assert.Equal(t, []string{"completion", "documentSync", "hover", "navigation", "rename", "symbols"}, got)
 	assert.True(t, sort.StringsAreSorted(got), "features must be registered in alphabetical order")
 }
 

--- a/pkg/lsp/completion.go
+++ b/pkg/lsp/completion.go
@@ -1,0 +1,153 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/schema"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// completionTriggerCharacters are the characters that (re)trigger completion:
+// "." inside expressions/templates, ":" after a key, and " " after a list dash
+// or key. Downstream branches (#774 symbols, #775 functions) rely on the same
+// triggers.
+var completionTriggerCharacters = []string{".", ":", " "}
+
+// completionFeature registers textDocument/completion and advertises the
+// completion provider with its trigger characters. This PR owns the dispatch
+// core; #774 and #775 extend it in their own files (completion_symbols.go /
+// completion_funcs.go) with one added dispatch branch each.
+func completionFeature() feature {
+	return feature{
+		name: "completion",
+		wire: func(h *protocol.Handler, s *Server) {
+			h.TextDocumentCompletion = s.completion
+		},
+		advertise: func(c *protocol.ServerCapabilities) {
+			c.CompletionProvider = &protocol.CompletionOptions{
+				TriggerCharacters: completionTriggerCharacters,
+			}
+		},
+	}
+}
+
+// completion answers textDocument/completion by classifying the cursor and
+// dispatching to a per-class completion source. It returns nil (no completion)
+// for classes without a source and never panics on a parse-error/unknown
+// document.
+func (s *Server) completion(_ *glsp.Context, params *protocol.CompletionParams) (any, error) {
+	entry, ok := s.getDoc(params.TextDocument.URI)
+	if !ok {
+		return nil, nil
+	}
+	cc := ResolveCursor(entry, params.Position)
+	items := completionItems(cc)
+	if len(items) == 0 {
+		return nil, nil
+	}
+	return items, nil
+}
+
+// completionItems dispatches a resolved cursor to its completion source. This PR
+// implements the structural (schema key) and enum-value branches; the SymbolRef
+// prefix branch (#774) and the CEL/template function branch (#775) are added by
+// those PRs as additional cases, each in its own file.
+func completionItems(cc CursorContext) []protocol.CompletionItem {
+	switch cc.Kind {
+	case CursorYAMLKey:
+		return keyCompletions(cc)
+	case CursorEnumValue:
+		return enumCompletions(cc)
+	case CursorNone, CursorSymbolRef, CursorCEL, CursorTemplate, CursorProviderName:
+		return nil
+	default:
+		return nil
+	}
+}
+
+// keyCompletions offers the valid child keys at the cursor's container, from the
+// solution schema, filtered by what the user has typed so far. It returns
+// nothing when the cursor is at a dynamic map-key position (naming a
+// resolver/action/call/etc.) rather than a schema field position.
+func keyCompletions(cc CursorContext) []protocol.CompletionItem {
+	parent := parentPath(cc.Path)
+	// A key directly under a map container (resolvers/calls/functions/actions/
+	// finally/inputs/args) is a user-chosen name, not a schema field, so there
+	// is nothing structural to suggest.
+	if _, isMapKeyPosition := mapContainerKeys[lastSegment(parent)]; isMapKeyPosition {
+		return nil
+	}
+	fields, ok := schema.FieldsAtPath((*solution.Solution)(nil), schemaPath(parent))
+	if !ok {
+		return nil
+	}
+
+	prefix := strings.ToLower(cc.PartialToken)
+	items := make([]protocol.CompletionItem, 0, len(fields))
+	for _, f := range fields {
+		if f.Name == "" {
+			continue
+		}
+		if prefix != "" && !strings.HasPrefix(strings.ToLower(f.Name), prefix) {
+			continue
+		}
+		items = append(items, newCompletionItem(f.Name, protocol.CompletionItemKindField, f.Type, f.Description))
+	}
+	sortCompletionItems(items)
+	return items
+}
+
+// enumCompletions offers the allowed values of an enum-valued field, filtered by
+// what the user has typed so far.
+func enumCompletions(cc CursorContext) []protocol.CompletionItem {
+	values, ok := enumValueKeys[lastSegment(cc.Path)]
+	if !ok {
+		return nil
+	}
+	prefix := strings.ToLower(cc.PartialToken)
+	items := make([]protocol.CompletionItem, 0, len(values))
+	for _, v := range values {
+		if prefix != "" && !strings.HasPrefix(strings.ToLower(v), prefix) {
+			continue
+		}
+		items = append(items, newCompletionItem(v, protocol.CompletionItemKindEnumMember, "", ""))
+	}
+	sortCompletionItems(items)
+	return items
+}
+
+// newCompletionItem builds a completion item, attaching a detail (type) and a
+// markdown documentation body when provided.
+func newCompletionItem(label string, kind protocol.CompletionItemKind, detail, doc string) protocol.CompletionItem {
+	k := kind
+	item := protocol.CompletionItem{Label: label, Kind: &k}
+	if detail != "" {
+		d := detail
+		item.Detail = &d
+	}
+	if doc != "" {
+		item.Documentation = protocol.MarkupContent{Kind: protocol.MarkupKindMarkdown, Value: doc}
+	}
+	return item
+}
+
+// sortCompletionItems orders items alphabetically by label for stable output.
+func sortCompletionItems(items []protocol.CompletionItem) {
+	sort.Slice(items, func(i, j int) bool { return items[i].Label < items[j].Label })
+}
+
+// parentPath returns the logical path of the container holding the last segment
+// of p (everything before the final "."). It returns "" when p has no parent
+// (a top-level key), which FieldsAtPath maps to the root type's fields.
+func parentPath(p string) string {
+	if i := strings.LastIndex(p, "."); i >= 0 {
+		return p[:i]
+	}
+	return ""
+}

--- a/pkg/lsp/completion_test.go
+++ b/pkg/lsp/completion_test.go
@@ -1,0 +1,278 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// completeAt opens content and returns the completion labels at the position of
+// token (offset by within) on the first line containing lineHint.
+func completeAt(t *testing.T, content, lineHint, token string, within int) []string {
+	t.Helper()
+	s := newTestServer(t)
+	uri := protocol.DocumentUri("file:///completion.yaml")
+	s.setDoc(uri, 1, content)
+	pos := posAt(t, content, lineHint, token, within)
+	res, err := s.completion(nil, &protocol.CompletionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+			Position:     pos,
+		},
+	})
+	require.NoError(t, err)
+	if res == nil {
+		return nil
+	}
+	items, ok := res.([]protocol.CompletionItem)
+	require.True(t, ok, "completion returns []CompletionItem")
+	labels := make([]string, 0, len(items))
+	for _, it := range items {
+		labels = append(labels, it.Label)
+	}
+	return labels
+}
+
+func contains(labels []string, want string) bool {
+	for _, l := range labels {
+		if l == want {
+			return true
+		}
+	}
+	return false
+}
+
+// completionFixture has partial keys (no colon) and an enum value being typed.
+const completionFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  resolvers:
+    appName:
+      desc
+      resolve:
+        with:
+          - provider: parameter
+            onErr
+            inputs:
+              value: dev
+    envName:
+      resolve:
+        with:
+          - provider: parameter
+            onError: fa
+            inputs:
+              value: dev
+`
+
+func TestCompletion_KeyUnderResolver(t *testing.T) {
+	labels := completeAt(t, completionFixture, "      desc", "desc", 4)
+	assert.Equal(t, []string{"description"}, labels, "partial 'desc' offers the description field")
+}
+
+func TestCompletion_KeyUnderProviderSource(t *testing.T) {
+	// "onErr" under a with[] element completes to provider-source fields.
+	labels := completeAt(t, completionFixture, "            onErr", "onErr", 5)
+	assert.Contains(t, labels, "onError", "partial 'onErr' offers onError")
+}
+
+func TestCompletion_BlockKey(t *testing.T) {
+	// Cursor on the existing "with" block key offers the resolve-phase children.
+	labels := completeAt(t, completionFixture, "        with:", "with", 2)
+	assert.True(t, contains(labels, "with"), "labels %v should include with", labels)
+}
+
+func TestCompletion_TopLevelKey(t *testing.T) {
+	content := "apiVersion: scafctl.io/v1\nkind: Solution\nmeta\n"
+	labels := completeAt(t, content, "meta", "meta", 4)
+	assert.Contains(t, labels, "metadata", "top-level partial 'meta' offers metadata")
+}
+
+func TestCompletion_EnumValue(t *testing.T) {
+	labels := completeAt(t, completionFixture, "            onError: fa", "fa", 2)
+	assert.Equal(t, []string{"fail"}, labels, "enum partial 'fa' offers fail")
+}
+
+func TestCompletion_EnumValueNoPartialOffersAll(t *testing.T) {
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: parameter
+            onError: 
+            inputs:
+              value: dev
+`
+	// Cursor right after "onError: " (empty value) offers every allowed value.
+	labels := completeAt(t, content, "            onError: ", "onError: ", len("onError: "))
+	assert.ElementsMatch(t, []string{"fail", "continue"}, labels)
+}
+
+func TestCompletion_MapKeyPositionOffersNothing(t *testing.T) {
+	// Typing a new resolver NAME (a dynamic map key) is not a schema field
+	// position, so there is nothing structural to suggest.
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  resolvers:
+    myNewResolver
+`
+	labels := completeAt(t, content, "    myNewResolver", "myNewResolver", 3)
+	assert.Empty(t, labels)
+}
+
+func TestCompletion_UnknownPathOffersNothing(t *testing.T) {
+	// A key under a mistyped/unknown section resolves to no schema type, so no
+	// child fields are offered (distinct from the map-key short-circuit).
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  notARealSection:
+    child
+`
+	labels := completeAt(t, content, "    child", "child", 3)
+	assert.Empty(t, labels)
+}
+
+func TestCompletion_UnknownDocument(t *testing.T) {
+	s := newTestServer(t)
+	res, err := s.completion(nil, &protocol.CompletionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///missing.yaml"},
+			Position:     protocol.Position{},
+		},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+}
+
+func TestCompletion_ParseErrorNoPanic(t *testing.T) {
+	s := newTestServer(t)
+	uri := protocol.DocumentUri("file:///bad.yaml")
+	s.setDoc(uri, 1, "spec: {resolvers:\n  provider")
+	require.NotPanics(t, func() {
+		res, err := s.completion(nil, &protocol.CompletionParams{
+			TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+				TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+				Position:     protocol.Position{Line: 1, Character: 4},
+			},
+		})
+		require.NoError(t, err)
+		assert.Nil(t, res, "a parse-error document yields no completions")
+	})
+}
+
+func TestCompletion_DispatchSkeletonReturnsNilForOtherClasses(t *testing.T) {
+	// The branches #774/#775 will fill are intentionally empty here.
+	for _, cc := range []CursorContext{
+		{Kind: CursorSymbolRef},
+		{Kind: CursorCEL, PartialToken: "siz"},
+		{Kind: CursorTemplate, PartialToken: "up"},
+		{Kind: CursorProviderName},
+		{Kind: CursorNone},
+	} {
+		assert.Nil(t, completionItems(cc), "kind %s has no source yet", cc.Kind)
+	}
+}
+
+func TestCompletion_FeatureRegisteredAndAdvertised(t *testing.T) {
+	s := newTestServer(t)
+	h := s.Handler()
+	assert.NotNil(t, h.TextDocumentCompletion, "completion handler wired")
+
+	res, err := h.Initialize(nil, &protocol.InitializeParams{})
+	require.NoError(t, err)
+	init := res.(protocol.InitializeResult)
+	require.NotNil(t, init.Capabilities.CompletionProvider)
+	assert.Equal(t, completionTriggerCharacters, init.Capabilities.CompletionProvider.TriggerCharacters)
+}
+
+func TestParentPath(t *testing.T) {
+	assert.Equal(t, "spec.resolvers", parentPath("spec.resolvers.appName"))
+	assert.Equal(t, "", parentPath("spec"))
+	assert.Equal(t, "", parentPath(""))
+}
+
+func TestContainerPathByIndent(t *testing.T) {
+	raw := []byte(completionFixture)
+	// "onErr" is on the line after "- provider: parameter"; its container walks
+	// up to spec.resolvers.appName.resolve.with (the list key).
+	line := lineIndexOf(t, completionFixture, "            onErr")
+	got := containerPathByIndent(raw, line, 12)
+	assert.Equal(t, "spec.resolvers.appName.resolve.with", got)
+
+	// "desc" under appName.
+	line = lineIndexOf(t, completionFixture, "      desc")
+	got = containerPathByIndent(raw, line, 6)
+	assert.Equal(t, "spec.resolvers.appName", got)
+}
+
+func TestBarePartialKey(t *testing.T) {
+	// "  desc" with cursor at end -> identifier "desc" starting at rune 2.
+	start, ok := barePartialKey([]rune("  desc"), 6)
+	require.True(t, ok)
+	assert.Equal(t, 2, start)
+
+	// A "key: value" line is NOT a bare key (handled by parseKeyLine).
+	_, ok = barePartialKey([]rune("  key: value"), 4)
+	assert.False(t, ok)
+
+	// A dash-led first field.
+	start, ok = barePartialKey([]rune("  - prov"), 8)
+	require.True(t, ok)
+	assert.Equal(t, 4, start)
+
+	// Blank line -> no bare key.
+	_, ok = barePartialKey([]rune("    "), 2)
+	assert.False(t, ok)
+}
+
+// lineIndexOf returns the 0-based index of the first line containing sub.
+func lineIndexOf(t *testing.T, content, sub string) int {
+	t.Helper()
+	line := 0
+	cur := ""
+	for _, c := range content {
+		if c == '\n' {
+			if containsSub(cur, sub) {
+				return line
+			}
+			line++
+			cur = ""
+			continue
+		}
+		cur += string(c)
+	}
+	if containsSub(cur, sub) {
+		return line
+	}
+	t.Fatalf("no line contains %q", sub)
+	return -1
+}
+
+func containsSub(s, sub string) bool {
+	if len(sub) > len(s) {
+		return false
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/lsp/cursor.go
+++ b/pkg/lsp/cursor.go
@@ -106,17 +106,21 @@ var templateValueKeys = map[string]struct{}{
 	"template": {},
 }
 
-// enumValueKeys are the leaf mapping keys whose scalar value is a fixed enum in
-// the current solution schema. The classifier only needs to know a field is an
-// enum; downstream completion sources the concrete values. Keep in sync with the
-// typed string enums in pkg/spec and pkg/action (OnErrorBehavior, BackoffType,
-// ResultSchemaMode, FingerprintScope). Note onError is deprecated in favor of
-// the boolean continueOnError, but remains a functional enum field.
-var enumValueKeys = map[string]struct{}{
-	"onError":          {},
-	"backoff":          {},
-	"resultSchemaMode": {},
-	"scope":            {},
+// enumValueKeys maps each leaf mapping key whose scalar value is a fixed enum in
+// the current solution schema to that enum's allowed values. It is the single
+// source of truth for both cursor classification (a key's presence marks an
+// EnumValue) and completion (the values it offers). It intentionally lists only
+// keys that are unambiguous enum fields; broad/generic keys that also appear as
+// free-form user input names (notably "type") are deliberately excluded to avoid
+// misclassifying arbitrary values. Keep in sync with the typed string enums in
+// pkg/spec and pkg/action (OnErrorBehavior, BackoffType, ResultSchemaMode,
+// FingerprintScope). Note onError is deprecated in favor of the boolean
+// continueOnError, but remains a functional enum field.
+var enumValueKeys = map[string][]string{
+	"onError":          {"fail", "continue"},
+	"backoff":          {"fixed", "linear", "exponential"},
+	"resultSchemaMode": {"error", "warn", "ignore"},
+	"scope":            {"all", "files"},
 }
 
 // ResolveCursor classifies pos against a cached document snapshot. It never
@@ -169,7 +173,33 @@ func ResolveCursor(doc *DocEntry, pos protocol.Position) CursorContext {
 		if path == "" {
 			path = blockKeyPath(doc, int(pos.Line)+1, key)
 		}
+		if path == "" {
+			// No node info (mid-edit/unparsed doc): derive the full key path by
+			// indentation so completion can still find the container.
+			if container := containerPathByIndent(doc.Raw, int(pos.Line), keyStart); container != "" {
+				path = container + "." + key
+			} else {
+				path = key
+			}
+		}
 		return CursorContext{Kind: CursorYAMLKey, Path: path, Node: node, PartialToken: string(runes[keyStart:cursor])}
+	}
+
+	// 2b. Bare partial key (no colon yet) -> completion-time key context. While a
+	// user types a new key the line has no ":", so parseKeyLine finds nothing; the
+	// document usually does not parse either. Detect a leading identifier under
+	// the cursor and derive its container path by indentation from the raw text,
+	// which works without a valid parse. The container is joined with the partial
+	// so parentPath(Path) yields the container for schema lookup.
+	if key == "" {
+		if bare, okBare := barePartialKey(runes, cursor); okBare {
+			partial := string(runes[bare:cursor])
+			path := partial
+			if container := containerPathByIndent(doc.Raw, int(pos.Line), bare); container != "" {
+				path = container + "." + partial
+			}
+			return CursorContext{Kind: CursorYAMLKey, Path: path, PartialToken: partial}
+		}
 	}
 
 	// 3. Value context: classify by the leaf key. Determine the key/path/value
@@ -199,6 +229,12 @@ func ResolveCursor(doc *DocEntry, pos protocol.Position) CursorContext {
 			valueStart2 = firstNonSpace(runes)
 		} else if key != "" && hasValue {
 			keyName = key
+			// No parsed node (mid-edit/unparsed doc): fall back to the bare key
+			// as the path so downstream consumers that key off the leaf segment
+			// (enum values, provider name) still work.
+			if leafPath == "" {
+				leafPath = key
+			}
 			valueStart2 = valueStart
 		} else {
 			return CursorContext{Kind: CursorNone}
@@ -213,7 +249,7 @@ func ResolveCursor(doc *DocEntry, pos protocol.Position) CursorContext {
 	switch {
 	case keyName == "provider":
 		return CursorContext{Kind: CursorProviderName, Path: leafPath, Node: leafNode, PartialToken: backwardProviderIdent(line, cursor)}
-	case isKey(enumValueKeys, keyName):
+	case isEnumKey(keyName):
 		return CursorContext{Kind: CursorEnumValue, Path: leafPath, Node: leafNode, PartialToken: backwardIdent(line, cursor)}
 	case isKey(celValueKeys, keyName):
 		ctx := CursorContext{Kind: CursorCEL, Path: leafPath, Node: leafNode}
@@ -301,6 +337,83 @@ func parseKeyLine(runes []rune) (key string, keyStart, keyEnd, valueStart int, h
 	valueStart = v
 	hasValue = v < len(runes) && runes[v] != '#'
 	return key, keyStart, keyEnd, valueStart, hasValue
+}
+
+// barePartialKey reports whether the cursor sits on a leading identifier token
+// that is a partial mapping key being typed: content that starts (after indent
+// and any block-sequence dashes) with an identifier, has no key/value colon yet,
+// and is otherwise blank after the token. It returns the 0-based rune index where
+// the identifier starts.
+func barePartialKey(runes []rune, cursor int) (int, bool) {
+	i := 0
+	for i < len(runes) {
+		if runes[i] == ' ' || runes[i] == '\t' {
+			i++
+			continue
+		}
+		if runes[i] == '-' && i+1 < len(runes) && (runes[i+1] == ' ' || runes[i+1] == '\t') {
+			i += 2
+			continue
+		}
+		break
+	}
+	start := i
+	end := i
+	for end < len(runes) && isIdentRune(runes[end]) {
+		end++
+	}
+	if end == start {
+		return 0, false // no identifier at content start
+	}
+	// The remainder of the line must be blank (a real "key: ..." is handled by
+	// parseKeyLine; anything else is not a bare partial key).
+	for j := end; j < len(runes); j++ {
+		if runes[j] != ' ' && runes[j] != '\t' {
+			return 0, false
+		}
+	}
+	if cursor < start || cursor > end {
+		return 0, false
+	}
+	return start, true
+}
+
+// containerPathByIndent reconstructs the logical path of the mapping that
+// contains a key at the given 0-based key column on line (0-based), using only
+// indentation of the raw text. It walks upward, adding each ancestor mapping key
+// whose key column is strictly less than the running target column. This is
+// robust to a mid-edit document that does not parse (the common completion case),
+// where the cached node map is unavailable. Sequence dashes are transparent: a
+// list element's fields share their key column, so a "- key:" sibling is skipped
+// and the enclosing list key (at a smaller column) becomes the parent -- which
+// FieldsAtPath resolves into the element type.
+func containerPathByIndent(raw []byte, line, keyCol int) string {
+	var segs []string
+	target := keyCol
+	for l := line - 1; l >= 0 && target > 0; l-- {
+		text, ok := lineAt(raw, l)
+		if !ok {
+			continue
+		}
+		lr := []rune(text)
+		trimmed := strings.TrimSpace(text)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		k, ks, _, _, _ := parseKeyLine(lr)
+		if k == "" {
+			continue // not a mapping key line
+		}
+		if ks < target {
+			segs = append(segs, k)
+			target = ks
+		}
+	}
+	// Reverse into top-down order.
+	for i, j := 0, len(segs)-1; i < j; i, j = i+1, j-1 {
+		segs[i], segs[j] = segs[j], segs[i]
+	}
+	return strings.Join(segs, ".")
 }
 
 // scalarLeafOnLine returns the scalar value node whose start is on the 1-based
@@ -460,6 +573,12 @@ func lastSegment(path string) string {
 
 func isKey(set map[string]struct{}, k string) bool {
 	_, ok := set[k]
+	return ok
+}
+
+// isEnumKey reports whether k is a leaf mapping key with a fixed enum value.
+func isEnumKey(k string) bool {
+	_, ok := enumValueKeys[k]
 	return ok
 }
 

--- a/pkg/schema/introspect.go
+++ b/pkg/schema/introspect.go
@@ -296,7 +296,7 @@ func introspectFieldsWithSeen(t reflect.Type, depth int, seen map[reflect.Type]b
 		// named after its Go type and its real keys are hidden a level down.
 		if embeddedType, ok := inlineEmbeddedStruct(f); ok {
 			if depth < 10 && !seen[embeddedType] {
-				fields = append(fields, introspectFieldsWithSeen(embeddedType, depth, seen)...)
+				fields = append(fields, introspectFieldsWithSeen(embeddedType, depth+1, seen)...)
 			}
 			continue
 		}
@@ -327,10 +327,31 @@ func inlineEmbeddedStruct(f reflect.StructField) (reflect.Type, bool) {
 		return nil, false
 	}
 	yamlTag := f.Tag.Get("yaml")
-	if name := tagName(yamlTag); name != "" && !strings.Contains(yamlTag, "inline") {
+	// A renamed embed (e.g. `yaml:"base"`) is a normal named nested field, not
+	// inline -- even if the name happens to contain the substring "inline".
+	if tagName(yamlTag) != "" {
+		return nil, false
+	}
+	// With no yaml tag, a Go embed serializes inline by default. When a yaml
+	// tag is present (but unnamed), require an explicit ",inline" option rather
+	// than substring-matching the raw tag.
+	if yamlTag != "" && !hasTagOption(yamlTag, "inline") {
 		return nil, false
 	}
 	return ft, true
+}
+
+// hasTagOption reports whether a struct tag value carries the given comma-
+// separated option (e.g. "inline" in ",inline" or "foo,omitempty,inline").
+// The name portion (before the first comma) is not treated as an option.
+func hasTagOption(tag, opt string) bool {
+	parts := strings.Split(tag, ",")
+	for _, p := range parts[1:] {
+		if p == opt {
+			return true
+		}
+	}
+	return false
 }
 
 // tagName returns the name portion of a struct tag value (the text before the

--- a/pkg/schema/introspect.go
+++ b/pkg/schema/introspect.go
@@ -149,6 +149,29 @@ func IntrospectType(v any) (*TypeInfo, error) {
 	return info, nil
 }
 
+// FieldsAtPath returns the child fields valid at a logical field path, for
+// schema-driven key completion. An empty path returns the top-level fields of v;
+// a non-empty path returns the nested fields of the struct/map/slice-element type
+// at that path. ok is false when the path does not resolve to a type with named
+// child fields (e.g. a scalar leaf or an unknown path). Path navigation follows
+// IntrospectField's rules: dot-separated JSON/Go field names, diving through
+// pointers, slice/array elements, and map values (indices and dynamic map keys
+// are not part of the path -- normalize before calling).
+func FieldsAtPath(v any, path string) ([]FieldInfo, bool) {
+	if path == "" {
+		ti, err := IntrospectType(v)
+		if err != nil || ti == nil {
+			return nil, false
+		}
+		return ti.Fields, len(ti.Fields) > 0
+	}
+	fi, err := IntrospectField(v, path)
+	if err != nil || fi == nil || len(fi.NestedFields) == 0 {
+		return nil, false
+	}
+	return fi.NestedFields, true
+}
+
 // IntrospectField returns field information for a specific field path.
 // The path uses dot notation: "schema.properties" or "metadata.version"
 func IntrospectField(v any, path string) (*FieldInfo, error) {
@@ -266,10 +289,57 @@ func introspectFieldsWithSeen(t reflect.Type, depth int, seen map[reflect.Type]b
 			continue
 		}
 
+		// Promote the fields of an anonymous embedded struct that serializes
+		// inline (no explicit key name; e.g. spec.CallRef with yaml:",inline").
+		// json/yaml both flatten such embeds into the parent object, so the
+		// schema must too -- otherwise the embed surfaces as a phantom field
+		// named after its Go type and its real keys are hidden a level down.
+		if embeddedType, ok := inlineEmbeddedStruct(f); ok {
+			if depth < 10 && !seen[embeddedType] {
+				fields = append(fields, introspectFieldsWithSeen(embeddedType, depth, seen)...)
+			}
+			continue
+		}
+
 		fields = append(fields, introspectFieldWithSeen(f, depth, seen))
 	}
 
 	return fields
+}
+
+// inlineEmbeddedStruct reports whether f is an anonymous embedded struct that
+// serializes inline (its fields promoted into the parent), returning the
+// embedded struct type. An embed is inline when it has no explicit serialized
+// key name -- no json name and either no yaml tag or an explicit ",inline". A
+// renamed embed (e.g. `json:"base"`) is a normal named nested field, not inline.
+func inlineEmbeddedStruct(f reflect.StructField) (reflect.Type, bool) {
+	if !f.Anonymous {
+		return nil, false
+	}
+	ft := f.Type
+	for ft.Kind() == reflect.Pointer {
+		ft = ft.Elem()
+	}
+	if ft.Kind() != reflect.Struct {
+		return nil, false
+	}
+	if tagName(f.Tag.Get("json")) != "" {
+		return nil, false
+	}
+	yamlTag := f.Tag.Get("yaml")
+	if name := tagName(yamlTag); name != "" && !strings.Contains(yamlTag, "inline") {
+		return nil, false
+	}
+	return ft, true
+}
+
+// tagName returns the name portion of a struct tag value (the text before the
+// first comma), e.g. "foo,omitempty" -> "foo", ",inline" -> "".
+func tagName(tag string) string {
+	if i := strings.IndexByte(tag, ','); i >= 0 {
+		return tag[:i]
+	}
+	return tag
 }
 
 // introspectFieldWithSeen extracts all tag information from a struct field,

--- a/pkg/schema/introspect_test.go
+++ b/pkg/schema/introspect_test.go
@@ -364,3 +364,21 @@ func TestFieldsAtPath_FlattensInlineEmbed(t *testing.T) {
 		"inline embed fields are promoted; no phantom type-named field")
 	assert.NotContains(t, names, "InlineEmbedInner")
 }
+
+// NamedEmbedOuter exercises the inline-detection guard: an anonymous embed whose
+// yaml name merely *contains* the substring "inline" is a NAMED nested field and
+// must NOT be flattened (regression for substring-based detection).
+type NamedEmbedOuter struct {
+	InlineEmbedInner `yaml:"inlineData"`
+	Provider         string `json:"provider,omitempty" doc:"provider name"`
+}
+
+func TestFieldsAtPath_NamedEmbedNotFlattened(t *testing.T) {
+	fields, ok := FieldsAtPath((*NamedEmbedOuter)(nil), "")
+	require.True(t, ok)
+	names := fieldNames(fields)
+	assert.NotContains(t, names, "call",
+		"a named embed (yaml name containing 'inline') must not be flattened")
+	assert.NotContains(t, names, "args")
+	assert.Contains(t, names, "provider")
+}

--- a/pkg/schema/introspect_test.go
+++ b/pkg/schema/introspect_test.go
@@ -293,3 +293,74 @@ func TestIntrospectType_NilPointer(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "SimpleStruct", info.Name)
 }
+
+// fapContainer exercises FieldsAtPath navigation through struct, slice-element,
+// and map-value types.
+type fapContainer struct {
+	Simple SimpleStruct            `json:"simple" doc:"nested struct"`
+	Items  []SimpleStruct          `json:"items" doc:"slice of structs"`
+	ByName map[string]SimpleStruct `json:"byName" doc:"map of structs"`
+}
+
+func TestFieldsAtPath(t *testing.T) {
+	// Root: top-level fields of the type.
+	fields, ok := FieldsAtPath((*fapContainer)(nil), "")
+	require.True(t, ok)
+	names := fieldNames(fields)
+	assert.Equal(t, []string{"simple", "items", "byName"}, names)
+
+	// Nested struct.
+	fields, ok = FieldsAtPath((*fapContainer)(nil), "simple")
+	require.True(t, ok)
+	assert.Equal(t, []string{"name", "description", "count"}, fieldNames(fields))
+
+	// Slice element type.
+	fields, ok = FieldsAtPath((*fapContainer)(nil), "items")
+	require.True(t, ok)
+	assert.Equal(t, []string{"name", "description", "count"}, fieldNames(fields))
+
+	// Map value type.
+	fields, ok = FieldsAtPath((*fapContainer)(nil), "byName")
+	require.True(t, ok)
+	assert.Equal(t, []string{"name", "description", "count"}, fieldNames(fields))
+}
+
+func TestFieldsAtPath_NoChildren(t *testing.T) {
+	// A scalar leaf has no child fields.
+	_, ok := FieldsAtPath((*fapContainer)(nil), "simple.name")
+	assert.False(t, ok)
+
+	// An unknown path resolves to nothing.
+	_, ok = FieldsAtPath((*fapContainer)(nil), "nope")
+	assert.False(t, ok)
+}
+
+func fieldNames(fields []FieldInfo) []string {
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		out = append(out, f.Name)
+	}
+	return out
+}
+
+// InlineEmbedOuter exercises inline-embedded struct flattening: an anonymous
+// embed with yaml:",inline" (and no json name) must have its fields promoted
+// into the parent, not surface as a phantom field named after the Go type.
+type InlineEmbedInner struct {
+	Call string `json:"call,omitempty" doc:"call ref"`
+	Args string `json:"args,omitempty" doc:"call args"`
+}
+
+type InlineEmbedOuter struct {
+	InlineEmbedInner `yaml:",inline"`
+	Provider         string `json:"provider,omitempty" doc:"provider name"`
+}
+
+func TestFieldsAtPath_FlattensInlineEmbed(t *testing.T) {
+	fields, ok := FieldsAtPath((*InlineEmbedOuter)(nil), "")
+	require.True(t, ok)
+	names := fieldNames(fields)
+	assert.Equal(t, []string{"call", "args", "provider"}, names,
+		"inline embed fields are promoted; no phantom type-named field")
+	assert.NotContains(t, names, "InlineEmbedInner")
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13909,6 +13909,23 @@ func TestIntegration_LspRename(t *testing.T) {
 	assert.Contains(t, out, lspSessionURI, "edits target the document")
 }
 
+func TestIntegration_LspCompletion(t *testing.T) {
+	t.Parallel()
+
+	// A partial key "desc" is on line 7 (0-based), under the appName resolver;
+	// completion at its end offers the schema's child keys.
+	sol := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: nav\nspec:\n  resolvers:\n    appName:\n      desc\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value: dev\n"
+
+	out := runLSPSession(t, sol,
+		map[string]any{"jsonrpc": "2.0", "id": 2, "method": "textDocument/completion", "params": map[string]any{
+			"textDocument": map[string]any{"uri": lspSessionURI},
+			"position":     map[string]any{"line": 7, "character": 10},
+		}},
+	)
+
+	assert.Contains(t, out, `"label":"description"`, "completion offers the description field for partial 'desc'")
+}
+
 func TestIntegration_LspHover(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Adds the LSP **`textDocument/completion`** handler and its cursor-class dispatch
core, plus the first two completion sources -- schema-driven **key** completion
and **enum value** completion. This is the flagship completion PR (part 1 of 3):
it owns the dispatch core; **#774** (symbol completion) and **#775** (function
completion) extend it with one disjoint branch each.

This is issue #773 (needs #766 cache, #767 seam, #768 cursor -- all merged) --
**S3**.

## Dispatch core

- `completionFeature()` registered via the seam; advertises `CompletionProvider`
  with trigger characters `.`, `:`, ` `.
- `completion.go` calls `ResolveCursor` (#768) and dispatches by `CursorKind`.
  This PR implements:
  - **YAMLKey** -> the valid child keys at the cursor's container, from the
    solution schema, filtered by what's typed. Each item carries its type and
    field doc.
  - **EnumValue** -> the field's allowed values (`onError`, `backoff`,
    `resultSchemaMode`, `scope`).
- `SymbolRef` / `CEL` / `Template` / `ProviderName` are intentionally no-op cases,
  so #774/#775 add exactly one `case` each without touching the core.

## Supporting changes

- **`schema.FieldsAtPath(v, path)`** (additive) -- returns the child fields at a
  logical path (root type fields for the empty path; nested fields otherwise).
- **Inline-embed flattening** -- the schema introspector now promotes anonymous
  inline-embedded structs (e.g. `spec.CallRef` with `yaml:",inline"`), so
  completion offers the real `call` / `args` keys under `with[]`/`actions`
  elements instead of a phantom `CallRef` field. This also fixes hover/explain,
  which inherited the same leak. Inline detection parses the yaml tag's
  comma-separated options (requiring an explicit `,inline` and no name) rather
  than substring-matching, and recurses with `depth+1` so the recursion-depth
  guard stays meaningful.
- **`cursor.go`** -- `enumValueKeys` becomes the single source of truth (key ->
  allowed values); `ResolveCursor` now classifies a **bare partial key**
  (mid-typing, no colon yet) as a `YAMLKey` and derives the container path by
  **indentation**, so completion works even while the document does not parse
  (the common mid-edit case).

## Tests / docs

- Table tests: key completion at several paths (root, resolver, resolve-phase,
  `with[]` element), enum-value completion (partial + offer-all), map-key and
  unknown-path positions offer nothing, parse-error doc returns empty, dispatch
  skeleton returns nil for the #774/#775 classes, feature registration + trigger
  chars. Helper unit tests for `containerPathByIndent` / `barePartialKey` /
  `parentPath`. `schema.FieldsAtPath` + inline-embed flattening tests, including
  a regression asserting a named embed (yaml name containing "inline") is not
  flattened.
- Integration test `TestIntegration_LspCompletion` via the `runLSPSession` harness.
- `docs/tutorials/lsp-tutorial.md` documents completion.

`-race` clean, `lint:changed` 0 new issues.

## Acceptance criteria

- [x] Typing a key under a known path offers valid child keys.
- [x] Enum-valued fields offer their allowed values.
- [x] Dispatch skeleton in place for #774/#775 to extend without touching core.

Closes #773
