### PR TITLE
fix(lsp): scope action dependsOn completion to its workflow section

### DIFF
--- a/docs/tutorials/lsp-tutorial.md
+++ b/docs/tutorials/lsp-tutorial.md
@@ -110,7 +110,11 @@ index:
   it offers **resolver** names (and `__actions.` / `.__actions.` offers **action**
   names); a `call:` value offers **call** names; a `rslvr:` value offers
   **resolver** names; and a `dependsOn:` list item offers **resolver** names (in a
-  resolver) or **action** names (in an action). Only defined symbols are suggested.
+  resolver) or **action** names (in an action). An action `dependsOn` is scoped to
+  the action's own workflow section -- an `actions` entry offers only `actions`
+  names and a `finally` entry only `finally` names -- matching what validation
+  allows, so a suggestion never produces a cross-section error. Only defined
+  symbols are suggested.
 
 Completion is triggered on `.`, `:`, and space. Structural key, enum-value, and
 CEL/template function completion work mid-edit even while the document does not
@@ -197,7 +201,7 @@ on the same file and keeps the server focused on what only scafctl can know.
 
 Beyond quick fixes, `textDocument/codeAction` also offers **generative and
 refactor actions**. Two of them are backed by the server's
-`workspace/executeCommand` infrastructure: the code action carries a *command*
+`workspace/executeCommand` infrastructure: the code action carries a _command_
 (not an inline edit); the editor collects a little input, then invokes the
 server command, which computes the source-preserving edit and applies it via a
 `workspace/applyEdit` request.

--- a/pkg/action/types.go
+++ b/pkg/action/types.go
@@ -32,6 +32,35 @@ type Workflow struct {
 	ResultSchemaMode ResultSchemaMode `json:"resultSchemaMode,omitempty" yaml:"resultSchemaMode,omitempty" doc:"Default result schema validation mode" maxLength:"16" example:"error" default:"error"`
 }
 
+// Workflow section identifiers. A dependsOn entry may only reference actions in
+// its OWN section (Rules 5 & 6 in validateDependsOn); these name the two.
+const (
+	// SectionActions is the regular workflow.actions section.
+	SectionActions = "actions"
+	// SectionFinally is the workflow.finally section (cleanup actions).
+	SectionFinally = "finally"
+)
+
+// SectionActions returns the actions in the named workflow section -- the exact
+// set a dependsOn entry declared in that section may reference. It is the single
+// source of truth for the same-section dependsOn constraint, shared by
+// validation (validateDependsOn) and editor tooling (dependsOn completion) so
+// the set of *suggested* targets can never drift from the set of *valid* ones.
+// An unknown section yields nil.
+func (w *Workflow) SectionActions(section string) map[string]*Action {
+	if w == nil {
+		return nil
+	}
+	switch section {
+	case SectionActions:
+		return w.Actions
+	case SectionFinally:
+		return w.Finally
+	default:
+		return nil
+	}
+}
+
 // Action represents a single action definition.
 // Actions perform side-effect operations using providers and can depend on
 // other actions for sequencing and data flow.

--- a/pkg/action/types_test.go
+++ b/pkg/action/types_test.go
@@ -323,3 +323,25 @@ func TestFingerprintScope_OrDefault(t *testing.T) {
 	assert.Equal(t, FingerprintScopeAll, FingerprintScopeAll.OrDefault())
 	assert.Equal(t, FingerprintScopeFiles, FingerprintScopeFiles.OrDefault())
 }
+
+func TestWorkflow_SectionActions(t *testing.T) {
+	build := &Action{Name: "build"}
+	cleanup := &Action{Name: "cleanup"}
+	w := &Workflow{
+		Actions: map[string]*Action{"build": build},
+		Finally: map[string]*Action{"cleanup": cleanup},
+	}
+
+	assert.Equal(t, w.Actions, w.SectionActions(SectionActions), "actions section returns the actions map")
+	assert.Equal(t, w.Finally, w.SectionActions(SectionFinally), "finally section returns the finally map")
+	assert.Nil(t, w.SectionActions("bogus"), "unknown section yields nil")
+
+	// A dependsOn entry is valid only within its own section.
+	_, mainHasCleanup := w.SectionActions(SectionActions)["cleanup"]
+	assert.False(t, mainHasCleanup, "a finally action is not a valid main-section dependsOn target")
+	_, finallyHasBuild := w.SectionActions(SectionFinally)["build"]
+	assert.False(t, finallyHasBuild, "a main action is not a valid finally-section dependsOn target")
+
+	var nilWorkflow *Workflow
+	assert.Nil(t, nilWorkflow.SectionActions(SectionActions), "nil workflow is safe")
+}

--- a/pkg/action/validation.go
+++ b/pkg/action/validation.go
@@ -433,15 +433,10 @@ func validateExclusive(action *Action, section string, workflow *Workflow, errs 
 // validateDependsOn validates action dependencies.
 func validateDependsOn(action *Action, section string, workflow *Workflow, errs *AggregatedValidationError) {
 	for _, dep := range action.DependsOn {
-		var validActions map[string]*Action
-
-		// Rule 5 & 6: dependsOn must reference actions in the same section
-		switch section {
-		case "actions":
-			validActions = workflow.Actions
-		case "finally":
-			validActions = workflow.Finally
-		}
+		// Rule 5 & 6: dependsOn must reference actions in the same section. The
+		// valid-target set is derived from the shared source of truth so it stays
+		// in lockstep with dependsOn completion.
+		validActions := workflow.SectionActions(section)
 
 		if _, exists := validActions[dep]; !exists {
 			msg := fmt.Sprintf("dependency %q not found in %s section", dep, section)

--- a/pkg/lsp/completion_symbols.go
+++ b/pkg/lsp/completion_symbols.go
@@ -123,6 +123,22 @@ func workflowSectionFromPath(path string) (string, bool) {
 	}
 }
 
+// refContentColumn returns the column at which the refindex records a
+// whole-scalar reference for value node n -- the scalar's CONTENT start, which
+// for a quoted scalar is one column past the opening quote (mirroring
+// refindex's contentStart). It is why dependsOnPathAt must not compare against
+// n.Column directly: a quoted dependsOn entry like `- "alphaMain"` has its
+// reference at n.Column+1, so an exact-column match on n.Column would miss it
+// and the swap case would fall back to the cross-section index. dependsOn values
+// are always plain or quoted flow scalars, so only the quote shift applies;
+// block (literal/folded) styles do not occur for an action-name reference.
+func refContentColumn(n *yaml.Node) int {
+	if n.Style&(yaml.DoubleQuotedStyle|yaml.SingleQuotedStyle) != 0 {
+		return n.Column + 1
+	}
+	return n.Column
+}
+
 // dependsOnPathAt returns the logical path of the action dependsOn item whose
 // value node starts at pos, or ok=false when no such item is there. It maps a
 // located reference's position back to its dependsOn path so the swap case can be
@@ -132,7 +148,7 @@ func dependsOnPathAt(entry *DocEntry, pos sourcepos.Position) (string, bool) {
 		return "", false
 	}
 	for path, n := range entry.Nodes {
-		if n == nil || n.Line != pos.Line || n.Column != pos.Column {
+		if n == nil || n.Line != pos.Line || refContentColumn(n) != pos.Column {
 			continue
 		}
 		base := stripIndex(path)

--- a/pkg/lsp/completion_symbols.go
+++ b/pkg/lsp/completion_symbols.go
@@ -6,7 +6,9 @@ package lsp
 import (
 	"strings"
 
+	"github.com/oakwood-commons/scafctl/pkg/action"
 	"github.com/oakwood-commons/scafctl/pkg/refindex"
+	"github.com/oakwood-commons/scafctl/pkg/sourcepos"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 	"gopkg.in/yaml.v3"
 )
@@ -36,11 +38,109 @@ func symbolCompletions(entry *DocEntry, pos protocol.Position, cc CursorContext)
 	if entry == nil || entry.Index == nil {
 		return nil
 	}
+	// An action's dependsOn is SECTION-SCOPED: a dependsOn entry may only
+	// reference actions in its own workflow section (actions vs finally), the same
+	// rule validateDependsOn enforces. Offering the unified action index here would
+	// suggest cross-section names the validator immediately rejects, so scope the
+	// candidates to the owning section (single source of truth: Workflow.SectionActions).
+	// This runs before the generic index path, which handles every other symbol.
+	if names, partial, ok := actionDependsOnCandidates(entry, cc); ok {
+		return completionItemsFromNames(names, refindex.SymbolAction, partial)
+	}
 	kind, partial, ok := symbolCompletionTarget(entry, pos, cc)
 	if !ok {
 		return nil
 	}
 	return symbolNameItems(entry.Index, kind, partial)
+}
+
+// actionDependsOnCandidates reports whether the cursor is on an action's
+// dependsOn entry and, if so, returns the same-section action names it may
+// reference (from the shared Workflow.SectionActions source of truth) plus the
+// partial token typed so far. It handles both the typing case (a CursorNone
+// dependsOn item, classified from cc.Path) and the swap case (a CursorSymbolRef
+// on a complete action name, classified from the reference's position). Resolver
+// dependsOn and non-dependsOn action references are left to the generic path.
+func actionDependsOnCandidates(entry *DocEntry, cc CursorContext) ([]string, string, bool) {
+	base, partial, ok := actionDependsOnBase(entry, cc)
+	if !ok {
+		return nil, "", false
+	}
+	section, ok := workflowSectionFromPath(base)
+	if !ok {
+		return nil, "", false
+	}
+	if entry.Sol == nil {
+		return nil, "", false
+	}
+	names := make([]string, 0, len(entry.Sol.Spec.Workflow.SectionActions(section)))
+	for name := range entry.Sol.Spec.Workflow.SectionActions(section) {
+		names = append(names, name)
+	}
+	return names, partial, true
+}
+
+// actionDependsOnBase returns the owning dependsOn path (e.g.
+// "spec.workflow.finally.notify.dependsOn") and the partial token when the cursor
+// is on an ACTION dependsOn entry. It reports ok=false for a resolver dependsOn,
+// a non-dependsOn position, or when the path cannot be determined.
+func actionDependsOnBase(entry *DocEntry, cc CursorContext) (string, string, bool) {
+	// Typing case: a partial dependsOn item is CursorNone with the item path.
+	if base := stripIndex(cc.Path); base != "" && lastSegment(base) == "dependsOn" && isActionDependsOnPath(base) {
+		return base, nodeValue(cc.Node), true
+	}
+	// Swap case: parked on a complete action name that the index located as a
+	// reference. Derive the owning dependsOn path from the reference position.
+	if cc.Kind == CursorSymbolRef && cc.Ref != nil && cc.Ref.Symbol.Kind == refindex.SymbolAction {
+		if base, ok := dependsOnPathAt(entry, cc.Ref.Range.Start); ok {
+			// Empty partial for a defined name (offer all in-section to swap);
+			// otherwise keep it as the filter prefix.
+			if _, defined := entry.Index.Definition(refindex.SymbolAction, cc.Ref.Symbol.Name); defined {
+				return base, "", true
+			}
+			return base, cc.Ref.Symbol.Name, true
+		}
+	}
+	return "", "", false
+}
+
+// isActionDependsOnPath reports whether a dependsOn path belongs to a workflow
+// action (either section) rather than a resolver.
+func isActionDependsOnPath(path string) bool {
+	return strings.Contains(path, ".workflow.actions.") || strings.Contains(path, ".workflow.finally.")
+}
+
+// workflowSectionFromPath returns the workflow section ("actions" or "finally")
+// a path lies within, or ok=false when it is in neither.
+func workflowSectionFromPath(path string) (string, bool) {
+	switch {
+	case strings.Contains(path, ".workflow.finally."):
+		return action.SectionFinally, true
+	case strings.Contains(path, ".workflow.actions."):
+		return action.SectionActions, true
+	default:
+		return "", false
+	}
+}
+
+// dependsOnPathAt returns the logical path of the action dependsOn item whose
+// value node starts at pos, or ok=false when no such item is there. It maps a
+// located reference's position back to its dependsOn path so the swap case can be
+// section-scoped like the typing case.
+func dependsOnPathAt(entry *DocEntry, pos sourcepos.Position) (string, bool) {
+	if entry.Nodes == nil {
+		return "", false
+	}
+	for path, n := range entry.Nodes {
+		if n == nil || n.Line != pos.Line || n.Column != pos.Column {
+			continue
+		}
+		base := stripIndex(path)
+		if lastSegment(base) == "dependsOn" && isActionDependsOnPath(base) {
+			return base, true
+		}
+	}
+	return "", false
 }
 
 // symbolCompletionTarget classifies the cursor into the symbol kind to complete
@@ -106,7 +206,10 @@ func valueRefCompletionTarget(entry *DocEntry, pos protocol.Position, cc CursorC
 		case "rslvr":
 			return refindex.SymbolResolver, partial, true
 		case "dependsOn":
-			return dependsOnKind(base), partial, true
+			// Action dependsOn is section-scoped and handled by
+			// actionDependsOnCandidates before this generic path runs, so a
+			// dependsOn reaching here is a resolver's (single resolver namespace).
+			return refindex.SymbolResolver, partial, true
 		}
 	}
 
@@ -133,16 +236,6 @@ func valueRefCompletionTarget(entry *DocEntry, pos protocol.Position, cc CursorC
 	return 0, "", false
 }
 
-// dependsOnKind returns the symbol kind a dependsOn entry references, from the
-// owning path: an action's dependsOn lists action names; a resolver's lists
-// resolver names.
-func dependsOnKind(path string) refindex.SymbolKind {
-	if strings.Contains(path, ".workflow.actions.") || strings.Contains(path, ".workflow.finally.") {
-		return refindex.SymbolAction
-	}
-	return refindex.SymbolResolver
-}
-
 // symbolNameItems builds completion items for every DEFINED name of kind in idx
 // whose name starts with partial (case-insensitive; an empty partial offers
 // all). Only definitions are offered -- idx.Names also includes reference names
@@ -150,15 +243,26 @@ func dependsOnKind(path string) refindex.SymbolKind {
 // filtering to names that resolve to a definition keeps the suggestions to
 // symbols that actually exist.
 func symbolNameItems(idx *refindex.Index, kind refindex.SymbolKind, partial string) []protocol.CompletionItem {
-	names := idx.Names(kind)
+	names := make([]string, 0)
+	for _, name := range idx.Names(kind) {
+		if _, defined := idx.Definition(kind, name); defined {
+			names = append(names, name)
+		}
+	}
+	return completionItemsFromNames(names, kind, partial)
+}
+
+// completionItemsFromNames builds and sorts completion items for the given
+// symbol names, filtered by the (case-insensitive) partial prefix -- an empty
+// partial offers all. The names are assumed to already be the valid candidate
+// set (e.g. defined symbols, or a section's actions), so no further existence
+// filtering is applied here.
+func completionItemsFromNames(names []string, kind refindex.SymbolKind, partial string) []protocol.CompletionItem {
 	lower := strings.ToLower(strings.TrimSpace(partial))
 	items := make([]protocol.CompletionItem, 0, len(names))
 	itemKind := symbolItemKind(kind)
 	detail := kind.String()
 	for _, name := range names {
-		if _, defined := idx.Definition(kind, name); !defined {
-			continue
-		}
 		if lower != "" && !strings.HasPrefix(strings.ToLower(name), lower) {
 			continue
 		}

--- a/pkg/lsp/completion_symbols_test.go
+++ b/pkg/lsp/completion_symbols_test.go
@@ -246,6 +246,21 @@ func TestSymbolCompletion_ActionDependsOn_SwapCrossSectionRefStaysInSection(t *t
 	assert.NotContains(t, labels, "alpha", "must not offer a main-section action")
 }
 
+func TestSymbolCompletion_ActionDependsOn_SwapQuotedRefStaysInSection(t *testing.T) {
+	// Same swap case as above, but the cross-section reference is QUOTED
+	// (`- "alphaMain"`). refindex positions a quoted scalar's reference at its
+	// CONTENT start -- one column past the opening quote -- so dependsOnPathAt
+	// must account for that shift (via refContentColumn). If it compared the raw
+	// node column instead, the lookup would miss, the swap case would fall back
+	// to the generic action index, and cross-section names would leak back in
+	// (the #798 over-suggestion). Guard that quoted entries stay section-scoped.
+	content := replaceOnce(sectionScopedFixture, "- FINPART", `- "alphaMain"`)
+	labels := completeAt(t, content, `- "alphaMain"`, "alphaMain", 3)
+	assert.Contains(t, labels, "alphaFinally", "offers a same-(finally-)section action to swap to: %v", labels)
+	assert.NotContains(t, labels, "alphaMain", "must not offer the main-section action it is parked on")
+	assert.NotContains(t, labels, "alpha", "must not offer a main-section action even when quoted")
+}
+
 // symbolSwapFixture references an existing resolver by its full name, so the
 // cursor lands on a located reference (CursorSymbolRef) rather than a partial
 // token being typed.

--- a/pkg/lsp/completion_symbols_test.go
+++ b/pkg/lsp/completion_symbols_test.go
@@ -174,6 +174,78 @@ func TestSymbolCompletion_ActionDependsOn(t *testing.T) {
 	assert.Equal(t, []string{"build"}, labels, "action dependsOn offers action names: %v", labels)
 }
 
+// sectionScopedFixture has both a main (actions) and a finally section so a
+// dependsOn in one section must not offer actions from the other. Actions:
+// alpha, alphaMain (main); alphaFinally, cleanup (finally).
+const sectionScopedFixture = `apiVersion: scafctl.io/v1
+kind: Solution
+metadata:
+  name: sym
+spec:
+  workflow:
+    actions:
+      alpha:
+        provider: message
+        inputs:
+          message: a
+      alphaMain:
+        provider: message
+        inputs:
+          message: am
+      build:
+        dependsOn:
+          - PARTIAL
+        provider: message
+        inputs:
+          message: b
+    finally:
+      alphaFinally:
+        provider: message
+        inputs:
+          message: af
+      cleanup:
+        dependsOn:
+          - FINPART
+        provider: message
+        inputs:
+          message: c
+`
+
+func TestSymbolCompletion_ActionDependsOn_MainSectionScoped(t *testing.T) {
+	// A main-section action's dependsOn typing "al" must offer only main actions
+	// (alpha, alphaMain) -- never the finally action "alphaFinally", which
+	// validateDependsOn would reject as cross-section.
+	content := replaceOnce(sectionScopedFixture, "- PARTIAL", "- al")
+	labels := completeAt(t, content, "- al", "al", 2)
+	assert.Equal(t, []string{"alpha", "alphaMain"}, labels,
+		"main dependsOn must be scoped to the actions section: %v", labels)
+	assert.NotContains(t, labels, "alphaFinally", "must not offer a finally action")
+}
+
+func TestSymbolCompletion_ActionDependsOn_FinallySectionScoped(t *testing.T) {
+	// A finally action's dependsOn typing "al" must offer only finally actions
+	// (alphaFinally) -- never the main-section "alpha"/"alphaMain". This is the
+	// #798 over-suggestion the fix closes.
+	content := replaceOnce(sectionScopedFixture, "- FINPART", "- al")
+	labels := completeAt(t, content, "- al", "al", 2)
+	assert.Equal(t, []string{"alphaFinally"}, labels,
+		"finally dependsOn must be scoped to the finally section: %v", labels)
+	assert.NotContains(t, labels, "alpha", "must not offer a main-section action")
+	assert.NotContains(t, labels, "alphaMain", "must not offer a main-section action")
+}
+
+func TestSymbolCompletion_ActionDependsOn_SwapCrossSectionRefStaysInSection(t *testing.T) {
+	// The cursor is parked on a COMPLETE main-section action name ("alphaMain")
+	// inside a FINALLY action's dependsOn -- an already-invalid cross-section
+	// reference the index still locates. The swap suggestions must be the finally
+	// section's actions (to correct it), never main-section names.
+	content := replaceOnce(sectionScopedFixture, "- FINPART", "- alphaMain")
+	labels := completeAt(t, content, "- alphaMain", "alphaMain", 9)
+	assert.Contains(t, labels, "alphaFinally", "offers a same-(finally-)section action to swap to: %v", labels)
+	assert.NotContains(t, labels, "alphaMain", "must not offer the main-section action it is parked on")
+	assert.NotContains(t, labels, "alpha", "must not offer a main-section action")
+}
+
 // symbolSwapFixture references an existing resolver by its full name, so the
 // cursor lands on a located reference (CursorSymbolRef) rather than a partial
 // token being typed.


### PR DESCRIPTION
## Summary

Fixes #798. An action's `dependsOn` may only reference actions in its **own** workflow section (`actions` vs `finally`) -- `validateDependsOn` (Rules 5 & 6) rejects a cross-section dependency. But symbol completion offered the **unified** action index for any action `dependsOn`, so a `finally` action's `dependsOn` suggested main-section actions (and vice versa) -- names the validator immediately rejects.

This violates the well-established completion principle that a language server should **only suggest candidates valid at the cursor** (gopls / rust-analyzer only offer in-scope symbols; JSON-schema YAML completion offers only schema-valid options -- all "proactively filter out suggestions that would lead to errors").

## Approach -- single source of truth (not a duplicated rule)

Rather than re-encode the section rule inside completion (which would risk drifting from the validator), the same-section constraint is centralized and shared:

- **`pkg/action`**: new `Workflow.SectionActions(section)` + `SectionActions`/`SectionFinally` constants -- the one place that maps a section to its valid dependsOn targets. `validateDependsOn` is refactored to use it (behavior-preserving; the existing cross-section validation tests still pass). Now the set of *suggested* targets and the set of *valid* targets come from the same function and cannot drift.
- **`pkg/lsp/completion_symbols.go`**: an action `dependsOn`'s candidates are scoped to the owning section via `Workflow.SectionActions`, covering both the **typing** case (a `CursorNone` item classified from its path) and the **swap** case (a `CursorSymbolRef` on a complete name, classified from the reference's position). Resolver `dependsOn` is unchanged. The now-dead `dependsOnKind` is removed and item-building is shared via `completionItemsFromNames`.
- **Quoted swap case**: `dependsOnPathAt` maps a located reference back to its `dependsOn` path by position. Because refindex records a whole-scalar reference at its **content start** -- one column past the opening quote for a quoted scalar (`refindex.contentStart`) -- a quoted swap-case entry like `- "alphaMain"` would otherwise miss the exact-column match, fall back to the generic action index, and re-leak cross-section names. `refContentColumn` derives the reference column from the node's quote style so quoted entries stay section-scoped too.

## Tests / docs

- `pkg/lsp/completion_symbols_test.go`: main-section scoping, **finally-section scoping** (the #798 case), the cross-section **swap** case (offers in-section alternatives), and the **quoted** swap case.
- `pkg/action/types_test.go`: `Workflow.SectionActions` (both sections, unknown section, nil receiver, and the cross-section invariant).
- `docs/tutorials/lsp-tutorial.md`: documents the section scoping.
- `go build`, `pkg/lsp` + `pkg/action` suites, and `task lint:changed` (0 new issues) all pass.

## Behavior

Before: a `finally` action's `dependsOn` typing `de` offered main-section `deploy` (which validation rejects); a quoted cross-section reference was also offered other-section swap targets.
After: it offers only same-section actions -- and a `dependsOn` parked on an invalid cross-section name (quoted or not) is offered in-section alternatives to correct it.

Closes #798
