### PR TITLE
fix: serialize kvx tui renders to fix theme race, isolate flaky catalog test

### DIFF
--- a/pkg/auth/loginui/loginui.go
+++ b/pkg/auth/loginui/loginui.go
@@ -218,7 +218,7 @@ func runStatusTUI(
 	cfg.Done = done
 
 	teaOpts := tui.WithIO(ioStreams.In, ioStreams.Out)
-	if runErr := tui.Run(data, cfg, teaOpts...); runErr != nil {
+	if runErr := skvx.WithRenderLock(func() error { return tui.Run(data, cfg, teaOpts...) }); runErr != nil {
 		if ctx.Err() != nil {
 			return nil, exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
 		}
@@ -314,7 +314,7 @@ func runBrowserTUI(
 	cfg.Done = done
 
 	teaOpts := tui.WithIO(ioStreams.In, ioStreams.Out)
-	if runErr := tui.Run(data, cfg, teaOpts...); runErr != nil {
+	if runErr := skvx.WithRenderLock(func() error { return tui.Run(data, cfg, teaOpts...) }); runErr != nil {
 		if ctx.Err() != nil {
 			return nil, exitcode.WithCode(auth.ErrUserCancelled, exitcode.GeneralError)
 		}

--- a/pkg/cmd/scafctl/get/solution/solution_test.go
+++ b/pkg/cmd/scafctl/get/solution/solution_test.go
@@ -692,7 +692,18 @@ func TestDeduplicateAndFormatSolutions(t *testing.T) {
 }
 
 func TestCommandSolution_NoArgsCallsListSolutions(t *testing.T) {
-	t.Parallel()
+	// Cannot be parallel: temporarily redirects xdg.DataHome to an empty
+	// catalog so this test is not polluted by solutions already present in
+	// the machine's real local catalog (e.g. from prior `scafctl build`/`run`
+	// invocations).
+	xdgMu.Lock()
+	tmpDir := t.TempDir()
+	origDataHome := xdg.DataHome
+	xdg.DataHome = tmpDir
+	t.Cleanup(func() {
+		xdg.DataHome = origDataHome
+		xdgMu.Unlock()
+	})
 
 	outBuf := &bytes.Buffer{}
 	errBuf := &bytes.Buffer{}
@@ -706,7 +717,8 @@ func TestCommandSolution_NoArgsCallsListSolutions(t *testing.T) {
 	cmd.SetContext(ctx)
 
 	// No args, no --file, no --local: should call ListSolutions.
-	// Without a real catalog this produces "No solutions found" info message.
+	// With an isolated, empty local catalog this produces "No solutions
+	// found" info message.
 	err := cmd.Execute()
 	require.NoError(t, err)
 

--- a/pkg/terminal/kvx/output.go
+++ b/pkg/terminal/kvx/output.go
@@ -699,11 +699,15 @@ func (o *OutputOptions) writeText(data any) error {
 	if cols := countDataColumns(outputData); cols > 0 {
 		width := o.terminalWidth()
 		if o.ColumnarMode != tui.ColumnarModeAlways && (width/(cols+1) < minColumnWidth || (piped && hasNestedValues(outputData))) {
-			output := tui.RenderList(outputData, tui.ListOptions{
-				NoColor:       true,
-				ColumnOrder:   o.ColumnOrder,
-				HiddenColumns: hiddenColumnsFromHints(hints),
-			})
+			output := func() string {
+				renderMu.Lock()
+				defer renderMu.Unlock()
+				return tui.RenderList(outputData, tui.ListOptions{
+					NoColor:       true,
+					ColumnOrder:   o.ColumnOrder,
+					HiddenColumns: hiddenColumnsFromHints(hints),
+				})
+			}()
 			fmt.Fprint(o.IOStreams.Out, output)
 			return nil
 		}
@@ -716,14 +720,18 @@ func (o *OutputOptions) writeText(data any) error {
 		outputData = normalizeSliceKeys(outputData)
 	}
 
-	output := tui.RenderTable(outputData, tui.TableOptions{
-		Bordered:      false,
-		NoColor:       true,
-		ColumnOrder:   o.ColumnOrder,
-		ColumnHints:   hints,
-		ColumnarMode:  o.ColumnarMode,
-		HiddenColumns: hiddenColumnsFromHints(hints),
-	})
+	output := func() string {
+		renderMu.Lock()
+		defer renderMu.Unlock()
+		return tui.RenderTable(outputData, tui.TableOptions{
+			Bordered:      false,
+			NoColor:       true,
+			ColumnOrder:   o.ColumnOrder,
+			ColumnHints:   hints,
+			ColumnarMode:  o.ColumnarMode,
+			HiddenColumns: hiddenColumnsFromHints(hints),
+		})
+	}()
 
 	// When piped on Windows the console defaults to OEM/CP437 encoding,
 	// which garbles UTF-8 box-drawing characters (e.g., ─ → ΓöÇ).

--- a/pkg/terminal/kvx/theme_guard.go
+++ b/pkg/terminal/kvx/theme_guard.go
@@ -1,0 +1,48 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kvx
+
+import "sync"
+
+// TODO(https://github.com/oakwood-commons/kvx/issues -- file upstream):
+// remove renderMu (and WithRenderLock) once kvx makes tui.CurrentTheme()
+// race-safe (e.g. sync.Once/RWMutex around the lazy theme init).
+
+// renderMu serializes all calls into the upstream kvx tui package, across
+// every caller in the process -- not just calls made through the same
+// OutputOptions/ViewerOptions instance, and not just within this package.
+//
+// tui.CurrentTheme() (github.com/oakwood-commons/kvx/internal/ui/theme.go)
+// lazily initializes a package-level theme global with no synchronization:
+// it reads currentTheme, and if unset, writes DefaultTheme() into it. Every
+// tui.Render*/tui.Run entry point reaches this on first use, so concurrent
+// renders from this package (or from tests that call them in parallel) race
+// on that global under `go test -race`, and could theoretically race on real
+// concurrent renders in an embedding application (e.g. a server rendering
+// kvx output for multiple requests at once).
+//
+// Until the race is fixed upstream, serialize every render call at this
+// wrapper boundary so scafctl (and its embedders) never trigger it.
+// Non-interactive renders are fast, so contention there is a non-issue.
+// Interactive sessions (tui.Run) are the exception: they hold this lock for
+// the full duration of the user's session, so a second render (interactive
+// or not) will block until that session ends. This is an accepted tradeoff
+// for typical single-user CLI usage; a server-style embedder running many
+// concurrent interactive sessions would serialize on this lock and should
+// consider a finer-grained guard (e.g. one that only protects the lazy theme
+// initialization, not the whole render) if that becomes a real workload.
+var renderMu sync.Mutex
+
+// WithRenderLock runs fn while holding renderMu, for callers outside this
+// package that invoke the upstream kvx tui package directly (e.g.
+// pkg/auth/loginui, which builds its own tui.Run invocations for interactive
+// login flows). renderMu is unexported, so this is the only way external
+// callers can participate in the same serialization as pkg/terminal/kvx's own
+// render call sites; without it, those callers would be invisible to the
+// guard and could still trigger the upstream race.
+func WithRenderLock(fn func() error) error {
+	renderMu.Lock()
+	defer renderMu.Unlock()
+	return fn()
+}

--- a/pkg/terminal/kvx/theme_guard_test.go
+++ b/pkg/terminal/kvx/theme_guard_test.go
@@ -1,0 +1,100 @@
+// Copyright 2025-2026 Oakwood Commons
+// SPDX-License-Identifier: Apache-2.0
+
+package kvx
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/oakwood-commons/kvx/pkg/tui"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRenderMu_ConcurrentRenders stress-tests concurrent calls into the
+// exported render entry points that all share renderMu (RenderTable,
+// RenderList, View). Run with -race: without the mutex serializing calls
+// into the upstream kvx tui package, this reliably trips the data race on
+// tui.CurrentTheme()'s unsynchronized package-level theme global. It passing
+// under -race is the regression guard for the fix in this file.
+func TestRenderMu_ConcurrentRenders(t *testing.T) {
+	data := []map[string]any{
+		{"name": "a", "value": 1},
+		{"name": "b", "value": 2},
+	}
+
+	const goroutines = 16
+	var wg sync.WaitGroup
+	wg.Add(goroutines * 2)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := RenderTable(data, tui.TableOptions{})
+			assert.NoError(t, err)
+		}()
+		go func() {
+			defer wg.Done()
+			_, err := RenderList(data, tui.ListOptions{})
+			assert.NoError(t, err)
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestWithRenderLock_RunsFnAndPropagatesError verifies WithRenderLock both
+// executes the wrapped function while holding renderMu, and propagates its
+// error unchanged, since external callers (e.g. pkg/auth/loginui) rely on
+// the returned error to detect failures/cancellation.
+func TestWithRenderLock_RunsFnAndPropagatesError(t *testing.T) {
+	called := false
+	err := WithRenderLock(func() error {
+		called = true
+		return nil
+	})
+	assert.NoError(t, err)
+	assert.True(t, called)
+
+	sentinel := errors.New("boom")
+	err = WithRenderLock(func() error {
+		return sentinel
+	})
+	assert.ErrorIs(t, err, sentinel)
+}
+
+// TestWithRenderLock_SerializesConcurrentCallers stress-tests WithRenderLock
+// itself: concurrent callers must never execute fn simultaneously. This
+// guards the external-caller entry point the same way
+// TestRenderMu_ConcurrentRenders guards the in-package render call sites.
+func TestWithRenderLock_SerializesConcurrentCallers(t *testing.T) {
+	const goroutines = 16
+	var active, maxActive int
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			err := WithRenderLock(func() error {
+				mu.Lock()
+				active++
+				if active > maxActive {
+					maxActive = active
+				}
+				mu.Unlock()
+
+				mu.Lock()
+				active--
+				mu.Unlock()
+				return nil
+			})
+			assert.NoError(t, err)
+		}()
+	}
+
+	wg.Wait()
+	assert.Equal(t, 1, maxActive, "WithRenderLock must never run fn concurrently")
+}

--- a/pkg/terminal/kvx/theme_guard_test.go
+++ b/pkg/terminal/kvx/theme_guard_test.go
@@ -4,7 +4,11 @@
 package kvx
 
 import (
+	"context"
 	"errors"
+	"os"
+	"os/exec"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -12,13 +16,42 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// kvxThemeRaceSubprocessEnv marks the re-exec'd child process spawned by
+// TestRenderMu_ConcurrentRenders, so it runs the actual stress workload
+// instead of re-spawning itself again.
+const kvxThemeRaceSubprocessEnv = "KVX_THEME_RACE_SUBPROCESS=1"
+
 // TestRenderMu_ConcurrentRenders stress-tests concurrent calls into the
 // exported render entry points that all share renderMu (RenderTable,
 // RenderList, View). Run with -race: without the mutex serializing calls
 // into the upstream kvx tui package, this reliably trips the data race on
 // tui.CurrentTheme()'s unsynchronized package-level theme global. It passing
 // under -race is the regression guard for the fix in this file.
+//
+// This only exercises the upstream race while tui's package-level theme is
+// still unset (see theme_guard.go). To avoid being order-dependent on
+// whichever other test in this package happens to run first and lazily
+// initializes the theme, this re-execs itself as a fresh subprocess (via
+// os.Args[0], the compiled test binary) so the race check always starts
+// from a guaranteed-unset theme global, regardless of test execution order.
 func TestRenderMu_ConcurrentRenders(t *testing.T) {
+	if os.Getenv("KVX_THEME_RACE_SUBPROCESS") == "1" {
+		renderMuConcurrentRendersWorkload(t)
+		return
+	}
+
+	cmd := exec.CommandContext(context.Background(), os.Args[0], "-test.run=^TestRenderMu_ConcurrentRenders$", "-test.v")
+	cmd.Env = append(os.Environ(), kvxThemeRaceSubprocessEnv)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("subprocess race check failed: %v\n%s", err, out)
+	}
+}
+
+// renderMuConcurrentRendersWorkload is the actual concurrent-render stress
+// workload, run inside the re-exec'd subprocess so it starts from a fresh,
+// unset theme global every time.
+func renderMuConcurrentRendersWorkload(t *testing.T) {
 	data := []map[string]any{
 		{"name": "a", "value": 1},
 		{"name": "b", "value": 2},
@@ -68,8 +101,17 @@ func TestWithRenderLock_RunsFnAndPropagatesError(t *testing.T) {
 // itself: concurrent callers must never execute fn simultaneously. This
 // guards the external-caller entry point the same way
 // TestRenderMu_ConcurrentRenders guards the in-package render call sites.
+//
+// The critical section does a small, non-optimizable amount of work (a busy
+// loop over an atomic counter) between the increment and decrement, rather
+// than just incrementing/decrementing back-to-back. An empty critical
+// section can pass even if the mutex is accidentally removed, because two
+// goroutines are unlikely to race into two bare instructions at the exact
+// same instant; widening the window makes an actual concurrency violation
+// far more likely to be observed, independent of running with -race.
 func TestWithRenderLock_SerializesConcurrentCallers(t *testing.T) {
 	const goroutines = 16
+	const busyWorkIterations = 10_000
 	var active, maxActive int
 	var mu sync.Mutex
 	var wg sync.WaitGroup
@@ -85,6 +127,12 @@ func TestWithRenderLock_SerializesConcurrentCallers(t *testing.T) {
 					maxActive = active
 				}
 				mu.Unlock()
+
+				var busy uint64
+				for j := 0; j < busyWorkIterations; j++ {
+					busy += uint64(j)
+				}
+				runtime.KeepAlive(busy)
 
 				mu.Lock()
 				active--

--- a/pkg/terminal/kvx/viewer.go
+++ b/pkg/terminal/kvx/viewer.go
@@ -321,18 +321,22 @@ func renderTable(root any, options *ViewerOptions) error {
 	if options.ColumnarMode == tui.ColumnarModeAlways {
 		root = normalizeSliceKeys(root)
 	}
-	output := tui.RenderTable(root, tui.TableOptions{
-		AppName:       options.AppName,
-		Path:          "_",
-		Bordered:      true,
-		Width:         options.Width,
-		NoColor:       options.NoColor,
-		ColumnOrder:   options.ColumnOrder,
-		ColumnHints:   hints,
-		ColumnarMode:  options.ColumnarMode,
-		HiddenColumns: hiddenColumnsFromHints(hints),
-		Schema:        resolveDisplaySchema(options.DisplaySchemaJSON),
-	})
+	output := func() string {
+		renderMu.Lock()
+		defer renderMu.Unlock()
+		return tui.RenderTable(root, tui.TableOptions{
+			AppName:       options.AppName,
+			Path:          "_",
+			Bordered:      true,
+			Width:         options.Width,
+			NoColor:       options.NoColor,
+			ColumnOrder:   options.ColumnOrder,
+			ColumnHints:   hints,
+			ColumnarMode:  options.ColumnarMode,
+			HiddenColumns: hiddenColumnsFromHints(hints),
+			Schema:        resolveDisplaySchema(options.DisplaySchemaJSON),
+		})
+	}()
 	fmt.Fprint(options.Out, output)
 	return nil
 }
@@ -368,12 +372,16 @@ func resolveColumnHints(schemaJSON []byte, programmatic map[string]tui.ColumnHin
 // renderList outputs data as a key-value list (non-interactive).
 func renderList(root any, options *ViewerOptions) error {
 	hints := resolveColumnHints(options.SchemaJSON, options.ColumnHints)
-	output := tui.RenderList(root, tui.ListOptions{
-		NoColor:       options.NoColor,
-		ArrayStyle:    options.ArrayStyle,
-		HiddenColumns: hiddenColumnsFromHints(hints),
-		ColumnOrder:   options.ColumnOrder,
-	})
+	output := func() string {
+		renderMu.Lock()
+		defer renderMu.Unlock()
+		return tui.RenderList(root, tui.ListOptions{
+			NoColor:       options.NoColor,
+			ArrayStyle:    options.ArrayStyle,
+			HiddenColumns: hiddenColumnsFromHints(hints),
+			ColumnOrder:   options.ColumnOrder,
+		})
+	}()
 	fmt.Fprint(options.Out, output)
 	return nil
 }
@@ -409,18 +417,26 @@ func resolveDisplaySchema(displaySchemaJSON []byte) *tui.DisplaySchema {
 
 // renderTree outputs data as an ASCII tree structure.
 func renderTree(root any, options *ViewerOptions) error {
-	output := tui.Render(root, tui.FormatTree, tui.TableOptions{
-		NoColor: options.NoColor,
-	})
+	output := func() string {
+		renderMu.Lock()
+		defer renderMu.Unlock()
+		return tui.Render(root, tui.FormatTree, tui.TableOptions{
+			NoColor: options.NoColor,
+		})
+	}()
 	fmt.Fprint(options.Out, output)
 	return nil
 }
 
 // renderMermaid outputs data as a Mermaid flowchart diagram.
 func renderMermaid(root any, options *ViewerOptions) error {
-	output := tui.Render(root, tui.FormatMermaid, tui.TableOptions{
-		NoColor: options.NoColor,
-	})
+	output := func() string {
+		renderMu.Lock()
+		defer renderMu.Unlock()
+		return tui.Render(root, tui.FormatMermaid, tui.TableOptions{
+			NoColor: options.NoColor,
+		})
+	}()
 	fmt.Fprint(options.Out, output)
 	return nil
 }
@@ -442,6 +458,8 @@ func runInteractive(root any, options *ViewerOptions) error {
 		teaOpts = append(teaOpts, tui.WithIO(options.In, options.Out)...)
 	}
 
+	renderMu.Lock()
+	defer renderMu.Unlock()
 	return tui.Run(root, cfg, teaOpts...)
 }
 
@@ -470,6 +488,8 @@ func RenderTable(data any, opts tui.TableOptions) (string, error) {
 		root = normalizeSliceKeys(root)
 	}
 
+	renderMu.Lock()
+	defer renderMu.Unlock()
 	return tui.RenderTable(root, opts), nil
 }
 
@@ -481,6 +501,8 @@ func RenderList(data any, opts tui.ListOptions) (string, error) {
 		return "", fmt.Errorf("failed to load data: %w", err)
 	}
 
+	renderMu.Lock()
+	defer renderMu.Unlock()
 	return tui.RenderList(root, opts), nil
 }
 
@@ -521,6 +543,8 @@ func Snapshot(data any, opts ...Option) (string, error) {
 		return "", fmt.Errorf("failed to build TUI config: %w", cfgErr)
 	}
 	cfg.HideFooter = true
+	renderMu.Lock()
+	defer renderMu.Unlock()
 	return tui.RenderSnapshot(root, cfg), nil
 }
 


### PR DESCRIPTION
## Summary

Fixes #647 (2 of 3 sub-issues confirmed still present; the third was already resolved by an earlier PR -- see below).

### 1. Data race in kvx theme rendering

The upstream `kvx` library's `tui.CurrentTheme()` (`internal/ui/theme.go`) lazily initializes a package-level `currentTheme` global with no synchronization: it reads the value, and if unset, writes `DefaultTheme()` into it. Every `tui.Render*`/`tui.Run` entry point reaches this on first use, so concurrent renders (e.g. parallel Go tests rendering kvx tables) race on that global under `go test -race`.

Reproduced exactly as described in the issue:

```
go test -race ./pkg/cmd/scafctl/get/celfunction/...
--- FAIL: TestRunListFunctions_SimpleList
    race detected during execution of test
```

Fix: added `pkg/terminal/kvx/theme_guard.go` with a package-level `renderMu sync.Mutex` and wrapped every call site that reaches into the upstream `tui` package:
- `output.go`: 2 call sites (`tui.RenderList`, `tui.RenderTable`)
- `viewer.go`: 8 call sites (`renderTable`, `renderList`, `renderTree`, `renderMermaid`, `runInteractive` (`tui.Run`), and the exported `RenderTable`/`RenderList`/`Snapshot` helpers)
- `pkg/auth/loginui/loginui.go` calls `tui.Run` directly (outside `pkg/terminal/kvx`) for its interactive login flows -- added an exported `kvx.WithRenderLock()` helper so these 2 call sites participate in the same serialization instead of being an unguarded gap.

Locking is scoped tightly around each render call only (not data prep/formatting), using an immediately-invoked closure + `defer` where the call isn't already the last statement in its function, so a future added early-return can't leak the lock.

Added `pkg/terminal/kvx/theme_guard_test.go` with concurrency stress tests (16 goroutines hammering `RenderTable`/`RenderList`/`WithRenderLock` under `-race`) as the regression guard, plus error-propagation and mutual-exclusion assertions for `WithRenderLock`.

### 2. Flaky catalog-assuming test

`TestCommandSolution_NoArgsCallsListSolutions` (`pkg/cmd/scafctl/get/solution/solution_test.go`) assumed an **empty** local catalog and asserted "No solutions found", without isolating `XDG_DATA_HOME` -- it failed whenever the machine's real local catalog already had a solution (e.g. `hello-world`). Fixed by isolating `xdg.DataHome` to a temp dir and dropping `t.Parallel()`, matching the exact pattern already used by two sibling tests in the same file (guarded by the file's existing `xdgMu` mutex).

Verified against a deliberately polluted catalog:
```
XDG_DATA_HOME=/tmp/polluted go test -run TestCommandSolution_NoArgsCallsListSolutions ./pkg/cmd/scafctl/get/solution/...
--- PASS (previously would FAIL)
```

### 3. `TestIntegration_RunSolution_FromCatalog_FallbackToFile` flakiness -- already fixed, no change needed

The issue describes this test as flaky under `-parallel 4` due to catalog/build contention, citing `cli_test.go:3817`. On current `main` this test is now at `cli_test.go:5806`, and `git log -L` shows an earlier, unrelated PR (#328) already refactored it to use isolated `XDG_DATA_HOME`/`XDG_CACHE_HOME` and it no longer invokes `build` at all -- there's no catalog build left to contend on. Confirmed with 15+ stress runs (`-count=10 -parallel 8` and `-count=5 -parallel 4` across the catalog test family): zero failures. No code change made for this part.

## Verification

- `CGO_ENABLED=1 go test -race -count=1 ./pkg/terminal/kvx/... ./pkg/auth/... ./pkg/cmd/scafctl/get/...` -- all pass
- `task lint:changed` -- 0 new issues
- `task test:e2e` -- only a pre-existing, unrelated failure in `pkg/examples` (duplicate example names), confirmed present on clean `main` before this change

## Review

Went through the repo's automatic review gate: `go-reviewer` found 1 HIGH (missed `loginui.go` call sites, now fixed via `WithRenderLock`) and 3 MEDIUM findings (defer-consistency, missing dedicated test file, doc-comment accuracy), all resolved. `artifact-auditor` confirmed adequate test coverage and correctly-scoped docs/CHANGELOG/MCP applicability (none needed for this internal fix).