### PR TITLE
docs(lsp): document the full editor feature set and non-goals

### DIFF
--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -1178,7 +1178,7 @@ reusing the reference index and rename engine of `refactor rename`:
   input schema, CEL/template function signatures, and schema field docs.
 - **Completion** (`textDocument/completion`) -- schema-driven keys and enum
   values, CEL/template function names (with call snippets), and symbol names
-  after `_.` / `._.` / `call:` / `rslvr:` / `dependsOn`.
+   after `_.` / `._.` / `call:` / `rslvr:` / `dependsOn:`.
 - **Signature help** (`textDocument/signatureHelp`) -- declared parameters for CEL
   functions, author/built-in template functions, and a call's `args:`, with the
   active parameter tracking the cursor.

--- a/docs/design/cli.md
+++ b/docs/design/cli.md
@@ -1147,25 +1147,49 @@ scafctl lsp
 scafctl lsp --stdio
 ~~~
 
-Currently the server publishes **lint diagnostics** for solution files as you
-edit them: on open/change/save it lints the in-memory document and sends
-`textDocument/publishDiagnostics`, mapping each finding's severity, message, and
-rule name to an LSP diagnostic anchored at the finding's location. It advertises
-full-document sync and reuses the same `lint` engine as `scafctl lint`, so
-editor diagnostics match the CLI.
+The server gives editors a full authoring experience for solution files, all
+consistent with the CLI because it reuses the same `lint` engine, positioned
+reference index (`refindex`), rename engine (`refactor`), generated schema, and
+built-in function registries.
 
-It also provides resolver, action, call, and function navigation and refactoring,
-reusing the same positioned reference index (`refindex`) and rename engine
-(`refactor`) as `refactor rename`:
+**Diagnostics** (`textDocument/publishDiagnostics`) -- on open/change/save it
+lints the in-memory document and maps each finding's severity, message, and rule
+name to an LSP diagnostic anchored at the finding's location. It advertises
+full-document sync and reuses the same `lint` engine as `scafctl lint`, so editor
+diagnostics match the CLI.
 
-- **Go-to-definition** (`textDocument/definition`) -- jump from any resolver,
-  action, call, or function reference to its definition.
-- **Find references** (`textDocument/references`) -- list every use of a resolver,
-  action, call, or function.
-- **Rename** (`textDocument/rename`, with `prepareRename`) -- rename any of them
-  and every reference to it as a single `WorkspaceEdit`. The same fail-safe
-  applies: if a reference cannot be located, the rename is refused and the error
-  is surfaced to the editor rather than a partial rewrite being applied.
+**Navigation and refactoring** over resolver, action, call, and function symbols,
+reusing the reference index and rename engine of `refactor rename`:
+
+- **Go-to-definition** (`textDocument/definition`) -- jump from any reference to
+  its definition.
+- **Find references** (`textDocument/references`) -- list every use of a symbol.
+- **Rename** (`textDocument/rename`, with `prepareRename`) -- rename a symbol and
+  every reference as a single `WorkspaceEdit`. The same fail-safe applies: if a
+  reference cannot be located, the rename is refused and the error is surfaced to
+  the editor rather than a partial rewrite being applied.
+- **Document outline** (`textDocument/documentSymbol`) -- a `spec` root with
+  `resolvers` / `actions` / `calls` / `functions` groups for the Outline pane,
+  breadcrumbs, and Go-to-Symbol.
+
+**Authoring assistance** driven by a shared cursor-context resolver:
+
+- **Hover** (`textDocument/hover`) -- symbol descriptions, provider descriptors +
+  input schema, CEL/template function signatures, and schema field docs.
+- **Completion** (`textDocument/completion`) -- schema-driven keys and enum
+  values, CEL/template function names (with call snippets), and symbol names
+  after `_.` / `._.` / `call:` / `rslvr:` / `dependsOn`.
+- **Signature help** (`textDocument/signatureHelp`) -- declared parameters for CEL
+  functions, author/built-in template functions, and a call's `args:`, with the
+  active parameter tracking the cursor.
+- **Quick fixes** (`textDocument/codeAction`) -- one-click fixes for auto-fixable
+  lint diagnostics (deprecated field, redundant `dependsOn`, unused resolver),
+  reusing the same fix logic as `scafctl lint --fix`.
+
+Formatting, folding ranges, semantic tokens, and inlay hints are intentional
+**non-goals** -- a solution file is YAML, so those are left to the editor's YAML
+support (Red Hat YAML / Prettier), keeping the server focused on what only scafctl
+can know and preserving other extensions' features on the same file.
 
 An editor client configures the server by pointing at the `scafctl lsp` command
 and attaching it to solution files. To keep editor targeting in lockstep with

--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -6,48 +6,69 @@ weight: 47
 # Language Server (LSP) Tutorial
 
 This tutorial covers `scafctl lsp`, which runs a Language Server Protocol (LSP)
-server so editors can surface solution diagnostics as you type.
+server so editors get a full authoring experience for solution files -- live
+diagnostics, navigation, rename, an outline, hover, completion, signature help,
+and quick fixes -- all consistent with the `scafctl` CLI.
 
 ## Overview
 
 `scafctl lsp` speaks LSP over stdin/stdout. An editor / LSP client launches it,
-sends the documents you open and edit, and the server replies with diagnostics.
-It is not meant to be run interactively -- stdout is the JSON-RPC channel.
+sends the documents you open and edit, and the server answers requests. It is
+not meant to be run interactively -- stdout is the JSON-RPC channel.
 
 ```mermaid
 flowchart LR
   A["Editor<br/>(LSP client)"] <-->|"stdio JSON-RPC"| B["scafctl lsp"]
-  B --> C["lint engine"]
-  C -->|"findings"| B
-  B -->|"publishDiagnostics"| A
+  B --> C["lint / schema / reference index"]
+  C -->|"diagnostics, symbols, completions, ..."| B
+  B -->|"LSP responses"| A
 ```
 
-Today the server publishes **lint diagnostics**: on open/change/save it lints
-the in-memory document and reports each finding (severity, message, rule name)
-at its source location, using the same engine as `scafctl lint` -- so what you
-see in the editor matches the CLI.
+Everything the server surfaces comes from the same sources the CLI already uses
+-- the `lint` engine, the positioned reference index (`refindex`), the generated
+solution schema, and the built-in function registries -- so the editor never
+disagrees with `scafctl lint`, `scafctl refactor`, or the schema. The bundled VS
+Code extension is a thin client over this server; the gestures below are written
+for it, but any LSP client exposes the same capabilities.
 
-It also supports resolver, action, call, and function **navigation and rename**,
-reusing the same reference index and rename engine as `scafctl refactor rename`:
+## Diagnostics
 
-- **Go to definition** on a resolver, action, call, or function reference jumps
-  to where it is defined.
-- **Find all references** lists every use of a resolver, action, call, or
-  function.
-- **Rename** any of them updates its definition and every reference in one edit.
-  If any reference cannot be located, the rename is refused (the editor shows the
-  error) rather than applying a partial, solution-breaking change.
+On open/change/save the server lints the in-memory document and reports each
+finding (severity, message, rule name) at its source location, using the same
+engine as `scafctl lint` -- so what you see in the editor matches the CLI.
 
-It also provides a **document outline**. `textDocument/documentSymbol` returns a
-hierarchy -- a `spec` root whose children are the `resolvers`, `actions`,
-`calls`, and `functions` groups, each listing its symbols -- so the editor's
-Outline pane and breadcrumbs populate and **Go to Symbol in File**
-(Cmd/Ctrl+Shift+O) fuzzy-jumps to any resolver, action, call, or function.
+_Try:_ reference an undefined resolver in a `_.` expression; the unknown-resolver
+diagnostic appears inline as you type, exactly as `scafctl lint` would report it.
+
+## Navigation and rename
+
+Resolver, action, call, and function references are navigable and support
+renaming, reusing the same reference index and rename engine as
+`scafctl refactor rename`:
+
+- **Go to definition** on a reference jumps to where it is defined.
+- **Find all references** lists every use of a resolver, action, call, or function.
+- **Rename** updates a symbol's definition and every reference in one edit. If any
+  reference cannot be located, the rename is refused (the editor shows the error)
+  rather than applying a partial, solution-breaking change.
+
+_Try:_ put the cursor on a resolver name and press F2 (Rename) -- every `_.name`,
+`rslvr: name`, and `dependsOn` entry updates together; or F12 (Go to Definition)
+on a reference to jump to its declaration.
+
+## Outline
+
+`textDocument/documentSymbol` returns a hierarchy -- a `spec` root whose children
+are the `resolvers`, `actions`, `calls`, and `functions` groups, each listing its
+symbols.
+
+_Try:_ open the Outline pane, or press Cmd/Ctrl+Shift+O to fuzzy-jump to any
+resolver, action, call, or function; the breadcrumb bar tracks your position.
 
 ## Hover
 
-Hovering the cursor over a symbol shows contextual markdown pulled from the same
-sources the CLI already knows about -- no separate documentation to maintain:
+Hovering a symbol shows contextual markdown pulled from the sources the CLI
+already knows about -- no separate documentation to maintain:
 
 - **Resolver / action / call / function reference** -> its kind, name, and
   `description` from the solution.
@@ -55,17 +76,21 @@ sources the CLI already knows about -- no separate documentation to maintain:
   summary of its input schema (each input's name, type, whether it is required,
   and its doc), straight from the provider descriptor.
 - **CEL / template function** -> the function's signature (CEL), description, and
-  a usage example, from the built-in function registries (the same set the
-  `list_cel_functions` / `list_go_template_functions` MCP tools report).
+  a usage example, from the built-in function registries (the same catalog
+  `scafctl` uses everywhere else).
 - **Mapping key** -> the schema documentation for that field, plus a related
   concept summary when one matches.
 
 Hover degrades gracefully: on an unknown target, a parse error, or whitespace it
 simply returns nothing, so it never interrupts editing.
 
+_Try:_ hover a `provider:` value to read its inputs, or a `_.name` reference to
+read the target resolver's description.
+
 ## Completion
 
-As you type, the server offers **schema-driven structural completions**:
+As you type, the server offers completions from the schema and the reference
+index:
 
 - **Keys** -- typing a key under a known path offers the valid child keys from the
   generated solution schema (e.g. under a resolver: `description`, `resolve`,
@@ -81,19 +106,21 @@ As you type, the server offers **schema-driven structural completions**:
   for that context: a parenthesized call in CEL (`name($0)`) and a space-separated
   call in templates (`name $0`, since `name()` is not valid template syntax).
 - **Symbols** -- scafctl-specific name completion no generic YAML tool can offer,
-  drawn from the document's reference index and filtered by what you have typed:
-  after `_.` (CEL) or `._.` (template) it offers **resolver** names (and
-  `__actions.` / `.__actions.` offers **action** names); a `call:` value offers
-  **call** names; a `rslvr:` value offers **resolver** names; and a `dependsOn:`
-  list item offers **resolver** names (in a resolver) or **action** names (in an
-  action). Only defined symbols are suggested.
+  drawn from the document's reference index: after `_.` (CEL) or `._.` (template)
+  it offers **resolver** names (and `__actions.` / `.__actions.` offers **action**
+  names); a `call:` value offers **call** names; a `rslvr:` value offers
+  **resolver** names; and a `dependsOn:` list item offers **resolver** names (in a
+  resolver) or **action** names (in an action). Only defined symbols are suggested.
 
 Completion is triggered on `.`, `:`, and space. Structural key, enum-value, and
 CEL/template function completion work mid-edit even while the document does not
 yet parse (the container is inferred from indentation). Symbol completion is
-sourced from the reference index, so it becomes available once the solution
-model builds successfully -- while the document does not yet parse it simply
-offers nothing rather than erroring.
+sourced from the reference index, so it becomes available once the solution model
+builds; while the document does not yet parse it simply offers nothing rather
+than erroring.
+
+_Try:_ on a new line under a resolver, type `de` and accept `description`; or in a
+`value:` expression type `_.` to pick a resolver by name.
 
 ## Signature help
 
@@ -112,19 +139,21 @@ highlights the one at the cursor:
 Signature help is triggered on `(` and space, and re-triggered on `,` so the
 highlighted parameter follows the cursor as you move between CEL arguments.
 
+_Try:_ type `arrays.groupBy(` in a `value:` expression -- the parameter list pops
+up and the active parameter advances as you type past each comma.
+
 ## Quick fixes
 
-It also offers **quick fixes**. `textDocument/codeAction` turns certain lint
-diagnostics into one-click fixes (the editor's lightbulb), reusing the same fix
-logic (`lint.QuickFixFor`) so the applied edit always matches what the linter
-would recommend:
+`textDocument/codeAction` turns certain lint diagnostics into one-click fixes (the
+editor's lightbulb), reusing the same fix logic (`lint.QuickFixFor`) so the
+applied edit always matches what the linter would recommend:
 
 - **deprecated field** -- replaces the deprecated `onError` field with its
   successor `continueOnError`, translating the value (`onError: continue` becomes
   `continueOnError: true`, and `onError: fail` becomes `continueOnError: false`).
-- **redundant dependsOn** -- removes the redundant `dependsOn` entry (or the
-  whole `dependsOn:` block when every listed dependency is already inferred from
-  value references).
+- **redundant dependsOn** -- removes the redundant `dependsOn` entry (or the whole
+  `dependsOn:` block when every listed dependency is already inferred from value
+  references).
 - **unused resolver** -- removes the entire unreferenced resolver block.
 
 For example, given a resolve source with the deprecated field:
@@ -138,8 +167,31 @@ resolve:
         value: dev
 ~~~
 
-invoking the quick fix rewrites just that line to `continueOnError: true`,
-leaving surrounding formatting and comments untouched.
+invoking the quick fix rewrites just that line to `continueOnError: true`, leaving
+surrounding formatting and comments untouched.
+
+_Try:_ place the cursor on a line with a fixable diagnostic and trigger Quick Fix
+(Cmd/Ctrl+.); accept the suggested edit.
+
+## Non-goals
+
+Some editor capabilities are deliberately **not** provided by `scafctl lsp`,
+because a solution file is YAML and the ecosystem already handles them well.
+Layering on top of the built-in YAML support (rather than owning the buffer) is
+the same approach GitHub Actions and other YAML-based tools take:
+
+- **Formatting** (`textDocument/formatting`) -- left to the Red Hat YAML extension
+  or Prettier. The server never rewrites whitespace/layout wholesale; its edits
+  (rename, quick fixes) are surgical and preserve surrounding formatting.
+- **Folding ranges** -- the editor's generic YAML support already folds by
+  indentation.
+- **Semantic tokens** -- the YAML grammar already colors the file; scafctl's value
+  is semantic _navigation and validation_, not re-coloring tokens.
+- **Inlay hints** -- omitted to avoid visual noise; the same information (types,
+  parameters, descriptions) is available on demand via hover and signature help.
+
+These are intentional: keeping them out preserves the other extensions' features
+on the same file and keeps the server focused on what only scafctl can know.
 
 ## Trying it by hand
 
@@ -150,7 +202,8 @@ scafctl lsp --help
 ```
 
 An LSP client drives it with framed JSON-RPC messages (`initialize`, then
-`textDocument/didOpen`, `didChange`, `didClose`). On `didOpen`/`didChange` the
+`textDocument/didOpen`, `didChange`, `didClose`, and requests like
+`textDocument/hover` or `textDocument/completion`). On `didOpen`/`didChange` the
 server responds with a `textDocument/publishDiagnostics` notification containing
 any lint findings for that document.
 
@@ -162,8 +215,8 @@ same:
 1. Point the client at the `scafctl lsp` command (the server process). Clients
    that pass a transport flag by convention can use `scafctl lsp --stdio`; it is
    accepted as a no-op since stdio is the only transport.
-2. Attach it to the solution files scafctl recognizes. To avoid hardcoding a
-   file list that drifts from CLI discovery, ask the binary which files it
+2. Attach it to the solution files scafctl recognizes. To avoid hardcoding a file
+   list that drifts from CLI discovery, ask the binary which files it
    auto-discovers:
 
    ~~~bash
@@ -173,28 +226,30 @@ same:
    This reports the recognized file names partitioned by editor language --
    `solution.{yaml,yml,json}`, `<binary>.{yaml,yml,json}`, `taskfile.{yaml,yml}`,
    and `actions.{yaml,yml}` -- along with the effective binary name. JSON
-   solutions are listed separately so the client attaches them as JSON (not
-   YAML) documents.
-3. Open a `solution.yaml` (or `solution.json`, `taskfile.yaml`, ...) --
-   diagnostics appear inline as you edit.
+   solutions are listed separately so the client attaches them as JSON (not YAML)
+   documents.
+3. Open a `solution.yaml` (or `solution.json`, `taskfile.yaml`, ...) -- diagnostics
+   appear inline and the other features activate as you edit.
 
 The bundled VS Code extension does this automatically: it queries
-`scafctl lsp document-selectors` at startup and builds its document selector
-from the result, so it always matches CLI auto-discovery -- including any
-embedder binary name. Users can add globs for non-standard file names via the
+`scafctl lsp document-selectors` at startup and builds its document selector from
+the result, so it always matches CLI auto-discovery -- including any embedder
+binary name. Users can add globs for non-standard file names via the
 `scafctl.solutionFilePatterns` setting.
 
-Because the server reuses the CLI's `lint` engine, no separate configuration is
-needed to keep editor and CLI diagnostics consistent.
+Because the server reuses the CLI's `lint` engine, schema, and reference index, no
+separate configuration is needed to keep the editor and CLI consistent.
 
 ## What's next
 
-Navigation, rename, hover, completion (structural keys, enum values, and
-CEL/template functions), signature help, and quick fixes cover resolvers,
-actions, functions, and calls. Planned additions extend the same completion
-dispatch to symbol references (after `_.` / `call:` / `dependsOn`).
+The server covers resolvers, actions, functions, and calls across diagnostics,
+navigation, rename, outline, hover, completion (keys, enum values, functions, and
+symbols), signature help, and quick fixes. Candidate future additions -- e.g. code
+lens (run/preview affordances) and generative code actions -- would build on the
+same reference index and cursor resolver; the deliberate exclusions are recorded
+in [Non-goals](#non-goals).
 
 ## See also
 
 - [Linting Tutorial](linting-tutorial.md) -- the diagnostics engine behind the server
-- [Refactoring Tutorial](refactor-tutorial.md) -- the reference index future LSP features will reuse
+- [Refactoring Tutorial](refactor-tutorial.md) -- the reference index and rename engine the server reuses

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -18,8 +18,8 @@ For scafctl solution and action files:
 - **Hover** -- symbol descriptions, provider inputs, CEL/template function
   signatures, and schema field docs.
 - **Completion** -- schema-driven keys and enum values, CEL/template functions
-  (with call snippets), and symbol names after `_.` / `._.` / `call:` / `rslvr:` /
-  `dependsOn`.
+   (with call snippets), and symbol names after `_.` / `._.` / `call:` / `rslvr:` /
+   `dependsOn:`.
 - **Signature Help** -- declared parameters for CEL functions, template functions,
   and a call's `args:`, with the active parameter tracking the cursor.
 - **Quick Fixes** -- one-click fixes (the lightbulb) for auto-fixable lint

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,22 +1,34 @@
 # scafctl for VS Code
 
 Language support for [scafctl](https://github.com/oakwood-commons/scafctl)
-solution files: diagnostics, go-to-definition, find references, and rename --
-powered by the `scafctl lsp` language server.
+solution files -- diagnostics, navigation, rename, outline, hover, completion,
+signature help, and quick fixes -- powered by the `scafctl lsp` language server.
 
 ## Features
 
 For scafctl solution and action files:
 
 - **Diagnostics** -- lint findings appear inline as you edit, matching `scafctl lint`.
-- **Go to Definition** -- jump from a resolver reference to its definition.
-- **Find All References** -- list every use of a resolver.
-- **Rename Symbol** -- rename a resolver and every reference to it in one edit. If
-  a reference cannot be located, the rename is refused rather than applied
-  partially.
+- **Go to Definition / Find All References** -- jump to, or list every use of, a
+  resolver, action, call, or function.
+- **Rename Symbol** -- rename a symbol and every reference to it in one edit. If a
+  reference cannot be located, the rename is refused rather than applied partially.
+- **Outline & Go to Symbol** -- the Outline pane, breadcrumbs, and
+  Cmd/Ctrl+Shift+O list resolvers, actions, calls, and functions.
+- **Hover** -- symbol descriptions, provider inputs, CEL/template function
+  signatures, and schema field docs.
+- **Completion** -- schema-driven keys and enum values, CEL/template functions
+  (with call snippets), and symbol names after `_.` / `._.` / `call:` / `rslvr:` /
+  `dependsOn`.
+- **Signature Help** -- declared parameters for CEL functions, template functions,
+  and a call's `args:`, with the active parameter tracking the cursor.
+- **Quick Fixes** -- one-click fixes (the lightbulb) for auto-fixable lint
+  diagnostics, matching `scafctl lint --fix`.
 
-The feature set grows automatically as the language server gains capabilities --
-the extension is a thin client.
+The extension is a thin client, so the feature set grows automatically as the
+language server gains capabilities. Formatting, folding, semantic tokens, and
+inlay hints are intentionally left to the built-in YAML support (see the language
+server tutorial's non-goals).
 
 ### Which files get language features
 
@@ -69,8 +81,9 @@ the server reports an error.
 By default, solution files keep their built-in `yaml` / `json` language. This is
 deliberate: it preserves other extensions' features on those files -- most
 notably the Red Hat YAML extension's schema validation, autocompletion, and
-formatting -- while the scafctl language server adds its diagnostics and
-navigation on top. This matches how tools like GitHub Actions layer over YAML.
+formatting -- while the scafctl language server adds its diagnostics, navigation,
+and the other language features on top. This matches how tools like GitHub Actions
+layer over YAML.
 
 Enabling `scafctl.language.enable` contributes a dedicated `scafctl` language
 (YAML syntax highlighting, scafctl diagnostics). It does **not** re-associate


### PR DESCRIPTION
## What

Final coherence pass over the LSP/editor documentation now that the full feature
set has landed (#766-#780). Consolidates the incrementally-updated docs into a
coherent tour and records the deliberate **non-goals**.

This is issue #781 (wrap-up; depends on the feature PRs it documents).

## Changes

- **`docs/tutorials/lsp-tutorial.md`** -- rewritten as a complete feature tour with
  a per-feature **"Try:"** step for each shipped capability: diagnostics,
  navigation, rename, outline, hover, completion (keys / enum values / functions /
  symbols), signature help, and quick fixes. Adds a **Non-goals** section
  (formatting, folding ranges, semantic tokens, inlay hints) with the rationale
  for deferring each to the editor's built-in YAML support. Reader-facing: the
  prior MCP-tool reference was removed so the tutorial stands alone.
- **`docs/design/cli.md`** -- the LSP section's capability list expanded from
  diagnostics + navigation to the full shipped set, with a condensed non-goals note.
- **`editors/vscode/README.md`** -- features list updated from the stale
  diagnostics/def/refs/rename to the full set; language-mode note refreshed.

Only shipped features are documented as working; code lens and generative actions
(not implemented) are mentioned only as candidate future work.

## Acceptance criteria

- [x] Every shipped LSP feature is documented with a usage example ("Try:" steps).
- [x] Non-goals section lists the deferred features + rationale.
- [x] Reader-facing docs stand alone (no MCP-only references).

## Notes

- Verified against `pkg/lsp/capabilities.go` `defaultFeatures()` (the 8 shipped
  features) and the trigger characters in the completion/signature-help code.
- Reviewed by `artifact-auditor` (all 3 acceptance criteria pass) and a docs
  quality pass; the em-dashes flagged in `cli.md` are pre-existing lines outside
  this diff (the LSP section and all added lines are ASCII-clean).

Closes #781
