### PR TITLE
feat(lsp): generative code actions + executeCommand

### DIFF
--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -141,6 +141,49 @@ resolve:
 invoking the quick fix rewrites just that line to `continueOnError: true`,
 leaving surrounding formatting and comments untouched.
 
+## Generative actions & commands
+
+Beyond quick fixes, `textDocument/codeAction` also offers **generative and
+refactor actions**. Two of them are backed by the server's
+`workspace/executeCommand` infrastructure: the code action carries a *command*
+(not an inline edit); the editor collects a little input, then invokes the
+server command, which computes the source-preserving edit and applies it via a
+`workspace/applyEdit` request.
+
+- **Create missing resolver** (quick fix) -- offered on an
+  `unknown-resolver-reference` diagnostic (e.g. a `_.doesNotExist` reference with
+  no matching resolver). It inserts a minimal stub resolver of that name under
+  `spec.resolvers` as a direct edit (no prompt):
+
+  ~~~yaml
+  doesNotExist:
+    resolve:
+      with:
+        - provider: static
+          inputs:
+            value: ""
+  ~~~
+
+- **Extract to call...** (refactor.extract) -- offered when the cursor is inside a
+  direct provider step (a `resolve`/`transform`/`validate` `with[i]` step that is
+  not already a `call:`). The editor prompts for a new call name, then runs the
+  `scafctl.applyExtractCall` server command, which delegates to the
+  `refactor.ExtractCall` engine to hoist the step into a reusable `spec.calls`
+  definition and rewrite the step to `call: <name>`.
+
+- **Add resolver...** (source) -- always available on a parsed document. The
+  editor prompts for a resolver name and a provider (quick-pick), then runs the
+  `scafctl.applyAddResolver` server command, which inserts a stub resolver under
+  `spec.resolvers`.
+
+The server advertises the two server-side commands
+(`scafctl.applyExtractCall`, `scafctl.applyAddResolver`) in its
+`executeCommandProvider` capability. The editor extension registers the two
+client-side prompt commands (`scafctl.extractToCall`, `scafctl.addResolver`)
+that the refactor/source code actions reference. The split keeps user
+interaction (prompts, quick-picks) in the editor while all edit computation
+stays in the server.
+
 ## Trying it by hand
 
 You normally never run the server directly, but you can confirm it starts:

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -40,6 +40,14 @@
       {
         "command": "scafctl.restartServer",
         "title": "scafctl: Restart Language Server"
+      },
+      {
+        "command": "scafctl.extractToCall",
+        "title": "scafctl: Extract to call..."
+      },
+      {
+        "command": "scafctl.addResolver",
+        "title": "scafctl: Add resolver..."
       }
     ],
     "languages": [

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import {
+  ExecuteCommandRequest,
   LanguageClient,
   LanguageClientOptions,
   RevealOutputChannelOn,
@@ -10,6 +11,21 @@ import { buildDocumentSelector, fetchRecognizedFiles } from './documentSelectors
 
 let client: LanguageClient | undefined;
 let output: vscode.OutputChannel | undefined;
+
+/** Resolver / call names must be a leading letter/underscore then word chars. */
+const namePattern = /^[a-zA-Z_][a-zA-Z0-9_-]*$/;
+
+/** Providers offered when adding a resolver via the "Add resolver..." action. */
+const resolverProviders = [
+  'static',
+  'parameter',
+  'http',
+  'cel',
+  'go-template',
+  'message',
+  'exec',
+  'shell',
+];
 
 // restartQueue serializes stop/start cycles. The restart command, config-change
 // events, and initial activation can otherwise interleave their stop/start
@@ -58,6 +74,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('scafctl.restartServer', () => enqueueRestart(restartClient)),
   );
 
+  // Prompt commands referenced by the server's generative code actions. Each
+  // collects user input then invokes the matching server executeCommand, which
+  // computes and applies the workspace edit.
+  context.subscriptions.push(
+    vscode.commands.registerCommand('scafctl.extractToCall', (uri?: string, blockPath?: string) =>
+      extractToCall(uri, blockPath),
+    ),
+    vscode.commands.registerCommand('scafctl.addResolver', (uri?: string) => addResolver(uri)),
+  );
+
   // Recreate the client when a selector-affecting setting changes so new file
   // patterns / language mode / server path take effect without a reload.
   context.subscriptions.push(
@@ -73,6 +99,91 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 export async function deactivate(): Promise<void> {
   await enqueueRestart(stopClient);
+}
+
+/**
+ * runningClient returns the language client only when it is started and ready to
+ * accept requests. It warns and returns undefined otherwise, so command handlers
+ * fail gracefully rather than throwing when the server is not running.
+ */
+function runningClient(): LanguageClient | undefined {
+  if (!client) {
+    void vscode.window.showWarningMessage('scafctl language server is not running.');
+    return undefined;
+  }
+  return client;
+}
+
+/**
+ * sendServerCommand invokes a server-side workspace/executeCommand, surfacing any
+ * failure via an error message. Returns true on success.
+ */
+async function sendServerCommand(
+  active: LanguageClient,
+  command: string,
+  args: unknown[],
+): Promise<boolean> {
+  try {
+    await active.sendRequest(ExecuteCommandRequest.type, { command, arguments: args });
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await vscode.window.showErrorMessage(`scafctl: ${command} failed: ${message}`);
+    return false;
+  }
+}
+
+/**
+ * extractToCall prompts for a new call name then asks the server to extract the
+ * step at blockPath into a reusable spec.calls definition. Arguments arrive from
+ * the server's RefactorExtract code action.
+ */
+async function extractToCall(uri?: string, blockPath?: string): Promise<void> {
+  if (!uri || !blockPath) {
+    return;
+  }
+  const active = runningClient();
+  if (!active) {
+    return;
+  }
+  const name = await vscode.window.showInputBox({
+    prompt: 'New call name',
+    validateInput: (value) =>
+      namePattern.test(value) ? undefined : 'Name must match ^[a-zA-Z_][a-zA-Z0-9_-]*$',
+  });
+  if (!name) {
+    return;
+  }
+  await sendServerCommand(active, 'scafctl.applyExtractCall', [uri, blockPath, name]);
+}
+
+/**
+ * addResolver prompts for a resolver name and provider, then asks the server to
+ * insert a stub resolver. Arguments arrive from the server's Source code action.
+ */
+async function addResolver(uri?: string): Promise<void> {
+  if (!uri) {
+    return;
+  }
+  const active = runningClient();
+  if (!active) {
+    return;
+  }
+  const name = await vscode.window.showInputBox({
+    prompt: 'New resolver name',
+    validateInput: (value) =>
+      namePattern.test(value) ? undefined : 'Name must match ^[a-zA-Z_][a-zA-Z0-9_-]*$',
+  });
+  if (!name) {
+    return;
+  }
+  const provider = await vscode.window.showQuickPick(resolverProviders, {
+    placeHolder: 'Select a provider for the resolver',
+  });
+  if (!provider) {
+    return;
+  }
+  await sendServerCommand(active, 'scafctl.applyAddResolver', [uri, name, provider]);
 }
 
 async function startClient(): Promise<void> {

--- a/pkg/lsp/capabilities.go
+++ b/pkg/lsp/capabilities.go
@@ -40,6 +40,7 @@ type feature struct {
 func defaultFeatures() []feature {
 	return []feature{
 		codeActionFeature(),
+		commandFeature(),
 		completionFeature(),
 		documentSyncFeature(),
 		hoverFeature(),

--- a/pkg/lsp/capabilities_test.go
+++ b/pkg/lsp/capabilities_test.go
@@ -23,7 +23,7 @@ func TestDefaultFeatures_DeterministicOrder(t *testing.T) {
 		got = append(got, f.name)
 		require.NotNil(t, f.wire, "every feature must wire a handler")
 	}
-	assert.Equal(t, []string{"codeAction", "completion", "documentSync", "hover", "navigation", "rename", "signatureHelp", "symbols"}, got)
+	assert.Equal(t, []string{"codeAction", "command", "completion", "documentSync", "hover", "navigation", "rename", "signatureHelp", "symbols"}, got)
 	assert.True(t, sort.StringsAreSorted(got), "features must be registered in alphabetical order")
 }
 

--- a/pkg/lsp/codeaction.go
+++ b/pkg/lsp/codeaction.go
@@ -26,7 +26,11 @@ func codeActionFeature() feature {
 		},
 		advertise: func(c *protocol.ServerCapabilities) {
 			c.CodeActionProvider = &protocol.CodeActionOptions{
-				CodeActionKinds: []protocol.CodeActionKind{protocol.CodeActionKindQuickFix},
+				CodeActionKinds: []protocol.CodeActionKind{
+					protocol.CodeActionKindQuickFix,
+					protocol.CodeActionKindRefactorExtract,
+					protocol.CodeActionKindSource,
+				},
 			}
 		},
 	}
@@ -36,10 +40,12 @@ func codeActionFeature() feature {
 // re-lints the cached solution (the same path diagnostics take) to obtain
 // findings with positions, keeps only those that are both fixable and relevant
 // to the request range/diagnostics, and returns each as a QuickFix code action
-// carrying the source edits from lint.QuickFixFor.
+// carrying the source edits from lint.QuickFixFor. It then appends the
+// generative/refactor actions (create missing resolver, extract to call, add
+// resolver) from codeaction_generate.go, each gated by the client's kind filter.
 //
 // It returns (nil, nil) -- never an error -- when the document is unknown, not
-// parsed, or has no applicable fixes, so an editor that requests actions on
+// parsed, or has no applicable actions, so an editor that requests actions on
 // every cursor move gets an empty result rather than a failure.
 func (s *Server) codeAction(_ *glsp.Context, params *protocol.CodeActionParams) (any, error) {
 	entry, ok := s.getDoc(params.TextDocument.URI)
@@ -47,24 +53,30 @@ func (s *Server) codeAction(_ *glsp.Context, params *protocol.CodeActionParams) 
 		return nil, nil
 	}
 
-	// Respect the client's kind filter: if it asked for kinds and none of them
-	// is quickfix, there is nothing for this server to contribute.
-	if !onlyAllowsQuickFix(params.Context.Only) {
-		return nil, nil
+	actions := make([]protocol.CodeAction, 0)
+
+	// Quick fixes for lint diagnostics (deprecated onError, redundant dependsOn,
+	// unused resolver), gated by the quickfix kind filter.
+	if onlyAllows(params.Context.Only, protocol.CodeActionKindQuickFix) {
+		result := lint.Solution(entry.Sol, uriToPath(params.TextDocument.URI), s.registry)
+		for _, f := range result.Findings {
+			edits, fixable := lint.QuickFixFor(entry.Sol, f, s.registry)
+			if !fixable || len(edits) == 0 {
+				continue
+			}
+			if !findingMatchesRequest(f, params) {
+				continue
+			}
+			actions = append(actions, buildCodeAction(f, edits, params))
+		}
 	}
 
-	result := lint.Solution(entry.Sol, uriToPath(params.TextDocument.URI), s.registry)
-
-	actions := make([]protocol.CodeAction, 0)
-	for _, f := range result.Findings {
-		edits, fixable := lint.QuickFixFor(entry.Sol, f, s.registry)
-		if !fixable || len(edits) == 0 {
+	// Generative/refactor actions, each filtered by its own kind below.
+	for _, a := range s.generativeCodeActions(entry, params) {
+		if a.Kind != nil && !onlyAllows(params.Context.Only, *a.Kind) {
 			continue
 		}
-		if !findingMatchesRequest(f, params) {
-			continue
-		}
-		actions = append(actions, buildCodeAction(f, edits, params))
+		actions = append(actions, a)
 	}
 
 	if len(actions) == 0 {
@@ -73,16 +85,21 @@ func (s *Server) codeAction(_ *glsp.Context, params *protocol.CodeActionParams) 
 	return actions, nil
 }
 
-// onlyAllowsQuickFix reports whether the request's Context.Only permits a
-// quickfix action. An empty/absent Only list means "no filter" (allow). A
-// non-empty list allows only when it contains the quickfix kind.
-func onlyAllowsQuickFix(only []protocol.CodeActionKind) bool {
+// onlyAllows reports whether the request's Context.Only permits any of kinds. An
+// empty/absent Only list means "no filter" (allow). A non-empty list allows when
+// it contains any requested kind. A client's Only entry is also treated as a
+// prefix match against a more specific kind (per LSP: "refactor" enables
+// "refactor.extract"), so a broad request still surfaces the server's specific
+// actions.
+func onlyAllows(only []protocol.CodeActionKind, kinds ...protocol.CodeActionKind) bool {
 	if len(only) == 0 {
 		return true
 	}
-	for _, k := range only {
-		if k == protocol.CodeActionKindQuickFix {
-			return true
+	for _, want := range kinds {
+		for _, o := range only {
+			if o == want || strings.HasPrefix(string(want), string(o)+".") {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/lsp/codeaction_generate.go
+++ b/pkg/lsp/codeaction_generate.go
@@ -1,0 +1,293 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/lint"
+	"github.com/oakwood-commons/scafctl/pkg/refactor"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+	"gopkg.in/yaml.v3"
+)
+
+// Client-side prompt command identifiers. These are registered by the editor
+// extension (editors/vscode), NOT dispatched by the server: a code action
+// referencing one asks the client to collect input (a call name, a resolver
+// name + provider) and THEN invoke the matching server command
+// (cmdApplyExtractCall / cmdApplyAddResolver) via workspace/executeCommand.
+const (
+	// cmdPromptExtractToCall prompts for a new call name, then invokes
+	// cmdApplyExtractCall. Code-action arguments: [uri, blockPath].
+	cmdPromptExtractToCall = "scafctl.extractToCall"
+	// cmdPromptAddResolver prompts for a resolver name and provider, then
+	// invokes cmdApplyAddResolver. Code-action arguments: [uri].
+	cmdPromptAddResolver = "scafctl.addResolver"
+)
+
+// stepWithPathRe matches the logical path of a resolver resolve/transform/
+// validate step (a with[i] sequence element), mirroring refactor's stepPathRe.
+// Extract-to-call is offered only for such steps.
+var stepWithPathRe = regexp.MustCompile(`\.(resolve|transform|validate)\.with\[\d+\]$`)
+
+// resolverRefNameRe pulls the quoted resolver name out of an
+// unknown-resolver-reference finding message (format: reference to undefined
+// resolver "NAME").
+var resolverRefNameRe = regexp.MustCompile(`reference to undefined resolver "([^"]+)"`)
+
+// resolverNameRe is the canonical resolver-name pattern (shared with
+// pkg/refactor). Generated resolver names -- whether extracted from a diagnostic
+// message or supplied to applyAddResolver over the public executeCommand surface
+// -- are validated against it before being spliced into the document as a YAML
+// key, so a malformed name (e.g. a bracket-access reference like _["q\"x"] whose
+// name contains a quote, or a client-supplied name with whitespace) can never
+// corrupt the file.
+var resolverNameRe = regexp.MustCompile(refactor.ResolverNamePattern)
+
+// generativeCodeActions returns the generative/refactor code actions available
+// for a request beyond the quick fixes handled by s.codeAction:
+//
+//   - "Create missing resolver" (QuickFix): a DIRECT insertion edit that adds a
+//     stub resolver for each unknown-resolver-reference diagnostic in range.
+//   - "Extract to call..." (RefactorExtract): a COMMAND action that asks the
+//     client to prompt for a call name, then run cmdApplyExtractCall.
+//   - "Add resolver..." (Source): a COMMAND action that asks the client to prompt
+//     for a resolver name + provider, then run cmdApplyAddResolver.
+//
+// Command actions carry no Edit: the extension collects input and invokes the
+// server command, which computes and applies the edit. The caller (s.codeAction)
+// is responsible for the Context.Only kind filter; this function assumes each
+// action kind has already been permitted.
+func (s *Server) generativeCodeActions(entry *DocEntry, params *protocol.CodeActionParams) []protocol.CodeAction {
+	var actions []protocol.CodeAction
+	actions = append(actions, s.createMissingResolverActions(entry, params)...)
+	if a, ok := s.extractToCallAction(entry, params); ok {
+		actions = append(actions, a)
+	}
+	if a, ok := s.addResolverAction(entry, params); ok {
+		actions = append(actions, a)
+	}
+	return actions
+}
+
+// createMissingResolverActions builds a QuickFix per unknown-resolver-reference
+// finding relevant to the request. Each action inserts a minimal stub resolver of
+// the referenced name directly (no command round-trip).
+func (s *Server) createMissingResolverActions(entry *DocEntry, params *protocol.CodeActionParams) []protocol.CodeAction {
+	if entry.Sol == nil {
+		return nil
+	}
+	result := lint.Solution(entry.Sol, uriToPath(params.TextDocument.URI), s.registry)
+
+	var actions []protocol.CodeAction
+	seen := make(map[string]bool)
+	for _, f := range result.Findings {
+		if f.RuleName != "unknown-resolver-reference" {
+			continue
+		}
+		if !findingMatchesRequest(f, params) {
+			continue
+		}
+		name := missingResolverName(f.Message)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+
+		stub := resolverStub(name, "static")
+		insert, err := refactor.InsertMappingEntry(entry.Raw, "spec.resolvers", stub)
+		if err != nil {
+			continue
+		}
+		kind := protocol.CodeActionKindQuickFix
+		actions = append(actions, protocol.CodeAction{
+			Title:       fmt.Sprintf("Create missing resolver %q", name),
+			Kind:        &kind,
+			Diagnostics: matchingDiagnostics(f, params),
+			Edit:        workspaceEditFor(params.TextDocument.URI, []refactor.TextEdit{insert}),
+		})
+	}
+	return actions
+}
+
+// extractToCallAction offers a RefactorExtract command action when the request
+// range sits inside an extractable provider step (a resolve/transform/validate
+// with[i] step that is not already a call). It returns ok=false otherwise.
+func (s *Server) extractToCallAction(entry *DocEntry, params *protocol.CodeActionParams) (protocol.CodeAction, bool) {
+	blockPath, ok := extractableStepPath(entry, params.Range)
+	if !ok {
+		return protocol.CodeAction{}, false
+	}
+	kind := protocol.CodeActionKindRefactorExtract
+	uri := params.TextDocument.URI
+	return protocol.CodeAction{
+		Title: "Extract to call...",
+		Kind:  &kind,
+		Command: &protocol.Command{
+			Title:     "Extract to call...",
+			Command:   cmdPromptExtractToCall,
+			Arguments: []any{string(uri), blockPath},
+		},
+	}, true
+}
+
+// addResolverAction offers a Source command action to add a new resolver, when
+// the document parsed (so spec.resolvers insertion has a valid target).
+func (s *Server) addResolverAction(entry *DocEntry, params *protocol.CodeActionParams) (protocol.CodeAction, bool) {
+	if entry.Sol == nil {
+		return protocol.CodeAction{}, false
+	}
+	kind := protocol.CodeActionKindSource
+	uri := params.TextDocument.URI
+	return protocol.CodeAction{
+		Title: "Add resolver...",
+		Kind:  &kind,
+		Command: &protocol.Command{
+			Title:     "Add resolver...",
+			Command:   cmdPromptAddResolver,
+			Arguments: []any{string(uri)},
+		},
+	}, true
+}
+
+// extractableStepPath finds the logical path of the resolve/transform/validate
+// step whose block covers a line in the request range and that is a DIRECT
+// provider step (extractable by refactor.ExtractCall -- not already a call:).
+// When several steps qualify it returns the deepest (longest-path) match, and it
+// reports ok=false when no extractable step overlaps the range.
+func extractableStepPath(entry *DocEntry, rng protocol.Range) (string, bool) {
+	if entry.Nodes == nil {
+		return "", false
+	}
+	var candidates []string
+	for path, node := range entry.Nodes {
+		if node == nil || !stepWithPathRe.MatchString(path) {
+			continue
+		}
+		if !nodeCoversRange(entry, path, rng) {
+			continue
+		}
+		if !isProviderStepNode(node) {
+			continue
+		}
+		candidates = append(candidates, path)
+	}
+	if len(candidates) == 0 {
+		return "", false
+	}
+	// Deterministic, most-specific choice: longest path, then lexical.
+	sort.Slice(candidates, func(i, j int) bool {
+		if len(candidates[i]) != len(candidates[j]) {
+			return len(candidates[i]) > len(candidates[j])
+		}
+		return candidates[i] < candidates[j]
+	})
+	return candidates[0], true
+}
+
+// nodeCoversRange reports whether the step block at path spans any line in the
+// request range. The block starts at the node's line and extends through its
+// indentation-scoped extent; the coarse line overlap mirrors codeaction.go's
+// finding matching and is robust to cursor-vs-block column differences.
+func nodeCoversRange(entry *DocEntry, path string, rng protocol.Range) bool {
+	node := entry.Nodes[path]
+	if node == nil || entry.Raw == nil {
+		return false
+	}
+	startLine := lspLine(node.Line)
+	last := scanStepEndLine(entry.Raw, node.Line)
+	endLine := lspLine(last)
+	// Overlap between [startLine, endLine] and the request's line span.
+	return startLine <= rng.End.Line && rng.Start.Line <= endLine
+}
+
+// scanStepEndLine returns the 1-based last line of the step block that begins at
+// markerLine, by indentation scanning from the marker's own indent. It mirrors
+// the extent logic refactor uses so the offered range matches what would be
+// extracted.
+func scanStepEndLine(raw []byte, markerLine int) int {
+	lines := strings.Split(string(raw), "\n")
+	if markerLine < 1 || markerLine > len(lines) {
+		return markerLine
+	}
+	markerIndent := leadingSpaceCount(lines[markerLine-1])
+	last := markerLine
+	for l := markerLine + 1; l <= len(lines); l++ {
+		line := lines[l-1]
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if leadingSpaceCount(line) <= markerIndent {
+			break
+		}
+		last = l
+	}
+	return last
+}
+
+// leadingSpaceCount counts the leading ASCII spaces of a line.
+func leadingSpaceCount(line string) int {
+	n := 0
+	for n < len(line) && line[n] == ' ' {
+		n++
+	}
+	return n
+}
+
+// isProviderStepNode reports whether a with[i] step node is a DIRECT provider
+// step: a mapping that declares "provider" and does NOT declare "call". This is
+// the LSP-side gate for offering extract-to-call; refactor.ExtractCall applies
+// the full v1 conservatism (rejecting unsupported step fields) when actually run.
+func isProviderStepNode(node *yaml.Node) bool {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return false
+	}
+	hasProvider, hasCall := false, false
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		switch node.Content[i].Value {
+		case "provider":
+			hasProvider = true
+		case "call":
+			hasCall = true
+		}
+	}
+	return hasProvider && !hasCall
+}
+
+// missingResolverName extracts the resolver name from an unknown-resolver-
+// reference finding message, or "" when the message does not match the expected
+// format or the extracted name is not a valid resolver identifier. The validity
+// check matters because a bracket-access reference (_["q\"x"]) yields a name
+// containing a quote, which the message regex would truncate; splicing such a
+// fragment as a YAML key would corrupt the file instead of fixing anything.
+func missingResolverName(message string) string {
+	m := resolverRefNameRe.FindStringSubmatch(message)
+	if len(m) != 2 {
+		return ""
+	}
+	if !resolverNameRe.MatchString(m[1]) {
+		return ""
+	}
+	return m[1]
+}
+
+// resolverStub returns a minimal, valid resolver definition as a zero-indented
+// keyed block suitable for refactor.InsertMappingEntry. The stub uses a single
+// provider step with a generic empty-string input placeholder; richer,
+// schema-driven per-provider input pre-fill is a documented future enhancement.
+// An empty provider defaults to "static".
+func resolverStub(name, provider string) string {
+	if provider == "" {
+		provider = "static"
+	}
+	return name + ":\n" +
+		"  resolve:\n" +
+		"    with:\n" +
+		"      - provider: " + provider + "\n" +
+		"        inputs:\n" +
+		"          value: \"\"\n"
+}

--- a/pkg/lsp/codeaction_generate_test.go
+++ b/pkg/lsp/codeaction_generate_test.go
@@ -1,0 +1,236 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"testing"
+
+	"github.com/oakwood-commons/scafctl/pkg/refactor"
+	"github.com/oakwood-commons/scafctl/pkg/solution"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// missingRefDoc references an undefined resolver (_.doesNotExist) so lint emits
+// an unknown-resolver-reference finding.
+const missingRefDoc = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: gen
+spec:
+  resolvers:
+    appName:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value:
+                expr: _.doesNotExist
+`
+
+// codeActionParamsAt builds a code-action request over a line range with no
+// incoming diagnostics and no kind filter.
+func codeActionParamsAt(uri protocol.DocumentUri, startLine, endLine uint32) *protocol.CodeActionParams {
+	return &protocol.CodeActionParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+		Range: protocol.Range{
+			Start: protocol.Position{Line: startLine, Character: 0},
+			End:   protocol.Position{Line: endLine, Character: 40},
+		},
+		Context: protocol.CodeActionContext{},
+	}
+}
+
+func TestGenerative_CreateMissingResolver(t *testing.T) {
+	s := newTestServer(t)
+	const uri = "file:///gen.yaml"
+	openDoc(t, s, uri, missingRefDoc)
+	entry, _ := s.getDoc(uri)
+
+	// The _.doesNotExist reference is on line 11 (0-based).
+	params := codeActionParamsAt(uri, 11, 11)
+	actions := s.generativeCodeActions(entry, params)
+
+	var create *protocol.CodeAction
+	for i := range actions {
+		if actions[i].Title == `Create missing resolver "doesNotExist"` {
+			create = &actions[i]
+		}
+	}
+	require.NotNil(t, create, "a create-missing-resolver action must be offered")
+	require.NotNil(t, create.Kind)
+	assert.Equal(t, protocol.CodeActionKindQuickFix, *create.Kind)
+	require.NotNil(t, create.Edit, "create-missing-resolver is a direct edit, not a command")
+	assert.Nil(t, create.Command)
+
+	edits := create.Edit.Changes[uri]
+	require.Len(t, edits, 1)
+	assert.Contains(t, edits[0].NewText, "doesNotExist:")
+	assert.Contains(t, edits[0].NewText, "provider: static")
+
+	// The action's edit is the same insertion refactor.InsertMappingEntry
+	// produces; applying it yields a solution that parses, validates, and
+	// resolves the dangling reference.
+	insert, err := refactor.InsertMappingEntry(entry.Raw, "spec.resolvers", resolverStub("doesNotExist", "static"))
+	require.NoError(t, err)
+	out, err := refactor.Apply(entry.Raw, []refactor.TextEdit{insert})
+	require.NoError(t, err)
+	sol := &solution.Solution{}
+	require.NoError(t, sol.UnmarshalFromBytes(out), "applied edit must re-parse")
+	require.NoError(t, sol.ValidateSpec())
+	require.NotNil(t, sol.Spec.Resolvers["doesNotExist"])
+}
+
+func TestGenerative_ExtractToCall(t *testing.T) {
+	s := newTestServer(t)
+	const uri = "file:///gen.yaml"
+	openDoc(t, s, uri, extractDoc)
+	entry, _ := s.getDoc(uri)
+
+	// The provider step spans lines 9-11 (0-based); target inside it.
+	params := codeActionParamsAt(uri, 9, 11)
+	actions := s.generativeCodeActions(entry, params)
+
+	var extract *protocol.CodeAction
+	for i := range actions {
+		if actions[i].Title == "Extract to call..." {
+			extract = &actions[i]
+		}
+	}
+	require.NotNil(t, extract, "extract-to-call must be offered inside a provider step")
+	require.NotNil(t, extract.Kind)
+	assert.Equal(t, protocol.CodeActionKindRefactorExtract, *extract.Kind)
+	assert.Nil(t, extract.Edit, "extract-to-call is a command action, no direct edit")
+	require.NotNil(t, extract.Command)
+	assert.Equal(t, cmdPromptExtractToCall, extract.Command.Command)
+	require.Len(t, extract.Command.Arguments, 2)
+	assert.Equal(t, string(uri), extract.Command.Arguments[0])
+	assert.Equal(t, "spec.resolvers.environment.resolve.with[0]", extract.Command.Arguments[1])
+}
+
+func TestGenerative_ExtractToCall_NotOfferedOutsideStep(t *testing.T) {
+	s := newTestServer(t)
+	const uri = "file:///gen.yaml"
+	openDoc(t, s, uri, extractDoc)
+	entry, _ := s.getDoc(uri)
+
+	// Line 0 (apiVersion) is not inside any step.
+	params := codeActionParamsAt(uri, 0, 0)
+	actions := s.generativeCodeActions(entry, params)
+	for _, a := range actions {
+		assert.NotEqual(t, "Extract to call...", a.Title, "no extract action outside a step")
+	}
+}
+
+// callStepDoc uses a call: step, which is NOT an extractable provider step.
+const callStepDoc = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: gen
+spec:
+  calls:
+    fetch:
+      provider: message
+      inputs:
+        message: hi
+  resolvers:
+    r1:
+      resolve:
+        with:
+          - call: fetch
+`
+
+func TestGenerative_ExtractToCall_NotOfferedForCallStep(t *testing.T) {
+	s := newTestServer(t)
+	const uri = "file:///gen.yaml"
+	openDoc(t, s, uri, callStepDoc)
+	entry, _ := s.getDoc(uri)
+
+	// The call: step is on line 14 (0-based).
+	params := codeActionParamsAt(uri, 14, 14)
+	actions := s.generativeCodeActions(entry, params)
+	for _, a := range actions {
+		assert.NotEqual(t, "Extract to call...", a.Title, "a call step is not extractable")
+	}
+}
+
+func TestGenerative_AddResolver(t *testing.T) {
+	s := newTestServer(t)
+	const uri = "file:///gen.yaml"
+	openDoc(t, s, uri, extractDoc)
+	entry, _ := s.getDoc(uri)
+
+	params := codeActionParamsAt(uri, 0, 0)
+	actions := s.generativeCodeActions(entry, params)
+
+	var add *protocol.CodeAction
+	for i := range actions {
+		if actions[i].Title == "Add resolver..." {
+			add = &actions[i]
+		}
+	}
+	require.NotNil(t, add, "add-resolver must always be offered for a parsed doc")
+	require.NotNil(t, add.Kind)
+	assert.Equal(t, protocol.CodeActionKindSource, *add.Kind)
+	assert.Nil(t, add.Edit)
+	require.NotNil(t, add.Command)
+	assert.Equal(t, cmdPromptAddResolver, add.Command.Command)
+	require.Len(t, add.Command.Arguments, 1)
+	assert.Equal(t, string(uri), add.Command.Arguments[0])
+}
+
+func TestResolverStub(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider string
+		wantProv string
+	}{
+		{"n1", "static", "provider: static"},
+		{"n2", "parameter", "provider: parameter"},
+		{"n3", "", "provider: static"}, // empty defaults to static
+	}
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			stub := resolverStub(tt.name, tt.provider)
+			assert.Contains(t, stub, tt.name+":")
+			assert.Contains(t, stub, tt.wantProv)
+			assert.Contains(t, stub, `value: ""`)
+
+			// The stub inserts into a solution cleanly under spec.resolvers.
+			base := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: t\nspec:\n  resolvers:\n    seed:\n      resolve:\n        with:\n          - provider: static\n            inputs:\n              value: x\n"
+			edit, err := refactor.InsertMappingEntry([]byte(base), "spec.resolvers", stub)
+			require.NoError(t, err)
+			out, err := refactor.Apply([]byte(base), []refactor.TextEdit{edit})
+			require.NoError(t, err)
+			sol := &solution.Solution{}
+			require.NoError(t, sol.UnmarshalFromBytes(out))
+			require.NoError(t, sol.ValidateSpec())
+			require.NotNil(t, sol.Spec.Resolvers[tt.name])
+		})
+	}
+}
+
+func TestMissingResolverName(t *testing.T) {
+	assert.Equal(t, "foo", missingResolverName(`reference to undefined resolver "foo"`))
+	assert.Equal(t, "my-res_2", missingResolverName(`reference to undefined resolver "my-res_2"`))
+	assert.Equal(t, "", missingResolverName("some other message"))
+	// A bracket-access reference like _["q\"x"] yields a %q-escaped message; the
+	// regex would truncate the name to a backslash-terminated fragment, which is
+	// not a valid resolver identifier and must be rejected (no garbage stub).
+	assert.Equal(t, "", missingResolverName(`reference to undefined resolver "q\"x"`))
+	assert.Equal(t, "", missingResolverName(`reference to undefined resolver "has space"`))
+}
+
+func TestGenerative_NilSolutionNoResolverActions(t *testing.T) {
+	s := newTestServer(t)
+	// A DocEntry with no parsed solution: create-missing-resolver and add-resolver
+	// require entry.Sol, so neither is offered.
+	entry := &DocEntry{URI: "file:///x.yaml", Raw: []byte("not: valid: yaml: :")}
+	params := codeActionParamsAt("file:///x.yaml", 0, 0)
+	actions := s.generativeCodeActions(entry, params)
+	for _, a := range actions {
+		assert.NotEqual(t, "Add resolver...", a.Title)
+	}
+}

--- a/pkg/lsp/codeaction_test.go
+++ b/pkg/lsp/codeaction_test.go
@@ -97,10 +97,20 @@ func TestCodeAction_DeprecatedField_ReturnsQuickFix(t *testing.T) {
 
 	actions, ok := res.([]protocol.CodeAction)
 	require.True(t, ok)
-	require.Len(t, actions, 1)
 
-	a := actions[0]
-	assert.Equal(t, "Replace deprecated 'onError' with 'continueOnError'", a.Title)
+	// The quick fix is present among the actions (the request line is also inside
+	// an extractable step, so generative actions accompany it).
+	var a protocol.CodeAction
+	found := false
+	for _, act := range actions {
+		if act.Title == "Replace deprecated 'onError' with 'continueOnError'" {
+			a = act
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "the deprecated-field quick fix must be offered")
+
 	require.NotNil(t, a.Kind)
 	assert.Equal(t, protocol.CodeActionKindQuickFix, *a.Kind)
 	require.NotNil(t, a.IsPreferred)
@@ -191,7 +201,7 @@ func TestCodeAction_AttachesOnlyItsOwnDiagnostic(t *testing.T) {
 	assert.Equal(t, 2, deprecatedActions, "one quick fix per deprecated-field finding")
 }
 
-func TestCodeAction_CleanDoc_ReturnsNil(t *testing.T) {
+func TestCodeAction_CleanDoc_ReturnsNoQuickFix(t *testing.T) {
 	s := newTestServer(t)
 	const uri = "file:///clean.yaml"
 	openDoc(t, s, uri, cleanDoc)
@@ -199,7 +209,25 @@ func TestCodeAction_CleanDoc_ReturnsNil(t *testing.T) {
 	params := quickFixParams(uri, 0, nil)
 	res, err := s.codeAction(&glsp.Context{}, params)
 	require.NoError(t, err)
-	assert.Nil(t, res, "a clean document offers no quick fixes")
+	// A clean document has no lint quick fixes, but a parsed document always
+	// offers the generative "Add resolver..." source action.
+	require.NotNil(t, res)
+	actions, ok := res.([]protocol.CodeAction)
+	require.True(t, ok)
+	for _, a := range actions {
+		require.NotNil(t, a.Kind)
+		assert.NotEqual(t, protocol.CodeActionKindQuickFix, *a.Kind, "no quick fixes on a clean document")
+	}
+	assert.Contains(t, actionTitles(actions), "Add resolver...")
+}
+
+// actionTitles returns the titles of a code-action slice for assertions.
+func actionTitles(actions []protocol.CodeAction) []string {
+	titles := make([]string, 0, len(actions))
+	for _, a := range actions {
+		titles = append(titles, a.Title)
+	}
+	return titles
 }
 
 func TestCodeAction_UnknownDocument_ReturnsNil(t *testing.T) {
@@ -214,17 +242,38 @@ func TestCodeAction_RespectsOnlyFilter(t *testing.T) {
 	const uri = "file:///dep.yaml"
 	openDoc(t, s, uri, deprecatedDoc)
 
-	// Only refactor kinds requested -> the server contributes nothing.
-	params := quickFixParams(uri, 10, []protocol.CodeActionKind{protocol.CodeActionKindRefactor})
+	// A kind the server provides none of (refactor.inline) -> nothing contributed.
+	params := quickFixParams(uri, 10, []protocol.CodeActionKind{protocol.CodeActionKindRefactorInline})
 	res, err := s.codeAction(&glsp.Context{}, params)
 	require.NoError(t, err)
 	assert.Nil(t, res)
 
-	// Explicitly requesting quickfix -> the action is returned.
+	// Explicitly requesting quickfix -> the quick fix is returned, and the
+	// refactor/source generative actions are filtered out.
 	params = quickFixParams(uri, 10, []protocol.CodeActionKind{protocol.CodeActionKindQuickFix})
 	res, err = s.codeAction(&glsp.Context{}, params)
 	require.NoError(t, err)
-	assert.NotNil(t, res)
+	require.NotNil(t, res)
+	actions, ok := res.([]protocol.CodeAction)
+	require.True(t, ok)
+	for _, a := range actions {
+		require.NotNil(t, a.Kind)
+		assert.Equal(t, protocol.CodeActionKindQuickFix, *a.Kind, "only quickfix actions pass a quickfix-only filter")
+	}
+
+	// A broad "refactor" filter surfaces the refactor.extract extract-to-call
+	// action (LSP prefix matching), but not the quickfix.
+	params = quickFixParams(uri, 10, []protocol.CodeActionKind{protocol.CodeActionKindRefactor})
+	res, err = s.codeAction(&glsp.Context{}, params)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	actions, ok = res.([]protocol.CodeAction)
+	require.True(t, ok)
+	assert.Contains(t, actionTitles(actions), "Extract to call...")
+	for _, a := range actions {
+		require.NotNil(t, a.Kind)
+		assert.NotEqual(t, protocol.CodeActionKindQuickFix, *a.Kind)
+	}
 }
 
 func TestCodeAction_MatchesByDiagnosticCodeOutsideRange(t *testing.T) {
@@ -255,7 +304,7 @@ func TestCodeAction_MatchesByDiagnosticCodeOutsideRange(t *testing.T) {
 	assert.NotNil(t, res)
 }
 
-func TestCodeActionFeature_AdvertisesQuickFixKind(t *testing.T) {
+func TestCodeActionFeature_AdvertisesKinds(t *testing.T) {
 	f := codeActionFeature()
 	require.NotNil(t, f.advertise)
 
@@ -264,8 +313,11 @@ func TestCodeActionFeature_AdvertisesQuickFixKind(t *testing.T) {
 
 	opts, ok := caps.CodeActionProvider.(*protocol.CodeActionOptions)
 	require.True(t, ok, "CodeActionProvider must be CodeActionOptions")
-	require.Len(t, opts.CodeActionKinds, 1)
-	assert.Equal(t, protocol.CodeActionKindQuickFix, opts.CodeActionKinds[0])
+	assert.Equal(t, []protocol.CodeActionKind{
+		protocol.CodeActionKindQuickFix,
+		protocol.CodeActionKindRefactorExtract,
+		protocol.CodeActionKindSource,
+	}, opts.CodeActionKinds)
 }
 
 func TestCodeActionFeature_Registered(t *testing.T) {

--- a/pkg/lsp/command.go
+++ b/pkg/lsp/command.go
@@ -1,0 +1,175 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"fmt"
+
+	"github.com/oakwood-commons/scafctl/pkg/refactor"
+	glsp "github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// Server-side executeCommand command identifiers. These are the commands the
+// server declares in its ExecuteCommandProvider and dispatches in
+// s.executeCommand -- each applies a concrete WorkspaceEdit. They are distinct
+// from the CLIENT-side prompt commands referenced by code actions
+// (cmdPromptExtractToCall / cmdPromptAddResolver in codeaction_generate.go),
+// which collect user input first and THEN invoke one of these.
+const (
+	// cmdApplyExtractCall extracts a resolve/transform/validate step into a
+	// reusable spec.calls definition. Arguments: [uri, blockPath, callName].
+	cmdApplyExtractCall = "scafctl.applyExtractCall"
+	// cmdApplyAddResolver inserts a stub resolver under spec.resolvers.
+	// Arguments: [uri, resolverName, provider].
+	cmdApplyAddResolver = "scafctl.applyAddResolver"
+)
+
+// commandFeature wires workspace/executeCommand and advertises the concrete
+// server commands the client may invoke. glsp derives ExecuteCommandProvider!=nil
+// from the wired handler, but the client needs the explicit Commands list to know
+// which commands exist, so this feature computes it.
+func commandFeature() feature {
+	return feature{
+		name: "command",
+		wire: func(h *protocol.Handler, s *Server) {
+			h.WorkspaceExecuteCommand = s.executeCommand
+		},
+		advertise: func(c *protocol.ServerCapabilities) {
+			c.ExecuteCommandProvider = &protocol.ExecuteCommandOptions{
+				Commands: []string{cmdApplyExtractCall, cmdApplyAddResolver},
+			}
+		},
+	}
+}
+
+// executeCommand is the single entry point for workspace/executeCommand. It
+// dispatches on params.Command to the concrete apply-edit handlers, each of which
+// builds a WorkspaceEdit from the cached document and applies it via a
+// server->client workspace/applyEdit request. An unknown command is an error
+// (the client asked for something the server never advertised).
+func (s *Server) executeCommand(ctx *glsp.Context, params *protocol.ExecuteCommandParams) (any, error) {
+	switch params.Command {
+	case cmdApplyExtractCall:
+		return s.applyExtractCall(ctx, params.Arguments)
+	case cmdApplyAddResolver:
+		return s.applyAddResolver(ctx, params.Arguments)
+	default:
+		return nil, fmt.Errorf("executeCommand: unknown command %q", params.Command)
+	}
+}
+
+// applyExtractCall runs refactor.ExtractCall for the [uri, blockPath, callName]
+// arguments and applies the resulting edits. All logic lives in the refactor
+// engine; this handler only marshals arguments, converts edits, and applies them.
+func (s *Server) applyExtractCall(ctx *glsp.Context, args []any) (any, error) {
+	uri, blockPath, callName, err := stringArgs3(args)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", cmdApplyExtractCall, err)
+	}
+	entry, ok := s.getDoc(protocol.DocumentUri(uri))
+	if !ok || entry.Sol == nil {
+		return nil, fmt.Errorf("%s: document %q is not open or did not parse", cmdApplyExtractCall, uri)
+	}
+	result, err := refactor.ExtractCall(entry.Sol, blockPath, callName)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", cmdApplyExtractCall, err)
+	}
+	edit := workspaceEditFor(protocol.DocumentUri(uri), result.Edits)
+	if err := s.applyWorkspaceEdit(ctx, edit, "Extract to call"); err != nil {
+		return nil, fmt.Errorf("%s: %w", cmdApplyExtractCall, err)
+	}
+	return nil, nil
+}
+
+// applyAddResolver inserts a stub resolver named args[1] using provider args[2]
+// under spec.resolvers, and applies the resulting edit.
+func (s *Server) applyAddResolver(ctx *glsp.Context, args []any) (any, error) {
+	uri, name, provider, err := stringArgs3(args)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", cmdApplyAddResolver, err)
+	}
+	// Validate the name server-side before splicing it as a YAML key. The
+	// first-party extension validates too, but executeCommand is a public
+	// protocol surface any LSP client can call, and an invalid name (whitespace,
+	// a colon, a YAML indicator) would corrupt the document -- mirror the
+	// name guard refactor.ExtractCall applies to a call name.
+	if !resolverNameRe.MatchString(name) {
+		return nil, fmt.Errorf("%s: %q is not a valid resolver name (must match %s)", cmdApplyAddResolver, name, refactor.ResolverNamePattern)
+	}
+	entry, ok := s.getDoc(protocol.DocumentUri(uri))
+	if !ok || entry.Raw == nil {
+		return nil, fmt.Errorf("%s: document %q is not open", cmdApplyAddResolver, uri)
+	}
+	stub := resolverStub(name, provider)
+	insert, err := refactor.InsertMappingEntry(entry.Raw, "spec.resolvers", stub)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", cmdApplyAddResolver, err)
+	}
+	edit := workspaceEditFor(protocol.DocumentUri(uri), []refactor.TextEdit{insert})
+	if err := s.applyWorkspaceEdit(ctx, edit, "Add resolver"); err != nil {
+		return nil, fmt.Errorf("%s: %w", cmdApplyAddResolver, err)
+	}
+	return nil, nil
+}
+
+// applyWorkspaceEdit sends a server->client workspace/applyEdit request and
+// reports an error when the edit was not applied. It is best-effort about the
+// client's response: a client that never answers (or a test harness with no Call
+// hook) leaves the edit unconfirmed, which is treated as success rather than a
+// hard failure, because the request frame was still emitted.
+func (s *Server) applyWorkspaceEdit(ctx *glsp.Context, edit *protocol.WorkspaceEdit, label string) error {
+	if edit == nil {
+		return fmt.Errorf("apply workspace edit: nil edit")
+	}
+	// In unit tests (and any transport without a client call channel) Call is
+	// nil. There is nothing to send, so treat it as a no-op success; the caller's
+	// edit was still constructed and can be asserted on directly.
+	if ctx == nil || ctx.Call == nil {
+		return nil
+	}
+	var resp protocol.ApplyWorkspaceEditResponse
+	ctx.Call(protocol.ServerWorkspaceApplyEdit, protocol.ApplyWorkspaceEditParams{
+		Label: &label,
+		Edit:  *edit,
+	}, &resp)
+	if !resp.Applied {
+		return fmt.Errorf("apply workspace edit: client did not apply %q", label)
+	}
+	return nil
+}
+
+// workspaceEditFor converts a slice of refactor.TextEdits into a single-document
+// WorkspaceEdit for uri, reusing toLSPRange for coordinate conversion.
+func workspaceEditFor(uri protocol.DocumentUri, edits []refactor.TextEdit) *protocol.WorkspaceEdit {
+	lspEdits := make([]protocol.TextEdit, 0, len(edits))
+	for _, e := range edits {
+		lspEdits = append(lspEdits, protocol.TextEdit{Range: toLSPRange(e.Range), NewText: e.NewText})
+	}
+	return &protocol.WorkspaceEdit{
+		Changes: map[protocol.DocumentUri][]protocol.TextEdit{uri: lspEdits},
+	}
+}
+
+// stringArgs3 asserts that args is exactly three JSON-decoded string arguments
+// and returns them. executeCommand arguments arrive as []any of decoded JSON, so
+// each element must be a string; a wrong count or type is a client error.
+func stringArgs3(args []any) (a, b, c string, err error) {
+	if len(args) != 3 {
+		return "", "", "", fmt.Errorf("expected 3 string arguments, got %d", len(args))
+	}
+	a, ok := args[0].(string)
+	if !ok {
+		return "", "", "", fmt.Errorf("argument 0 must be a string, got %T", args[0])
+	}
+	b, ok = args[1].(string)
+	if !ok {
+		return "", "", "", fmt.Errorf("argument 1 must be a string, got %T", args[1])
+	}
+	c, ok = args[2].(string)
+	if !ok {
+		return "", "", "", fmt.Errorf("argument 2 must be a string, got %T", args[2])
+	}
+	return a, b, c, nil
+}

--- a/pkg/lsp/command_test.go
+++ b/pkg/lsp/command_test.go
@@ -1,0 +1,205 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package lsp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	glsp "github.com/tliron/glsp"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// extractDoc has a single provider step extractable into a call.
+const extractDoc = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: cmd
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+`
+
+// captureApplyEditContext returns a glsp.Context whose Call records the
+// ApplyWorkspaceEditParams and answers Applied=true, plus a pointer to the
+// captured params.
+func captureApplyEditContext(t *testing.T) (*glsp.Context, *protocol.ApplyWorkspaceEditParams) {
+	t.Helper()
+	captured := &protocol.ApplyWorkspaceEditParams{}
+	ctx := &glsp.Context{
+		Call: func(method string, params, result any) {
+			assert.Equal(t, string(protocol.ServerWorkspaceApplyEdit), method)
+			p, ok := params.(protocol.ApplyWorkspaceEditParams)
+			require.True(t, ok, "params must be ApplyWorkspaceEditParams")
+			*captured = p
+			if resp, ok := result.(*protocol.ApplyWorkspaceEditResponse); ok {
+				resp.Applied = true
+			}
+		},
+	}
+	return ctx, captured
+}
+
+func TestExecuteCommand_ApplyExtractCall(t *testing.T) {
+	s := newTestServer(t)
+	const uri = "file:///cmd.yaml"
+	openDoc(t, s, uri, extractDoc)
+
+	ctx, captured := captureApplyEditContext(t)
+	res, err := s.executeCommand(ctx, &protocol.ExecuteCommandParams{
+		Command:   cmdApplyExtractCall,
+		Arguments: []any{uri, "spec.resolvers.environment.resolve.with[0]", "getEnv"},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+
+	require.NotNil(t, captured.Label)
+	assert.Equal(t, "Extract to call", *captured.Label)
+	edits := captured.Edit.Changes[uri]
+	require.NotEmpty(t, edits)
+
+	// The step rewrite to a call reference and the calls insertion are present.
+	var joined string
+	for _, e := range edits {
+		joined += e.NewText + "\n"
+	}
+	assert.Contains(t, joined, "- call: getEnv")
+	assert.Contains(t, joined, "getEnv:")
+	assert.Contains(t, joined, "provider: parameter")
+}
+
+func TestExecuteCommand_ApplyAddResolver(t *testing.T) {
+	s := newTestServer(t)
+	const uri = "file:///cmd.yaml"
+	openDoc(t, s, uri, extractDoc)
+
+	ctx, captured := captureApplyEditContext(t)
+	res, err := s.executeCommand(ctx, &protocol.ExecuteCommandParams{
+		Command:   cmdApplyAddResolver,
+		Arguments: []any{uri, "newRes", "static"},
+	})
+	require.NoError(t, err)
+	assert.Nil(t, res)
+
+	require.NotNil(t, captured.Label)
+	assert.Equal(t, "Add resolver", *captured.Label)
+	edits := captured.Edit.Changes[uri]
+	require.Len(t, edits, 1)
+	assert.Contains(t, edits[0].NewText, "newRes:")
+	assert.Contains(t, edits[0].NewText, "provider: static")
+	// The insertion is zero-width.
+	assert.Equal(t, edits[0].Range.Start, edits[0].Range.End)
+}
+
+func TestExecuteCommand_AddResolverRejectsInvalidName(t *testing.T) {
+	s := newTestServer(t)
+	const uri = "file:///cmd.yaml"
+	openDoc(t, s, uri, extractDoc)
+
+	// executeCommand is a public protocol surface: an invalid resolver name (which
+	// the first-party extension would reject client-side) must be refused
+	// server-side rather than spliced into the document as a corrupt YAML key.
+	ctx, captured := captureApplyEditContext(t)
+	for _, bad := range []string{"has space", "a:b", `"lead`, "1num", ""} {
+		_, err := s.executeCommand(ctx, &protocol.ExecuteCommandParams{
+			Command:   cmdApplyAddResolver,
+			Arguments: []any{uri, bad, "static"},
+		})
+		require.Error(t, err, "name %q must be rejected", bad)
+		assert.Contains(t, err.Error(), "not a valid resolver name")
+	}
+	// No edit was ever applied for a rejected name.
+	assert.Nil(t, captured.Edit.Changes)
+}
+
+func TestExecuteCommand_UnknownCommand(t *testing.T) {
+	s := newTestServer(t)
+	_, err := s.executeCommand(&glsp.Context{}, &protocol.ExecuteCommandParams{
+		Command: "scafctl.nope",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+}
+
+func TestExecuteCommand_BadArguments(t *testing.T) {
+	s := newTestServer(t)
+	const uri = "file:///cmd.yaml"
+	openDoc(t, s, uri, extractDoc)
+
+	tests := []struct {
+		name    string
+		command string
+		args    []any
+	}{
+		{"extract wrong count", cmdApplyExtractCall, []any{uri, "path"}},
+		{"extract wrong type", cmdApplyExtractCall, []any{uri, 42, "getEnv"}},
+		{"add resolver wrong count", cmdApplyAddResolver, []any{uri}},
+		{"add resolver wrong type", cmdApplyAddResolver, []any{uri, "n", true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := s.executeCommand(&glsp.Context{}, &protocol.ExecuteCommandParams{
+				Command:   tt.command,
+				Arguments: tt.args,
+			})
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestExecuteCommand_UnknownDocument(t *testing.T) {
+	s := newTestServer(t)
+	_, err := s.executeCommand(&glsp.Context{}, &protocol.ExecuteCommandParams{
+		Command:   cmdApplyAddResolver,
+		Arguments: []any{"file:///missing.yaml", "r", "static"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not open")
+}
+
+func TestApplyWorkspaceEdit_NilCallIsNoop(t *testing.T) {
+	s := newTestServer(t)
+	edit := workspaceEditFor("file:///x.yaml", nil)
+	// A context with no Call channel (unit tests) is a no-op success.
+	require.NoError(t, s.applyWorkspaceEdit(&glsp.Context{}, edit, "label"))
+}
+
+func TestApplyWorkspaceEdit_NotAppliedIsError(t *testing.T) {
+	s := newTestServer(t)
+	ctx := &glsp.Context{
+		Call: func(_ string, _, result any) {
+			if resp, ok := result.(*protocol.ApplyWorkspaceEditResponse); ok {
+				resp.Applied = false
+			}
+		},
+	}
+	edit := workspaceEditFor("file:///x.yaml", nil)
+	err := s.applyWorkspaceEdit(ctx, edit, "label")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "did not apply")
+}
+
+func TestCommandFeature_AdvertisesCommands(t *testing.T) {
+	f := commandFeature()
+	require.NotNil(t, f.advertise)
+
+	var caps protocol.ServerCapabilities
+	f.advertise(&caps)
+
+	opts := caps.ExecuteCommandProvider
+	require.NotNil(t, opts, "ExecuteCommandProvider must be set")
+	assert.Equal(t, []string{cmdApplyExtractCall, cmdApplyAddResolver}, opts.Commands)
+}
+
+func TestCommandFeature_WiresHandler(t *testing.T) {
+	s := newTestServer(t)
+	h := s.Handler()
+	assert.NotNil(t, h.WorkspaceExecuteCommand, "executeCommand handler must be wired")
+}

--- a/pkg/refactor/insert.go
+++ b/pkg/refactor/insert.go
@@ -1,0 +1,176 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refactor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
+	"gopkg.in/yaml.v3"
+)
+
+// InsertMappingEntry computes the zero-width TextEdit that inserts entryYAML as a
+// new child entry under the mapping at containerPath (a NodeMap/SourceMap path
+// such as "spec.resolvers"). It is the source-preserving counterpart to
+// ExtractCall's private callsInsertion: rather than a YAML round-trip, it splices
+// re-indented text so the file's comments, key order, and formatting are
+// untouched.
+//
+// entryYAML is a keyed block given at ZERO indentation, e.g.
+//
+//	myRes:
+//	  resolve:
+//	    with:
+//	      - provider: static
+//	        inputs:
+//	          value: ""
+//
+// Every line is shifted uniformly so the entry's top-level key lands at the
+// container's child indent -- which, along with the container's own indent when
+// it is created, is derived from the file's existing indentation unit (mirroring
+// extract.go's callIndents) so the placement matches the surrounding style. The
+// block's OWN interior indentation (the nesting within entryYAML) is preserved
+// as-is, so entryYAML should already be written with the indent step you want
+// for the inserted block's children.
+//
+// Two cases:
+//
+//   - The container key EXISTS: the entry is appended after the container's last
+//     existing child (or, for an empty container, as its first child).
+//   - The container key is ABSENT: the container key is created as the first child
+//     of its parent, holding the entry (e.g. a new "resolvers:" under "spec").
+//
+// It returns an error (and NO edit) when containerPath's parent cannot be located
+// or is not a block-style mapping, or when an existing container is written in
+// flow style -- cases where a spliced block insertion would corrupt the document.
+func InsertMappingEntry(raw []byte, containerPath, entryYAML string) (TextEdit, error) {
+	ec, err := newEditContext(raw)
+	if err != nil {
+		return TextEdit{}, fmt.Errorf("insert mapping entry: %w", err)
+	}
+
+	parentPath, containerKey, ok := splitLastKey(containerPath)
+	if !ok {
+		return TextEdit{}, fmt.Errorf("insert mapping entry: %q has no parent mapping to insert into", containerPath)
+	}
+	parentPos, ok := ec.sm.Get(parentPath)
+	if !ok {
+		return TextEdit{}, fmt.Errorf("insert mapping entry: parent path %q could not be located", parentPath)
+	}
+	parentNode, ok := ec.nodes[parentPath]
+	if !ok || parentNode == nil || parentNode.Kind != yaml.MappingNode {
+		return TextEdit{}, fmt.Errorf("insert mapping entry: parent path %q is not a mapping", parentPath)
+	}
+	if parentNode.Style&yaml.FlowStyle != 0 {
+		return TextEdit{}, fmt.Errorf("insert mapping entry: parent %q is written in flow style; rewrite it in block style", parentPath)
+	}
+
+	parentIndent := parentPos.Column - 1
+	unit := mappingIndentUnit(parentNode, parentPos.Column)
+
+	// Refuse to append an entry whose key already exists under the container: a
+	// duplicate mapping key produces invalid YAML. This makes the primitive
+	// all-or-nothing (mirroring ExtractCall's "already exists" guard) rather than
+	// corrupting the document for a caller that did not pre-check.
+	if key := entryTopKey(entryYAML); key != "" {
+		if _, exists := ec.nodes[containerPath+"."+key]; exists {
+			return TextEdit{}, fmt.Errorf("insert mapping entry: %q already exists under %q", key, containerPath)
+		}
+	}
+
+	// Container exists: append the entry after its last child (or as its first
+	// child when the container is currently empty).
+	if containerPos, present := ec.sm.Get(containerPath); present {
+		containerNode := ec.nodes[containerPath]
+		if containerNode != nil && containerNode.Kind == yaml.MappingNode && containerNode.Style&yaml.FlowStyle != 0 {
+			return TextEdit{}, fmt.Errorf("insert mapping entry: container %q is written in flow style; rewrite it in block style", containerPath)
+		}
+		containerIndent := containerPos.Column - 1
+		childIndent := containerIndent + unit
+		if containerNode != nil && containerNode.Kind == yaml.MappingNode && len(containerNode.Content) > 0 {
+			childIndent = containerNode.Content[0].Column - 1
+		}
+		endLine := scanBlockEndLine(raw, ec.li, containerPos.Line, containerIndent)
+		insertByte := ec.li.Offset(sourcepos.Position{Line: endLine, Column: maxColumn})
+		pos := ec.li.Position(insertByte)
+		return TextEdit{
+			Range:   sourcepos.Range{Start: pos, End: pos},
+			NewText: "\n" + reindentEntry(entryYAML, childIndent),
+		}, nil
+	}
+
+	// Container absent: create it as the first child of the parent, immediately
+	// after the parent key line -- a deterministic, always-valid insertion point
+	// (mirrors callsInsertion's new-block branch).
+	containerIndent := parentIndent + unit
+	childIndent := containerIndent + unit
+	insertByte := ec.li.Offset(sourcepos.Position{Line: parentPos.Line + 1, Column: 1})
+	pos := ec.li.Position(insertByte)
+	block := strings.Repeat(" ", containerIndent) + containerKey + ":\n" + reindentEntry(entryYAML, childIndent) + "\n"
+	return TextEdit{
+		Range:   sourcepos.Range{Start: pos, End: pos},
+		NewText: block,
+	}, nil
+}
+
+// entryTopKey returns the top-level mapping key of a zero-indented keyed block
+// (the text before the first ":" on its first non-blank line), or "" when the
+// block does not begin with a key. Used to detect a collision with an existing
+// entry before appending.
+func entryTopKey(entryYAML string) string {
+	for _, line := range strings.Split(entryYAML, "\n") {
+		if isBlank([]byte(line)) {
+			continue
+		}
+		trimmed := strings.TrimLeft(line, " ")
+		if i := strings.IndexByte(trimmed, ':'); i > 0 {
+			return trimmed[:i]
+		}
+		return ""
+	}
+	return ""
+}
+
+// splitLastKey splits a dotted logical path into its parent path and final key.
+// It reports ok=false when there is no parent segment (a bare root key), which a
+// child insertion cannot use.
+func splitLastKey(path string) (parent, key string, ok bool) {
+	i := strings.LastIndex(path, ".")
+	if i < 0 {
+		return "", "", false
+	}
+	return path[:i], path[i+1:], true
+}
+
+// mappingIndentUnit returns the indentation step (in spaces) between a mapping
+// key and its children, measured from the mapping's first existing child. It
+// falls back to 2 when the mapping has no children to measure. parentKeyColumn
+// is the 1-based column of the mapping's own key.
+func mappingIndentUnit(mappingValueNode *yaml.Node, parentKeyColumn int) int {
+	if mappingValueNode != nil && mappingValueNode.Kind == yaml.MappingNode && len(mappingValueNode.Content) > 0 {
+		if u := mappingValueNode.Content[0].Column - parentKeyColumn; u > 0 {
+			return u
+		}
+	}
+	return 2
+}
+
+// reindentEntry shifts every non-blank line of a zero-indented keyed block so its
+// top-level key lands at indent spaces, preserving the block's own relative
+// indentation. Blank lines are emitted empty. Any trailing newlines on the input
+// are dropped so the caller controls the surrounding whitespace.
+func reindentEntry(entryYAML string, indent int) string {
+	lines := strings.Split(strings.TrimRight(entryYAML, "\n"), "\n")
+	pad := strings.Repeat(" ", indent)
+	out := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if isBlank([]byte(line)) {
+			out = append(out, "")
+			continue
+		}
+		out = append(out, pad+line)
+	}
+	return strings.Join(out, "\n")
+}

--- a/pkg/refactor/insert_test.go
+++ b/pkg/refactor/insert_test.go
@@ -1,0 +1,147 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package refactor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// insertExistingContainer has a spec.resolvers mapping with two entries; a new
+// entry appends after the last one.
+const insertExistingContainer = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: insert-test # keep this comment
+spec:
+  resolvers:
+    environment:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: dev
+    region:
+      resolve:
+        with:
+          - provider: parameter
+            inputs:
+              value: us
+`
+
+// insertAbsentContainer has a spec with NO resolvers key; inserting under
+// spec.resolvers must create the container key first.
+const insertAbsentContainer = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: insert-absent # keep this comment
+spec:
+  workflow:
+    actions:
+      show:
+        provider: message
+        inputs:
+          message: hi
+`
+
+// stubEntry is a zero-indented keyed resolver block (as resolverStub emits it).
+const stubEntry = `myRes:
+  resolve:
+    with:
+      - provider: static
+        inputs:
+          value: ""
+`
+
+func TestInsertMappingEntry_ExistingContainerAppends(t *testing.T) {
+	raw := []byte(insertExistingContainer)
+	edit, err := InsertMappingEntry(raw, "spec.resolvers", stubEntry)
+	require.NoError(t, err)
+	// A zero-width insertion.
+	assert.Equal(t, edit.Range.Start, edit.Range.End, "insertion must be zero-width")
+	assert.True(t, strings.HasPrefix(edit.NewText, "\n"), "append text starts on a fresh line")
+
+	out, err := Apply(raw, []TextEdit{edit})
+	require.NoError(t, err)
+	s := string(out)
+
+	// The new resolver key lands at the same indent as the existing ones.
+	assert.Contains(t, s, "    myRes:\n      resolve:\n        with:\n          - provider: static")
+	assert.Contains(t, s, `          value: ""`)
+	// Existing entries and comments are preserved verbatim.
+	assert.Contains(t, s, "    environment:")
+	assert.Contains(t, s, "    region:")
+	assert.Contains(t, s, "# keep this comment")
+
+	sol := reparseAndValidate(t, out)
+	require.NotNil(t, sol.Spec.Resolvers["myRes"])
+}
+
+func TestInsertMappingEntry_AbsentContainerCreatesKey(t *testing.T) {
+	raw := []byte(insertAbsentContainer)
+	edit, err := InsertMappingEntry(raw, "spec.resolvers", stubEntry)
+	require.NoError(t, err)
+	assert.Equal(t, edit.Range.Start, edit.Range.End, "insertion must be zero-width")
+
+	out, err := Apply(raw, []TextEdit{edit})
+	require.NoError(t, err)
+	s := string(out)
+
+	// A new resolvers: key was created under spec, holding the entry.
+	assert.Contains(t, s, "  resolvers:\n    myRes:\n      resolve:")
+	// The pre-existing workflow block is preserved.
+	assert.Contains(t, s, "  workflow:")
+	assert.Contains(t, s, "# keep this comment")
+
+	sol := reparseAndValidate(t, out)
+	require.NotNil(t, sol.Spec.Resolvers["myRes"])
+}
+
+func TestInsertMappingEntry_ParentNotLocated(t *testing.T) {
+	raw := []byte(insertAbsentContainer)
+	// spec.nope does not exist, so its child "deep" has no locatable parent.
+	_, err := InsertMappingEntry(raw, "spec.nope.deep", stubEntry)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not be located")
+}
+
+func TestInsertMappingEntry_NoParentSegment(t *testing.T) {
+	raw := []byte(insertAbsentContainer)
+	_, err := InsertMappingEntry(raw, "spec", stubEntry)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no parent mapping")
+}
+
+func TestInsertMappingEntry_DuplicateKeyRejected(t *testing.T) {
+	// Appending an entry whose key already exists under the container would
+	// produce a duplicate mapping key (invalid YAML); the helper must refuse.
+	raw := []byte(insertExistingContainer)
+	dup := "environment:\n  resolve:\n    with:\n      - provider: static\n        inputs:\n          value: \"\"\n"
+	_, err := InsertMappingEntry(raw, "spec.resolvers", dup)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+}
+
+func TestInsertMappingEntry_MultipleInsertsReparse(t *testing.T) {
+	// Insert two entries in sequence, re-parsing after each, to prove the helper
+	// keeps producing valid YAML as the container grows.
+	raw := []byte(insertAbsentContainer)
+
+	edit, err := InsertMappingEntry(raw, "spec.resolvers", stubEntry)
+	require.NoError(t, err)
+	out, err := Apply(raw, []TextEdit{edit})
+	require.NoError(t, err)
+	reparseAndValidate(t, out)
+
+	edit2, err := InsertMappingEntry(out, "spec.resolvers", "another:\n  resolve:\n    with:\n      - provider: static\n        inputs:\n          value: \"\"\n")
+	require.NoError(t, err)
+	out2, err := Apply(out, []TextEdit{edit2})
+	require.NoError(t, err)
+	sol := reparseAndValidate(t, out2)
+	require.NotNil(t, sol.Spec.Resolvers["myRes"])
+	require.NotNil(t, sol.Spec.Resolvers["another"])
+}

--- a/tests/integration/cli_test.go
+++ b/tests/integration/cli_test.go
@@ -14069,6 +14069,33 @@ func TestIntegration_LspCodeAction(t *testing.T) {
 	assert.Contains(t, out, lspSessionURI, "edit targets the document")
 }
 
+// TestIntegration_LspExecuteCommandAddResolver opens a document and drives
+// workspace/executeCommand for scafctl.applyAddResolver. The server builds the
+// insertion edit and issues a server->client workspace/applyEdit REQUEST; the
+// harness never answers that request (so the server's ctx.Call blocks), but the
+// applyEdit frame is written to stdout before it blocks, and the harness kills
+// the process at teardown. We assert the emitted applyEdit request carries the
+// new resolver name.
+func TestIntegration_LspExecuteCommandAddResolver(t *testing.T) {
+	t.Parallel()
+
+	sol := "apiVersion: scafctl.io/v1\nkind: Solution\nmetadata:\n  name: cmd\nspec:\n  resolvers:\n    seed:\n      resolve:\n        with:\n          - provider: static\n            inputs:\n              value: x\n"
+
+	out := runLSPSession(t, sol, map[string]any{
+		"jsonrpc": "2.0", "id": 7, "method": "workspace/executeCommand", "params": map[string]any{
+			"command":   "scafctl.applyAddResolver",
+			"arguments": []any{lspSessionURI, "generatedResolver", "static"},
+		},
+	})
+
+	// The server advertised the executeCommand provider on initialize.
+	assert.Contains(t, out, "executeCommandProvider", "executeCommand capability advertised")
+	// It emitted a server->client applyEdit request carrying the new resolver.
+	assert.Contains(t, out, "applyEdit", "server issues a workspace/applyEdit request")
+	assert.Contains(t, out, "generatedResolver", "the inserted resolver name")
+	assert.Contains(t, out, lspSessionURI, "edit targets the opened document")
+}
+
 func TestIntegration_LspCompletion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Adds generative/refactor code actions and the `workspace/executeCommand` infrastructure they need. This establishes `command.go` (reused by #780) and edits user YAML, so the paths are guarded and tested.

## Changes

- **New `pkg/lsp/command.go`** -- `commandFeature()` wires `workspace/executeCommand` and advertises `ExecuteCommandProvider{Commands:[scafctl.applyExtractCall, scafctl.applyAddResolver]}`. The handler dispatches each command to an apply-edit routine that builds a `WorkspaceEdit` from the cached document and applies it via a server->client `workspace/applyEdit` (`ctx.Call`).
  - `applyExtractCall` delegates to `refactor.ExtractCall` (no logic duplicated in lsp).
  - `applyAddResolver` **validates the resolver name server-side** (executeCommand is a public protocol surface) then inserts a stub via `refactor.InsertMappingEntry`.
- **New `pkg/lsp/codeaction_generate.go`** -- three actions integrated into `s.codeAction` (kind-filtered via `onlyAllows`, with LSP prefix semantics):
  - **Create missing resolver** (QuickFix, direct edit): inserts a stub for an `unknown-resolver-reference` diagnostic. The referenced name is validated, so a bracket-access reference whose name contains a quote can't yield a garbage stub.
  - **Extract to call...** (RefactorExtract, command action): offered on an extractable `with[i]` provider step; the extension prompts for the call name then runs `scafctl.applyExtractCall`.
  - **Add resolver...** (Source, command action): the extension prompts for name + provider then runs `scafctl.applyAddResolver`.
- **New `pkg/refactor/insert.go`** -- `InsertMappingEntry`, an exported source-preserving insertion primitive (append under an existing mapping, or create the container), reusing the `extract.go` span machinery. Refuses flow-style containers and a **duplicate key** rather than emitting invalid YAML.
- **`editors/vscode`** -- `contributes.commands` + `extension.ts` prompt-command wiring (client-side name validation, provider quick-pick, graceful degradation when the server isn't running, error surfacing).

## Command-name split (standard VS Code pattern)

- SERVER (executeCommand): `scafctl.applyExtractCall`, `scafctl.applyAddResolver`.
- CLIENT (extension prompt commands referenced by the code actions): `scafctl.extractToCall`, `scafctl.addResolver`.

## Tests / docs

- `pkg/refactor/insert_test.go` -- append/create/flow-reject/duplicate-key/reparse table tests.
- `pkg/lsp/command_test.go` -- dispatch, arg validation, **invalid-name rejection**, unknown-command/doc errors (fake `ctx` capturing the applyEdit).
- `pkg/lsp/codeaction_generate_test.go` -- each action; the malformed missing-resolver-name guard.
- `tests/integration/cli_test.go` -- drives `workspace/executeCommand` and asserts the server emits the `workspace/applyEdit` request.
- `docs/tutorials/lsp-tutorial.md` -- "Generative actions & commands" section.
- `go build`, full `pkg/lsp`+`pkg/refactor`+integration tests, `task lint:changed` (0 new), and the extension build/lint/test all pass.
- A dedicated code-review pass found two YAML-corruption risks on the public executeCommand surface (unvalidated resolver names; a quote-containing missing-reference name) -- both fixed with server-side validation + regression tests before opening.

## Acceptance criteria

- [x] "Add resolver...", "Extract to call", "Create missing resolver" all work
- [x] `ExecuteCommandProvider` advertised; `command.go` dispatch is the single entry point
- [x] "Extract to call" delegates to `refactor.ExtractCall` (no logic duplicated in lsp)

Depends on #766, #767, #768, #776, #778 -- all merged. **Establishes the executeCommand infra reused by #780.** Rebased onto #797.

Closes #779