### PR TITLE
feat(lsp): CEL and Go-template function completion

### DIFF
--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -74,12 +74,16 @@ As you type, the server offers **schema-driven structural completions**:
   documentation.
 - **Enum values** -- an enum-valued field (`onError`, `backoff`,
   `resultSchemaMode`, `scope`) offers its allowed values.
+- **Functions** -- inside a CEL expression the server offers CEL functions (with
+  their signatures); inside a `{{ }}` template it offers Go-template functions and
+  the solution's own author-defined helpers (`spec.functions`). Each is inserted
+  as a call snippet with the cursor placed inside the parentheses.
 
 Completion is triggered on `.`, `:`, and space, and works mid-edit even while the
 document does not yet parse (the container is inferred from indentation).
-Structural key and enum-value completion are available today; symbol completion
-(after `_.` / `call:` / `dependsOn`) and CEL/template function completion extend
-the same dispatch.
+Structural key, enum-value, and CEL/template function completion are available
+today; symbol completion (after `_.` / `call:` / `dependsOn`) extends the same
+dispatch.
 
 ## Trying it by hand
 
@@ -129,10 +133,10 @@ needed to keep editor and CLI diagnostics consistent.
 
 ## What's next
 
-Navigation, rename, hover, and structural completion cover resolvers, actions,
-functions, and calls. Planned additions extend the same completion dispatch to
-symbol references (after `_.` / `call:` / `dependsOn`) and CEL/template function
-names.
+Navigation, rename, hover, and completion (structural keys, enum values, and
+CEL/template functions) cover resolvers, actions, functions, and calls. Planned
+additions extend the same completion dispatch to symbol references (after `_.` /
+`call:` / `dependsOn`).
 
 ## See also
 

--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -77,7 +77,9 @@ As you type, the server offers **schema-driven structural completions**:
 - **Functions** -- inside a CEL expression the server offers CEL functions (with
   their signatures); inside a `{{ }}` template it offers Go-template functions and
   the solution's own author-defined helpers (`spec.functions`). Each is inserted
-  as a call snippet with the cursor placed inside the parentheses.
+  as a call snippet with the cursor at the first argument, using the syntax valid
+  for that context: a parenthesized call in CEL (`name($0)`) and a space-separated
+  call in templates (`name $0`, since `name()` is not valid template syntax).
 
 Completion is triggered on `.`, `:`, and space, and works mid-edit even while the
 document does not yet parse (the container is inferred from indentation).

--- a/pkg/lsp/completion.go
+++ b/pkg/lsp/completion.go
@@ -47,24 +47,27 @@ func (s *Server) completion(_ *glsp.Context, params *protocol.CompletionParams) 
 		return nil, nil
 	}
 	cc := ResolveCursor(entry, params.Position)
-	items := completionItems(cc)
+	items := completionItems(entry, cc)
 	if len(items) == 0 {
 		return nil, nil
 	}
 	return items, nil
 }
 
-// completionItems dispatches a resolved cursor to its completion source. This PR
-// implements the structural (schema key) and enum-value branches; the SymbolRef
-// prefix branch (#774) and the CEL/template function branch (#775) are added by
-// those PRs as additional cases, each in its own file.
-func completionItems(cc CursorContext) []protocol.CompletionItem {
+// completionItems dispatches a resolved cursor to its completion source. The
+// structural (schema key) and enum-value branches live in this file; the CEL and
+// Go-template function branch lives in completion_funcs.go, and the SymbolRef
+// prefix branch (#774) is added by that PR -- each a single case, so the
+// completion PRs never edit each other's sources beyond this switch.
+func completionItems(entry *DocEntry, cc CursorContext) []protocol.CompletionItem {
 	switch cc.Kind {
 	case CursorYAMLKey:
 		return keyCompletions(cc)
 	case CursorEnumValue:
 		return enumCompletions(cc)
-	case CursorNone, CursorSymbolRef, CursorCEL, CursorTemplate, CursorProviderName:
+	case CursorCEL, CursorTemplate:
+		return funcCompletions(entry, cc)
+	case CursorNone, CursorSymbolRef, CursorProviderName:
 		return nil
 	default:
 		return nil

--- a/pkg/lsp/completion_funcs.go
+++ b/pkg/lsp/completion_funcs.go
@@ -70,7 +70,9 @@ func matchesPrefix(name, lowerPrefix string) bool {
 
 // funcCompletionItem builds a completion item for a built-in CEL/template
 // function, rendering its signature as detail and inserting a call snippet that
-// places the cursor between the parentheses.
+// places the cursor at the first argument. CEL uses a parenthesized call --
+// "name($0)"; Go templates use space-separated args -- "name $0" (parenthesized
+// "name()" is invalid template syntax).
 func funcCompletionItem(fn FuncInfo) protocol.CompletionItem {
 	kind := protocol.CompletionItemKindFunction
 	item := protocol.CompletionItem{Label: fn.Name, Kind: &kind}
@@ -89,8 +91,15 @@ func funcCompletionItem(fn FuncInfo) protocol.CompletionItem {
 		item.Documentation = protocol.MarkupContent{Kind: protocol.MarkupKindMarkdown, Value: doc}
 	}
 
-	// Insert "name($0)" as a snippet so the cursor lands between the parens.
-	snippet := fmt.Sprintf("%s($0)", fn.Name)
+	// Insert a call snippet placing the cursor at the first argument. CEL calls
+	// are parenthesized -- "name($0)"; Go-template calls are space-separated --
+	// "name $0" ("name()" is invalid template syntax).
+	var snippet string
+	if fn.CEL {
+		snippet = fmt.Sprintf("%s($0)", fn.Name)
+	} else {
+		snippet = fmt.Sprintf("%s $0", fn.Name)
+	}
 	format := protocol.InsertTextFormatSnippet
 	item.InsertText = &snippet
 	item.InsertTextFormat = &format

--- a/pkg/lsp/completion_funcs.go
+++ b/pkg/lsp/completion_funcs.go
@@ -1,0 +1,130 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"fmt"
+	"strings"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// funcCompletions offers function-name completions inside a CEL expression or a
+// Go template. CEL context lists CEL functions; template context lists Go-template
+// functions plus the solution's author-defined helpers (spec.functions). It
+// reuses the shared funcref.go registry view (no duplicate registry walking).
+//
+// It fires only for a bare function token (ExprPrefix == ""); a reference-prefixed
+// token ("_.", "._.", "__actions.", ".") is a data/symbol reference handled by
+// the SymbolRef completion branch (#774), not a function.
+func funcCompletions(entry *DocEntry, cc CursorContext) []protocol.CompletionItem {
+	if cc.ExprPrefix != "" {
+		return nil
+	}
+	prefix := strings.ToLower(cc.PartialToken)
+	wantCEL := cc.Kind == CursorCEL
+
+	// AllFuncs() de-duplicates by name (CEL wins on a collision), so the
+	// fn.CEL==wantCEL split is exact only while the CEL and template namespaces
+	// don't collide -- true today. A future collision would hide the template
+	// entry; funcref's index is the single place to reconcile that if it arises.
+	var items []protocol.CompletionItem
+	for _, fn := range AllFuncs() {
+		if fn.CEL != wantCEL {
+			continue
+		}
+		if !matchesPrefix(fn.Name, prefix) {
+			continue
+		}
+		items = append(items, funcCompletionItem(fn))
+	}
+
+	// Template context also completes author-defined helper functions declared in
+	// spec.functions.
+	if cc.Kind == CursorTemplate && entry != nil && entry.Sol != nil {
+		for name, fn := range entry.Sol.Spec.Functions {
+			if !matchesPrefix(name, prefix) {
+				continue
+			}
+			doc := ""
+			if fn != nil {
+				doc = fn.Description
+			}
+			items = append(items, authorFuncCompletionItem(name, doc))
+		}
+	}
+
+	sortCompletionItems(items)
+	return items
+}
+
+// matchesPrefix reports whether name starts with the (already lowercased) prefix.
+// An empty prefix matches everything.
+func matchesPrefix(name, lowerPrefix string) bool {
+	if lowerPrefix == "" {
+		return true
+	}
+	return strings.HasPrefix(strings.ToLower(name), lowerPrefix)
+}
+
+// funcCompletionItem builds a completion item for a built-in CEL/template
+// function, rendering its signature as detail and inserting a call snippet that
+// places the cursor between the parentheses.
+func funcCompletionItem(fn FuncInfo) protocol.CompletionItem {
+	kind := protocol.CompletionItemKindFunction
+	item := protocol.CompletionItem{Label: fn.Name, Kind: &kind}
+
+	detail := fn.Signature
+	if detail == "" {
+		if fn.CEL {
+			detail = "CEL function"
+		} else {
+			detail = "template function"
+		}
+	}
+	item.Detail = &detail
+
+	if doc := funcDocMarkdown(fn); doc != "" {
+		item.Documentation = protocol.MarkupContent{Kind: protocol.MarkupKindMarkdown, Value: doc}
+	}
+
+	// Insert "name($0)" as a snippet so the cursor lands between the parens.
+	snippet := fmt.Sprintf("%s($0)", fn.Name)
+	format := protocol.InsertTextFormatSnippet
+	item.InsertText = &snippet
+	item.InsertTextFormat = &format
+	return item
+}
+
+// authorFuncCompletionItem builds a completion item for a solution author-defined
+// template helper function.
+func authorFuncCompletionItem(name, description string) protocol.CompletionItem {
+	kind := protocol.CompletionItemKindFunction
+	detail := "author function"
+	item := protocol.CompletionItem{Label: name, Kind: &kind, Detail: &detail}
+	if description != "" {
+		item.Documentation = protocol.MarkupContent{Kind: protocol.MarkupKindMarkdown, Value: description}
+	}
+	snippet := fmt.Sprintf("%s $0", name)
+	format := protocol.InsertTextFormatSnippet
+	item.InsertText = &snippet
+	item.InsertTextFormat = &format
+	return item
+}
+
+// funcDocMarkdown renders a function's description and first example as markdown
+// for the completion documentation popup.
+func funcDocMarkdown(fn FuncInfo) string {
+	var b strings.Builder
+	if fn.Description != "" {
+		b.WriteString(fn.Description)
+	}
+	if len(fn.Examples) > 0 {
+		if b.Len() > 0 {
+			b.WriteString("\n\n")
+		}
+		fmt.Fprintf(&b, "_Example:_\n\n```\n%s\n```", fn.Examples[0])
+	}
+	return b.String()
+}

--- a/pkg/lsp/completion_funcs_test.go
+++ b/pkg/lsp/completion_funcs_test.go
@@ -1,0 +1,191 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+const funcCompletionFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  functions:
+    myHelper:
+      description: A custom helper
+      template: "{{ . }}"
+  resolvers:
+    celR:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: arr
+    tmplR:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              value:
+                tmpl: "{{ up }}"
+    authorR:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              value:
+                tmpl: "{{ my }}"
+`
+
+func funcCompleteAt(t *testing.T, lineHint, token string, within int) []protocol.CompletionItem {
+	t.Helper()
+	s := newTestServer(t)
+	uri := protocol.DocumentUri("file:///fc.yaml")
+	s.setDoc(uri, 1, funcCompletionFixture)
+	pos := posAt(t, funcCompletionFixture, lineHint, token, within)
+	res, err := s.completion(nil, &protocol.CompletionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+			Position:     pos,
+		},
+	})
+	require.NoError(t, err)
+	if res == nil {
+		return nil
+	}
+	items, ok := res.([]protocol.CompletionItem)
+	require.True(t, ok)
+	return items
+}
+
+func labelsOf(items []protocol.CompletionItem) []string {
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.Label)
+	}
+	return out
+}
+
+func TestFuncCompletion_CELContextListsCELFunctions(t *testing.T) {
+	items := funcCompleteAt(t, "                expr: arr", "arr", 3)
+	labels := labelsOf(items)
+	require.NotEmpty(t, labels)
+	assert.Contains(t, labels, "arrays.groupBy")
+	// Every suggestion is a CEL function (has a signature detail) with a call snippet.
+	for _, it := range items {
+		require.NotNil(t, it.Kind)
+		assert.Equal(t, protocol.CompletionItemKindFunction, *it.Kind)
+		require.NotNil(t, it.InsertText)
+		assert.Contains(t, *it.InsertText, "($0)")
+		require.NotNil(t, it.InsertTextFormat)
+		assert.Equal(t, protocol.InsertTextFormatSnippet, *it.InsertTextFormat)
+	}
+}
+
+func TestFuncCompletion_CELDoesNotListTemplateFunctions(t *testing.T) {
+	// "up" would match template "upper"; in CEL context it must not appear.
+	items := funcCompleteAt(t, "                expr: arr", "arr", 3)
+	assert.NotContains(t, labelsOf(items), "upper")
+}
+
+func TestFuncCompletion_TemplateContextListsTemplateFunctions(t *testing.T) {
+	items := funcCompleteAt(t, `                tmpl: "{{ up`, "up", 2)
+	assert.Contains(t, labelsOf(items), "upper")
+	// Template builtins have no CEL signature, so their detail is the generic
+	// "template function" label.
+	for _, it := range items {
+		if it.Label == "upper" {
+			require.NotNil(t, it.Detail)
+			assert.Equal(t, "template function", *it.Detail)
+		}
+	}
+}
+
+func TestFuncCompletion_LiteralTemplateTextOffersNothing(t *testing.T) {
+	// Outside a {{ }} action (plain literal text in a tmpl value) is not an
+	// expression position, so no functions are offered.
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              value:
+                tmpl: "hello wo"
+`
+	s := newTestServer(t)
+	uri := protocol.DocumentUri("file:///lit.yaml")
+	s.setDoc(uri, 1, content)
+	pos := posAt(t, content, `tmpl: "hello wo`, "wo", 2)
+	res, err := s.completion(nil, &protocol.CompletionParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+			Position:     pos,
+		},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, res, "literal text in a template offers no completions")
+}
+
+func TestFuncCompletion_TemplateContextListsAuthorFunctions(t *testing.T) {
+	items := funcCompleteAt(t, `                tmpl: "{{ my`, "my", 2)
+	labels := labelsOf(items)
+	assert.Contains(t, labels, "myHelper")
+	// The author function carries its declared description and an author detail.
+	for _, it := range items {
+		if it.Label == "myHelper" {
+			require.NotNil(t, it.Detail)
+			assert.Equal(t, "author function", *it.Detail)
+			mc, ok := it.Documentation.(protocol.MarkupContent)
+			require.True(t, ok)
+			assert.Contains(t, mc.Value, "A custom helper")
+		}
+	}
+}
+
+func TestFuncCompletion_PrefixFilters(t *testing.T) {
+	all := funcCompleteAt(t, `                tmpl: "{{ up`, "up", 2)
+	for _, l := range labelsOf(all) {
+		assert.True(t, len(l) >= 2 && (l[:2] == "up" || l[:2] == "Up"), "unexpected non-matching label %q", l)
+	}
+}
+
+func TestFuncCompletion_ReferencePrefixIsNotFunction(t *testing.T) {
+	// A reference-prefixed token is a data/symbol reference (handled by #774),
+	// not a function completion.
+	assert.Nil(t, funcCompletions(nil, CursorContext{Kind: CursorCEL, ExprPrefix: "_.", PartialToken: "env"}))
+	assert.Nil(t, funcCompletions(nil, CursorContext{Kind: CursorTemplate, ExprPrefix: "._.", PartialToken: "app"}))
+}
+
+func TestFuncCompletion_NilEntryTemplateStillListsBuiltins(t *testing.T) {
+	// Author functions need the doc, but built-in template functions do not.
+	items := funcCompletions(nil, CursorContext{Kind: CursorTemplate, PartialToken: "upper"})
+	assert.Contains(t, labelsOf(items), "upper")
+}
+
+func TestFuncDocMarkdown(t *testing.T) {
+	md := funcDocMarkdown(FuncInfo{Description: "does a thing", Examples: []string{"thing(x)"}})
+	assert.Contains(t, md, "does a thing")
+	assert.Contains(t, md, "thing(x)")
+	assert.Contains(t, md, "_Example:_")
+
+	assert.Empty(t, funcDocMarkdown(FuncInfo{}))
+}
+
+func TestMatchesPrefix(t *testing.T) {
+	assert.True(t, matchesPrefix("upper", ""))
+	assert.True(t, matchesPrefix("Upper", "up"))
+	assert.False(t, matchesPrefix("lower", "up"))
+}

--- a/pkg/lsp/completion_funcs_test.go
+++ b/pkg/lsp/completion_funcs_test.go
@@ -99,13 +99,24 @@ func TestFuncCompletion_TemplateContextListsTemplateFunctions(t *testing.T) {
 	items := funcCompleteAt(t, `                tmpl: "{{ up`, "up", 2)
 	assert.Contains(t, labelsOf(items), "upper")
 	// Template builtins have no CEL signature, so their detail is the generic
-	// "template function" label.
+	// "template function" label. Their insert snippet must be space-separated
+	// ("upper $0"), not parenthesized ("upper($0)") -- Go templates invoke
+	// functions with space-separated args, and "upper()" is invalid template
+	// syntax.
+	found := false
 	for _, it := range items {
 		if it.Label == "upper" {
+			found = true
 			require.NotNil(t, it.Detail)
 			assert.Equal(t, "template function", *it.Detail)
+			require.NotNil(t, it.InsertText)
+			assert.Equal(t, "upper $0", *it.InsertText)
+			assert.NotContains(t, *it.InsertText, "(")
+			require.NotNil(t, it.InsertTextFormat)
+			assert.Equal(t, protocol.InsertTextFormatSnippet, *it.InsertTextFormat)
 		}
 	}
+	assert.True(t, found, "expected an 'upper' template function completion")
 }
 
 func TestFuncCompletion_LiteralTemplateTextOffersNothing(t *testing.T) {

--- a/pkg/lsp/completion_test.go
+++ b/pkg/lsp/completion_test.go
@@ -177,16 +177,15 @@ func TestCompletion_ParseErrorNoPanic(t *testing.T) {
 	})
 }
 
-func TestCompletion_DispatchSkeletonReturnsNilForOtherClasses(t *testing.T) {
-	// The branches #774/#775 will fill are intentionally empty here.
+func TestCompletion_DispatchSkeletonReturnsNilForUnhandledClasses(t *testing.T) {
+	// The branches #774 will fill (SymbolRef) plus classes with no source remain
+	// empty. CEL/Template are now handled by funcCompletions (see completion_funcs_test.go).
 	for _, cc := range []CursorContext{
 		{Kind: CursorSymbolRef},
-		{Kind: CursorCEL, PartialToken: "siz"},
-		{Kind: CursorTemplate, PartialToken: "up"},
 		{Kind: CursorProviderName},
 		{Kind: CursorNone},
 	} {
-		assert.Nil(t, completionItems(cc), "kind %s has no source yet", cc.Kind)
+		assert.Nil(t, completionItems(nil, cc), "kind %s has no source", cc.Kind)
 	}
 }
 

--- a/pkg/lsp/cursor.go
+++ b/pkg/lsp/cursor.go
@@ -256,6 +256,14 @@ func ResolveCursor(doc *DocEntry, pos protocol.Position) CursorContext {
 		ctx.PartialToken, ctx.ExprPrefix = celTokenAt(line, cursor)
 		return ctx
 	case isKey(templateValueKeys, keyName):
+		// Only a cursor inside a {{ ... }} action is an expression position; in
+		// the surrounding literal text there is nothing to complete/hover, so
+		// classify it as None (otherwise completion would offer every template
+		// function while the user types prose). An empty but open action still
+		// counts as inside.
+		if _, inAction := enclosingAction(line, cursor); !inAction {
+			return CursorContext{Kind: CursorNone, Path: leafPath, Node: leafNode}
+		}
 		ctx := CursorContext{Kind: CursorTemplate, Path: leafPath, Node: leafNode}
 		ctx.PartialToken, ctx.ExprPrefix = templateTokenAt(line, cursor)
 		return ctx

--- a/pkg/lsp/cursor_test.go
+++ b/pkg/lsp/cursor_test.go
@@ -426,6 +426,28 @@ spec:
 	assert.True(t, strings.HasSuffix(ctx.Path, ".onError"), "path %q", ctx.Path)
 }
 
+func TestResolveCursor_TemplateLiteralTextIsNone(t *testing.T) {
+	// A cursor in a tmpl value but outside any {{ }} action is not an expression
+	// position; it classifies as None so completion/hover offer nothing there.
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              value:
+                tmpl: "hello world"
+`
+	pos := posAt(t, content, `tmpl: "hello world`, "world", 2)
+	ctx := resolveFixture(t, content, pos)
+	assert.Equal(t, CursorNone, ctx.Kind)
+}
+
 func TestResolveCursor_Whitespace(t *testing.T) {
 	// Cursor in leading indentation is unclassifiable.
 	pos := posAt(t, cursorFixture, "provider: parameter", "provider", -4)

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13926,6 +13926,24 @@ func TestIntegration_LspCompletion(t *testing.T) {
 	assert.Contains(t, out, `"label":"description"`, "completion offers the description field for partial 'desc'")
 }
 
+func TestIntegration_LspCompletionFunctions(t *testing.T) {
+	t.Parallel()
+
+	// A partial CEL expression "arr" is on line 12 (0-based); completion at its
+	// end offers CEL functions from the registry.
+	sol := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: nav\nspec:\n  resolvers:\n    appName:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value:\n                expr: arr\n"
+
+	out := runLSPSession(t, sol,
+		map[string]any{"jsonrpc": "2.0", "id": 2, "method": "textDocument/completion", "params": map[string]any{
+			"textDocument": map[string]any{"uri": lspSessionURI},
+			"position":     map[string]any{"line": 12, "character": 25},
+		}},
+	)
+
+	assert.Contains(t, out, `"label":"arrays.groupBy"`, "CEL context offers CEL functions")
+	assert.Contains(t, out, `arrays.groupBy($0)`, "function completion inserts a call snippet")
+}
+
 func TestIntegration_LspHover(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Extends the completion dispatch (#773) with **CEL and Go-template function
completion**, in a new disjoint file (`completion_funcs.go`) plus one switch case,
so the three completion PRs never edit each other's sources.

This is issue #775 (part 3 of 3; needs #773 completion core and #772 `funcref.go`
-- both merged).

## Behavior

- **CEL context** -> CEL functions, each rendering its signature.
- **Template context** -> Go-template functions **plus** the solution's
  author-defined helpers (`spec.functions`).
- Each item inserts a **call snippet** placing the cursor at the first argument,
  using the syntax valid for that context: a **parenthesized** call in CEL
  (`name($0)`) and a **space-separated** call in templates (`name $0`), since
  Go templates invoke functions without parens and `name()` is invalid template
  syntax. This applies to both built-in template functions and author helpers.
- Fires only for a **bare function token** (`ExprPrefix == ""`); a
  reference-prefixed token (`_.` / `._.` / `__actions.` / `.`) is a data/symbol
  reference handled by the SymbolRef branch (#774), not a function.

## Changes

- New `pkg/lsp/completion_funcs.go` (+ test). Reuses the shared `funcref.go`
  `AllFuncs()` -- **no duplicate registry walking** (AC3).
- `pkg/lsp/completion.go`: `completionItems` now threads the `*DocEntry` through
  the dispatch (author-function completion needs the parsed solution; #774's
  symbol completion will need the index too) and adds one branch:
  `case CursorCEL, CursorTemplate -> funcCompletions`.
- `pkg/lsp/cursor.go`: a cursor in a `tmpl:` value but **outside** any `{{ }}`
  action now classifies as `None`, so completion does not offer every template
  function while the user types literal prose (fixes a rough edge this PR would
  otherwise expose).

## Tests / docs

- Table tests: CEL context lists CEL functions (and not template ones), template
  context lists template + author functions, prefix filter, signature/snippet
  rendering (CEL parenthesized vs template space-separated), reference-prefix
  declines, nil-entry safety, literal-text-offers-nothing.
- `TestResolveCursor_TemplateLiteralTextIsNone` for the cursor-level change.
- Integration test `TestIntegration_LspCompletionFunctions` via `runLSPSession`.
- `docs/tutorials/lsp-tutorial.md` documents function completion.

`-race` clean, `lint:changed` 0 new issues, `completion_funcs.go` 93-100% per-function.

## Acceptance criteria

- [x] Inside a CEL expr, function names complete with signatures.
- [x] Inside a `{{ }}` template, template + author functions complete.
- [x] Reuses `funcref.go` (no duplicate registry walking).

Closes #775
