### PR TITLE
feat(lsp): symbol completion after _./call:/rslvr:/dependsOn

### DIFF
--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -88,10 +88,12 @@ As you type, the server offers **schema-driven structural completions**:
   list item offers **resolver** names (in a resolver) or **action** names (in an
   action). Only defined symbols are suggested.
 
-Completion is triggered on `.`, `:`, and space, and works mid-edit even while the
-document does not yet parse (the container is inferred from indentation).
-Structural key, enum-value, CEL/template function, and scafctl symbol completion
-are all available.
+Completion is triggered on `.`, `:`, and space. Structural key, enum-value, and
+CEL/template function completion work mid-edit even while the document does not
+yet parse (the container is inferred from indentation). Symbol completion is
+sourced from the reference index, so it becomes available once the solution
+model builds successfully -- while the document does not yet parse it simply
+offers nothing rather than erroring.
 
 ## Quick fixes
 

--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -80,12 +80,18 @@ As you type, the server offers **schema-driven structural completions**:
   as a call snippet with the cursor at the first argument, using the syntax valid
   for that context: a parenthesized call in CEL (`name($0)`) and a space-separated
   call in templates (`name $0`, since `name()` is not valid template syntax).
+- **Symbols** -- scafctl-specific name completion no generic YAML tool can offer,
+  drawn from the document's reference index and filtered by what you have typed:
+  after `_.` (CEL) or `._.` (template) it offers **resolver** names (and
+  `__actions.` / `.__actions.` offers **action** names); a `call:` value offers
+  **call** names; a `rslvr:` value offers **resolver** names; and a `dependsOn:`
+  list item offers **resolver** names (in a resolver) or **action** names (in an
+  action). Only defined symbols are suggested.
 
 Completion is triggered on `.`, `:`, and space, and works mid-edit even while the
 document does not yet parse (the container is inferred from indentation).
-Structural key, enum-value, and CEL/template function completion are available
-today; symbol completion (after `_.` / `call:` / `dependsOn`) extends the same
-dispatch.
+Structural key, enum-value, CEL/template function, and scafctl symbol completion
+are all available.
 
 ## Quick fixes
 

--- a/pkg/lsp/completion.go
+++ b/pkg/lsp/completion.go
@@ -49,6 +49,12 @@ func (s *Server) completion(_ *glsp.Context, params *protocol.CompletionParams) 
 	cc := ResolveCursor(entry, params.Position)
 	items := completionItems(entry, cc)
 	if len(items) == 0 {
+		// SymbolRef branch (#774): scafctl symbol-name completion (resolver/call/
+		// action names after _./._./call:/rslvr:/dependsOn). Runs only when the
+		// structural/enum/function sources produced nothing, so it never competes.
+		items = symbolCompletions(entry, params.Position, cc)
+	}
+	if len(items) == 0 {
 		return nil, nil
 	}
 	return items, nil

--- a/pkg/lsp/completion_symbols.go
+++ b/pkg/lsp/completion_symbols.go
@@ -65,10 +65,23 @@ func symbolCompletionTarget(entry *DocEntry, pos protocol.Position, cc CursorCon
 			return refindex.SymbolAction, cc.PartialToken, true
 		}
 	case CursorSymbolRef:
-		// The cursor sits on an already-located reference (the typed text matches
-		// an existing symbol). Offer same-kind names so it can be swapped.
+		// The cursor sits on a located reference. The refindex records the token
+		// under the cursor as a reference whether it is a complete symbol name or
+		// a partial still being typed, so distinguish the two:
+		//   - a complete, DEFINED name -> the user is parked on an existing
+		//     reference; offer ALL same-kind names (empty partial) so it can be
+		//     swapped to another symbol.
+		//   - a partial/dangling token -> keep it as the filter prefix so the
+		//     suggestion list narrows as the user types (matches the CEL/value
+		//     branches' server-side filtering).
+		// entry.Index is non-nil here: ResolveCursor only classifies a cursor as
+		// CursorSymbolRef when the index is present.
 		if cc.Ref != nil {
-			return cc.Ref.Symbol.Kind, cc.Ref.Symbol.Name, true
+			kind, name := cc.Ref.Symbol.Kind, cc.Ref.Symbol.Name
+			if _, defined := entry.Index.Definition(kind, name); defined {
+				return kind, "", true
+			}
+			return kind, name, true
 		}
 	}
 

--- a/pkg/lsp/completion_symbols.go
+++ b/pkg/lsp/completion_symbols.go
@@ -1,0 +1,189 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+	"gopkg.in/yaml.v3"
+)
+
+// symbolCompletions offers scafctl-specific symbol-name completions -- the
+// suggestions no generic YAML tooling can provide -- from the document's
+// reference index:
+//
+//   - after "_." (CEL) or "._." (Go template)          -> resolver names
+//   - after "__actions." (CEL) or ".__actions." (tmpl) -> action names
+//   - a "call:" value                                  -> call names
+//   - a "rslvr:" value                                 -> resolver names
+//   - a "dependsOn:" list item (resolver)              -> resolver names
+//   - a "dependsOn:" list item (action)                -> action names
+//
+// It is the SymbolRef branch #773's dispatch reserves and #775's function
+// completion defers to (funcCompletions returns nothing for a reference-prefixed
+// token). It composes as a fallback in the completion handler: it runs only when
+// the structural/enum/function sources produced nothing, so it never competes
+// with them.
+//
+// Names come from refindex (idx.Names), filtered by what the user has typed. It
+// returns nil (no completion) when the document has no index (a parse error
+// mid-edit) or the cursor is not on a symbol-reference position, so it never
+// panics and degrades gracefully.
+func symbolCompletions(entry *DocEntry, pos protocol.Position, cc CursorContext) []protocol.CompletionItem {
+	if entry == nil || entry.Index == nil {
+		return nil
+	}
+	kind, partial, ok := symbolCompletionTarget(entry, pos, cc)
+	if !ok {
+		return nil
+	}
+	return symbolNameItems(entry.Index, kind, partial)
+}
+
+// symbolCompletionTarget classifies the cursor into the symbol kind to complete
+// and the partial token typed so far. It reports ok=false when the cursor is not
+// on a symbol-reference position this branch handles.
+func symbolCompletionTarget(entry *DocEntry, pos protocol.Position, cc CursorContext) (refindex.SymbolKind, string, bool) {
+	// 1. CEL / Go-template reference prefixes. ResolveCursor has already isolated
+	// the prefix (_. / ._. / __actions. / .__actions.) and the partial token.
+	switch cc.Kind { //nolint:exhaustive // only the three reference-bearing kinds are handled here; all others fall through to value/list classification
+	case CursorCEL:
+		switch cc.ExprPrefix {
+		case celResolverPrefix:
+			return refindex.SymbolResolver, cc.PartialToken, true
+		case celActionPrefix:
+			return refindex.SymbolAction, cc.PartialToken, true
+		}
+	case CursorTemplate:
+		switch cc.ExprPrefix {
+		case tmplResolverPrefix:
+			return refindex.SymbolResolver, cc.PartialToken, true
+		case tmplActionPrefix:
+			return refindex.SymbolAction, cc.PartialToken, true
+		}
+	case CursorSymbolRef:
+		// The cursor sits on an already-located reference (the typed text matches
+		// an existing symbol). Offer same-kind names so it can be swapped.
+		if cc.Ref != nil {
+			return cc.Ref.Symbol.Kind, cc.Ref.Symbol.Name, true
+		}
+	}
+
+	// 2. call:/rslvr: values and dependsOn: list items resolve to CursorNone from
+	// the completion core (their leaf key is not a CEL/template/enum/provider
+	// field), so classify them from the cursor's path and line.
+	return valueRefCompletionTarget(entry, pos, cc)
+}
+
+// valueRefCompletionTarget handles the non-expression symbol positions: a
+// "call:" or "rslvr:" scalar value and a "dependsOn:" sequence item. It prefers
+// the parsed path (cc.Path, populated whenever the surrounding YAML parses --
+// the common case, since these values stay valid while typing) and falls back to
+// re-reading the line for a mid-edit document that does not parse.
+func valueRefCompletionTarget(entry *DocEntry, pos protocol.Position, cc CursorContext) (refindex.SymbolKind, string, bool) {
+	// Parsed-path classification.
+	if base := stripIndex(cc.Path); base != "" {
+		partial := nodeValue(cc.Node)
+		switch lastSegment(base) {
+		case "call":
+			return refindex.SymbolCall, partial, true
+		case "rslvr":
+			return refindex.SymbolResolver, partial, true
+		case "dependsOn":
+			return dependsOnKind(base), partial, true
+		}
+	}
+
+	// Text fallback (unparsed mid-edit): classify from the current line.
+	line, ok := lineAt(entry.Raw, int(pos.Line))
+	if !ok {
+		return 0, "", false
+	}
+	runes := []rune(line)
+	cursor := int(pos.Character)
+	if cursor > len(runes) {
+		cursor = len(runes)
+	}
+	key, _, _, valueStart, hasValue := parseKeyLine(runes)
+	if !hasValue || cursor < valueStart {
+		return 0, "", false
+	}
+	switch key {
+	case "call":
+		return refindex.SymbolCall, backwardProviderIdent(line, cursor), true
+	case "rslvr":
+		return refindex.SymbolResolver, backwardProviderIdent(line, cursor), true
+	}
+	return 0, "", false
+}
+
+// dependsOnKind returns the symbol kind a dependsOn entry references, from the
+// owning path: an action's dependsOn lists action names; a resolver's lists
+// resolver names.
+func dependsOnKind(path string) refindex.SymbolKind {
+	if strings.Contains(path, ".workflow.actions.") || strings.Contains(path, ".workflow.finally.") {
+		return refindex.SymbolAction
+	}
+	return refindex.SymbolResolver
+}
+
+// symbolNameItems builds completion items for every DEFINED name of kind in idx
+// whose name starts with partial (case-insensitive; an empty partial offers
+// all). Only definitions are offered -- idx.Names also includes reference names
+// (e.g. the partial token the user is currently typing, or a dangling ref), so
+// filtering to names that resolve to a definition keeps the suggestions to
+// symbols that actually exist.
+func symbolNameItems(idx *refindex.Index, kind refindex.SymbolKind, partial string) []protocol.CompletionItem {
+	names := idx.Names(kind)
+	lower := strings.ToLower(strings.TrimSpace(partial))
+	items := make([]protocol.CompletionItem, 0, len(names))
+	itemKind := symbolItemKind(kind)
+	detail := kind.String()
+	for _, name := range names {
+		if _, defined := idx.Definition(kind, name); !defined {
+			continue
+		}
+		if lower != "" && !strings.HasPrefix(strings.ToLower(name), lower) {
+			continue
+		}
+		items = append(items, newCompletionItem(name, itemKind, detail, ""))
+	}
+	sortCompletionItems(items)
+	return items
+}
+
+// symbolItemKind maps a scafctl symbol kind to the LSP completion item kind that
+// renders a fitting editor icon: resolvers as variables (values), calls as
+// methods (invocations), actions as functions.
+func symbolItemKind(kind refindex.SymbolKind) protocol.CompletionItemKind {
+	switch kind { //nolint:exhaustive // resolver and function share the Variable icon via the default
+	case refindex.SymbolCall:
+		return protocol.CompletionItemKindMethod
+	case refindex.SymbolAction:
+		return protocol.CompletionItemKindFunction
+	default:
+		// SymbolResolver and SymbolFunction render as a value/variable.
+		return protocol.CompletionItemKindVariable
+	}
+}
+
+// stripIndex removes a trailing sequence "[i]" from a path, so a dependsOn item
+// path ("...dependsOn[0]") reduces to its owning key ("...dependsOn"). Paths
+// without a trailing index are returned unchanged.
+func stripIndex(path string) string {
+	if i := strings.LastIndex(path, "["); i >= 0 && strings.HasSuffix(path, "]") {
+		return path[:i]
+	}
+	return path
+}
+
+// nodeValue returns a value node's scalar text, or "" when the node is nil.
+func nodeValue(n *yaml.Node) string {
+	if n == nil {
+		return ""
+	}
+	return n.Value
+}

--- a/pkg/lsp/completion_symbols_test.go
+++ b/pkg/lsp/completion_symbols_test.go
@@ -174,6 +174,39 @@ func TestSymbolCompletion_ActionDependsOn(t *testing.T) {
 	assert.Equal(t, []string{"build"}, labels, "action dependsOn offers action names: %v", labels)
 }
 
+// symbolSwapFixture references an existing resolver by its full name, so the
+// cursor lands on a located reference (CursorSymbolRef) rather than a partial
+// token being typed.
+const symbolSwapFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: sym
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    appName:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                rslvr: environment
+`
+
+func TestSymbolCompletion_SwapExistingRef(t *testing.T) {
+	// Cursor on a complete, valid reference (CursorSymbolRef) offers ALL
+	// same-kind names so the reference can be swapped -- not just the one
+	// already typed.
+	labels := completeAt(t, symbolSwapFixture, "rslvr: environment", "environment", 3)
+	assert.True(t, contains(labels, "environment"), "offers the current symbol: %v", labels)
+	assert.True(t, contains(labels, "appName"), "offers other same-kind symbols to swap to: %v", labels)
+}
+
 func TestSymbolCompletion_UnknownScopeOffersNothing(t *testing.T) {
 	// A plain scalar value that is not a symbol position -> no symbol completion.
 	labels := completeAt(t, symbolCELFixture, "value: dev", "dev", 1)

--- a/pkg/lsp/completion_symbols_test.go
+++ b/pkg/lsp/completion_symbols_test.go
@@ -1,0 +1,189 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// replaceOnce substitutes the first occurrence of old with repl in s, used to
+// drop a partial token into a fixture at one place.
+func replaceOnce(s, old, repl string) string {
+	return strings.Replace(s, old, repl, 1)
+}
+
+// symbolCELFixture defines two resolvers and a CEL expr value being typed.
+const symbolCELFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: sym
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    appName:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                expr: _.PARTIAL
+`
+
+func TestSymbolCompletion_CELResolverPrefix(t *testing.T) {
+	// After "_." (empty partial) all resolver names are offered.
+	content := replaceOnce(symbolCELFixture, "_.PARTIAL", "_.")
+	labels := completeAt(t, content, "expr: _.", "_.", 2)
+	assert.True(t, contains(labels, "environment"), "offers environment: %v", labels)
+	assert.True(t, contains(labels, "appName"), "offers appName: %v", labels)
+}
+
+func TestSymbolCompletion_CELResolverPrefixFiltered(t *testing.T) {
+	// "_.env" narrows to resolvers starting with "env".
+	content := replaceOnce(symbolCELFixture, "_.PARTIAL", "_.env")
+	labels := completeAt(t, content, "expr: _.env", "_.env", 5)
+	assert.Equal(t, []string{"environment"}, labels, "only environment matches the env prefix")
+}
+
+func TestSymbolCompletion_TemplateResolverPrefix(t *testing.T) {
+	content := replaceOnce(symbolCELFixture, "expr: _.PARTIAL", `tmpl: "{{ ._. }}"`)
+	labels := completeAt(t, content, `tmpl: "{{ ._. }}"`, "._.", 3)
+	assert.True(t, contains(labels, "environment"), "offers environment: %v", labels)
+	assert.True(t, contains(labels, "appName"), "offers appName: %v", labels)
+}
+
+// symbolCallFixture defines a call and a resolver step that references one.
+const symbolCallFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: sym
+spec:
+  calls:
+    fetch:
+      provider: message
+      inputs:
+        message: hi
+  resolvers:
+    appName:
+      resolve:
+        with:
+          - call: PARTIAL
+`
+
+func TestSymbolCompletion_CallValue(t *testing.T) {
+	content := replaceOnce(symbolCallFixture, "call: PARTIAL", "call: fet")
+	labels := completeAt(t, content, "call: fet", "fet", 3)
+	assert.Equal(t, []string{"fetch"}, labels, "call value offers call names: %v", labels)
+}
+
+// symbolRslvrFixture references a resolver via a rslvr ValueRef.
+const symbolRslvrFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: sym
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    appName:
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value:
+                rslvr: PARTIAL
+`
+
+func TestSymbolCompletion_RslvrValue(t *testing.T) {
+	content := replaceOnce(symbolRslvrFixture, "rslvr: PARTIAL", "rslvr: env")
+	labels := completeAt(t, content, "rslvr: env", "env", 3)
+	assert.Equal(t, []string{"environment"}, labels, "rslvr value offers resolver names: %v", labels)
+}
+
+// symbolDependsOnFixture has a resolver dependsOn list item being typed.
+const symbolDependsOnFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: sym
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    appName:
+      dependsOn:
+        - PARTIAL
+      resolve:
+        with:
+          - provider: static
+            inputs:
+              value: x
+`
+
+func TestSymbolCompletion_ResolverDependsOn(t *testing.T) {
+	content := replaceOnce(symbolDependsOnFixture, "- PARTIAL", "- env")
+	labels := completeAt(t, content, "- env", "env", 3)
+	assert.Equal(t, []string{"environment"}, labels, "resolver dependsOn offers resolver names: %v", labels)
+}
+
+// symbolActionDependsOnFixture has an action dependsOn list item being typed.
+const symbolActionDependsOnFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: sym
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+  workflow:
+    actions:
+      build:
+        provider: message
+        inputs:
+          message: building
+      deploy:
+        dependsOn:
+          - PARTIAL
+        provider: message
+        inputs:
+          message: deploying
+`
+
+func TestSymbolCompletion_ActionDependsOn(t *testing.T) {
+	content := replaceOnce(symbolActionDependsOnFixture, "- PARTIAL", "- bui")
+	labels := completeAt(t, content, "- bui", "bui", 3)
+	assert.Equal(t, []string{"build"}, labels, "action dependsOn offers action names: %v", labels)
+}
+
+func TestSymbolCompletion_UnknownScopeOffersNothing(t *testing.T) {
+	// A plain scalar value that is not a symbol position -> no symbol completion.
+	labels := completeAt(t, symbolCELFixture, "value: dev", "dev", 1)
+	assert.Empty(t, labels, "a normal value offers no symbol names: %v", labels)
+}
+
+func TestSymbolCompletion_ParseErrorNoPanic(t *testing.T) {
+	// A malformed document must not panic; symbol completion returns nothing.
+	broken := "apiVersion: scafctl.io/v1\nkind: Solution\nspec:\n  resolvers:\n  - : : :\n    expr: _.\n"
+	assert.NotPanics(t, func() {
+		_ = completeAt(t, broken, "expr: _.", "_.", 2)
+	})
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13983,6 +13983,24 @@ func TestIntegration_LspCompletionFunctions(t *testing.T) {
 	assert.Contains(t, out, `arrays.groupBy($0)`, "function completion inserts a call snippet")
 }
 
+func TestIntegration_LspCompletionSymbols(t *testing.T) {
+	t.Parallel()
+
+	// Two resolvers (environment, appName); a CEL expr "_." is on line 13
+	// (0-based). Completion at its end offers the resolver names.
+	sol := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: nav\nspec:\n  resolvers:\n    environment:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value: dev\n    appName:\n      resolve:\n        with:\n          - provider: static\n            inputs:\n              value:\n                expr: _.\n"
+
+	out := runLSPSession(t, sol,
+		map[string]any{"jsonrpc": "2.0", "id": 2, "method": "textDocument/completion", "params": map[string]any{
+			"textDocument": map[string]any{"uri": lspSessionURI},
+			"position":     map[string]any{"line": 18, "character": 24},
+		}},
+	)
+
+	assert.Contains(t, out, `"label":"environment"`, "_. offers resolver names")
+	assert.Contains(t, out, `"label":"appName"`, "_. offers all resolver names")
+}
+
 func TestIntegration_LspHover(t *testing.T) {
 	t.Parallel()
 

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13986,7 +13986,7 @@ func TestIntegration_LspCompletionFunctions(t *testing.T) {
 func TestIntegration_LspCompletionSymbols(t *testing.T) {
 	t.Parallel()
 
-	// Two resolvers (environment, appName); a CEL expr "_." is on line 13
+	// Two resolvers (environment, appName); a CEL expr "_." is on line 18
 	// (0-based). Completion at its end offers the resolver names.
 	sol := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: nav\nspec:\n  resolvers:\n    environment:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value: dev\n    appName:\n      resolve:\n        with:\n          - provider: static\n            inputs:\n              value:\n                expr: _.\n"
 


### PR DESCRIPTION
## Summary

Extends the completion handler (from #773) with scafctl-specific **symbol-name completion** -- the suggestions no generic YAML extension can offer -- drawn from the document's `refindex` and filtered by what the user has typed:

| Cursor position | Offers |
| --- | --- |
| after `_.` (CEL) / `._.` (template) | resolver names |
| after `__actions.` / `.__actions.` | action names |
| a `call:` value | call names |
| a `rslvr:` value | resolver names |
| a `dependsOn:` item (in a resolver) | resolver names |
| a `dependsOn:` item (in an action) | action names |

## Changes

- **New `pkg/lsp/completion_symbols.go`** -- `symbolCompletions` classifies the cursor and offers `idx.Names` for the matching kind:
  - CEL/template prefixes come straight from the completion core's `CursorContext` (`ExprPrefix` + `PartialToken`).
  - `call:`/`rslvr:`/`dependsOn:` resolve to `CursorNone`, so they're classified from the cursor's parsed path (the common case, since these stay valid YAML while typing) with a line-re-read fallback for a mid-edit unparsed document.
  - When the cursor is parked on a **complete, already-defined** reference, all same-kind names are offered (empty partial) so the reference can be swapped to another symbol; a **partial/dangling** token still filters the list by what has been typed (the `refindex` records both as references, so the definition check separates them).
  - Only **defined** symbols are offered (`idx.Names` also returns reference names, including the partial being typed), and it returns nothing when the doc has no index (parse error) so it never panics.
- **`pkg/lsp/completion.go`** -- exactly one dispatch branch: `symbolCompletions` runs only when the structural/enum/function sources produced nothing. It composes cleanly with #773 (structural/enum) and #775 (`funcCompletions` already defers reference-prefixed tokens to "the SymbolRef completion branch (#774)"), keeping all new logic in its own file per the coordination note.

## Tests / docs

- **`pkg/lsp/completion_symbols_test.go`** -- per-trigger tests (each kind, `_.env` prefix filtering, resolver-vs-action dependsOn, swapping a complete reference offers all same-kind names, unknown scope offers nothing, parse-error-no-panic).
- **`tests/integration/cli_test.go`** -- `TestIntegration_LspCompletionSymbols` via the `runLSPSession` harness (#769): `_.` offers `environment`/`appName`.
- `docs/tutorials/lsp-tutorial.md` -- documents symbol completion, noting it becomes available once the solution model builds (it is sourced from the reference index and offers nothing while the document does not yet parse).
- `go build`, full `pkg/lsp` + integration tests (no regression to #773/#775), `task lint:changed` (0 new issues) all pass.

## Acceptance criteria

- [x] `_.` completes resolver names; `call:` completes call names; etc.
- [x] Filtered by what the user has typed
- [x] No conflict with structural completion (#773) or function completion (#775)

Depends on #766, #767, #768, and #773/#775 -- all merged. Rebased onto #795.

Closes #774
