### PR TITLE
docs: add publish-hygiene skill and wire it into Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -75,6 +75,7 @@ The project uses `task` (go-task/task) for builds and linting. **Always use `tas
 - **Test coverage**: Every new or changed file must have tests. Target 70%+ patch coverage. Never submit a new file with 0% test coverage
 - **No magic values**: Always define constants or use settings for configuration values
 - **Git safety**: The AI may commit, push, and open/merge PRs, but must **ask for approval first**; a **single approval covers the whole commit -> push -> PR sequence** (never publish any step without having asked). `git commit --amend` is **denied** and run manually by the user. Before committing, verify a signing key is loaded (`ssh-add -l`); if none is loaded, prompt the user to load their signing key into the ssh-agent per their local setup rather than attempting a doomed commit. All commits must be signed (`-S`) and DCO signed-off (`-s`). **Do not `sleep` to wait for CI**; ask the user whether to wait, and if so loop-poll (`gh pr checks`). See `AGENTS.md` for details.
+- **Publish hygiene**: This repo is public. Before creating/editing an issue, PR, or comment, or committing any file, check for and scrub employer- or organization-specific references (internal tool names, internal hostnames/domains, internal codenames, employee identifiers, credentials) -- see `.github/skills/publish-hygiene/SKILL.md` for the full checklist. This applies to human contributors, AI agents, and reviewers alike.
 
 ## Issue Definition of Done (automatic quality gate)
 

--- a/.github/instructions/docs-examples.instructions.md
+++ b/.github/instructions/docs-examples.instructions.md
@@ -17,3 +17,7 @@ applyTo: "{docs,examples,pkg/docs,pkg/examples}/**"
   `list_lint_rules` / `explain_lint_rule`, `explain_concepts`,
   `list_context_variables`) to **verify or
   generate** that reference rather than as the sole reader-facing source.
+- This repo is public: before committing docs or examples, check them against
+  `.github/skills/publish-hygiene/SKILL.md` -- examples and screenshots are a
+  common place for an employer-specific hostname, tool name, or identifier to
+  leak in.

--- a/.github/instructions/markdown.instructions.md
+++ b/.github/instructions/markdown.instructions.md
@@ -20,3 +20,10 @@ Use only ASCII characters in markdown files:
 - Use straight quotes (`"`, `'`) instead of curly/smart quotes
 - Use `...` instead of ellipsis characters
 - Use standard hyphens (`-`) instead of en dashes
+
+## Publish Hygiene
+
+This repo is public. Before committing any markdown file, check it against
+`.github/skills/publish-hygiene/SKILL.md` for employer- or organization-specific
+references (internal tool names, hostnames/domains, codenames, employee
+identifiers, credentials).

--- a/.github/skills/publish-hygiene/SKILL.md
+++ b/.github/skills/publish-hygiene/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: publish-hygiene
+description: Use before posting anything to this public repository's external surfaces -- GitHub issues, PR titles/bodies/comments, commit messages, or committed docs/examples -- to check for and scrub any employer- or organization-specific references (internal tool names, internal hostnames/domains, internal project codenames, employee identifiers, internal infrastructure names, or other non-public organizational details) that a contributor's local environment or notes might otherwise leak into a public artifact.
+---
+
+# Publish Hygiene
+
+This repository is public. Contributors work from many different employers,
+personal setups, and local tooling configurations. None of that context
+belongs in anything this repo publishes externally: GitHub issues, PR titles
+and bodies, PR/issue comments, commit messages, or any content committed to
+the repo (docs, examples, code comments, test fixtures).
+
+This skill is intentionally **organization-agnostic** -- it names no specific
+company, product, or internal tool. Apply the same checklist regardless of
+which employer or environment you're working from.
+
+## When to run this check
+
+Before any of these actions:
+
+- Creating or commenting on a GitHub issue
+- Opening a PR or editing its title/body
+- Writing a commit message
+- Adding or editing a file that will be committed (docs, examples, fixtures,
+  skills, agent/config files)
+
+## What to scrub
+
+Look for anything that identifies a specific non-public organization or
+reveals its internal details, including:
+
+- **Organization names** -- the literal name of an employer or internal team,
+  in any casing or as part of a compound word (e.g. a company name fused into
+  a tool, package, or hostname).
+- **Internal tool/product names** -- proprietary or internal-only systems,
+  platforms, or codenames that only make sense inside one organization.
+- **Internal infrastructure** -- internal domains (anything other than
+  clearly public services), internal hostnames, cluster/environment names,
+  internal registries, VPN/network names, or internal IP ranges.
+- **Identity details** -- corporate email domains, employee/user IDs, SSO
+  tenant names, internal usernames, or anything that maps back to a specific
+  person's employer.
+- **Credentials and secrets** -- tokens, keys, connection strings, or
+  anything that should never appear in a public artifact regardless of whose
+  it is.
+- **Screenshots, logs, or pasted output** -- these often carry hostnames,
+  usernames, or tool names baked into the image/text that a text scrub alone
+  won't catch. Review these visually, not just with grep.
+
+## How to scrub
+
+Replace with neutral, clearly-fictional placeholders instead of deleting
+context wholesale:
+
+- A specific company/org name -> `example-corp`, `Acme Corp`, or similar
+- An internal hostname/domain -> `example.com`, `internal.example.com`
+- An internal cluster/environment name -> `cluster-a`, `staging-env`
+- An internal registry -> `registry.example.com`
+- A corporate email address -> a generic placeholder such as name-at-example-dot-com
+- An internal tool/codename -> a generic functional description of what it
+  does, not its internal name (e.g. "the internal CI system" rather than a
+  proper name)
+
+Keep the technical substance of the report/issue/PR intact -- only the
+identifying details change. A reader should be able to reproduce or
+understand the issue using only public information after the scrub.
+
+## Quick self-check before publishing
+
+1. Would this text make sense to someone with zero knowledge of my employer?
+2. Does it name, or allow inference of, a specific non-public organization?
+3. Does it contain a hostname, domain, or identifier that isn't clearly a
+   public, well-known service?
+4. Are there credentials, tokens, or internal identifiers anywhere in the
+   text, including inside code blocks, logs, or pasted command output?
+
+If any answer raises doubt, scrub before publishing rather than after.
+
+## Note on personal/local tooling
+
+Some contributors' local AI-assistant or editor configurations enforce this
+kind of check automatically as part of their own environment (for example, a
+pre-publish hook that blocks a commit or PR containing a specific employer's
+references). That kind of enforcement is personal machine configuration and
+deliberately lives outside this repository -- it is not something this repo
+should assume, require, or reference by name. This skill exists so the same
+discipline is available to every contributor, regardless of their local
+setup.


### PR DESCRIPTION
## Summary

Adds `.github/skills/publish-hygiene/SKILL.md`: an organization-agnostic checklist for scrubbing employer/organization-specific references (internal tool names, hostnames/domains, codenames, employee identifiers, credentials) before publishing anything from this public repo -- issues, PRs, comments, commits, or committed docs/examples.

Wires it into GitHub Copilot's visible instructions so PR reviews can enforce the same check:

- `.github/copilot-instructions.md`: new Critical Rules bullet (repo-wide)
- `.github/instructions/docs-examples.instructions.md`: pointer scoped to docs/examples (the highest-risk area for leaked details)
- `.github/instructions/markdown.instructions.md`: pointer scoped to all markdown files

The skill itself names no specific company, product, or internal tool, so it applies equally to any contributor regardless of employer.

## Test plan

- Docs-only change; no code/build impact
- Reviewed the new skill file for any accidental company/tool references before committing