### PR TITLE
chore: enable scafctl MCP server in opencode config

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -12,6 +12,13 @@
     "opencode-vibeguard",
     "@tarquinen/opencode-dcp@3.1.14"
   ],
+  "mcp": {
+    "scafctl": {
+      "type": "local",
+      "command": ["./dist/scafctl", "mcp", "serve"],
+      "enabled": true
+    }
+  },
   "formatter": {},
   "lsp": {
     "gopls": {


### PR DESCRIPTION
## Summary

Registers the scafctl MCP server in `opencode.json` so contributors using opencode get live access to the solution schema, provider catalog, lint rules, and other reference tools straight from the built binary, instead of relying on hand-maintained docs alone.

- Adds a `mcp.scafctl` local server entry running `./dist/scafctl mcp serve`

## Test plan

- Verified `./dist/scafctl mcp serve` starts and `scafctl mcp list` reports all tools/prompts