### PR TITLE
feat(lsp): signature help for calls and template/CEL functions

### DIFF
--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -87,6 +87,22 @@ Structural key, enum-value, and CEL/template function completion are available
 today; symbol completion (after `_.` / `call:` / `dependsOn`) extends the same
 dispatch.
 
+## Signature help
+
+While typing a call's arguments the server shows the declared parameters and
+highlights the one at the cursor:
+
+- **CEL function** (`arrays.groupBy(...)`) -- the function's signature, with the
+  active parameter tracking the comma-separated position.
+- **Go-template function** (`{{ greet ... }}`) -- an author-defined helper's
+  declared parameters (`spec.functions[name].params`), tracked by space-separated
+  position; a built-in template function shows its name and description.
+- **Call args** -- inside a call invocation's `args:` block, the invoked call's
+  declared arguments (`spec.calls[name].args`), highlighting the argument on the
+  current line.
+
+Signature help is triggered on `(` and space.
+
 ## Quick fixes
 
 It also offers **quick fixes**. `textDocument/codeAction` turns certain lint
@@ -164,10 +180,10 @@ needed to keep editor and CLI diagnostics consistent.
 
 ## What's next
 
-Navigation, rename, hover, and completion (structural keys, enum values, and
-CEL/template functions) cover resolvers, actions, functions, and calls. Planned
-additions extend the same completion dispatch to symbol references (after `_.` /
-`call:` / `dependsOn`).
+Navigation, rename, hover, completion (structural keys, enum values, and
+CEL/template functions), signature help, and quick fixes cover resolvers,
+actions, functions, and calls. Planned additions extend the same completion
+dispatch to symbol references (after `_.` / `call:` / `dependsOn`).
 
 ## See also
 

--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -101,7 +101,8 @@ highlights the one at the cursor:
   declared arguments (`spec.calls[name].args`), highlighting the argument on the
   current line.
 
-Signature help is triggered on `(` and space.
+Signature help is triggered on `(` and space, and re-triggered on `,` so the
+highlighted parameter follows the cursor as you move between CEL arguments.
 
 ## Quick fixes
 

--- a/pkg/lsp/capabilities.go
+++ b/pkg/lsp/capabilities.go
@@ -45,6 +45,7 @@ func defaultFeatures() []feature {
 		hoverFeature(),
 		navigationFeature(),
 		renameFeature(),
+		signatureHelpFeature(),
 		symbolsFeature(),
 	}
 }

--- a/pkg/lsp/capabilities_test.go
+++ b/pkg/lsp/capabilities_test.go
@@ -23,7 +23,7 @@ func TestDefaultFeatures_DeterministicOrder(t *testing.T) {
 		got = append(got, f.name)
 		require.NotNil(t, f.wire, "every feature must wire a handler")
 	}
-	assert.Equal(t, []string{"codeAction", "completion", "documentSync", "hover", "navigation", "rename", "symbols"}, got)
+	assert.Equal(t, []string{"codeAction", "completion", "documentSync", "hover", "navigation", "rename", "signatureHelp", "symbols"}, got)
 	assert.True(t, sort.StringsAreSorted(got), "features must be registered in alphabetical order")
 }
 

--- a/pkg/lsp/signaturehelp.go
+++ b/pkg/lsp/signaturehelp.go
@@ -301,11 +301,17 @@ func setActiveParameter(info *protocol.SignatureInformation, idx uint32) {
 func enclosingCallParen(runes []rune, cursor int) (int, bool) {
 	var stack []int
 	inStr := rune(0)
+	escaped := false
 	for i := 0; i < cursor && i < len(runes); i++ {
 		r := runes[i]
 		switch {
 		case inStr != 0:
-			if r == inStr {
+			switch {
+			case escaped:
+				escaped = false // this char is escaped; consume it literally
+			case r == '\\':
+				escaped = true // backslash escapes the next char (e.g. \" inside a string)
+			case r == inStr:
 				inStr = 0
 			}
 		case r == '"' || r == '\'':
@@ -352,11 +358,17 @@ func topLevelCommas(runes []rune, from, to int) uint32 {
 	}
 	var count, depth uint32
 	inStr := rune(0)
+	escaped := false
 	for i := from; i < to; i++ {
 		r := runes[i]
 		switch {
 		case inStr != 0:
-			if r == inStr {
+			switch {
+			case escaped:
+				escaped = false // this char is escaped; consume it literally
+			case r == '\\':
+				escaped = true // backslash escapes the next char (e.g. \" inside a string)
+			case r == inStr:
 				inStr = 0
 			}
 		case r == '"' || r == '\'':
@@ -429,34 +441,100 @@ func appendParam(params []string, s string) []string {
 }
 
 // enclosingCallName scans upward from the given 0-based line to find the call
-// name of an enclosing "args:" block: the nearest "call:" mapping (seen after an
-// "args:" key on the way up) whose value names the invoked call. ok is false when
-// the cursor is not inside an args block. Callers should first exclude the case
-// where the cursor is on the "call:"/"args:" key line itself.
+// name of an enclosing "args:" block: the nearest "call:" mapping whose value
+// names the invoked call. ok is false when the cursor is not inside an args
+// block. The search is indentation-aware -- it only climbs through true ancestor
+// lines (strictly shallower content indent), so a cursor in a sibling list item
+// below an unrelated call's args (e.g. a provider's inputs) does not borrow that
+// call's arguments. Callers should first exclude the case where the cursor is on
+// the "call:"/"args:" key line itself.
 func enclosingCallName(raw []byte, line int) (string, bool) {
-	// Require an enclosing "args:" ancestor before the "call:" sibling.
-	sawArgs := false
+	cursorText, ok := lineAt(raw, line)
+	if !ok {
+		return "", false
+	}
+	// minIndent tracks the shallowest ancestor seen so far; only lines strictly
+	// shallower than it are genuine ancestors of the cursor.
+	minIndent := contentIndent([]rune(cursorText))
 	for l := line - 1; l >= 0; l-- {
 		text, ok := lineAt(raw, l)
 		if !ok {
 			continue
 		}
 		lr := []rune(text)
+		if isBlankOrComment(lr) {
+			continue
+		}
+		ind := contentIndent(lr)
+		if ind >= minIndent {
+			continue // sibling or descendant of an already-passed line, not an ancestor
+		}
+		minIndent = ind
+		key, _, _, _, _ := parseKeyLine(lr)
+		if key != "args" {
+			continue // an ancestor, but not the enclosing args block -- keep climbing
+		}
+		// Found the enclosing "args:" block. Its "call:" sibling shares the same
+		// content indent; scan up from here to read the invoked call name.
+		return callSiblingName(raw, l, ind)
+	}
+	return "", false
+}
+
+// callSiblingName scans upward from the "args:" line at argsLine (content indent
+// argsIndent) for the sibling "call:" mapping and returns its value. ok is false
+// when no such sibling is found before leaving the mapping.
+func callSiblingName(raw []byte, argsLine, argsIndent int) (string, bool) {
+	for m := argsLine - 1; m >= 0; m-- {
+		text, ok := lineAt(raw, m)
+		if !ok {
+			continue
+		}
+		lr := []rune(text)
+		if isBlankOrComment(lr) {
+			continue
+		}
+		ind := contentIndent(lr)
+		if ind < argsIndent {
+			break // left the enclosing mapping without finding a call: sibling
+		}
+		if ind > argsIndent {
+			continue // deeper than the sibling level, skip
+		}
 		key, _, _, valStart, hasVal := parseKeyLine(lr)
-		if key == "" {
-			continue
-		}
-		if key == "args" {
-			sawArgs = true
-			continue
-		}
-		if key == "call" && sawArgs && hasVal {
-			name := strings.TrimSpace(string(lr[valStart:]))
-			name = strings.Trim(name, `"'`)
+		if key == "call" && hasVal {
+			name := strings.Trim(strings.TrimSpace(string(lr[valStart:])), `"'`)
 			if name != "" {
 				return name, true
 			}
 		}
 	}
 	return "", false
+}
+
+// contentIndent returns the rune column of the first non-space content on the
+// line, skipping leading whitespace and block-sequence "- " markers. It matches
+// parseKeyLine's key column, so "- call:" and its sibling "args:" report the same
+// indent and ancestor/sibling comparisons line up.
+func contentIndent(runes []rune) int {
+	i := 0
+	for i < len(runes) {
+		if runes[i] == ' ' || runes[i] == '\t' {
+			i++
+			continue
+		}
+		if runes[i] == '-' && i+1 < len(runes) && (runes[i+1] == ' ' || runes[i+1] == '\t') {
+			i += 2
+			continue
+		}
+		break
+	}
+	return i
+}
+
+// isBlankOrComment reports whether the line has no YAML content (blank or a
+// comment) so ancestor scanning can skip it.
+func isBlankOrComment(runes []rune) bool {
+	i := contentIndent(runes)
+	return i >= len(runes) || runes[i] == '#'
 }

--- a/pkg/lsp/signaturehelp.go
+++ b/pkg/lsp/signaturehelp.go
@@ -1,0 +1,450 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/spec"
+	"github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// signatureHelpTriggerCharacters (re)trigger signature help: "(" opens a CEL
+// call's argument list, " " separates template function arguments.
+var signatureHelpTriggerCharacters = []string{"(", " "}
+
+// signatureHelpFeature registers textDocument/signatureHelp and advertises the
+// provider with its trigger characters.
+func signatureHelpFeature() feature {
+	return feature{
+		name: "signatureHelp",
+		wire: func(h *protocol.Handler, s *Server) {
+			h.TextDocumentSignatureHelp = s.signatureHelp
+		},
+		advertise: func(c *protocol.ServerCapabilities) {
+			c.SignatureHelpProvider = &protocol.SignatureHelpOptions{
+				TriggerCharacters: signatureHelpTriggerCharacters,
+			}
+		},
+	}
+}
+
+// signatureHelp answers textDocument/signatureHelp by locating the call the
+// cursor is inside and describing its parameters. It returns nil (no help) when
+// the cursor is not inside a recognized call and never panics.
+func (s *Server) signatureHelp(_ *glsp.Context, params *protocol.SignatureHelpParams) (*protocol.SignatureHelp, error) {
+	entry, ok := s.getDoc(params.TextDocument.URI)
+	if !ok {
+		return nil, nil
+	}
+	return SignatureHelp(entry, params.Position), nil
+}
+
+// SignatureHelp computes signature help for the cursor position against a cached
+// document snapshot. It recognizes three call contexts: a Go-template function
+// invocation ({{ fn ... }}), a CEL function call (fn(...)), and a call's args:
+// block. Returns nil when none applies.
+func SignatureHelp(entry *DocEntry, pos protocol.Position) *protocol.SignatureHelp {
+	if entry == nil {
+		return nil
+	}
+	line, ok := lineAt(entry.Raw, int(pos.Line))
+	if !ok {
+		return nil
+	}
+	runes := []rune(line)
+	cursor := int(pos.Character)
+	if cursor > len(runes) {
+		cursor = len(runes)
+	}
+
+	// Template action: {{ fn arg1 arg2 ... }}.
+	if action, inAction := enclosingAction(line, cursor); inAction {
+		if sh := templateSignature(entry, action); sh != nil {
+			return sh
+		}
+	}
+	// CEL function call: fn(arg1, arg2, ...).
+	if sh := celSignature(runes, cursor); sh != nil {
+		return sh
+	}
+	// A call's args: block.
+	if sh := callArgsSignature(entry, pos, runes); sh != nil {
+		return sh
+	}
+	return nil
+}
+
+// templateSignature builds signature help for a Go-template function invocation.
+// action is the text from just after "{{" up to the cursor. The first token is
+// the function name; subsequent space-separated tokens are its positional
+// arguments. Author-defined functions (spec.functions) contribute declared
+// parameters; a built-in template function contributes its name and description.
+func templateSignature(entry *DocEntry, action string) *protocol.SignatureHelp {
+	// Strip a leading pipe segment: in "{{ .x | fn a", the active call is "fn a".
+	// (The piped value binds fn's trailing positional slot, which is not the
+	// argument the user is typing, so it is not the highlighted one.)
+	if i := strings.LastIndex(action, "|"); i >= 0 {
+		action = action[i+1:]
+	}
+	trailingSpace := strings.HasSuffix(action, " ")
+	tokens := strings.Fields(action)
+	if len(tokens) == 0 {
+		return nil
+	}
+	fn := tokens[0]
+	active := len(tokens) - 1 // args typed so far
+	if !trailingSpace && active > 0 {
+		active-- // the last token is the arg currently being typed
+	}
+
+	// Author-defined function: positional params.
+	if entry != nil && entry.Sol != nil {
+		if f, ok := entry.Sol.Spec.Functions[fn]; ok && f != nil {
+			return paramDefSignature(fn, f.Description, f.Params, active)
+		}
+	}
+	// Built-in template function: no declared params, show name + description.
+	if fi, ok := LookupFunc(fn); ok && !fi.CEL {
+		info := protocol.SignatureInformation{Label: fn}
+		if doc := funcDocMarkdown(fi); doc != "" {
+			info.Documentation = protocol.MarkupContent{Kind: protocol.MarkupKindMarkdown, Value: doc}
+		}
+		return &protocol.SignatureHelp{Signatures: []protocol.SignatureInformation{info}}
+	}
+	return nil
+}
+
+// celSignature builds signature help for a CEL function call fn(...) whose open
+// parenthesis encloses the cursor. The active parameter is the number of
+// top-level commas between the "(" and the cursor.
+func celSignature(runes []rune, cursor int) *protocol.SignatureHelp {
+	open, ok := enclosingCallParen(runes, cursor)
+	if !ok {
+		return nil
+	}
+	fn := identifierBefore(runes, open)
+	if fn == "" {
+		return nil
+	}
+	fi, ok := LookupFunc(fn)
+	if !ok || !fi.CEL {
+		return nil
+	}
+	active := topLevelCommas(runes, open+1, cursor)
+	params := signatureParams(fi.Signature)
+	label := fi.Signature
+	if label == "" {
+		label = fn + "()"
+	}
+	info := protocol.SignatureInformation{
+		Label:      label,
+		Parameters: make([]protocol.ParameterInformation, 0, len(params)),
+	}
+	for _, p := range params {
+		info.Parameters = append(info.Parameters, protocol.ParameterInformation{Label: p})
+	}
+	if doc := funcDocMarkdown(fi); doc != "" {
+		info.Documentation = protocol.MarkupContent{Kind: protocol.MarkupKindMarkdown, Value: doc}
+	}
+	setActiveParameter(&info, active)
+	return &protocol.SignatureHelp{Signatures: []protocol.SignatureInformation{info}}
+}
+
+// callArgsSignature builds signature help when the cursor is inside the args:
+// block of a call invocation, listing the invoked call's declared arguments.
+func callArgsSignature(entry *DocEntry, pos protocol.Position, runes []rune) *protocol.SignatureHelp {
+	if entry == nil || entry.Sol == nil {
+		return nil
+	}
+	// If the cursor is on the "call:" invocation line (or the "args:" key line)
+	// itself, it is not inside an args value, so it must not borrow a sibling
+	// call's arguments.
+	if key, _, _, _, _ := parseKeyLine(runes); key == "call" || key == "args" {
+		return nil
+	}
+	name, ok := enclosingCallName(entry.Raw, int(pos.Line))
+	if !ok {
+		return nil
+	}
+	call, ok := entry.Sol.Spec.Calls[name]
+	if !ok || call == nil || len(call.Args) == 0 {
+		return nil
+	}
+
+	names := sortedKeys(call.Args)
+	info := protocol.SignatureInformation{
+		Label:      fmt.Sprintf("%s(%s)", name, strings.Join(argLabels(call.Args, names), ", ")),
+		Parameters: make([]protocol.ParameterInformation, 0, len(names)),
+	}
+	for _, n := range names {
+		p := protocol.ParameterInformation{Label: argLabel(n, call.Args[n])}
+		if call.Args[n] != nil && call.Args[n].Description != "" {
+			p.Documentation = call.Args[n].Description
+		}
+		info.Parameters = append(info.Parameters, p)
+	}
+	if call.Description != "" {
+		info.Documentation = protocol.MarkupContent{Kind: protocol.MarkupKindMarkdown, Value: call.Description}
+	}
+	// Highlight the argument key currently on the cursor's line, if any.
+	if key, _, _, _, _ := parseKeyLine(runes); key != "" {
+		for i, n := range names {
+			if n == key {
+				//nolint:gosec // i is a small slice index
+				setActiveParameter(&info, uint32(i))
+				break
+			}
+		}
+	}
+	return &protocol.SignatureHelp{Signatures: []protocol.SignatureInformation{info}}
+}
+
+// paramDefSignature builds a signature from ordered positional parameter
+// declarations (author functions).
+func paramDefSignature(fn, description string, params []*spec.ParamDef, active int) *protocol.SignatureHelp {
+	labels := make([]string, 0, len(params))
+	for _, p := range params {
+		if p != nil {
+			labels = append(labels, paramDefLabel(p))
+		}
+	}
+	info := protocol.SignatureInformation{
+		Label:      fmt.Sprintf("%s(%s)", fn, strings.Join(labels, ", ")),
+		Parameters: make([]protocol.ParameterInformation, 0, len(params)),
+	}
+	for _, p := range params {
+		if p == nil {
+			continue
+		}
+		pi := protocol.ParameterInformation{Label: paramDefLabel(p)}
+		if p.Description != "" {
+			pi.Documentation = p.Description
+		}
+		info.Parameters = append(info.Parameters, pi)
+	}
+	if description != "" {
+		info.Documentation = protocol.MarkupContent{Kind: protocol.MarkupKindMarkdown, Value: description}
+	}
+	if active >= 0 && active < len(info.Parameters) {
+		//nolint:gosec // active is a small, bounded index
+		setActiveParameter(&info, uint32(active))
+	}
+	return &protocol.SignatureHelp{Signatures: []protocol.SignatureInformation{info}}
+}
+
+// paramDefLabel renders a parameter as "name: type" (or "name" when untyped),
+// marking required parameters.
+func paramDefLabel(p *spec.ParamDef) string {
+	label := p.Name
+	if t := string(p.Type); t != "" {
+		label += ": " + t
+	}
+	if p.Required {
+		label += "!"
+	}
+	return label
+}
+
+// argLabel renders a call argument as "name: type", marking required arguments.
+func argLabel(name string, a *spec.ArgDef) string {
+	label := name
+	if a != nil {
+		if t := string(a.Type); t != "" {
+			label += ": " + t
+		}
+		if a.Required {
+			label += "!"
+		}
+	}
+	return label
+}
+
+func argLabels(args map[string]*spec.ArgDef, order []string) []string {
+	out := make([]string, 0, len(order))
+	for _, n := range order {
+		out = append(out, argLabel(n, args[n]))
+	}
+	return out
+}
+
+func sortedKeys(args map[string]*spec.ArgDef) []string {
+	out := make([]string, 0, len(args))
+	for k := range args {
+		out = append(out, k)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// setActiveParameter sets the 0-based active parameter index on a signature.
+func setActiveParameter(info *protocol.SignatureInformation, idx uint32) {
+	v := idx
+	info.ActiveParameter = &v
+}
+
+// enclosingCallParen returns the rune index of the innermost unmatched "(" that
+// encloses the cursor, ignoring parentheses inside quoted strings. ok is false
+// when the cursor is not inside a parenthesized call.
+func enclosingCallParen(runes []rune, cursor int) (int, bool) {
+	var stack []int
+	inStr := rune(0)
+	for i := 0; i < cursor && i < len(runes); i++ {
+		r := runes[i]
+		switch {
+		case inStr != 0:
+			if r == inStr {
+				inStr = 0
+			}
+		case r == '"' || r == '\'':
+			inStr = r
+		case r == '(':
+			stack = append(stack, i)
+		case r == ')':
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		}
+	}
+	if len(stack) == 0 {
+		return 0, false
+	}
+	return stack[len(stack)-1], true
+}
+
+// identifierBefore returns the CEL identifier (including dotted namespaces like
+// "arrays.groupBy") ending immediately before index i.
+func identifierBefore(runes []rune, i int) string {
+	end := i
+	start := end
+	for start > 0 {
+		r := runes[start-1]
+		if isIdentRune(r) || r == '.' {
+			start--
+			continue
+		}
+		break
+	}
+	return strings.Trim(string(runes[start:end]), ".")
+}
+
+// topLevelCommas counts commas between [from, to) that are not nested inside
+// parentheses, brackets, braces, or angle brackets, and not inside strings.
+func topLevelCommas(runes []rune, from, to int) uint32 {
+	if to > len(runes) {
+		to = len(runes)
+	}
+	var count, depth uint32
+	inStr := rune(0)
+	for i := from; i < to; i++ {
+		r := runes[i]
+		switch {
+		case inStr != 0:
+			if r == inStr {
+				inStr = 0
+			}
+		case r == '"' || r == '\'':
+			inStr = r
+		case r == '(' || r == '[' || r == '{' || r == '<':
+			depth++
+		case r == ')' || r == ']' || r == '}' || r == '>':
+			if depth > 0 {
+				depth--
+			}
+		case r == ',' && depth == 0:
+			count++
+		}
+	}
+	return count
+}
+
+// signatureParams extracts the parameter type list from a CEL signature such as
+// "arrays.groupBy(list<map<string,dyn>>, string) -> map<...>": the substring
+// between the first "(" and its matching ")", split on top-level commas.
+func signatureParams(signature string) []string {
+	open := strings.IndexByte(signature, '(')
+	if open < 0 {
+		return nil
+	}
+	var depth int
+	var params []string
+	var cur strings.Builder
+	inStr := rune(0)
+	for _, r := range signature[open+1:] {
+		switch {
+		case inStr != 0:
+			if r == inStr {
+				inStr = 0
+			}
+			cur.WriteRune(r)
+		case r == '"' || r == '\'':
+			inStr = r
+			cur.WriteRune(r)
+		case r == '(' || r == '[' || r == '{' || r == '<':
+			depth++
+			cur.WriteRune(r)
+		case r == ')':
+			if depth == 0 {
+				params = appendParam(params, cur.String())
+				return params
+			}
+			depth--
+			cur.WriteRune(r)
+		case r == ']' || r == '}' || r == '>':
+			if depth > 0 {
+				depth--
+			}
+			cur.WriteRune(r)
+		case r == ',' && depth == 0:
+			params = appendParam(params, cur.String())
+			cur.Reset()
+		default:
+			cur.WriteRune(r)
+		}
+	}
+	return params
+}
+
+func appendParam(params []string, s string) []string {
+	if t := strings.TrimSpace(s); t != "" {
+		return append(params, t)
+	}
+	return params
+}
+
+// enclosingCallName scans upward from the given 0-based line to find the call
+// name of an enclosing "args:" block: the nearest "call:" mapping (seen after an
+// "args:" key on the way up) whose value names the invoked call. ok is false when
+// the cursor is not inside an args block. Callers should first exclude the case
+// where the cursor is on the "call:"/"args:" key line itself.
+func enclosingCallName(raw []byte, line int) (string, bool) {
+	// Require an enclosing "args:" ancestor before the "call:" sibling.
+	sawArgs := false
+	for l := line - 1; l >= 0; l-- {
+		text, ok := lineAt(raw, l)
+		if !ok {
+			continue
+		}
+		lr := []rune(text)
+		key, _, _, valStart, hasVal := parseKeyLine(lr)
+		if key == "" {
+			continue
+		}
+		if key == "args" {
+			sawArgs = true
+			continue
+		}
+		if key == "call" && sawArgs && hasVal {
+			name := strings.TrimSpace(string(lr[valStart:]))
+			name = strings.Trim(name, `"'`)
+			if name != "" {
+				return name, true
+			}
+		}
+	}
+	return "", false
+}

--- a/pkg/lsp/signaturehelp.go
+++ b/pkg/lsp/signaturehelp.go
@@ -333,7 +333,11 @@ func identifierBefore(runes []rune, i int) string {
 }
 
 // topLevelCommas counts commas between [from, to) that are not nested inside
-// parentheses, brackets, braces, or angle brackets, and not inside strings.
+// parentheses, brackets, or braces, and not inside strings. It operates on real
+// CEL expression text, where '<' and '>' are comparison operators (not nesting
+// delimiters), so an expression like fn(a < b, c) still counts its top-level
+// comma. Generic angle brackets only appear in function signatures, which are
+// parsed separately by signatureParams.
 func topLevelCommas(runes []rune, from, to int) uint32 {
 	if to > len(runes) {
 		to = len(runes)
@@ -349,9 +353,9 @@ func topLevelCommas(runes []rune, from, to int) uint32 {
 			}
 		case r == '"' || r == '\'':
 			inStr = r
-		case r == '(' || r == '[' || r == '{' || r == '<':
+		case r == '(' || r == '[' || r == '{':
 			depth++
-		case r == ')' || r == ']' || r == '}' || r == '>':
+		case r == ')' || r == ']' || r == '}':
 			if depth > 0 {
 				depth--
 			}

--- a/pkg/lsp/signaturehelp.go
+++ b/pkg/lsp/signaturehelp.go
@@ -13,12 +13,19 @@ import (
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
-// signatureHelpTriggerCharacters (re)trigger signature help: "(" opens a CEL
-// call's argument list, " " separates template function arguments.
+// signatureHelpTriggerCharacters open signature help automatically: "(" opens a
+// CEL call's argument list, " " separates template function arguments.
 var signatureHelpTriggerCharacters = []string{"(", " "}
 
+// signatureHelpRetriggerCharacters update already-showing signature help so the
+// active parameter follows the cursor to the next argument. "," advances to the
+// next CEL argument; clients that only re-request on advertised characters would
+// otherwise leave the highlighted parameter stale. Per the LSP spec, all trigger
+// characters are also retrigger characters, so only "," needs listing here.
+var signatureHelpRetriggerCharacters = []string{","}
+
 // signatureHelpFeature registers textDocument/signatureHelp and advertises the
-// provider with its trigger characters.
+// provider with its trigger and retrigger characters.
 func signatureHelpFeature() feature {
 	return feature{
 		name: "signatureHelp",
@@ -27,7 +34,8 @@ func signatureHelpFeature() feature {
 		},
 		advertise: func(c *protocol.ServerCapabilities) {
 			c.SignatureHelpProvider = &protocol.SignatureHelpOptions{
-				TriggerCharacters: signatureHelpTriggerCharacters,
+				TriggerCharacters:   signatureHelpTriggerCharacters,
+				RetriggerCharacters: signatureHelpRetriggerCharacters,
 			}
 		},
 	}

--- a/pkg/lsp/signaturehelp_test.go
+++ b/pkg/lsp/signaturehelp_test.go
@@ -1,0 +1,316 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+const sigFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  functions:
+    greet:
+      description: Greets someone
+      params:
+        - name: who
+          type: string
+          required: true
+        - name: punct
+          type: string
+      template: "{{ .args.who }}"
+  calls:
+    fetchThing:
+      description: Fetches a thing
+      args:
+        url:
+          type: string
+          required: true
+        retries:
+          type: int
+      provider: http
+  resolvers:
+    celR:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: arrays.groupBy(_.items, dev)
+    tmplR:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              value:
+                tmpl: "{{ greet .x .y }}"
+    callR:
+      resolve:
+        with:
+          - call: fetchThing
+            args:
+              retries: 3
+`
+
+func sigAt(t *testing.T, content, lineHint, token string, within int) *protocol.SignatureHelp {
+	t.Helper()
+	s := newTestServer(t)
+	uri := protocol.DocumentUri("file:///sig.yaml")
+	s.setDoc(uri, 1, content)
+	pos := posAt(t, content, lineHint, token, within)
+	sh, err := s.signatureHelp(nil, &protocol.SignatureHelpParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+			Position:     pos,
+		},
+	})
+	require.NoError(t, err)
+	return sh
+}
+
+func firstSig(t *testing.T, sh *protocol.SignatureHelp) protocol.SignatureInformation {
+	t.Helper()
+	require.NotNil(t, sh)
+	require.NotEmpty(t, sh.Signatures)
+	return sh.Signatures[0]
+}
+
+func paramLabels(si protocol.SignatureInformation) []string {
+	out := make([]string, 0, len(si.Parameters))
+	for _, p := range si.Parameters {
+		out = append(out, fmt.Sprint(p.Label))
+	}
+	return out
+}
+
+func activeParam(si protocol.SignatureInformation) int {
+	if si.ActiveParameter == nil {
+		return -1
+	}
+	return int(*si.ActiveParameter)
+}
+
+func TestSignatureHelp_CELFunction(t *testing.T) {
+	// Cursor on the first argument (_.items).
+	si := firstSig(t, sigAt(t, sigFixture, "expr: arrays.groupBy", "_.items", 1))
+	assert.Contains(t, si.Label, "arrays.groupBy")
+	assert.Equal(t, []string{"list<map<string,dyn>>", "string"}, paramLabels(si),
+		"CEL params split on top-level commas (generic commas ignored)")
+	assert.Equal(t, 0, activeParam(si), "on the first arg")
+}
+
+func TestSignatureHelp_CELActiveParameterTracksCursor(t *testing.T) {
+	// Cursor on the second argument (after the comma).
+	si := firstSig(t, sigAt(t, sigFixture, "expr: arrays.groupBy", "dev", 1))
+	assert.Equal(t, 1, activeParam(si), "on the second arg")
+}
+
+func TestSignatureHelp_TemplateAuthorFunction(t *testing.T) {
+	// Cursor on the first template argument ".x".
+	si := firstSig(t, sigAt(t, sigFixture, `tmpl: "{{ greet`, ".x", 1))
+	assert.Contains(t, si.Label, "greet(")
+	assert.Equal(t, []string{"who: string!", "punct: string"}, paramLabels(si))
+	assert.Equal(t, 0, activeParam(si))
+}
+
+func TestSignatureHelp_TemplateActiveParameterTracksCursor(t *testing.T) {
+	// Cursor on the second template argument ".y".
+	si := firstSig(t, sigAt(t, sigFixture, `tmpl: "{{ greet`, ".y", 1))
+	assert.Equal(t, 1, activeParam(si), "on the second template arg")
+}
+
+func TestSignatureHelp_TemplateBuiltinFunction(t *testing.T) {
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              value:
+                tmpl: "{{ upper .x }}"
+`
+	si := firstSig(t, sigAt(t, content, `tmpl: "{{ upper`, ".x", 1))
+	assert.Equal(t, "upper", si.Label, "builtin template function shows its name")
+}
+
+func TestSignatureHelp_CallArgs(t *testing.T) {
+	// Cursor on the "retries" arg key inside the call's args block.
+	si := firstSig(t, sigAt(t, sigFixture, "              retries: 3", "retries", 2))
+	assert.Contains(t, si.Label, "fetchThing(")
+	// Args are listed sorted; retries before url.
+	assert.Equal(t, []string{"retries: int", "url: string!"}, paramLabels(si))
+	assert.Equal(t, 0, activeParam(si), "highlights the retries arg on the cursor line")
+}
+
+func TestSignatureHelp_CursorOnCallLineDoesNotBorrowSiblingArgs(t *testing.T) {
+	// With the cursor on a "- call:" invocation line, we must not surface a
+	// sibling call's args (regression for the nearest-key scan).
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  calls:
+    first:
+      args:
+        a:
+          type: string
+      provider: http
+    second:
+      provider: http
+  resolvers:
+    r:
+      resolve:
+        with:
+          - call: first
+            args:
+              a: x
+          - call: second
+`
+	// Cursor on the "- call: second" line (naming the call, not filling args).
+	sh := sigAt(t, content, "          - call: second", "second", 2)
+	assert.Nil(t, sh, "no args signature on the call invocation line")
+}
+
+func TestSignatureHelp_TemplatePipedCall(t *testing.T) {
+	// In "{{ .x | greet a }}" the active call after the pipe is greet.
+	content := `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: c
+spec:
+  functions:
+    greet:
+      params:
+        - name: who
+          type: string
+      template: "{{ .args.who }}"
+  resolvers:
+    a:
+      resolve:
+        with:
+          - provider: go-template
+            inputs:
+              value:
+                tmpl: "{{ .x | greet a }}"
+`
+	si := firstSig(t, sigAt(t, content, `tmpl: "{{ .x | greet`, "greet a", len("greet ")))
+	assert.Contains(t, si.Label, "greet(")
+}
+
+func TestSignatureHelp_NoneWhenNotInCall(t *testing.T) {
+	// A plain scalar value is not a call.
+	sh := sigAt(t, sigFixture, "  name: c", "c", 0)
+	assert.Nil(t, sh)
+}
+
+func TestSignatureHelp_UnknownDocument(t *testing.T) {
+	s := newTestServer(t)
+	sh, err := s.signatureHelp(nil, &protocol.SignatureHelpParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: "file:///missing.yaml"},
+			Position:     protocol.Position{},
+		},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, sh)
+}
+
+func TestSignatureHelp_ParseErrorNoPanic(t *testing.T) {
+	s := newTestServer(t)
+	uri := protocol.DocumentUri("file:///bad.yaml")
+	s.setDoc(uri, 1, "spec: {calls:\n  expr: arrays.groupBy(x")
+	require.NotPanics(t, func() {
+		_, err := s.signatureHelp(nil, &protocol.SignatureHelpParams{
+			TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+				TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+				Position:     protocol.Position{Line: 1, Character: 22},
+			},
+		})
+		require.NoError(t, err)
+	})
+}
+
+func TestSignatureHelp_NilEntry(t *testing.T) {
+	assert.Nil(t, SignatureHelp(nil, protocol.Position{}))
+}
+
+func TestSignatureHelp_FeatureRegisteredAndAdvertised(t *testing.T) {
+	s := newTestServer(t)
+	h := s.Handler()
+	assert.NotNil(t, h.TextDocumentSignatureHelp)
+
+	res, err := h.Initialize(nil, &protocol.InitializeParams{})
+	require.NoError(t, err)
+	init := res.(protocol.InitializeResult)
+	require.NotNil(t, init.Capabilities.SignatureHelpProvider)
+	assert.Equal(t, signatureHelpTriggerCharacters, init.Capabilities.SignatureHelpProvider.TriggerCharacters)
+}
+
+// --- helper unit tests ---
+
+func TestEnclosingCallParen(t *testing.T) {
+	r := []rune(`foo(a, bar(b`)
+	open, ok := enclosingCallParen(r, len(r)) // inside bar(
+	require.True(t, ok)
+	assert.Equal(t, 10, open)
+
+	// A closed call: cursor after the ")" is not inside a call.
+	r = []rune(`foo(a)`)
+	_, ok = enclosingCallParen(r, len(r))
+	assert.False(t, ok)
+
+	// Parens inside a string are ignored.
+	r = []rune(`foo("(") `)
+	_, ok = enclosingCallParen(r, len(r))
+	assert.False(t, ok)
+}
+
+func TestIdentifierBefore(t *testing.T) {
+	r := []rune("arrays.groupBy(")
+	assert.Equal(t, "arrays.groupBy", identifierBefore(r, len(r)-1))
+	assert.Equal(t, "", identifierBefore([]rune("  ("), 2))
+}
+
+func TestTopLevelCommas(t *testing.T) {
+	r := []rune("a, b, c")
+	assert.Equal(t, uint32(2), topLevelCommas(r, 0, len(r)))
+	// Commas inside generics/brackets are not counted.
+	r = []rune("map<string,dyn>, x")
+	assert.Equal(t, uint32(1), topLevelCommas(r, 0, len(r)))
+	// Commas inside a string literal are not counted.
+	r = []rune(`"a,b", c`)
+	assert.Equal(t, uint32(1), topLevelCommas(r, 0, len(r)))
+}
+
+func TestSignatureParams(t *testing.T) {
+	params := signatureParams("arrays.groupBy(list<map<string,dyn>>, string) -> map<string, list>")
+	assert.Equal(t, []string{"list<map<string,dyn>>", "string"}, params)
+
+	assert.Nil(t, signatureParams("noParens"))
+	assert.Empty(t, signatureParams("fn()"))
+}
+
+func TestEnclosingCallName(t *testing.T) {
+	raw := []byte("spec:\n  resolvers:\n    a:\n      resolve:\n        with:\n          - call: myCall\n            args:\n              foo: 1\n")
+	name, ok := enclosingCallName(raw, 7) // the "foo: 1" line
+	require.True(t, ok)
+	assert.Equal(t, "myCall", name)
+
+	// Not inside an args block.
+	_, ok = enclosingCallName(raw, 5)
+	assert.False(t, ok)
+}

--- a/pkg/lsp/signaturehelp_test.go
+++ b/pkg/lsp/signaturehelp_test.go
@@ -278,6 +278,13 @@ func TestEnclosingCallParen(t *testing.T) {
 	r = []rune(`foo("(") `)
 	_, ok = enclosingCallParen(r, len(r))
 	assert.False(t, ok)
+
+	// An escaped quote inside a string does not end the string, so a "(" after
+	// it is still treated as string content, not a call opener.
+	r = []rune(`foo("a\"(", `)
+	open, ok = enclosingCallParen(r, len(r))
+	require.True(t, ok)
+	assert.Equal(t, 3, open) // still inside foo(, not a spurious inner "("
 }
 
 func TestIdentifierBefore(t *testing.T) {
@@ -299,6 +306,10 @@ func TestTopLevelCommas(t *testing.T) {
 	// Commas inside a string literal are not counted.
 	r = []rune(`"a,b", c`)
 	assert.Equal(t, uint32(1), topLevelCommas(r, 0, len(r)))
+	// An escaped quote does not end the string, so a comma after it inside the
+	// string is still not counted.
+	r = []rune(`"a\",b", c`)
+	assert.Equal(t, uint32(1), topLevelCommas(r, 0, len(r)))
 }
 
 func TestSignatureParams(t *testing.T) {
@@ -318,4 +329,57 @@ func TestEnclosingCallName(t *testing.T) {
 	// Not inside an args block.
 	_, ok = enclosingCallName(raw, 5)
 	assert.False(t, ok)
+}
+
+func TestEnclosingCallNameIndentation(t *testing.T) {
+	// A call with args followed by a sibling provider list item. Editing the
+	// provider's expr (below the call's args) must NOT borrow the call's args.
+	raw := []byte(
+		"spec:\n" + // 0
+			"  resolvers:\n" + // 1
+			"    a:\n" + // 2
+			"      resolve:\n" + // 3
+			"        with:\n" + // 4
+			"          - call: myCall\n" + // 5
+			"            args:\n" + // 6
+			"              foo: 1\n" + // 7
+			"          - provider: parameter\n" + // 8
+			"            inputs:\n" + // 9
+			"              value:\n" + // 10
+			"                expr: something\n") // 11
+
+	// Genuinely inside myCall's args.
+	name, ok := enclosingCallName(raw, 7)
+	require.True(t, ok)
+	assert.Equal(t, "myCall", name)
+
+	// In the sibling provider item below the args block: no enclosing call.
+	_, ok = enclosingCallName(raw, 11)
+	assert.False(t, ok, "cursor in a sibling provider must not resolve the earlier call's args")
+	_, ok = enclosingCallName(raw, 10) // the "value:" line
+	assert.False(t, ok)
+
+	// A nested arg value: the cursor is deeper than "foo:" but still inside args.
+	nested := []byte(
+		"spec:\n" +
+			"  resolvers:\n" +
+			"    a:\n" +
+			"      resolve:\n" +
+			"        with:\n" +
+			"          - call: myCall\n" + // 5
+			"            args:\n" + // 6
+			"              foo:\n" + // 7
+			"                bar: 1\n") // 8
+	name, ok = enclosingCallName(nested, 8) // the "bar: 1" line, nested under foo
+	require.True(t, ok)
+	assert.Equal(t, "myCall", name)
+}
+
+func TestContentIndent(t *testing.T) {
+	assert.Equal(t, 12, contentIndent([]rune("          - call: myCall")))
+	assert.Equal(t, 12, contentIndent([]rune("            args:")))
+	assert.Equal(t, 0, contentIndent([]rune("spec:")))
+	assert.True(t, isBlankOrComment([]rune("   ")))
+	assert.True(t, isBlankOrComment([]rune("  # a comment")))
+	assert.False(t, isBlankOrComment([]rune("  key: value")))
 }

--- a/pkg/lsp/signaturehelp_test.go
+++ b/pkg/lsp/signaturehelp_test.go
@@ -258,6 +258,7 @@ func TestSignatureHelp_FeatureRegisteredAndAdvertised(t *testing.T) {
 	init := res.(protocol.InitializeResult)
 	require.NotNil(t, init.Capabilities.SignatureHelpProvider)
 	assert.Equal(t, signatureHelpTriggerCharacters, init.Capabilities.SignatureHelpProvider.TriggerCharacters)
+	assert.Equal(t, signatureHelpRetriggerCharacters, init.Capabilities.SignatureHelpProvider.RetriggerCharacters)
 }
 
 // --- helper unit tests ---

--- a/pkg/lsp/signaturehelp_test.go
+++ b/pkg/lsp/signaturehelp_test.go
@@ -288,8 +288,12 @@ func TestIdentifierBefore(t *testing.T) {
 func TestTopLevelCommas(t *testing.T) {
 	r := []rune("a, b, c")
 	assert.Equal(t, uint32(2), topLevelCommas(r, 0, len(r)))
-	// Commas inside generics/brackets are not counted.
-	r = []rune("map<string,dyn>, x")
+	// '<' and '>' are CEL comparison operators, not nesting: the top-level comma
+	// after a comparison is still counted.
+	r = []rune("a < b, c")
+	assert.Equal(t, uint32(1), topLevelCommas(r, 0, len(r)))
+	// Commas inside brackets/braces/parens are not counted.
+	r = []rune("[1, 2], x")
 	assert.Equal(t, uint32(1), topLevelCommas(r, 0, len(r)))
 	// Commas inside a string literal are not counted.
 	r = []rune(`"a,b", c`)

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13986,8 +13986,8 @@ func TestIntegration_LspCompletionFunctions(t *testing.T) {
 func TestIntegration_LspSignatureHelp(t *testing.T) {
 	t.Parallel()
 
-	// A CEL call "arrays.groupBy(_.items, )" is on line 12 (0-based); the cursor
-	// at character 47 sits before the second argument.
+	// A CEL call "arrays.groupBy(_.items, x)" is on line 12 (0-based); the cursor
+	// at character 47 sits on the second argument.
 	sol := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: nav\nspec:\n  resolvers:\n    a:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value:\n                expr: arrays.groupBy(_.items, x)\n"
 
 	out := runLSPSession(t, sol,

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -13983,6 +13983,25 @@ func TestIntegration_LspCompletionFunctions(t *testing.T) {
 	assert.Contains(t, out, `arrays.groupBy($0)`, "function completion inserts a call snippet")
 }
 
+func TestIntegration_LspSignatureHelp(t *testing.T) {
+	t.Parallel()
+
+	// A CEL call "arrays.groupBy(_.items, )" is on line 12 (0-based); the cursor
+	// at character 47 sits before the second argument.
+	sol := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: nav\nspec:\n  resolvers:\n    a:\n      resolve:\n        with:\n          - provider: parameter\n            inputs:\n              value:\n                expr: arrays.groupBy(_.items, x)\n"
+
+	out := runLSPSession(t, sol,
+		map[string]any{"jsonrpc": "2.0", "id": 2, "method": "textDocument/signatureHelp", "params": map[string]any{
+			"textDocument": map[string]any{"uri": lspSessionURI},
+			"position":     map[string]any{"line": 12, "character": 47},
+		}},
+	)
+
+	assert.Contains(t, out, `"signatures"`, "signature help returns signatures")
+	assert.Contains(t, out, "arrays.groupBy", "describes the CEL function under the cursor")
+	assert.Contains(t, out, `"activeParameter":1`, "active parameter tracks the cursor onto the second arg")
+}
+
 func TestIntegration_LspHover(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Implements LSP **`textDocument/signatureHelp`** so typing a call's arguments
shows the declared parameters and highlights the one at the cursor.

This is issue #777 (the final feature of the cursor/intelligence stream; needs

# 766/#767/#768 and #772 `funcref.go` -- all merged)

## Contexts

- **CEL function** `arrays.groupBy(...)` -> the function's signature from the
  shared `funcref.go` (#772). The signature label is split into parameters on
  **top-level** commas so generic types like `list<map<string,dyn>>` are not
  mis-split; the active parameter is the top-level comma count before the cursor.
  The active-parameter counter treats `<`/`>` in the expression as CEL
  comparison operators (not nesting), so an argument like `fn(a < b, c)` still
  highlights the correct parameter.
- **Go-template** `{{ greet ... }}` -> an author-defined helper's declared
  parameters (`spec.functions[name].params`, positional), or a built-in template
  function's name + description; active parameter = space-separated token index
  (a leading pipe segment is stripped).
- **Call args** -> inside a call invocation's `args:` block, the invoked call's
  declared arguments (`spec.calls[name].args`, sorted), highlighting the argument
  key on the cursor's line.

Registered via the seam; advertises `SignatureHelpProvider` with trigger
characters `(` and space, plus `,` as a **retrigger** character so an
already-showing signature updates its active parameter as the cursor moves
between CEL arguments. Reuses `funcref.go` `LookupFunc` for ext-function
signatures -- no registry walking.

## Safety

Returns nil (no help, no panic) on unknown/parse-error documents, when the cursor
is on the `call:`/`args:` key line itself (so it can't borrow a sibling call's
args), and when the cursor is not inside a recognized call. Call-args resolution
is **indentation-aware**: it climbs only true YAML ancestor lines, so editing a
sibling list item below a call (e.g. a provider's `inputs.expr`) does not pop up
that call's argument signature. The CEL scanners (`enclosingCallParen`,
`topLevelCommas`) track backslash escapes inside string literals, so an escaped
quote does not end the string early and misparse the following parens/commas.

## Tests / docs

- Table tests per context: CEL function (+ generic-comma splitting), template
  author function, template built-in, call args, piped template call, and
  active-parameter tracking in each. Plus none/unknown-doc/parse-error/nil-entry
  safety, regression tests for the on-`call:`-line case, the
  sibling-item-below-`args:` false positive, and escaped-quote handling, and
  helper unit tests (`enclosingCallParen`, `identifierBefore`, `topLevelCommas`,
  `signatureParams`, `enclosingCallName`, `contentIndent`).
- Integration test `TestIntegration_LspSignatureHelp` via `runLSPSession`
  (asserts `activeParameter:1` tracking).
- `docs/tutorials/lsp-tutorial.md` documents signature help.

`-race` clean, `lint:changed` 0 new issues, `signaturehelp.go` 85-100% per-function.

## Acceptance criteria

- [x] Typing a call's args shows the call's declared parameters.
- [x] Typing inside `{{ fn ... }}` shows the function's parameters.
- [x] Active parameter tracks the cursor.

Closes #777
